### PR TITLE
QM gets Blacksmith access

### DIFF
--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -785,6 +785,7 @@
 		ACCESS_EVA,
 		ACCESS_BRIG_ENTRANCE,
 		ACCESS_WEAPONS, //BUBBER EDIT
+		ACCESS_BLACKSMITH, //BUBBER EDIT
 		)
 	extra_access = list()
 	minimal_wildcard_access = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives the QM access to the blacksmithing area. This is part of cargo, they should have access. 

Tested by walking into the blacksmithy on ice box. Didn't test on other maps, but I see no reason it'd be different.

## Changelog

:cl: SingingSpock
tweak: The QM gets access to the blacksmith area
/:cl:
