### PR TITLE
energy sec

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2_bubber.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_bubber.dmm
@@ -19933,6 +19933,12 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/service/library/lounge)
+"eNQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/space)
 "eOe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -61357,22 +61363,7 @@
 /area/station/security/brig)
 "oYa" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/rack,
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = 5
-	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = 2
-	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = -1
-	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = -7
-	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = -4
-	},
+/obj/machinery/flasher/portable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "oYe" = (
@@ -142611,7 +142602,7 @@ xms
 diL
 rWj
 drj
-aaa
+eNQ
 uYv
 gOU
 prt

--- a/_maps/map_files/Deltastation/DeltaStation2_bubber.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_bubber.dmm
@@ -20295,6 +20295,12 @@
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"eRx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/space)
 "eRB" = (
 /obj/effect/turf_decal/tile/dark_blue/half{
 	dir = 8
@@ -33401,6 +33407,12 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
+"idi" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/rack/gunrack,
+/obj/effect/spawner/armory_spawn/microfusion,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "idj" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Library Access"
@@ -61357,22 +61369,7 @@
 /area/station/security/brig)
 "oYa" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/rack,
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = 5
-	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = 2
-	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = -1
-	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = -7
-	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = -4
-	},
+/obj/machinery/flasher/portable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "oYe" = (
@@ -142611,7 +142608,7 @@ xms
 diL
 rWj
 drj
-aaa
+eRx
 uYv
 gOU
 prt
@@ -153152,7 +153149,7 @@ mub
 nRh
 rlU
 bLs
-pDt
+idi
 pDt
 oYa
 otJ

--- a/_maps/map_files/Deltastation/DeltaStation2_bubber.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_bubber.dmm
@@ -19933,12 +19933,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/service/library/lounge)
-"eNQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/space)
 "eOe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -61363,7 +61357,22 @@
 /area/station/security/brig)
 "oYa" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/flasher/portable,
+/obj/structure/rack,
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = 5
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = 2
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = -1
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = -7
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = -4
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "oYe" = (
@@ -142602,7 +142611,7 @@ xms
 diL
 rWj
 drj
-eNQ
+aaa
 uYv
 gOU
 prt

--- a/_maps/map_files/Deltastation/DeltaStation2_bubber.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_bubber.dmm
@@ -7893,6 +7893,10 @@
 /obj/item/storage/box/lethalshot,
 /obj/item/storage/box/lethalshot,
 /obj/item/storage/box/lethalshot,
+/obj/item/storage/box/rubbershot,
+/obj/item/storage/box/rubbershot,
+/obj/item/storage/box/rubbershot,
+/obj/item/storage/box/rubbershot,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "bOU" = (
@@ -44713,8 +44717,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/rack/gunrack,
-/obj/effect/spawner/armory_spawn/microfusion,
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun{
+	pixel_y = 6
+	},
+/obj/item/gun/energy/e_gun{
+	pixel_y = -5
+	},
+/obj/item/gun/energy/e_gun{
+	pixel_y = -3
+	},
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun{
+	pixel_y = 3
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "kNw" = (
@@ -61339,6 +61355,26 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
+"oYa" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/rack,
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = 5
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = 2
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = -1
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = -7
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = -4
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "oYe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -97525,8 +97561,22 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/rack/gunrack,
-/obj/effect/spawner/armory_spawn/cmg,
+/obj/structure/rack,
+/obj/item/gun/energy/laser{
+	pixel_y = -5
+	},
+/obj/item/gun/energy/laser{
+	pixel_y = -3
+	},
+/obj/item/gun/energy/laser{
+	pixel_y = -1
+	},
+/obj/item/gun/energy/laser{
+	pixel_y = 7
+	},
+/obj/item/gun/energy/laser{
+	pixel_y = 6
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "xHW" = (
@@ -153104,7 +153154,7 @@ rlU
 bLs
 pDt
 pDt
-pDt
+oYa
 otJ
 bOT
 wTu

--- a/_maps/map_files/IceBoxStation/IceBoxStation_bubber.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_bubber.dmm
@@ -15087,18 +15087,20 @@
 	dir = 4
 	},
 /obj/structure/rack,
-/obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun{
-	pixel_y = 6
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = 5
 	},
-/obj/item/gun/energy/e_gun{
-	pixel_y = -5
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = -7
 	},
-/obj/item/gun/energy/e_gun{
-	pixel_y = 1
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = -4
 	},
-/obj/item/gun/energy/e_gun{
-	pixel_y = 3
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = -1
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = 2
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
@@ -17782,10 +17784,22 @@
 	pixel_y = 30;
 	req_access = list("armory")
 	},
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun{
+	pixel_x = 3;
+	pixel_y = -3
+	},
 /obj/effect/turf_decal/tile/red/half{
 	dir = 4
 	},
 /obj/machinery/light/directional/north,
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory/upper)
 "fkj" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation_bubber.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_bubber.dmm
@@ -15087,20 +15087,18 @@
 	dir = 4
 	},
 /obj/structure/rack,
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = 5
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun{
+	pixel_y = 6
 	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = -7
+/obj/item/gun/energy/e_gun{
+	pixel_y = -5
 	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = -4
+/obj/item/gun/energy/e_gun{
+	pixel_y = 1
 	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = -1
-	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = 2
+/obj/item/gun/energy/e_gun{
+	pixel_y = 3
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
@@ -17784,22 +17782,10 @@
 	pixel_y = 30;
 	req_access = list("armory")
 	},
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/effect/turf_decal/tile/red/half{
 	dir = 4
 	},
 /obj/machinery/light/directional/north,
-/obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory/upper)
 "fkj" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation_bubber.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_bubber.dmm
@@ -15086,22 +15086,8 @@
 /obj/effect/turf_decal/tile/red/half{
 	dir = 4
 	},
-/obj/structure/rack,
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = 5
-	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = -7
-	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = -4
-	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = -1
-	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = 2
-	},
+/obj/structure/rack/gunrack,
+/obj/effect/spawner/armory_spawn/microfusion,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
 "evk" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation_bubber.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_bubber.dmm
@@ -15086,8 +15086,22 @@
 /obj/effect/turf_decal/tile/red/half{
 	dir = 4
 	},
-/obj/structure/rack/gunrack,
-/obj/effect/spawner/armory_spawn/microfusion,
+/obj/structure/rack,
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = 5
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = -7
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = -4
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = -1
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = 2
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
 "evk" = (
@@ -17784,6 +17798,8 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/north,
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory/upper)
 "fkj" = (
@@ -28670,9 +28686,23 @@
 /area/station/science/explab)
 "iCa" = (
 /obj/machinery/light/directional/north,
-/obj/structure/rack/gunrack,
-/obj/effect/spawner/armory_spawn/cmg,
 /obj/effect/turf_decal/tile/red/half,
+/obj/structure/rack,
+/obj/item/gun/energy/laser{
+	pixel_y = 6
+	},
+/obj/item/gun/energy/laser{
+	pixel_y = -5
+	},
+/obj/item/gun/energy/laser{
+	pixel_y = -3
+	},
+/obj/item/gun/energy/laser{
+	pixel_y = -1
+	},
+/obj/item/gun/energy/laser{
+	pixel_y = 7
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
 "iCg" = (
@@ -59294,6 +59324,9 @@
 /obj/item/storage/box/lethalshot,
 /obj/item/storage/box/lethalshot,
 /obj/item/storage/box/lethalshot,
+/obj/item/storage/box/rubbershot,
+/obj/item/storage/box/rubbershot,
+/obj/item/storage/box/rubbershot,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
 "rUo" = (

--- a/_maps/map_files/MetaStation/MetaStation_bubber.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_bubber.dmm
@@ -39360,22 +39360,8 @@
 "nMw" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/delivery/red,
-/obj/structure/rack,
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = 5
-	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = 2
-	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = -1
-	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = -4
-	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = -7
-	},
+/obj/structure/rack/gunrack,
+/obj/effect/spawner/armory_spawn/microfusion,
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/security/armory)
 "nMz" = (

--- a/_maps/map_files/MetaStation/MetaStation_bubber.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_bubber.dmm
@@ -276,6 +276,20 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "agc" = (
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun{
+	pixel_y = 5
+	},
+/obj/item/gun/energy/e_gun{
+	pixel_y = 3
+	},
+/obj/item/gun/energy/e_gun{
+	pixel_y = -3
+	},
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun{
+	pixel_y = 3
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "ago" = (
@@ -39347,19 +39361,20 @@
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/delivery/red,
 /obj/structure/rack,
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun{
-	pixel_y = 6
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = 5
 	},
-/obj/item/gun/energy/e_gun{
-	pixel_y = -5
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = 2
 	},
-/obj/item/gun/energy/e_gun{
-	pixel_y = 1
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = -1
 	},
-/obj/item/gun/energy/e_gun{
-	pixel_y = 3
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = -4
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = -7
 	},
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/security/armory)

--- a/_maps/map_files/MetaStation/MetaStation_bubber.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_bubber.dmm
@@ -276,20 +276,6 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "agc" = (
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun{
-	pixel_y = 5
-	},
-/obj/item/gun/energy/e_gun{
-	pixel_y = 3
-	},
-/obj/item/gun/energy/e_gun{
-	pixel_y = -3
-	},
-/obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun{
-	pixel_y = 3
-	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "ago" = (
@@ -39361,20 +39347,19 @@
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/delivery/red,
 /obj/structure/rack,
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = 5
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun{
+	pixel_y = 6
 	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = 2
+/obj/item/gun/energy/e_gun{
+	pixel_y = -5
 	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = -1
+/obj/item/gun/energy/e_gun{
+	pixel_y = 1
 	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = -4
-	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = -7
+/obj/item/gun/energy/e_gun{
+	pixel_y = 3
 	},
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/security/armory)

--- a/_maps/map_files/MetaStation/MetaStation_bubber.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_bubber.dmm
@@ -276,8 +276,20 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "agc" = (
-/obj/effect/turf_decal/bot,
-/mob/living/simple_animal/bot/secbot/beepsky/armsky,
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun{
+	pixel_y = 5
+	},
+/obj/item/gun/energy/e_gun{
+	pixel_y = 3
+	},
+/obj/item/gun/energy/e_gun{
+	pixel_y = -3
+	},
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun{
+	pixel_y = 3
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "ago" = (
@@ -29579,6 +29591,10 @@
 /obj/item/storage/box/lethalshot,
 /obj/item/storage/box/lethalshot,
 /obj/item/storage/box/lethalshot,
+/obj/item/storage/box/rubbershot,
+/obj/item/storage/box/rubbershot,
+/obj/item/storage/box/rubbershot,
+/obj/item/storage/box/rubbershot,
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/security/armory)
 "ktZ" = (
@@ -39343,9 +39359,23 @@
 /area/station/maintenance/starboard/aft)
 "nMw" = (
 /obj/machinery/airalarm/directional/north,
-/obj/structure/rack/gunrack,
-/obj/effect/spawner/armory_spawn/microfusion,
 /obj/effect/turf_decal/delivery/red,
+/obj/structure/rack,
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = 5
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = 2
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = -1
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = -4
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = -7
+	},
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/security/armory)
 "nMz" = (
@@ -40444,6 +40474,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/armory,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
+"ofV" = (
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/bot,
+/mob/living/simple_animal/bot/secbot/beepsky/armsky,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "ofZ" = (
 /obj/machinery/vending/hydroseeds{
 	slogan_delay = 700
@@ -60356,8 +60392,22 @@
 /area/station/security/brig)
 "uWr" = (
 /obj/effect/turf_decal/delivery/red,
-/obj/structure/rack/gunrack,
-/obj/effect/spawner/armory_spawn/cmg,
+/obj/structure/rack,
+/obj/item/gun/energy/laser{
+	pixel_y = 6
+	},
+/obj/item/gun/energy/laser{
+	pixel_y = -1
+	},
+/obj/item/gun/energy/laser{
+	pixel_y = -5
+	},
+/obj/item/gun/energy/laser{
+	pixel_y = -3
+	},
+/obj/item/gun/energy/laser{
+	pixel_y = 7
+	},
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/security/armory)
 "uWt" = (
@@ -96905,7 +96955,7 @@ tms
 kVU
 tJE
 kVU
-tJE
+ofV
 fzi
 wTp
 jxV

--- a/_maps/map_files/VoidRaptor/VoidRaptor_bubber.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor_bubber.dmm
@@ -22034,22 +22034,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
-/obj/structure/rack,
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = 5
-	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = 2
-	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = -1
-	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = -4
-	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = -7
-	},
+/obj/structure/rack/gunrack,
+/obj/effect/spawner/armory_spawn/microfusion,
 /turf/open/floor/engine,
 /area/station/ai_monitored/security/armory)
 "grg" = (

--- a/_maps/map_files/VoidRaptor/VoidRaptor_bubber.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor_bubber.dmm
@@ -22030,25 +22030,25 @@
 	},
 /area/station/medical/medbay/central)
 "gra" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun{
-	pixel_y = 6
-	},
-/obj/item/gun/energy/e_gun{
-	pixel_y = -5
-	},
-/obj/item/gun/energy/e_gun{
-	pixel_y = 1
-	},
-/obj/item/gun/energy/e_gun{
-	pixel_y = 3
-	},
-/obj/item/gun/energy/e_gun{
-	pixel_y = -3
-	},
 /obj/effect/turf_decal/tile/dark_red/half{
 	dir = 1
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/rack,
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = 5
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = 2
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = -1
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = -4
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = -7
 	},
 /turf/open/floor/engine,
 /area/station/ai_monitored/security/armory)
@@ -60112,15 +60112,21 @@
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/delivery,
-/obj/structure/table/reinforced,
-/obj/item/clothing/suit/armor/vest/alt/sec{
-	pixel_x = -8
-	},
-/obj/item/clothing/suit/armor/vest/alt/sec{
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun{
 	pixel_y = 6
 	},
-/obj/item/clothing/suit/armor/vest/alt/sec{
-	pixel_x = 8
+/obj/item/gun/energy/e_gun{
+	pixel_y = -5
+	},
+/obj/item/gun/energy/e_gun{
+	pixel_y = 1
+	},
+/obj/item/gun/energy/e_gun{
+	pixel_y = 3
+	},
+/obj/item/gun/energy/e_gun{
+	pixel_y = -3
 	},
 /turf/open/floor/engine,
 /area/station/ai_monitored/security/armory)

--- a/_maps/map_files/VoidRaptor/VoidRaptor_bubber.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor_bubber.dmm
@@ -22030,25 +22030,25 @@
 	},
 /area/station/medical/medbay/central)
 "gra" = (
-/obj/effect/turf_decal/tile/dark_red/half{
-	dir = 1
-	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/rack,
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = 5
+/obj/item/gun/energy/e_gun{
+	pixel_y = 6
 	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = 2
+/obj/item/gun/energy/e_gun{
+	pixel_y = -5
 	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = -1
+/obj/item/gun/energy/e_gun{
+	pixel_y = 1
 	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = -4
+/obj/item/gun/energy/e_gun{
+	pixel_y = 3
 	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = -7
+/obj/item/gun/energy/e_gun{
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/station/ai_monitored/security/armory)
@@ -60112,21 +60112,15 @@
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/delivery,
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun{
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/armor/vest/alt/sec{
+	pixel_x = -8
+	},
+/obj/item/clothing/suit/armor/vest/alt/sec{
 	pixel_y = 6
 	},
-/obj/item/gun/energy/e_gun{
-	pixel_y = -5
-	},
-/obj/item/gun/energy/e_gun{
-	pixel_y = 1
-	},
-/obj/item/gun/energy/e_gun{
-	pixel_y = 3
-	},
-/obj/item/gun/energy/e_gun{
-	pixel_y = -3
+/obj/item/clothing/suit/armor/vest/alt/sec{
+	pixel_x = 8
 	},
 /turf/open/floor/engine,
 /area/station/ai_monitored/security/armory)

--- a/_maps/map_files/VoidRaptor/VoidRaptor_bubber.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor_bubber.dmm
@@ -22030,12 +22030,26 @@
 	},
 /area/station/medical/medbay/central)
 "gra" = (
-/obj/structure/rack/gunrack,
-/obj/effect/spawner/armory_spawn/microfusion,
 /obj/effect/turf_decal/tile/dark_red/half{
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/rack,
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = 5
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = 2
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = -1
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = -4
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = -7
+	},
 /turf/open/floor/engine,
 /area/station/ai_monitored/security/armory)
 "grg" = (
@@ -24736,8 +24750,6 @@
 	},
 /area/station/hallway/primary/fore)
 "hcr" = (
-/obj/structure/rack/gunrack,
-/obj/effect/spawner/armory_spawn/cmg,
 /obj/effect/turf_decal/tile/dark_red/anticorner{
 	dir = 4
 	},
@@ -24745,6 +24757,22 @@
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/rack,
+/obj/item/gun/energy/laser{
+	pixel_y = 7
+	},
+/obj/item/gun/energy/laser{
+	pixel_y = 6
+	},
+/obj/item/gun/energy/laser{
+	pixel_y = -1
+	},
+/obj/item/gun/energy/laser{
+	pixel_y = -3
+	},
+/obj/item/gun/energy/laser{
+	pixel_y = -5
+	},
 /turf/open/floor/engine,
 /area/station/ai_monitored/security/armory)
 "hcw" = (
@@ -60070,18 +60098,6 @@
 	},
 /area/station/science/ordnance/testlab)
 "qKP" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/suit/armor/vest/alt/sec{
-	pixel_y = 2
-	},
-/obj/item/clothing/suit/armor/vest/alt/sec{
-	pixel_x = -4;
-	pixel_y = -6
-	},
-/obj/item/clothing/suit/armor/vest/alt/sec{
-	pixel_x = 4;
-	pixel_y = -6
-	},
 /obj/structure/window/reinforced{
 	dir = 1;
 	pixel_y = 1
@@ -60096,6 +60112,22 @@
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun{
+	pixel_y = 6
+	},
+/obj/item/gun/energy/e_gun{
+	pixel_y = -5
+	},
+/obj/item/gun/energy/e_gun{
+	pixel_y = 1
+	},
+/obj/item/gun/energy/e_gun{
+	pixel_y = 3
+	},
+/obj/item/gun/energy/e_gun{
+	pixel_y = -3
+	},
 /turf/open/floor/engine,
 /area/station/ai_monitored/security/armory)
 "qLf" = (

--- a/_maps/map_files/tramstation/tramstation_bubber.dmm
+++ b/_maps/map_files/tramstation/tramstation_bubber.dmm
@@ -37809,20 +37809,8 @@
 	},
 /obj/machinery/status_display/ai/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/rack,
-/obj/item/gun/energy/laser/scatter/shotty,
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = -7
-	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = -4
-	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = 2
-	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = 5
-	},
+/obj/structure/rack/gunrack,
+/obj/effect/spawner/armory_spawn/microfusion,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "noI" = (

--- a/_maps/map_files/tramstation/tramstation_bubber.dmm
+++ b/_maps/map_files/tramstation/tramstation_bubber.dmm
@@ -37809,6 +37809,20 @@
 	},
 /obj/machinery/status_display/ai/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/rack,
+/obj/item/gun/energy/laser/scatter/shotty,
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = -7
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = -4
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = 2
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = 5
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "noI" = (

--- a/_maps/map_files/tramstation/tramstation_bubber.dmm
+++ b/_maps/map_files/tramstation/tramstation_bubber.dmm
@@ -37809,20 +37809,6 @@
 	},
 /obj/machinery/status_display/ai/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/rack,
-/obj/item/gun/energy/laser/scatter/shotty,
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = -7
-	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = -4
-	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = 2
-	},
-/obj/item/gun/energy/laser/scatter/shotty{
-	pixel_y = 5
-	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "noI" = (

--- a/_maps/map_files/tramstation/tramstation_bubber.dmm
+++ b/_maps/map_files/tramstation/tramstation_bubber.dmm
@@ -1468,6 +1468,9 @@
 	pixel_y = -3
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "aFR" = (
@@ -34615,8 +34618,22 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/rack/gunrack,
-/obj/effect/spawner/armory_spawn/cmg,
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun{
+	pixel_y = 6
+	},
+/obj/item/gun/energy/e_gun{
+	pixel_y = -5
+	},
+/obj/item/gun/energy/e_gun{
+	pixel_y = 1
+	},
+/obj/item/gun/energy/e_gun{
+	pixel_y = 3
+	},
+/obj/item/gun/energy/e_gun{
+	pixel_y = -3
+	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "mmk" = (
@@ -36555,8 +36572,22 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/rack/gunrack,
-/obj/effect/spawner/armory_spawn/microfusion,
+/obj/structure/rack,
+/obj/item/gun/energy/laser{
+	pixel_y = 6
+	},
+/obj/item/gun/energy/laser{
+	pixel_y = 7
+	},
+/obj/item/gun/energy/laser{
+	pixel_y = -1
+	},
+/obj/item/gun/energy/laser{
+	pixel_y = -3
+	},
+/obj/item/gun/energy/laser{
+	pixel_y = -5
+	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "mUn" = (
@@ -37778,6 +37809,20 @@
 	},
 /obj/machinery/status_display/ai/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/rack,
+/obj/item/gun/energy/laser/scatter/shotty,
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = -7
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = -4
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = 2
+	},
+/obj/item/gun/energy/laser/scatter/shotty{
+	pixel_y = 5
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "noI" = (


### PR DESCRIPTION
Removed MCRs and SMGs from Icebox, Meta, Delta, Void Raptor and Tram Station. Added 5 SC-1s, 5 SC-2s and 5 nonlethal energy shotguns to each armoury.

Added rubber rounds to icebox, meta and delta. Added lethal rounds to tram station. Removed 3 standard armour vests (non riot/bulletproof) from void raptor.
