### PR TITLE
NTrepstamps

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -9767,8 +9767,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/grunge{
-	name = "Cell 4";
-	id_tag = "Cell4Privacy"
+	id_tag = "Cell4Privacy";
+	name = "Cell 4"
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/prison)
@@ -11146,7 +11146,7 @@
 "dqZ" = (
 /obj/structure/flora/ocean/longseaweed,
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/station/medical/medbay/lobby)
@@ -14251,8 +14251,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/grunge{
-	name = "Cell 6";
-	id_tag = "Cell6Privacy"
+	id_tag = "Cell6Privacy";
+	name = "Cell 6"
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/prison)
@@ -16611,7 +16611,7 @@
 /obj/structure/flora/ocean/coral,
 /obj/structure/flora/ocean/glowweed,
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/station/commons/dorms)
@@ -23495,8 +23495,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/grunge{
-	name = "Cell 3";
-	id_tag = "Cell3Privacy"
+	id_tag = "Cell3Privacy";
+	name = "Cell 3"
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/prison)
@@ -29214,10 +29214,10 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for monitoring the engine.";
+	dir = 4;
 	name = "Engine Monitor";
 	network = list("engine");
-	pixel_x = -32;
-	dir = 4
+	pixel_x = -32
 	},
 /turf/open/floor/iron/smooth_edge{
 	dir = 4
@@ -32804,7 +32804,7 @@
 "jtG" = (
 /obj/structure/flora/ocean/glowweed,
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/station/medical/medbay/lobby)
@@ -34258,8 +34258,8 @@
 	},
 /obj/machinery/button/curtain{
 	id = "Cell6Privacy";
-	pixel_y = 24;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 24
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
@@ -34541,8 +34541,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/grunge{
-	name = "Cell 5";
-	id_tag = "Cell5Privacy"
+	id_tag = "Cell5Privacy";
+	name = "Cell 5"
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/prison)
@@ -37942,7 +37942,7 @@
 /area/station/cargo/office)
 "kMZ" = (
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/station/commons/dorms)
@@ -38813,15 +38813,15 @@
 	},
 /obj/machinery/button/curtain{
 	id = "Cell3Privacy";
-	pixel_y = 24;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 24
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "kZc" = (
 /obj/structure/flora/ocean/seaweed,
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/station/commons/dorms)
@@ -39033,7 +39033,7 @@
 "lcC" = (
 /obj/structure/flora/rock/pile,
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/station/commons/dorms)
@@ -44296,9 +44296,9 @@
 "mxE" = (
 /obj/structure/table,
 /obj/effect/spawner/random/food_or_drink/booze{
+	pixel_y = 6;
 	spawn_loot_count = 2;
-	spawn_random_offset = 1;
-	pixel_y = 6
+	spawn_random_offset = 1
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/miningoffice)
@@ -46895,22 +46895,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/command/cc_dock)
-"nge" = (
-/obj/item/paper/fluff/gateway,
-/obj/item/coin/gold{
-	pixel_x = -7;
-	pixel_y = 8
-	},
-/obj/item/phone{
-	pixel_x = 9;
-	pixel_y = 6
-	},
-/obj/item/clothing/mask/cigarette/pipe{
-	pixel_x = -5
-	},
-/obj/structure/table/wood,
-/turf/open/floor/carpet/green,
-/area/command/heads_quarters/captain/private/nt_rep)
 "ngt" = (
 /obj/machinery/power/shuttle_engine/heater,
 /obj/effect/turf_decal/stripes/line{
@@ -47053,11 +47037,11 @@
 "niQ" = (
 /obj/docking_port/stationary{
 	dir = 4;
+	dwidth = 9;
+	height = 25;
 	name = "DeltaStation emergency evac bay";
 	shuttle_id = "emergency_home";
-	dwidth = 9;
-	width = 29;
-	height = 25
+	width = 29
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -49296,8 +49280,8 @@
 	},
 /obj/machinery/button/curtain{
 	id = "Cell5Privacy";
-	pixel_y = 24;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 24
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
@@ -50046,8 +50030,8 @@
 	},
 /obj/machinery/button/curtain{
 	id = "Cell4Privacy";
-	pixel_y = 24;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 24
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
@@ -50265,7 +50249,7 @@
 /obj/structure/flora/ocean/longseaweed,
 /obj/structure/flora/ocean/glowweed,
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/station/commons/dorms)
@@ -50287,8 +50271,8 @@
 "nZZ" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow{
-	pixel_y = 3;
-	pixel_x = -2
+	pixel_x = -2;
+	pixel_y = 3
 	},
 /obj/item/stamp/ce{
 	pixel_x = -2;
@@ -52817,8 +52801,8 @@
 	},
 /obj/machinery/button/curtain{
 	id = "Cell1Privacy";
-	pixel_y = 24;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 24
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
@@ -53871,11 +53855,11 @@
 "paZ" = (
 /obj/docking_port/stationary{
 	dir = 8;
+	dwidth = 1;
+	height = 13;
 	name = "arrivals";
 	shuttle_id = "arrivals_stationary";
-	dwidth = 1;
-	width = 5;
-	height = 13
+	width = 5
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -62460,8 +62444,8 @@
 	},
 /obj/machinery/button/curtain{
 	id = "Cell2Privacy";
-	pixel_y = 24;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 24
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
@@ -63594,7 +63578,7 @@
 "rJK" = (
 /obj/structure/flora/ocean/longseaweed,
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/station/commons/dorms)
@@ -65564,8 +65548,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/grunge{
-	name = "Cell 1";
-	id_tag = "Cell1Privacy"
+	id_tag = "Cell1Privacy";
+	name = "Cell 1"
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/prison)
@@ -70038,7 +70022,7 @@
 "tvN" = (
 /obj/structure/flora/rock,
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /turf/open/misc/asteroid,
 /area/station/commons/dorms)
@@ -72023,12 +72007,12 @@
 	pixel_y = -1
 	},
 /obj/item/coffee_cartridge/bootleg{
-	pixel_y = 9;
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = 9
 	},
 /obj/item/coffee_cartridge/decaf{
-	pixel_y = 4;
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = 4
 	},
 /obj/item/coffee_cartridge/fancy{
 	pixel_x = 3;
@@ -83286,6 +83270,23 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/execution/education)
+"xil" = (
+/obj/item/paper/fluff/gateway,
+/obj/item/coin/gold{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/obj/item/phone{
+	pixel_x = 9;
+	pixel_y = 6
+	},
+/obj/item/clothing/mask/cigarette/pipe{
+	pixel_x = -5
+	},
+/obj/structure/table/wood,
+/obj/item/stamp/void,
+/turf/open/floor/carpet/green,
+/area/command/heads_quarters/captain/private/nt_rep)
 "xir" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/black,
@@ -83498,7 +83499,7 @@
 /area/station/security/courtroom)
 "xlC" = (
 /obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+	reagent_list = list(/datum/reagent/water = 600)
 	},
 /mob/living/basic/carp/mega/shorki{
 	obj_damage = 0
@@ -86372,8 +86373,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/grunge{
-	name = "Cell 2";
-	id_tag = "Cell2Privacy"
+	id_tag = "Cell2Privacy";
+	name = "Cell 2"
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/prison)
@@ -123777,7 +123778,7 @@ oaA
 dzx
 eRV
 cXb
-nge
+xil
 sfv
 ujJ
 xlE

--- a/_maps/skyrat/automapper/templates/deltastation/deltastation_ntrep_office.dmm
+++ b/_maps/skyrat/automapper/templates/deltastation/deltastation_ntrep_office.dmm
@@ -2,7 +2,17 @@
 "a" = (
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/captain/private/nt_rep)
-"b" = (
+"c" = (
+/obj/structure/sign/directions/engineering,
+/obj/structure/sign/directions/evac{
+	pixel_y = -8
+	},
+/obj/structure/sign/directions/science{
+	pixel_y = 8
+	},
+/turf/closed/wall/r_wall,
+/area/command/heads_quarters/captain/private/nt_rep)
+"d" = (
 /obj/structure/table/wood,
 /obj/item/stamp{
 	pixel_x = -6
@@ -13,17 +23,8 @@
 /obj/item/stamp/centcom{
 	pixel_y = 8
 	},
+/obj/item/stamp/void,
 /turf/open/floor/carpet/executive,
-/area/command/heads_quarters/captain/private/nt_rep)
-"c" = (
-/obj/structure/sign/directions/engineering,
-/obj/structure/sign/directions/evac{
-	pixel_y = -8
-	},
-/obj/structure/sign/directions/science{
-	pixel_y = 8
-	},
-/turf/closed/wall/r_wall,
 /area/command/heads_quarters/captain/private/nt_rep)
 "f" = (
 /obj/structure/table/wood,
@@ -315,7 +316,7 @@ a
 a
 a
 m
-b
+d
 J
 a
 "}

--- a/_maps/skyrat/automapper/templates/icebox/icebox_ntrep_office.dmm
+++ b/_maps/skyrat/automapper/templates/icebox/icebox_ntrep_office.dmm
@@ -1,19 +1,4 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"ak" = (
-/obj/structure/table/wood,
-/obj/item/stamp/centcom{
-	pixel_x = -6;
-	pixel_y = 8
-	},
-/obj/item/stamp/denied{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/stamp{
-	pixel_x = -6
-	},
-/turf/open/floor/carpet/executive,
-/area/command/heads_quarters/captain/private/nt_rep)
 "an" = (
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/captain/private/nt_rep)
@@ -194,6 +179,22 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private/nt_rep)
+"oO" = (
+/obj/structure/table/wood,
+/obj/item/stamp/centcom{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/stamp/denied{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/stamp{
+	pixel_x = -6
+	},
+/obj/item/stamp/void,
+/turf/open/floor/carpet/executive,
+/area/command/heads_quarters/captain/private/nt_rep)
 "oP" = (
 /obj/machinery/light/directional/east,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -208,8 +209,8 @@
 	},
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/bottle/champagne{
-	pixel_y = 18;
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = 18
 	},
 /obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
 	pixel_x = -7;
@@ -849,7 +850,7 @@ Uj
 YS
 do
 RS
-ak
+oO
 uZ
 Hy
 vS

--- a/_maps/skyrat/automapper/templates/metastation/metastation_ntrep_office.dmm
+++ b/_maps/skyrat/automapper/templates/metastation/metastation_ntrep_office.dmm
@@ -104,13 +104,6 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private/nt_rep)
-"w" = (
-/obj/structure/table/wood,
-/obj/item/stamp/centcom{
-	pixel_x = 8
-	},
-/turf/open/floor/carpet/executive,
-/area/command/heads_quarters/captain/private/nt_rep)
 "x" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/modular_computer/console/preset/command{
@@ -163,6 +156,14 @@
 /obj/machinery/light_switch/directional/east,
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/wood,
+/area/command/heads_quarters/captain/private/nt_rep)
+"G" = (
+/obj/structure/table/wood,
+/obj/item/stamp/centcom{
+	pixel_x = 8
+	},
+/obj/item/stamp/void,
+/turf/open/floor/carpet/executive,
 /area/command/heads_quarters/captain/private/nt_rep)
 "I" = (
 /obj/structure/table/wood,
@@ -297,7 +298,7 @@ D
 Y
 Y
 b
-w
+G
 z
 T
 u


### PR DESCRIPTION
## About The Pull Request
Adds the VOID stamp to the NT rep office. As requested.
## Proof of Testing
![totally-not-a-fucking-web-edit](https://user-images.githubusercontent.com/39163353/214264807-d1bd1086-fc9e-47c2-9ada-d58b8f68ab41.svg)
![made-with-fastdmm2](https://user-images.githubusercontent.com/39163353/214264808-3e8dc727-30ff-4168-b609-2b9410fa3248.svg)
## Changelog

:cl:
add: Adds stamps to all CC rep offices. Rejoice.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
