### PR TITLE
enables progtot

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -48,10 +48,10 @@
 		else
 			uplink_handler = uplink.uplink_handler
 		uplink_handler.primary_objectives = objectives
-		uplink_handler.has_progression = progression_enabled
+		uplink_handler.has_progression = TRUE
 		SStraitor.register_uplink_handler(uplink_handler)
 
-		uplink_handler.has_objectives = progression_enabled //SKYRAT EDIT
+		uplink_handler.has_objectives = TRUE
 		uplink_handler.generate_objectives()
 
 		if(uplink_handler.progression_points < SStraitor.current_global_progression)

--- a/code/modules/antagonists/traitor/objectives/assassination.dm
+++ b/code/modules/antagonists/traitor/objectives/assassination.dm
@@ -28,7 +28,7 @@
 	/// The objective period at which we consider if it is an 'objective'. Set to 0 to accept all objectives.
 	var/objective_period = 15 MINUTES
 	/// The maximum number of objectives we can get within this period.
-	var/maximum_objectives_in_period = 3
+	var/maximum_objectives_in_period = 0
 
 	/**
 	 * Makes the objective only set heads as targets when true, and block them from being targets when false.

--- a/code/modules/antagonists/traitor/objectives/destroy_machinery.dm
+++ b/code/modules/antagonists/traitor/objectives/destroy_machinery.dm
@@ -2,7 +2,7 @@
 	name = "Destroy Protolathe"
 	objectives = list(
 		/datum/traitor_objective/destroy_machinery = 1,
-		/datum/traitor_objective/destroy_machinery/high_risk = 1
+		/datum/traitor_objective/destroy_machinery/high_risk = 0
 	)
 
 /datum/traitor_objective/destroy_machinery
@@ -16,7 +16,7 @@
 	progression_maximum = 10 MINUTES
 
 	/// The maximum amount of this type of objective a traitor can have.
-	var/maximum_allowed = 2
+	var/maximum_allowed = 0
 	/// The possible target machinery and the jobs tied to each one.
 	var/list/applicable_jobs = list(
 		JOB_RESEARCH_DIRECTOR = /obj/machinery/rnd/production/protolathe/department/science,

--- a/code/modules/antagonists/traitor/objectives/eyesnatching.dm
+++ b/code/modules/antagonists/traitor/objectives/eyesnatching.dm
@@ -19,7 +19,7 @@
 	/// The objective period at which we consider if it is an 'objective'. Set to 0 to accept all objectives.
 	var/objective_period = 15 MINUTES
 	/// The maximum number of objectives we can get within this period.
-	var/maximum_objectives_in_period = 3
+	var/maximum_objectives_in_period = 0
 
 	/// Who we're stealing eyes from
 	var/mob/living/victim

--- a/code/modules/antagonists/traitor/objectives/final_objective/final_objective.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/final_objective.dm
@@ -6,7 +6,7 @@
 		/datum/traitor_objective/ultimate/space_dragon = 1,
 		/datum/traitor_objective/ultimate/supermatter_cascade = 1,
 	)
-	weight = 100
+	weight = 0
 
 /datum/traitor_objective/ultimate
 	abstract_type = /datum/traitor_objective/ultimate

--- a/modular_skyrat/master_files/code/modules/antagonists/_common/objectives.dm
+++ b/modular_skyrat/master_files/code/modules/antagonists/_common/objectives.dm
@@ -1,5 +1,5 @@
 /// Chance that the traitor could roll hijack if the pop limit is met.
-#define HIJACK_PROB 10
+#define HIJACK_PROB 0
 /// Hijack is unavailable as a random objective below this player count.
 #define HIJACK_MIN_PLAYERS 50
 
@@ -7,7 +7,7 @@
 #define MARTYR_PROB 20
 
 /// Chance the traitor gets a kill objective. If this prob fails, they will get a steal objective instead.
-#define KILL_PROB 50
+#define KILL_PROB 0
 /// If a kill objective is rolled, chance that it is to destroy the AI.
 #define DESTROY_AI_PROB(denominator) (100 / denominator)
 


### PR DESCRIPTION
does what it says. People can choose their objectives that make sense icly and get paid in TC for doing it.

update2: removes kill and destroy objectives as well as the new objectives we have are far more fun for everyone.
update3: removes kill obj better as well as hijack objectives.
update4: Remove's eye snatching and final objectives. Eye objective because while its pretty cool, it leaves a bit to be desired. As for final objectives. This is a bandaid. Ideally, people would be able to summon the final objective with admin permission incase there is to low pop or no security. 


:cl: Gr33d & others, the original authors of progtot
add: Progressive Traitors! This is a new(at least for some of you) form of Traitor from upstream tg, which lets you pick your objectives from a selection & rewarding it with Telecrystals & Reputation! Reputation is used to unlock gear in the uplink.
del: Regular traitors
del: Kill objectives
/:cl: