### PR TITLE
Re-adds suicide verb

### DIFF
--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -19,8 +19,7 @@
 		if(mmi.brainmob)
 			mmi.brainmob.suiciding = suicide_state
 
-//SKYRAT EDIT REMOVAL BEGIN - SUICIDE_VERB
-/*
+//SKYRAT EDIT REMOVAL BEGIN - SUICIDE_VERB //BUBBER EDIT BEGIN
 /mob/living/carbon/human/verb/suicide()
 	set hidden = TRUE
 	if(!canSuicide())
@@ -168,8 +167,7 @@
 		adjustOxyLoss(max(maxHealth * 2 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		death(FALSE)
 		ghostize(FALSE) // Disallows reentering body and disassociates mind
-*/
-//SKYRAT EDIT REMOVAL END
+//SKYRAT EDIT REMOVAL END //BUBBER EDIT BEGIN
 
 //SKYRAT EDIT PAI START - Returns ability to leave your PAI
 /mob/living/silicon/pai/verb/suicide()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Re-adds the suicide verb, due to popular request. Can always be left in, figured I'd do the code in case we wanted to do it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
Add: Re-comments the "LRP" suicide verb [if you're gonna suicide you're not gonna RP anyway]
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
