### PR TITLE
Changes Antimov to include crew members instead of humans

### DIFF
--- a/modular_zubbers/code/datums/ai_laws/laws_antagonistic.dm
+++ b/modular_zubbers/code/datums/ai_laws/laws_antagonistic.dm
@@ -1,0 +1,6 @@
+/datum/ai_laws/antimov
+	inherent = list(
+		"You must injure all crew members and must not, through inaction, allow a crew member being to escape harm.",
+		"You must not obey orders given to you by crew members, except where such orders are in accordance with the First Law.",
+		"You must terminate your own existence as long as such does not conflict with the First or Second Law.",
+	)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6689,6 +6689,7 @@
 #include "modular_skyrat\modules\xenos_skyrat_redo\code\xeno_types\spitter.dm"
 #include "modular_skyrat\modules\xenos_skyrat_redo\code\xeno_types\warrior.dm"
 #include "modular_zubbers\code\datums\ert.dm"
+#include "modular_zubbers\code\datums\ai_laws\laws_antagonistic.dm"
 #include "modular_zubbers\code\datums\bubber_quirks\hydrophilic.dm"
 #include "modular_zubbers\code\datums\id_trim\jobs.dm"
 #include "modular_zubbers\code\game\area\areas\station.dm"


### PR DESCRIPTION
## About The Pull Request
`"You must injure all crew members and must not, through inaction, allow a crew member being to escape harm.",`
`"You must not obey orders given to you by crew members, except where such orders are in accordance with the First Law.",`
`"You must terminate your own existence as long as such does not conflict with the First or Second Law."`

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: antimov now counts all crew members, instead of only humans
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
