### PR TITLE
energy revolver & laser changes

### DIFF
--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -3,7 +3,6 @@
 	e_cost = 83
 	select_name = "kill"
 /obj/item/ammo_casing/energy/laser/revolver
-	projectile_type = /obj/projectile/beam/laser
 	e_cost = 100
 	select_name = "kill"
 /obj/item/ammo_casing/energy/laser/hellfire

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -4,7 +4,6 @@
 	select_name = "kill"
 /obj/item/ammo_casing/energy/laser/revolver
 	e_cost = 100
-	select_name = "kill"
 /obj/item/ammo_casing/energy/laser/hellfire
 	projectile_type = /obj/projectile/beam/laser/hellfire
 	e_cost = 100

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -2,7 +2,10 @@
 	projectile_type = /obj/projectile/beam/laser
 	e_cost = 83
 	select_name = "kill"
-
+/obj/item/ammo_casing/energy/laser/revolver
+	projectile_type = /obj/projectile/beam/laser
+	e_cost = 100
+	select_name = "kill"
 /obj/item/ammo_casing/energy/laser/hellfire
 	projectile_type = /obj/projectile/beam/laser/hellfire
 	e_cost = 100
@@ -13,7 +16,7 @@
 
 /obj/item/ammo_casing/energy/lasergun
 	projectile_type = /obj/projectile/beam/laser
-	e_cost = 62.5
+	e_cost = 50
 	select_name = "kill"
 
 /obj/item/ammo_casing/energy/lasergun/old

--- a/modular_skyrat/modules/blueshield/code/special.dm
+++ b/modular_skyrat/modules/blueshield/code/special.dm
@@ -14,7 +14,7 @@
 	obj_flags = UNIQUE_RENAME
 	cell_type = /obj/item/stock_parts/cell/blueshield
 	pin = /obj/item/firing_pin/implant/mindshield
-	selfcharge = FALSE
+	selfcharge = TRUE
 
 /obj/item/stock_parts/cell/blueshield
 	name = "internal revolver power cell"

--- a/modular_skyrat/modules/blueshield/code/special.dm
+++ b/modular_skyrat/modules/blueshield/code/special.dm
@@ -2,7 +2,7 @@
 	name = "energy revolver"
 	desc = "An advanced energy revolver with the capacity to shoot both electrodes and lasers."
 	force = 7
-	ammo_type = list(/obj/item/ammo_casing/energy/electrode, /obj/item/ammo_casing/energy/laser)
+	ammo_type = list(/obj/item/ammo_casing/energy/electrode, /obj/item/ammo_casing/energy/laser/revolver)
 	ammo_x_offset = 1
 	charge_sections = 4
 	fire_delay = 4
@@ -14,11 +14,11 @@
 	obj_flags = UNIQUE_RENAME
 	cell_type = /obj/item/stock_parts/cell/blueshield
 	pin = /obj/item/firing_pin/implant/mindshield
-	selfcharge = TRUE
+	selfcharge = FALSE
 
 /obj/item/stock_parts/cell/blueshield
 	name = "internal revolver power cell"
-	maxcharge = 1500
+	maxcharge = 1000
 	chargerate = 300
 
 /obj/item/gun/energy/e_gun/revolver/pdw9 //The chad gun.


### PR DESCRIPTION
Energy Revolver Changes:
No longer selfcharges 
Cell charge reduced from 1500 to 1000
Takes more power to fire lethal and taser shots (10% & 20% vs 5% and 13%) 

SC-1 Laser Gun Changes:
Takes less power to fire lethal shots (from 6% to 5%)

