### PR TITLE
Department Sec Update

### DIFF
--- a/modular_skyrat/modules/goofsec/code/department_guards.dm
+++ b/modular_skyrat/modules/goofsec/code/department_guards.dm
@@ -180,8 +180,8 @@
 		/obj/item/food/donut/caramel = 10,
 		/obj/item/food/donut/matcha = 10,
 		/obj/item/food/donut/blumpkin = 5,
-		/obj/item/clothing/mask/whistle = 5,
-		/obj/item/melee/baton/security/boomerang/loaded = 1
+		/obj/item/clothing/mask/whistle = 10,
+		/obj/item/melee/baton = 5
 	)
 	job_flags = JOB_ANNOUNCE_ARRIVAL | JOB_CREW_MANIFEST | JOB_EQUIP_RANK | JOB_CREW_MEMBER | JOB_NEW_PLAYER_JOINABLE | JOB_REOPEN_ON_ROUNDSTART_LOSS | JOB_ASSIGN_QUIRKS | JOB_CAN_BE_INTERN
 
@@ -193,13 +193,14 @@
 	ears = /obj/item/radio/headset/headset_sci
 	uniform = /obj/item/clothing/under/rank/security/officer/blueshirt/skyrat
 	shoes = /obj/item/clothing/shoes/jackboots
-	head =  /obj/item/clothing/head/helmet/blueshirt/skyrat
-	suit = /obj/item/clothing/suit/armor/vest/blueshirt/skyrat
-	r_pocket = /obj/item/assembly/flash/handheld
-	l_pocket = /obj/item/restraints/handcuffs/cable/pink
+	head =  /obj/item/clothing/head/beret/sec/science
+	suit = /obj/item/clothing/suit/armor/vest/alt
+	r_pocket = /obj/item/reagent_containers/spray/pepper
+	l_pocket = /obj/item/restraints/handcuffs
 	backpack_contents = list(
 		/obj/item/melee/baton/security/loaded/departmental/science = 1,
-		/obj/item/storage/box/gunset/pepperball = 1,
+		/obj/item/gun/energy/disabler = 1,
+		/obj/item/holosign_creator/security = 1
 	)
 
 	backpack = /obj/item/storage/backpack/science
@@ -282,8 +283,8 @@
 		/obj/item/food/donut/caramel = 10,
 		/obj/item/food/donut/matcha = 10,
 		/obj/item/food/donut/blumpkin = 5,
-		/obj/item/clothing/mask/whistle = 5,
-		/obj/item/melee/baton/security/boomerang/loaded = 1
+		/obj/item/clothing/mask/whistle = 10,
+		/obj/item/melee/baton = 5
 	)
 
 	job_flags = JOB_ANNOUNCE_ARRIVAL | JOB_CREW_MANIFEST | JOB_EQUIP_RANK | JOB_CREW_MEMBER | JOB_NEW_PLAYER_JOINABLE | JOB_REOPEN_ON_ROUNDSTART_LOSS | JOB_ASSIGN_QUIRKS | JOB_CAN_BE_INTERN
@@ -296,13 +297,15 @@
 	ears = /obj/item/radio/headset/headset_med
 	uniform = /obj/item/clothing/under/rank/security/officer/blueshirt/skyrat/orderly
 	shoes = /obj/item/clothing/shoes/sneakers/white
-	head =  /obj/item/clothing/head/helmet/blueshirt/skyrat/guard
+	head =  /obj/item/clothing/head/beret/sec/medical
 	suit = /obj/item/clothing/suit/armor/vest/blueshirt/skyrat/orderly
-	r_pocket = /obj/item/assembly/flash/handheld
-	l_pocket = /obj/item/restraints/handcuffs/cable/blue
+	glasses = /obj/item/clothing/glasses/hud/health/sunglasses
+	r_pocket = /obj/item/reagent_containers/spray/pepper
+	l_pocket = /obj/item/restraints/handcuffs
 	backpack_contents = list(
 		/obj/item/melee/baton/security/loaded/departmental/medical = 1,
-		/obj/item/storage/box/gunset/pepperball = 1,
+		/obj/item/gun/energy/disabler = 1,
+		/obj/item/holosign_creator/security = 1
 	)
 
 	backpack = /obj/item/storage/backpack/medic
@@ -380,8 +383,8 @@
 		/obj/item/food/donut/caramel = 10,
 		/obj/item/food/donut/matcha = 10,
 		/obj/item/food/donut/blumpkin = 5,
-		/obj/item/clothing/mask/whistle = 5,
-		/obj/item/melee/baton/security/boomerang/loaded = 1
+		/obj/item/clothing/mask/whistle = 10,
+		/obj/item/melee/baton = 5
 	)
 	job_flags = JOB_ANNOUNCE_ARRIVAL | JOB_CREW_MANIFEST | JOB_EQUIP_RANK | JOB_CREW_MEMBER | JOB_NEW_PLAYER_JOINABLE | JOB_REOPEN_ON_ROUNDSTART_LOSS | JOB_ASSIGN_QUIRKS | JOB_CAN_BE_INTERN
 
@@ -393,13 +396,14 @@
 	ears = /obj/item/radio/headset/headset_eng
 	shoes = /obj/item/clothing/shoes/workboots
 	uniform = /obj/item/clothing/under/rank/security/officer/blueshirt/skyrat/engineering_guard
-	head =  /obj/item/clothing/head/helmet/blueshirt/skyrat/guard
+	head =  /obj/item/clothing/head/beret/sec/engineering
 	suit = /obj/item/clothing/suit/armor/vest/blueshirt/skyrat/engineering_guard
-	r_pocket = /obj/item/assembly/flash/handheld
-	l_pocket = /obj/item/restraints/handcuffs/cable/yellow
+	r_pocket = /obj/item/reagent_containers/spray/pepper
+	l_pocket = /obj/item/restraints/handcuffs
 	backpack_contents = list(
 		/obj/item/melee/baton/security/loaded/departmental/engineering = 1,
-		/obj/item/storage/box/gunset/pepperball = 1,
+		/obj/item/gun/energy/disabler = 1,
+		/obj/item/holosign_creator/security = 1
 	)
 
 	backpack = /obj/item/storage/backpack/industrial
@@ -483,8 +487,8 @@
 		/obj/item/food/donut/caramel = 10,
 		/obj/item/food/donut/matcha = 10,
 		/obj/item/food/donut/blumpkin = 5,
-		/obj/item/clothing/mask/whistle = 5,
-		/obj/item/melee/baton/security/boomerang/loaded = 1
+		/obj/item/clothing/mask/whistle = 10,
+		/obj/item/melee/baton = 5
 	)
 	job_flags = JOB_ANNOUNCE_ARRIVAL | JOB_CREW_MANIFEST | JOB_EQUIP_RANK | JOB_CREW_MEMBER | JOB_NEW_PLAYER_JOINABLE | JOB_REOPEN_ON_ROUNDSTART_LOSS | JOB_ASSIGN_QUIRKS | JOB_CAN_BE_INTERN
 
@@ -496,14 +500,15 @@
 	ears = /obj/item/radio/headset/headset_cargo
 	shoes = /obj/item/clothing/shoes/sneakers/black
 	uniform = /obj/item/clothing/under/rank/security/officer/blueshirt/skyrat/customs_agent
-	head =  /obj/item/clothing/head/helmet/blueshirt/skyrat/guard
+	head =  /obj/item/clothing/head/beret/sec/cargo
 	suit = /obj/item/clothing/suit/armor/vest/blueshirt/skyrat/customs_agent
 	glasses = /obj/item/clothing/glasses/hud/gun_permit
-	r_pocket = /obj/item/assembly/flash/handheld
-	l_pocket = /obj/item/restraints/handcuffs/cable/orange
+	r_pocket = /obj/item/reagent_containers/spray/pepper
+	l_pocket = /obj/item/restraints/handcuffs
 	backpack_contents = list(
 		/obj/item/melee/baton/security/loaded/departmental/cargo = 1,
-		/obj/item/storage/box/gunset/pepperball = 1,
+		/obj/item/gun/energy/disabler = 1,
+		/obj/item/holosign_creator/security = 1
 	)
 
 	backpack = /obj/item/storage/backpack
@@ -580,8 +585,8 @@
 		/obj/item/food/donut/caramel = 10,
 		/obj/item/food/donut/matcha = 10,
 		/obj/item/food/donut/blumpkin = 5,
-		/obj/item/clothing/mask/whistle = 5,
-		/obj/item/melee/baton/security/boomerang/loaded = 1
+		/obj/item/clothing/mask/whistle = 10,
+		/obj/item/melee/baton = 5
 	)
 	job_flags = JOB_ANNOUNCE_ARRIVAL | JOB_CREW_MANIFEST | JOB_EQUIP_RANK | JOB_CREW_MEMBER | JOB_NEW_PLAYER_JOINABLE | JOB_REOPEN_ON_ROUNDSTART_LOSS | JOB_ASSIGN_QUIRKS | JOB_CAN_BE_INTERN
 
@@ -593,15 +598,16 @@
 	ears = /obj/item/radio/headset/headset_srv
 	uniform = /obj/item/clothing/under/rank/security/officer/blueshirt/skyrat/bouncer
 	shoes = /obj/item/clothing/shoes/sneakers/black
-	head =  /obj/item/clothing/head/helmet/blueshirt/skyrat/guard
-	suit = /obj/item/clothing/suit/armor/vest/blueshirt/skyrat/guard
-	l_pocket = /obj/item/restraints/handcuffs/cable/green
-	r_pocket = /obj/item/assembly/flash/handheld
+	head =  /obj/item/clothing/head/beret/sec/service
+	suit = /obj/item/clothing/suit/armor/vest/alt
+	l_pocket = /obj/item/restraints/handcuffs
+	r_pocket = /obj/item/reagent_containers/spray/pepper
 	backpack_contents = list(
 		/obj/item/melee/baton/security/loaded/departmental/service = 1,
-		/obj/item/storage/box/gunset/pepperball = 1,
+		/obj/item/gun/energy/disabler = 1,
+		/obj/item/holosign_creator/security = 1
 		)
-	glasses = /obj/item/clothing/glasses/sunglasses
+	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 
 	backpack = /obj/item/storage/backpack
 	satchel = /obj/item/storage/backpack/satchel


### PR DESCRIPTION
Changes:
- Helmets replaced with Berets with the same stats
- Flash replaced with Pepper Spray
- Pepperball re[;aced with Disabler
- Add Security Holobarriers to the Department Guard Loadout
- Change Science Guard and Bouncer vests to better-looking vests with the same stats.
- Cable Restraints replaced with Handcuffs
- Gives Bouncers SecHuds
- Gives Orderlies Medhuds
- Added the Police Baton to department guards Mail options
- Removed the boomerang from mail options for department guards
- Added weight to the whistle in mail options for department guards

The last change, giving SecHuds to Bouncers is because Bouncers, currently, have no way to obtain SecHuds without breaking into Security as no maps spawn them an office.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The Pull Request changes the spawn loadout for Department Sec to be more versatile and more stylish. This also gives Bouncers the Service beret which is otherwise unobtainable UNLESS they spawn with it as an heirloom.

Changes:
- Helmets replaced with Berets with the same stats
- Flash replaced with Pepper Spray
- Pepperball re[;aced with Disabler
- Add Security Holobarriers to the Department Guard Loadout
- Change Science Guard and Bouncer vests to better-looking vests with the same stats.
- Cable Restraints replaced with Handcuffs
- Gives Bouncers SecHuds
- Gives Orderlies Medhuds
- Added the Police Baton to department guards Mail options
- Removed the boomerang from mail options for department guards
- Added weight to the whistle in mail options for department guards
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

This said it was not tested before.

I have since tested it and it works as intended

## Changelog

🆑 
Changes:
- Helmets replaced with Berets with the same stats
- Flash replaced with Pepper Spray
- Pepperball re[;aced with Disabler
- Add Security Holobarriers to the Department Guard Loadout
- Change Science Guard and Bouncer vests to better-looking vests with the same stats.
- Cable Restraints replaced with Handcuffs
- Gives Bouncers SecHuds
- Gives Orderlies Medhuds
- Added the Police Baton to department guards Mail options
- Removed the boomerang from mail options for department guards
- Added weight to the whistle in mail options for department guards
:cl:

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
