### PR TITLE
Changes various event overrides

### DIFF
--- a/modular_skyrat/modules/events/code/event_overrides.dm
+++ b/modular_skyrat/modules/events/code/event_overrides.dm
@@ -95,11 +95,9 @@
  * Removed:
  * Does not have policy. Will re-add if/when policy is added
  */
-// BUBBERS EDIT BEGIN
-/* /datum/round_event_control/operative
-/	max_occurrences = 0
-*/
-//* BUBBERS EDIT END.
+/datum/round_event_control/operative
+	//max_occurrences = 0
+	min_players = 20 //Bubberstation edit
 
 /**
  * Ninja

--- a/modular_skyrat/modules/events/code/event_overrides.dm
+++ b/modular_skyrat/modules/events/code/event_overrides.dm
@@ -57,8 +57,8 @@
  * Upped to ensure lowpop steamroll does not happen
  */
 /datum/round_event_control/spider_infestation
-	min_players = 40 //ZUBBERS EDIT CHANGE, ORIGINAL: //min_players = 70
-	max_occurrences = 1 //ZUBBERS EDIT CHANGE, ORIGINAL: //max_occurrences = 0
+	min_players = 40 //BUBBERS EDIT CHANGE, ORIGINAL: //min_players = 70
+	max_occurrences = 1 //BUBBERS EDIT CHANGE, ORIGINAL: //max_occurrences = 0
 
 /**
  * Meteor Waves
@@ -95,11 +95,11 @@
  * Removed:
  * Does not have policy. Will re-add if/when policy is added
  */
-// ZUBBERS EDIT BEGIN
+// BUBBERS EDIT BEGIN
 /* /datum/round_event_control/operative
 /	max_occurrences = 0
 */
-//* ZUBBERS EDIT END.
+//* BUBBERS EDIT END.
 
 /**
  * Ninja
@@ -135,9 +135,9 @@
  * Removed:
  * Paperwork Error is too intrusive and should be staff-only.
  */
-/* ZUBBERS EDIT START
+/* BUBBERS EDIT START
 /datum/round_event_control/bureaucratic_error
 	max_occurrences = 0
 */
-// ZUBBERS EDIT END
+// BUBBERS EDIT END
 

--- a/modular_skyrat/modules/events/code/event_overrides.dm
+++ b/modular_skyrat/modules/events/code/event_overrides.dm
@@ -57,7 +57,7 @@
  * Upped to ensure lowpop steamroll does not happen
  */
 /datum/round_event_control/spider_infestation
-	min_players = 40 //BUBBERS EDIT CHANGE, ORIGINAL: //min_players = 70
+	min_players = 70
 	max_occurrences = 1 //BUBBERS EDIT CHANGE, ORIGINAL: //max_occurrences = 0
 
 /**

--- a/modular_skyrat/modules/events/code/event_overrides.dm
+++ b/modular_skyrat/modules/events/code/event_overrides.dm
@@ -57,8 +57,8 @@
  * Upped to ensure lowpop steamroll does not happen
  */
 /datum/round_event_control/spider_infestation
-	// min_players = 70
-	max_occurrences = 0
+	min_players = 40 //ZUBBERS EDIT CHANGE, ORIGINAL: //min_players = 70
+	max_occurrences = 1 //ZUBBERS EDIT CHANGE, ORIGINAL: //max_occurrences = 0
 
 /**
  * Meteor Waves
@@ -95,8 +95,11 @@
  * Removed:
  * Does not have policy. Will re-add if/when policy is added
  */
-/datum/round_event_control/operative
-	max_occurrences = 0
+// ZUBBERS EDIT BEGIN
+/* /datum/round_event_control/operative
+/	max_occurrences = 0
+*/
+//* ZUBBERS EDIT END.
 
 /**
  * Ninja
@@ -132,5 +135,9 @@
  * Removed:
  * Paperwork Error is too intrusive and should be staff-only.
  */
+/* ZUBBERS EDIT START
 /datum/round_event_control/bureaucratic_error
 	max_occurrences = 0
+*/
+// ZUBBERS EDIT END
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/102828457/216735466-a909bf1b-0aab-4bba-9f90-96499279d272.png)

As requested.
## How This Contributes To The Bubbers Roleplay Experience

Host request.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Cursor
balance: Lone-Ops and Bureaucratic error are back.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
