### PR TITLE
Show DNR state for dead crew on crew monitor

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -45,7 +45,7 @@
 		"name",
 		"job",
 		"is_robot", //SKYRAT EDIT ADDITION - Displaying robotic species Icon
-		"is_dnr", //SKYRAT EDIT ADDITION - Displays DNR status
+		"is_dnr", //BUBBERSTATION EDIT ADDITION - Displays DNR status
 		"life_status",
 		"suffocation",
 		"toxin",
@@ -262,11 +262,11 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 			entry["is_robot"] = TRUE
 		// SKYRAT EDIT END
 
-		// SKYRAT EDIT BEGIN: Add DNR status
+		// BUBBERSTATION EDIT BEGIN: Add DNR status
 		// If sensors are above living tracking, set DNR state
 		if (sensor_mode >= SENSOR_LIVING)
 			entry["is_dnr"] = HAS_TRAIT(tracked_living_mob, TRAIT_DNR)
-		// SKYRAT EDIT END
+		// BUBBERSTATION EDIT END
 
 		// Binary living/dead status
 		if (sensor_mode >= SENSOR_LIVING)

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -45,6 +45,7 @@
 		"name",
 		"job",
 		"is_robot", //SKYRAT EDIT ADDITION - Displaying robotic species Icon
+		"is_dnr", //SKYRAT EDIT ADDITION - Displays DNR status
 		"life_status",
 		"suffocation",
 		"toxin",
@@ -259,6 +260,12 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		// SKYRAT EDIT BEGIN: Checking for robotic race
 		if (issynthetic(tracked_human))
 			entry["is_robot"] = TRUE
+		// SKYRAT EDIT END
+
+		// SKYRAT EDIT BEGIN: Add DNR status
+		// If sensors are above living tracking, set DNR state
+		if (sensor_mode >= SENSOR_LIVING)
+			entry["is_dnr"] = HAS_TRAIT(tracked_living_mob, TRAIT_DNR)
 		// SKYRAT EDIT END
 
 		// Binary living/dead status

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -199,7 +199,7 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 
 	for(var/mob/living/M in compiled)
 		var/mob/living/mob_occupant = get_mob_or_brainmob(M)
-		if(mob_occupant.client && !mob_occupant.suiciding && !(HAS_TRAIT(mob_occupant, TRAIT_BADDNA)))
+		if(mob_occupant.client && !mob_occupant.suiciding && !(HAS_TRAIT(mob_occupant, TRAIT_BADDNA)) && !(HAS_TRAIT(mob_occupant, TRAIT_DNR)))
 			icon_state = "morgue4" // Revivable
 			if(mob_occupant.stat == DEAD && beeper && COOLDOWN_FINISHED(src, next_beep))
 				playsound(src, 'sound/weapons/gun/general/empty_alarm.ogg', 50, FALSE) //Revive them you blind fucks

--- a/tgui/packages/tgui/interfaces/CrewConsoleSkyrat.js
+++ b/tgui/packages/tgui/interfaces/CrewConsoleSkyrat.js
@@ -113,6 +113,7 @@ const CrewTableEntry = (props, context) => {
     assignment,
     ijob,
     is_robot,
+    is_dnr,
     life_status,
     oxydam,
     toxdam,
@@ -155,6 +156,7 @@ const CrewTableEntry = (props, context) => {
         ) : (
           <Icon name="skull" color="#801308" size={1} />
         )}
+        {!life_status && is_dnr ? ' (DNR)' : ''}
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">
         {oxydam !== undefined ? (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds a DNR state if a crew member is dead (and has suit sensors enabled).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The ~~Skyrat~~ Bubberstation Roleplay Experience

This is so medic personnel are able to make a choice to rescue a DNR body, or ignore them.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

I have tested this on a local server and confirm that the DNR state only appears if the crew member in question is dead.

![example](https://user-images.githubusercontent.com/80724828/217991381-b8925ac1-f592-4e81-a9a3-25fe81d26c01.png)
