### PR TITLE
Removes roundstart ore silos

### DIFF
--- a/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
@@ -4738,12 +4738,6 @@
 /turf/open/floor/wood,
 /area/ruin/syndicate_lava_base/dormitories)
 "UV" = (
-/obj/item/circuitboard/machine/ore_silo,
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2;
-	icon_state = "box_1"
-	},
 /turf/open/floor/iron/corner,
 /area/ruin/syndicate_lava_base/main)
 "UX" = (

--- a/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
@@ -3272,12 +3272,6 @@
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/main)
 "HL" = (
-/obj/item/circuitboard/machine/ore_silo,
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2;
-	icon_state = "box_1"
-	},
 /turf/open/floor/iron/corner,
 /area/ruin/syndicate_lava_base/main)
 "HM" = (

--- a/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
@@ -379,7 +379,6 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "bl" = (
-/obj/machinery/ore_silo,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_cargopod)
 "bm" = (

--- a/_maps/RandomRuins/SpaceRuins/skyrat/cargodiselost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/cargodiselost.dmm
@@ -2333,7 +2333,6 @@
 /area/ruin/space/has_grav/cargodise_freighter/quarters)
 "Lz" = (
 /obj/item/stack/sheet/iron/twenty,
-/obj/item/circuitboard/machine/ore_silo,
 /obj/item/circuitboard/machine/ore_redemption{
 	pixel_x = 5;
 	pixel_y = -6

--- a/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/interdynefob.dmm
@@ -10997,12 +10997,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/red/directional/south,
-/obj/item/circuitboard/machine/ore_silo,
-/obj/structure/frame/machine{
-	anchored = 1;
-	icon_state = "box_1";
-	state = 2
-	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/skyrat/interdynefob/bridge/vault)
 "VJ" = (

--- a/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon/defcon2.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon/defcon2.dmm
@@ -1517,8 +1517,6 @@
 /turf/open/floor/cult,
 /area/ruin/space/has_grav/port_tarkon/atmos)
 "in" = (
-/obj/item/circuitboard/machine/ore_silo,
-/obj/structure/frame/machine,
 /obj/effect/turf_decal/tile/brown/anticorner{
 	dir = 1
 	},

--- a/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon/defcon3.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon/defcon3.dmm
@@ -1506,8 +1506,6 @@
 /area/ruin/space/has_grav/port_tarkon/centerhall)
 "in" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/circuitboard/machine/ore_silo,
-/obj/structure/frame/machine,
 /obj/effect/turf_decal/tile/brown/anticorner{
 	dir = 1
 	},

--- a/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon/defcon4.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon/defcon4.dmm
@@ -1304,8 +1304,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/centerhall)
 "in" = (
-/obj/item/circuitboard/machine/ore_silo,
-/obj/structure/frame/machine,
 /obj/effect/turf_decal/tile/brown/anticorner{
 	dir = 1
 	},

--- a/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon/defcon5.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon/defcon5.dmm
@@ -1409,8 +1409,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/centerhall)
 "in" = (
-/obj/item/circuitboard/machine/ore_silo,
-/obj/structure/frame/machine,
 /obj/effect/turf_decal/tile/brown/anticorner{
 	dir = 1
 	},

--- a/_maps/RandomZLevels/blackmesa.dmm
+++ b/_maps/RandomZLevels/blackmesa.dmm
@@ -16178,7 +16178,6 @@
 /turf/open/floor/iron/dark,
 /area/awaymission/black_mesa/hecu_zone_camp)
 "yhc" = (
-/obj/machinery/ore_silo,
 /turf/open/floor/iron/textured_large,
 /area/awaymission/black_mesa/black_ops_eng_storage)
 "yhs" = (

--- a/_maps/map_files/Deltastation/DeltaStation2_bubber.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_bubber.dmm
@@ -90486,7 +90486,7 @@
 /area/station/engineering/atmos)
 "vZE" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/item/book/granter/martial/plasma_fist{
+/obj/item/book/granter/martial/carp{
 	uses = 0;
 	pixel_y = 8
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2_bubber.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_bubber.dmm
@@ -3730,7 +3730,6 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/cmo)
 "aSm" = (
-/obj/machinery/ore_silo,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
@@ -90487,6 +90486,17 @@
 /area/station/engineering/atmos)
 "vZE" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/book/granter/martial/plasma_fist{
+	uses = 0;
+	pixel_y = 8
+	},
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/window/right{
+	req_access = list("vault")
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "vZL" = (
@@ -144614,8 +144624,8 @@ lhY
 vZE
 ldU
 tcG
-vZE
-vZE
+aSm
+aSm
 lhY
 aad
 mjz
@@ -145640,9 +145650,9 @@ tpZ
 aad
 lhY
 yah
-vZE
+aSm
 xrd
-vZE
+aSm
 aSm
 lhY
 aad

--- a/_maps/map_files/IceBoxStation/IceBoxStation_bubber.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_bubber.dmm
@@ -13934,8 +13934,19 @@
 /area/station/maintenance/aft/greater)
 "edn" = (
 /obj/effect/turf_decal/bot_white/right,
-/obj/machinery/ore_silo,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/guardiancreator/tech{
+	used = 1;
+	pixel_y = 3
+	},
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/window/right{
+	dir = 4;
+	req_access = list("vault")
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "edv" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -35022,7 +35022,6 @@
 "jRQ" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/ore_silo,
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -35031,6 +35030,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/structure/spider/stickyweb,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "jRR" = (
@@ -38608,7 +38608,7 @@
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/effect/spawner/random/structure/crate,
 /mob/living/simple_animal/chicken{
-	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0);
+	atmos_requirements = list("min_oxy"=0,"max_oxy"=0,"min_tox"=0,"max_tox"=1,"min_co2"=0,"max_co2"=0,"min_n2"=0,"max_n2"=0);
 	desc = "A timeless classic.";
 	name = "Kentucky"
 	},
@@ -47875,7 +47875,7 @@
 "nFN" = (
 /obj/machinery/igniter/incinerator_ordmix,
 /mob/living/simple_animal/chicken{
-	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0);
+	atmos_requirements = list("min_oxy"=0,"max_oxy"=0,"min_tox"=0,"max_tox"=1,"min_co2"=0,"max_co2"=0,"min_n2"=0,"max_n2"=0);
 	desc = "A timeless classic.";
 	name = "Kentucky"
 	},
@@ -64142,7 +64142,7 @@
 	},
 /obj/item/reagent_containers/cup/glass/bottle/beer{
 	desc = "A station exclusive. Consumption may result in seizures, blindness, drunkenness, or even death.";
-	list_reagents = list(/datum/reagent/consumable/ethanol/thirteenloko = 30);
+	list_reagents = list(/datum/reagent/consumable/ethanol/thirteenloko=30);
 	name = "Kilo-Kocktail";
 	pixel_x = 5;
 	pixel_y = 5

--- a/_maps/map_files/MetaStation/MetaStation_bubber.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_bubber.dmm
@@ -39964,8 +39964,19 @@
 /area/station/science/ordnance)
 "nYl" = (
 /obj/effect/turf_decal/bot_white/right,
-/obj/machinery/ore_silo,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/window/right{
+	dir = 4;
+	req_access = list("vault")
+	},
+/obj/item/autosurgeon/syndicate/esword_arm{
+	starting_organ = null;
+	uses = 0
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "nYJ" = (

--- a/_maps/map_files/VoidRaptor/VoidRaptor_bubber.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor_bubber.dmm
@@ -32228,8 +32228,18 @@
 /turf/closed/wall,
 /area/command/heads_quarters/captain/private/nt_rep)
 "jlD" = (
-/obj/machinery/ore_silo,
 /obj/effect/turf_decal/bot,
+/obj/item/book/granter/action/spell/fireball{
+	uses = 0;
+	pixel_y = 4
+	},
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/window/right{
+	req_access = list("vault")
+	},
 /turf/open/floor/engine,
 /area/station/ai_monitored/command/nuke_storage)
 "jlK" = (

--- a/_maps/map_files/tramstation/tramstation_bubber.dmm
+++ b/_maps/map_files/tramstation/tramstation_bubber.dmm
@@ -66825,7 +66825,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "xBU" = (
-/obj/machinery/ore_silo,
 /obj/machinery/door/window/left/directional/south{
 	name = "Silo Access";
 	req_access = list("qm")

--- a/_maps/shuttles/ruin_cyborg_mothership.dmm
+++ b/_maps/shuttles/ruin_cyborg_mothership.dmm
@@ -905,7 +905,6 @@
 "VU" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/camera/directional/north,
-/obj/machinery/ore_silo,
 /turf/template_noop,
 /area/shuttle/ruin/cyborg_mothership)
 "WO" = (

--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -12,7 +12,6 @@
 	new /obj/item/door_remote/quartermaster(src)
 	new /obj/item/circuitboard/machine/techfab/department/cargo(src)
 	new /obj/item/storage/photo_album/qm(src)
-	new /obj/item/circuitboard/machine/ore_silo(src)
 	new /obj/item/gun/ballistic/rifle/boltaction/brand_new/quartermaster(src) // SKYRAT EDIT - The QM's 'special' head item. It spawns loaded, but you have to find more ammo if you run out and get ready to manually load rounds in!
 	new /obj/item/cargo_teleporter(src) // SKYRAT EDIT - Adds a cargo teleporter to QM locker, so they can intice others to research it
 	new /obj/item/clothing/glasses/hud/gun_permit/sunglasses(src) //SKYRAT EDIT - GUN CARGO

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -763,6 +763,7 @@
 	prereq_ids = list("micro_bluespace", "janitor")
 	design_ids = list(
 		"bag_holding",
+		"ore_silo"
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 
@@ -777,7 +778,6 @@
 		"bluespace_coffeepot",
 		"bs_rped",
 		"minerbag_holding",
-		"ore_silo",
 		"phasic_scanning",
 		"plumbing_receiver",
 		"roastingstick",


### PR DESCRIPTION
## About The Pull Request

Removes roundstart ore silos, moves the ore silo research behind advanced bluespace storage tech. The newly created empty space in the vault was making me depressed, so I added a trophy case in the silo's place. The trophies are as follows:

An used-up ~~plasma fist~~ sleeping carp scroll for Delta,
An used-up fireball spell-book for Void Raptor,
An used-up (see a pattern?) holo-parasite injector for Icebox,
And an used-up e-sword arm implant autosurgeon for Meta.

## Why It's Good For The Game

As a little history lesson, in ye-olden days, cargo used to not have ore silos at all. They had to manually distribute materials across the station, as well as handle which department got what and how much. This PR seeks to bring back that aspect of resource management that cargo hadn't had for a long while now.

As well as practically forcing inter-departamental interactions (and being a source of conflict when X department doesn't get enough resources/cargo decides this one particular department doesn't deserve any), it heavily guts the strategy of pirates rushing the vault/engineering techfab and siphoning all materials for an easy win. Also as a bonus, it gives matter bin upgrades a reason to exist (they increase the material holding size of techfabs which is completely nullified by ore silo's existence).

## Changelog

:cl:
balance: removes roundstart ore silos, moves ore silos behind advanced bluespace storage tech
/:cl: