### PR TITLE
[CONFIG] Dynamic.json tweaks

### DIFF
--- a/config/dynamic.json
+++ b/config/dynamic.json
@@ -6,7 +6,7 @@
 			"scaling_cost": 9,
 			"weight": 0,
 			"required_candidates": 1,
-			"minimum_required_age": 0,
+			"minimum_required_age": 14,
 			"requirements": [
 				10,
 				10,
@@ -45,15 +45,18 @@
 		},
 
 		"Blood Brothers": {
-			"weight": 0
+			"weight": 0,
+			"minimum_required_age": 14
 		},
 
 		"Changelings": {
-			"weight": 0
+			"weight": 0,
+			"minimum_required_age": 14
 		},
 
 		"Heretics": {
-			"weight": 0
+			"weight": 0,
+			"minimum_required_age": 14
 		},
 
 		"Wizard": {
@@ -61,79 +64,103 @@
 		},
 
 		"Blood Cult": {
-			"weight": 0
+			"weight": 0,
+			"minimum_required_age": 14
 		},
 
 		"Nuclear Emergency": {
-			"weight": 0
+			"weight": 0,
+			"minimum_required_age": 14
 		},
 
 		"Revolution": {
-			"weight": 0
+			"weight": 0,
+			"minimum_required_age": 14
 		}
 	},
 
 	"Midround": {
 		"Syndicate Sleeper Agent": {
-			"weight": 0
+			"weight": 0,
+			"minimum_required_age": 14
 		},
 
 		"Malfunctioning AI": {
-			"weight": 0
+			"weight": 0,
+			"minimum_required_age": 14
 		},
 
 		"Wizard": {
-			"weight": 0
+			"weight": 0,
+			"minimum_required_age": 14
 		},
 
 		"Nuclear Assault": {
-			"weight": 0
+			"weight": 0,
+			"minimum_required_age": 14,
+			"minimum_round_time": 42000
 		},
 
 		"Blob": {
-			"weight": 0
+			"weight": 0,
+			"minimum_required_age": 14,
+			"minimum_round_time": 42000
 		},
 
 		"Blob Infection": {
-			"weight": 0
+			"weight": 0,
+			"minimum_required_age": 14,
+			"minimum_round_time": 42000
 		},
 
 		"Alien Infestation": {
-			"weight": 0
+			"weight": 0,
+			"minimum_required_age": 14,
+			"minimum_round_time": 42000
 		},
 
 		"Nightmare": {
-			"weight": 0
+			"weight": 0,
+			"minimum_required_age": 14
 		},
 
 		"Space Dragon": {
-			"weight": 0
+			"weight": 0,
+			"minimum_required_age": 14,
+			"minimum_round_time": 42000
 		},
 
 		"Abductors": {
-			"weight": 0
+			"weight": 0,
+			"minimum_required_age": 14
 		},
 
 		"Space Ninja": {
-			"weight": 0
+			"weight": 0,
+			"minimum_required_age": 14
 		},
 
 		"Spiders": {
-			"weight": 0
+			"weight": 0,
+			"minimum_required_age": 14
 		}
 	},
 
 	"Latejoin": {
 		"Syndicate Infiltrator": {
-			"weight": 0
+			"weight": 0,
+			"minimum_required_age": 14
 		},
 
 		"Provocateur": {
-			"weight": 0
+			"weight": 0,
+			"minimum_required_age": 14,
+			"minimum_round_time": 42000
 		},
 
 		"Heretic Smuggler": {
-			"weight": 0
+			"weight": 0,
+			"minimum_required_age": 14
 		}
 	}
 }


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it so that all antags require 2 weeks of account age, and adds minimum round times to all super dangerous midround antags.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Makes it so that players have to get settled in properly, or that they have the opportunity to, before they can roll antag. Rolling antagonist day 1 can encourage a low roleplay environment.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

Config change, no testing needed.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
config: adds a minimum account age of 14 before a player can roll antag.
config: Adds a minimum round time of 70 minutes (42000 deciseconds) before dangerous midround and latejoin antags may spawn.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
