### PR TITLE
Restores abductors' objectives

### DIFF
--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -164,7 +164,7 @@
 	..()
 	team_number = team_count++
 	name = "Mothership [pick(GLOB.greek_letters)]" //TODO Ensure unique and actual alieny names
-	//add_objective(new /datum/objective/experiment) //SKYRAT EDIT REMOVAL
+	add_objective(new /datum/objective/experiment)
 
 /datum/team/abductor_team/roundend_report()
 	var/list/result = list()


### PR DESCRIPTION
## Changelog

:cl:
fix: fixed abductors not getting objectives
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
