### PR TITLE
Potential config

### DIFF
--- a/config/dynamic.json
+++ b/config/dynamic.json
@@ -42,7 +42,9 @@
 		"Revolution": {
 			"weight": 1,
 			"cost": 40
-		}
+		},
+		"Extended": {
+            		"weight": 4
 	},
 
 	"Midround": {

--- a/config/dynamic.json
+++ b/config/dynamic.json
@@ -43,9 +43,10 @@
 			"weight": 1,
 			"cost": 40
 		},
+		
 		"Extended": {
             		"weight": 4
-	},
+		}
 
 	"Midround": {
 		"Syndicate Sleeper Agent": {

--- a/config/dynamic.json
+++ b/config/dynamic.json
@@ -5,99 +5,122 @@
 	},
 	"Roundstart": {
 		"Traitors": {
-			"weight": 8
+			"weight": 8,
+			"cost": 10
 		},
 
 		"Blood Brothers": {
-			"weight": 7
+			"weight": 7,
+			"cost": 14
 		},
 
 		"Changelings": {
-			"weight": 5
+			"weight": 5,
+			"cost": 18
 		},
 
 		"Heretics": {
-			"weight": 5
+			"weight": 5,
+			"cost": 18
 		},
 
 		"Wizard": {
-			"weight": 2
+			"weight": 2,
+			"cost": 28
 		},
 
 		"Blood Cult": {
-			"weight": 1
+			"weight": 1,
+			"cost": 40
 		},
 
 		"Nuclear Emergency": {
-			"weight": 1
+			"weight": 1,
+			"cost": 60
 		},
 
 		"Revolution": {
-			"weight": 1
+			"weight": 1,
+			"cost": 40
 		}
 	},
 
 	"Midround": {
 		"Syndicate Sleeper Agent": {
-			"weight": 14
+			"weight": 14,
+			"cost": 9
 		},
 
 		"Malfunctioning AI": {
-			"weight": 12
+			"weight": 12,
+			"cost": 12
 		},
 
 		"Wizard": {
-			"weight": 4
+			"weight": 4,
+			"cost": 30
 		},
 
 		"Nuclear Assault": {
-			"weight": 1
+			"weight": 1,
+			"cost": 60
 		},
 
 		"Blob": {
-			"weight": 3
+			"weight": 3,
+			"cost": 36
 		},
 
 		"Blob Infection": {
-			"weight": 2
+			"weight": 2,
+			"cost": 40
 		},
 
 		"Alien Infestation": {
-			"weight": 4
+			"weight": 4,
+			"cost": 35
 		},
 
 		"Nightmare": {
-			"weight": 6
+			"weight": 6,
+			"cost": 18
 		},
 
 		"Space Dragon": {
-			"weight": 1
+			"weight": 1,
+			"cost": 70
 		},
 
 		"Abductors": {
-			"weight": 6
+			"weight": 6,
+			"cost": 25
 		},
 
 		"Space Ninja": {
-			"weight": 6
+			"weight": 6,
+			"cost": 30
 		},
 
 		"Spiders": {
-			"weight": 8
+			"weight": 8,
+			"cost": 20
 		}
 	},
 
 	"Latejoin": {
 		"Syndicate Infiltrator": {
-			"weight": 7
+			"weight": 7,
+			"cost": 15
 		},
 
 		"Provocateur": {
-			"weight": 1
+			"weight": 1,
+			"cost": 20
 		},
 
 		"Heretic Smuggler": {
-			"weight": 4
+			"weight": 4,
+			"cost": 12
 		}
 	}
 }

--- a/config/dynamic.json
+++ b/config/dynamic.json
@@ -1,139 +1,103 @@
 {
-	"Dynamic": {},
+	"Dynamic": {
+		"latejoin_roll_chance": 20
+		
+	},
 	"Roundstart": {
 		"Traitors": {
-			"cost": 8,
-			"scaling_cost": 9,
-			"weight": 0,
-			"required_candidates": 1,
-			"minimum_required_age": 0,
-			"requirements": [
-				10,
-				10,
-				10,
-				10,
-				10,
-				10,
-				10,
-				10,
-				10,
-				10
-			],
-			"antag_cap": {
-				"denominator": 24
-			},
-			"protected_roles": [
-				"Prisoner",
-				"Blueshield",
-				"Corrections Officer",
-				"Security Officer",
-				"Warden",
-				"Detective",
-				"Security Medic",
-				"Head of Security",
-				"Captain",
-				"Nanotrasen Consultant",
-				"Head of Personnel",
-				"Chief Engineer",
-				"Chief Medical Officer",
-				"Research Director",
-				"Quartermaster"
-			],
-			"restricted_roles": [
-				"Cyborg"
-			]
+			"weight": 8
 		},
 
 		"Blood Brothers": {
-			"weight": 0
+			"weight": 7
 		},
 
 		"Changelings": {
-			"weight": 0
+			"weight": 5
 		},
 
 		"Heretics": {
-			"weight": 0
+			"weight": 5
 		},
 
 		"Wizard": {
-			"weight": 0
+			"weight": 2
 		},
 
 		"Blood Cult": {
-			"weight": 0
+			"weight": 1
 		},
 
 		"Nuclear Emergency": {
-			"weight": 0
+			"weight": 1
 		},
 
 		"Revolution": {
-			"weight": 0
+			"weight": 1
 		}
 	},
 
 	"Midround": {
 		"Syndicate Sleeper Agent": {
-			"weight": 0
+			"weight": 14
 		},
 
 		"Malfunctioning AI": {
-			"weight": 0
+			"weight": 12
 		},
 
 		"Wizard": {
-			"weight": 0
+			"weight": 4
 		},
 
 		"Nuclear Assault": {
-			"weight": 0
+			"weight": 1
 		},
 
 		"Blob": {
-			"weight": 0
+			"weight": 3
 		},
 
 		"Blob Infection": {
-			"weight": 0
+			"weight": 2
 		},
 
 		"Alien Infestation": {
-			"weight": 0
+			"weight": 4
 		},
 
 		"Nightmare": {
-			"weight": 0
+			"weight": 6
 		},
 
 		"Space Dragon": {
-			"weight": 0
+			"weight": 1
 		},
 
 		"Abductors": {
-			"weight": 0
+			"weight": 6
 		},
 
 		"Space Ninja": {
-			"weight": 0
+			"weight": 6
 		},
 
 		"Spiders": {
-			"weight": 0
+			"weight": 8
 		}
 	},
 
 	"Latejoin": {
 		"Syndicate Infiltrator": {
-			"weight": 0
+			"weight": 7
 		},
 
 		"Provocateur": {
-			"weight": 0
+			"weight": 1
 		},
 
 		"Heretic Smuggler": {
-			"weight": 0
+			"weight": 4
 		}
 	}
 }


### PR DESCRIPTION
This is the potential config that should enable antags in a very simple way, just by weight, appearently TG does it this way and it works, so why can't we? Feel free to tweak as needed obviously.

Right now, ASSUMING this works. It should be like this:
Rarity of roundstart antags, common to rare:
Traitor - Blood Brothers (x1.2 rarer than previous) - Changeling and Heretic (x1,5 rarer than previous) - Wizard (x2.5 rarer than previous) - Nuke ops, Revolution, Blood cult, basically round enders. (x2 rarer than previous)

Rarity of midround antags, common to rare:
Sleeper Agent - Malf AI (x1.1 rarer) - Spiders (x1.5 rarer) - Nightmare, Abductors and Space Ninja - (x1.2 rarer) - Xenos and Wizard (x1.3 rarer) - Blob - (x1.1 rarer) - Blob Infected [1 dude can burst into blob any time he wants within 5 mins from infection] (x1.1 rarer) - Nukies and Space Dragon (x1.1 rarer)

Rarity of latejoin antags, common to rare:
Infiltrator -  Heretic Smuggler (x1.9 rarer) - Provocateur (x1.7 rarer)

All the multipliers were made on a whim without a calculator but I think they're somewhat accurate. Obviously, tweaking should be done as we play roundss out and see how much of what we have