### PR TITLE
Re-buffs ice demons and goliaths

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice_demon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice_demon.dm
@@ -50,8 +50,6 @@
 /obj/projectile/temp/basilisk/ice
 	name = "ice blast"
 	damage = 5
-	speed = 1
-	pixel_speed_multiplier = 0.25
 	range = 200
 	nodamage = FALSE
 	temperature = -75

--- a/modular_zubbers/code/modules/mob/mining/goliath.dm
+++ b/modular_zubbers/code/modules/mob/mining/goliath.dm
@@ -1,0 +1,5 @@
+/mob/living/simple_animal/hostile/asteroid/goliath
+	move_to_delay = 10
+	ranged_cooldown_time = 60
+	melee_damage_lower = 18
+	melee_damage_upper = 22

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6698,6 +6698,7 @@
 #include "modular_zubbers\code\modules\jobs\job_types\blacksmith.dm"
 #include "modular_zubbers\code\modules\mapping\access_helpers.dm"
 #include "modular_zubbers\code\modules\mob\living\carbon\human\species_types\felinid.dm"
+#include "modular_zubbers\code\modules\mob\mining\goliath.dm"
 #include "modular_zubbers\code\modules\mod\mod_theme.dm"
 #include "modular_zubbers\code\modules\mod\mod_types.dm"
 #include "modular_zubbers\code\modules\projectiles\guns\energy\pulse.dm"


### PR DESCRIPTION
## About The Pull Request

So apparently someone, at some point, decided to cut ice demons' projectile speed by 3/4th. This restores the previous speed.
Also rebalances goliaths so they match the ones on Citadel.

## Changelog

:cl:
fix: fixes demonic watchers' projectiles being abnormally slow
balance: rebalanced goliaths to be more lethal
/:cl: