### PR TITLE
Community-wanted station quirk changes [DIRTY STATION IS NOW 1/15 CHANCE]

### DIFF
--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -100,7 +100,7 @@
 /datum/station_trait/overflow_job_bureaucracy
 	name = "Overflow bureaucracy mistake"
 	trait_type = STATION_TRAIT_NEGATIVE
-	weight = 2 //BUBBERS EDIT: FUCK SKYRAT WE WANT BUREAUCRACY, OLD SKYRAT WEIGHT: 0
+	weight = 1 //BUBBERS EDIT: FUCK SKYRAT WE WANT BUREAUCRACY, OLD SKYRAT WEIGHT: 0
 	show_in_report = TRUE
 	var/chosen_job_name
 
@@ -282,7 +282,7 @@
 	report_message = "A radioactive stormfront is passing through your station's system. Expect an increased likelihood of radiation storms passing over your station, as well the potential for multiple radiation storms to occur during your shift."
 	trait_type = STATION_TRAIT_NEGATIVE
 	trait_flags = NONE
-	weight = 1 //BUBBERS EDIT CHANGE - ORIGINAL: weight = 0
+	weight = 0 //SKYRAT EDIT CHANGE - ORIGINAL: weight = 0
 	event_control_path = /datum/round_event_control/radiation_storm
 	weight_multiplier = 1.5
 	max_occurrences_modifier = 0 //SKYRAT EDIT CHANGE - ORIGINAL: max_occurrences_modifier = 0

--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -1,7 +1,7 @@
 /datum/station_trait/carp_infestation
 	name = "Carp infestation"
 	trait_type = STATION_TRAIT_NEGATIVE
-	weight = 5
+	weight = 3
 	show_in_report = TRUE
 	report_message = "Dangerous fauna is present in the area of this station."
 	trait_to_give = STATION_TRAIT_CARP_INFESTATION
@@ -100,7 +100,7 @@
 /datum/station_trait/overflow_job_bureaucracy
 	name = "Overflow bureaucracy mistake"
 	trait_type = STATION_TRAIT_NEGATIVE
-	weight = 0 //SKYRAT EDIT: - CHANGES WEIGHT FROM FIVE TO ZERO
+	weight = 2 //BUBBERS EDIT: FUCK SKYRAT WE WANT BUREAUCRACY, OLD SKYRAT WEIGHT: 0
 	show_in_report = TRUE
 	var/chosen_job_name
 
@@ -137,7 +137,7 @@
 /datum/station_trait/bot_languages
 	name = "Bot Language Matrix Malfunction"
 	trait_type = STATION_TRAIT_NEGATIVE
-	weight = 4
+	weight = 2
 	show_in_report = TRUE
 	report_message = "Your station's friendly bots have had their language matrix fried due to an event, resulting in some strange and unfamiliar speech patterns."
 	trait_to_give = STATION_TRAIT_BOTS_GLITCHED
@@ -282,7 +282,7 @@
 	report_message = "A radioactive stormfront is passing through your station's system. Expect an increased likelihood of radiation storms passing over your station, as well the potential for multiple radiation storms to occur during your shift."
 	trait_type = STATION_TRAIT_NEGATIVE
 	trait_flags = NONE
-	weight = 0 //SKYRAT EDIT CHANGE - ORIGINAL: weight = 0
+	weight = 1 //BUBBERS EDIT CHANGE - ORIGINAL: weight = 0
 	event_control_path = /datum/round_event_control/radiation_storm
 	weight_multiplier = 1.5
 	max_occurrences_modifier = 0 //SKYRAT EDIT CHANGE - ORIGINAL: max_occurrences_modifier = 0

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -97,7 +97,7 @@
 /datum/station_trait/glitched_pdas
 	name = "PDA glitch"
 	trait_type = STATION_TRAIT_NEUTRAL
-	weight = 15
+	weight = 8
 	show_in_report = TRUE
 	report_message = "Something seems to be wrong with the PDAs issued to you all this shift. Nothing too bad though."
 	trait_to_give = STATION_TRAIT_PDA_GLITCHED

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -108,7 +108,7 @@
 /datum/station_trait/filled_maint
 	name = "Filled up maintenance"
 	trait_type = STATION_TRAIT_POSITIVE
-	weight = 5
+	weight = 6
 	show_in_report = TRUE
 	report_message = "Our workers accidentally forgot more of their personal belongings in the maintenace areas."
 	blacklist = list(/datum/station_trait/empty_maint)
@@ -120,7 +120,7 @@
 /datum/station_trait/quick_shuttle
 	name = "Quick Shuttle"
 	trait_type = STATION_TRAIT_POSITIVE
-	weight = 5
+	weight = 4
 	show_in_report = TRUE
 	report_message = "Due to proximity to our supply station, the cargo shuttle will have a quicker flight time to your cargo department."
 	blacklist = list(/datum/station_trait/slow_shuttle)
@@ -204,7 +204,7 @@
 /datum/station_trait/deathrattle_department/medical
 	name = "Deathrattled Medical"
 	trait_flags = NONE
-	weight = 1
+	weight = 2
 	department_to_apply_to = DEPARTMENT_BITFLAG_MEDICAL
 	department_name = "Medical"
 
@@ -236,7 +236,7 @@
 	name = "Wallets!"
 	trait_type = STATION_TRAIT_POSITIVE
 	show_in_report = TRUE
-	weight = 10
+	weight = 5
 	report_message = "It has become temporarily fashionable to use a wallet, so everyone on the station has been issued one."
 
 /datum/station_trait/wallets/New()

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -45,7 +45,7 @@
 				stack_trace("[icon_state] (from [type]), which should be [burnt ? "NOT burnt, IS" : "burnt, IS NOT"]")
 				previous_errors[type] = TRUE
 
-	if(mapload && prob(33))
+	if(mapload && prob(7))
 		MakeDirty()
 
 	if(is_station_level(z))


### PR DESCRIPTION
## About The Pull Request

After massive complaints, people don't really want the station being destroyed if there's no impact upon the players roleplay-wise. It's unnecessary chaos that only annoys people.

I'm sure these changes aren't entirely controversial, and maintainers have priority with tweaking my changes.
Nobody wants dirty station once every THREE ROUNDS, seriously? Who thought of that?

Details in the changelog.

## Changelog

:cl:
balance: Carp infestation is 3/5th as common
balance: Overflow Job Bureaucracy is now possible again
balance: Station machine language randomization is 1/2 as common
balance: Radstorm quirk is possible again, but very rare
balance: Glitched pdas [Beep Beep] 8/15 as common
balance: Wallet quirk are 1/2 as common
balance: Medical personnel are more likely to have deathrattle implants, Woo!
balance: Dirty station quirk has been changed from being 1/3 chance to ~1/15 chance
/:cl:
