### PR TITLE
Changes the access on the doors of the NT rep's doors to ACCESS_NTREP

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2_bubber.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_bubber.dmm
@@ -26409,7 +26409,8 @@
 "gqA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch"
+	name = "Maintenance Hatch";
+	req_access = ACCESS_NTREP
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -35234,7 +35235,8 @@
 /area/station/maintenance/port)
 "iAQ" = (
 /obj/machinery/door/airlock/corporate{
-	name = "NT Consultant's Office"
+	name = "NT Consultant's Office";
+	req_access = ACCESS_NTREP
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4

--- a/_maps/map_files/IceBoxStation/IceBoxStation_bubber.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_bubber.dmm
@@ -14665,7 +14665,8 @@
 /area/station/maintenance/port/aft)
 "eoR" = (
 /obj/machinery/door/airlock/corporate{
-	name = "NT Consultant's Office"
+	name = "NT Consultant's Office";
+	req_access = ACCESS_NTREP
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/cent_com/rep_door,
@@ -26453,7 +26454,8 @@
 /area/station/security/brig/upper)
 "hTx" = (
 /obj/machinery/door/airlock/corporate{
-	name = "NT Consultant's Office"
+	name = "NT Consultant's Office";
+	req_access = ACCESS_NTREP
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,

--- a/_maps/map_files/VoidRaptor/VoidRaptor_bubber.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor_bubber.dmm
@@ -12475,7 +12475,8 @@
 "dGZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/corporate{
-	name = "Consultant's Quarters"
+	name = "Consultant's Quarters";
+	req_access = ACCESS_NTREP
 	},
 /obj/effect/mapping_helpers/airlock/access/all/cent_com/rep_door,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30165,7 +30166,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/corporate{
 	id_tag = "consultantdoor";
-	name = "Consultant's Office"
+	name = "Consultant's Office";
+	req_access = ACCESS_NTREP
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added new mechanics or gameplay changes
add: Added more things
del: Removed old things
qol: made something easier to use
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
