### PR TITLE
Fixes a bunch of issues + removes planting on ash

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -87,6 +87,8 @@ GLOBAL_LIST_EMPTY(flora_uprooting_tools_typepaths)
 	disallowed_tools = GLOB.flora_disallowed_tools_typepaths[type]
 	uprooting_tools = GLOB.flora_uprooting_tools_typepaths[type]
 
+//BUBBER EDIT START - MOVED TO MODULAR
+/*
 /obj/structure/flora/attackby(obj/item/used_item, mob/living/user, params)
 	if(user.combat_mode)
 		return ..()
@@ -128,6 +130,8 @@ GLOBAL_LIST_EMPTY(flora_uprooting_tools_typepaths)
 
 	if(harvest(user))
 		after_harvest(user)
+*/
+//BUBBER EDIT END
 
 /obj/structure/flora/attack_hand(mob/user, list/modifiers)
 	. = ..()

--- a/modular_skyrat/modules/ashwalkers/code/buildings/ash_farming.dm
+++ b/modular_skyrat/modules/ashwalkers/code/buildings/ash_farming.dm
@@ -1,6 +1,4 @@
 /datum/component/simple_farm
-	///whether you can actually farm it at the moment
-	var/allow_plant = FALSE
 	///whether we limit the amount of plants you can have per turf
 	var/one_per_turf = TRUE
 	///the reference to the movable parent the component is attached to
@@ -13,8 +11,6 @@
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
 	atom_parent = parent
-	//important to allow people to just straight up set allowing to plant
-	allow_plant = set_plant
 	one_per_turf = set_turf_limit
 	pixel_shift = set_shift
 	//now lets register the signals
@@ -32,11 +28,6 @@
  */
 /datum/component/simple_farm/proc/check_attack(datum/source, obj/item/attacking_item, mob/user)
 	SIGNAL_HANDLER
-	//if it behaves like a shovel
-	if(attacking_item.tool_behaviour == TOOL_SHOVEL)
-		//flip the allow plant-- we either cover or uncover the plantable bit
-		allow_plant = !allow_plant
-		atom_parent.balloon_alert_to_viewers("[allow_plant ? "uncovered" : "covered"] the growing place!")
 
 	//if its a seed, lets try to plant
 	if(istype(attacking_item, /obj/item/seeds))
@@ -61,11 +52,9 @@
  * check_examine is meant to listen for the comsig_parent_examine signal, where it will put additional information in the examine
  */
 /datum/component/simple_farm/proc/check_examine(datum/source, mob/user, list/examine_list)
-	if(allow_plant)
-		examine_list += span_notice("You are able to plant seeds here!")
+	SIGNAL_HANDLER
 
-	else
-		examine_list += span_warning("You need to use a shovel before you can plant seeds here!")
+	examine_list += span_notice("You are able to plant seeds here!")
 
 /obj/structure/simple_farm
 	name = "simple farm"
@@ -236,7 +225,3 @@
 			creating_obj = planted_seed.type
 
 		new creating_obj(get_turf(src))
-
-/turf/open/misc/asteroid/basalt/Initialize(mapload)
-	. = ..()
-	AddComponent(/datum/component/simple_farm)

--- a/modular_skyrat/modules/ashwalkers/code/effects/ash_ritual.dm
+++ b/modular_skyrat/modules/ashwalkers/code/effects/ash_ritual.dm
@@ -51,13 +51,36 @@
 	for(var/checked_component in required_components)
 		var/set_direction = text2dir(checked_component)
 		var/turf/checked_turf = get_step(checked_rune, set_direction)
-		var/atom_check = locate(required_components[checked_component]) in checked_turf.contents
+		var/atom/movable/atom_check
+		if(ispath(required_components[checked_component], /mob/living))
+			var/fallback
+			for(var/mob/living/checked_mob in checked_turf)
+				if(checked_mob.stat == CONSCIOUS)
+					if(isnull(fallback))
+						fallback = checked_mob
+					continue
+
+				atom_check = checked_mob
+
+			atom_check ||= fallback
+
+		else
+			atom_check = locate(required_components[checked_component]) in checked_turf
+
+
 		if(!atom_check)
 			ritual_fail(checked_rune)
 			return FALSE
 
 		if(is_type_in_list(atom_check, consumed_components))
-			qdel(atom_check)
+			if(isliving(atom_check))
+				var/mob/living/sacrifice = atom_check
+				sacrifice.dust(TRUE, TRUE)
+			else if(isstack(atom_check))
+				var/obj/item/stack/stack = atom_check
+				stack.use(1)
+			else
+				qdel(atom_check)
 			checked_rune.balloon_alert_to_viewers("[checked_component] component has been consumed...")
 
 		else

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -465,8 +465,8 @@
 	sound = 'modular_skyrat/modules/emotes/sound/voice/warbles.ogg'
 
 /datum/emote/living/trills
-	key = "trills"
-	key_third_person = "trills!"
+	key = "trill"
+	key_third_person = "trills"
 	message = "trills!"
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
@@ -490,7 +490,7 @@
 
 /datum/emote/living/moo
 	key = "moo"
-	key_third_person = "moos!"
+	key_third_person = "moos"
 	message = "moos!"
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE

--- a/modular_zubbers/code/modules/fluff/flora/ash_flora.dm
+++ b/modular_zubbers/code/modules/fluff/flora/ash_flora.dm
@@ -1,0 +1,70 @@
+/obj/structure/flora/ash/cacti
+	can_uproot = TRUE
+
+/obj/structure/flora/attackby(obj/item/used_item, mob/living/user, params)
+	if(user.combat_mode)
+		return ..()
+	if(flags_1 & HOLOGRAM_1)
+		to_chat(user, "Your [used_item] goes right through \the [src]!")
+		return ..()
+	if(can_uproot && is_type_in_typecache(used_item, uprooting_tools))
+		if(uprooted)
+			if(locate(/obj/structure/flora) in (loc.contents - src))
+				to_chat(user, span_warning("There's already a plant here!"))
+				return
+
+			user.visible_message(
+				span_notice("[user] starts to replant [src]..."),
+				span_notice("You start to replant [src]...")
+			)
+			used_item.play_tool_sound(src, 50)
+			if(!do_after(user, harvest_time, src) || locate(/obj/structure/flora) in (loc.contents - src))
+				return
+
+			user.visible_message(
+				span_notice("[user] replants [src]."),
+				span_notice("You replant [src].")
+			)
+			replant()
+		else
+			user.visible_message(
+				span_notice("[user] starts to uproot [src]..."),
+				span_notice("You start to uproot [src]...")
+			)
+			used_item.play_tool_sound(src, 50)
+			if(!do_after(user, harvest_time, src))
+				return
+
+			user.visible_message(
+				span_notice("[user] uproots [src]."),
+				span_notice("You uproot [src].")
+			)
+			uproot()
+
+		used_item.play_tool_sound(src, 50)
+		return
+
+	if(!can_harvest(user, used_item))
+		return ..()
+
+	user.visible_message(
+		span_notice("[user] starts to [harvest_verb] [src]..."),
+		span_notice("You start to [harvest_verb] [src] with [used_item]...")
+	)
+	play_attack_sound(used_item.force)
+	if(!do_after(user, harvest_time * used_item.toolspeed, src))
+		return
+	visible_message(span_notice("[user] [harvest_verb][harvest_verb_suffix] [src]."), ignored_mobs = list(user))
+	play_attack_sound(used_item.force)
+
+	if(harvest(user))
+		after_harvest(user)
+
+/obj/structure/flora/ash/cacti/uproot(mob/living/user)
+	. = ..()
+	qdel(GetComponent(/datum/component/caltrop))
+
+/obj/structure/flora/ash/cacti/replant(mob/living/user)
+	. = ..()
+	AddComponent(/datum/component/caltrop, min_damage = 3, max_damage = 6, probability = 70)
+

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6702,6 +6702,7 @@
 #include "modular_zubbers\code\modules\customization\sprite_accessories\genitals.dm"
 #include "modular_zubbers\code\modules\dynamic\midround_rulesets.dm"
 #include "modular_zubbers\code\modules\food_and_drinks\recipes\tablecraft\recipes_seafood.dm"
+#include "modular_zubbers\code\modules\fluff\flora\ash_flora.dm"
 #include "modular_zubbers\code\modules\jobs\job_types\blacksmith.dm"
 #include "modular_zubbers\code\modules\loadouts\loadout_items\loadout_datum_toys.dm"
 #include "modular_zubbers\code\modules\mapping\access_helpers.dm"


### PR DESCRIPTION
## About The Pull Request

­­> Fixes ash rune accidentally consuming ashwalkers when a sacrifice is already present
­­> Fixes ash rune consuming the entire stack instead of only one
­­> Fixes ash rune consuming equipment
­­> Fixes the "trill" emote so it can be called via "trill", and not "trills"
­­> Allows replanting fruiting cacti, restricts to one-plant-per-tile
­­> Aaand removes planting things on ash soil. Teshari B-Gone.

I'll think of a replacement for the dirt piles later.

## Changelog

:cl:
balance: removed planting on ash
fix: fixed ash runes being horribly broken
/:cl: