### PR TITLE
Ash Walker Ashtongue Fix

### DIFF
--- a/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -255,6 +255,7 @@
 
 	spawned_human.mind.add_antag_datum(/datum/antagonist/ashwalker, team)
 
+	spawned_human.grant_language(/datum/language/ashtongue)	// Bubber Addition - Ashtongue Fix
 	//spawned_human.remove_language(/datum/language/common) -Nonmodular removal. Allows Ashwalkers to speak common and properly learn other languages.
 	team.players_spawned += (spawned_human.key)
 	eggshell.egg = null


### PR DESCRIPTION
## About The Pull Request
Hopefull fixes ashwalkers not having the language granted.
I've examined the code, and they **should** be given the language, but something is missing out somewhere along the chain, specifically for the ash walker species players picking the ghost role.

My methodology here is to go along the chain that involves spawning a player in as an ash-walker, and finding the last few links in that chain, in which I'll add a little link of my own to give the language. So, we're having the ghost role spawners grant the language.

## Changelog

:cl:
fix: Ashwalker species characters that join as the ghost-role should now start with Ashtongue, instead of just Draconic and Common.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
