### PR TITLE
I'll show you who's the boss of this security department: Armory Reworks & Energy Sec

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2_bubber.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_bubber.dmm
@@ -123,11 +123,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "abw" = (
-/obj/structure/closet/secure_closet/contraband/armory,
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/spawner/random/maintenance/three,
-/obj/effect/spawner/random/contraband/armory,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "aby" = (
@@ -2633,9 +2631,11 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "aEs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/structure/closet/secure_closet/contraband/armory,
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/spawner/random/maintenance/three,
+/obj/effect/spawner/random/contraband/armory,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "aEz" = (
@@ -14704,9 +14704,6 @@
 /area/station/service/hydroponics)
 "dwU" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "dwV" = (
@@ -27227,8 +27224,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/rack/gunrack,
-/obj/effect/spawner/armory_spawn/shotguns,
+/obj/structure/rack,
+/obj/item/gun/energy/disabler{
+	pixel_y = 6
+	},
+/obj/item/gun/energy/disabler{
+	pixel_y = 2
+	},
+/obj/item/gun/energy/disabler{
+	pixel_y = -2
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "gzQ" = (
@@ -29264,6 +29269,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
+"haB" = (
+/obj/structure/rack,
+/obj/item/gun/energy/ionrifle,
+/obj/item/clothing/suit/hooded/ablative,
+/obj/item/gun/energy/temperature/security,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "haF" = (
 /obj/structure/sign/warning/secure_area/directional/west,
 /turf/open/space/basic,
@@ -35723,6 +35736,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"iGl" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/dish_drive/bullet{
+	succrange = 6
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "iGm" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -41285,41 +41306,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"jUS" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/head/helmet/toggleable/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/toggleable/riot,
-/obj/item/clothing/head/helmet/toggleable/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/shield/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/shield/riot,
-/obj/item/shield/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "jUT" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -41598,6 +41584,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "jYM" = (
@@ -43948,6 +43935,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
+/obj/machinery/ammo_workbench,
 /turf/open/floor/iron,
 /area/station/security/lockers)
 "kCf" = (
@@ -44791,8 +44779,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/rack/gunrack,
-/obj/effect/spawner/armory_spawn/microfusion,
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun{
+	pixel_y = 7
+	},
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun{
+	pixel_y = -7
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "kNw" = (
@@ -50763,9 +50757,16 @@
 /area/station/engineering/atmos/pumproom)
 "mnT" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/secure_closet/smartgun,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/structure/rack,
+/obj/item/gun/energy/laser{
+	pixel_y = 7
+	},
+/obj/item/gun/energy/laser,
+/obj/item/gun/energy/laser{
+	pixel_y = -7
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
@@ -51781,7 +51782,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
-/area/station/security/prison)
+/area/station/security/prison/garden)
 "mAD" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "brigfront";
@@ -54238,6 +54239,44 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
+"neb" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = -7;
+	pixel_y = -6
+	},
+/obj/item/clothing/suit/armor/riot{
+	pixel_y = -6
+	},
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = 7;
+	pixel_y = -6
+	},
+/obj/item/clothing/head/helmet/toggleable/riot{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/toggleable/riot{
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/toggleable/riot{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/shield/riot{
+	pixel_x = -8;
+	pixel_y = -8
+	},
+/obj/item/shield/riot{
+	pixel_y = -8
+	},
+/obj/item/shield/riot{
+	pixel_x = 8;
+	pixel_y = -8
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "nei" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -54796,22 +54835,17 @@
 	},
 /area/station/security/brig)
 "nlZ" = (
-/obj/item/grenade/barrier{
-	pixel_x = -3;
-	pixel_y = 1
-	},
-/obj/item/grenade/barrier,
-/obj/item/grenade/barrier{
-	pixel_x = 3;
-	pixel_y = -1
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 6;
-	pixel_y = -2
-	},
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/item/radio/intercom/directional/north,
+/obj/item/storage/box/firingpins,
+/obj/item/grenade/barrier{
+	pixel_x = -6
+	},
+/obj/item/grenade/barrier,
+/obj/item/grenade/barrier{
+	pixel_x = 6
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "nma" = (
@@ -57003,7 +57037,7 @@
 "nOz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/security/prison)
+/area/station/security/prison/garden)
 "nOD" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -59365,16 +59399,7 @@
 "otJ" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/firealarm/directional/west,
-/obj/structure/rack,
-/obj/item/gun/energy/disabler{
-	pixel_y = 6
-	},
-/obj/item/gun/energy/disabler{
-	pixel_y = 2
-	},
-/obj/item/gun/energy/disabler{
-	pixel_y = -2
-	},
+/obj/structure/closet/secure_closet/smartgun,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "ouc" = (
@@ -60413,7 +60438,7 @@
 	name = "falsewall or wall spawner"
 	},
 /turf/open/floor/plating,
-/area/station/security/prison)
+/area/station/security/prison/garden)
 "oIi" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -61566,14 +61591,6 @@
 /obj/effect/turf_decal/tile/neutral/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/break_room)
-"oYX" = (
-/obj/structure/rack,
-/obj/item/gun/energy/ionrifle,
-/obj/item/clothing/suit/hooded/ablative,
-/obj/item/gun/energy/temperature/security,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "oZb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wood{
@@ -61713,20 +61730,9 @@
 /area/station/engineering/main)
 "pbN" = (
 /obj/structure/reagent_dispensers/wall/peppertank/directional/east,
-/obj/structure/table/reinforced,
-/obj/item/clothing/mask/gas/sechailer{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/flashlight/seclite,
-/obj/item/flashlight/seclite,
-/obj/item/flashlight/seclite,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "pbP" = (
@@ -62104,27 +62110,24 @@
 /turf/open/floor/plating,
 /area/station/service/chapel/storage)
 "pgn" = (
-/obj/structure/closet/crate/freezer{
-	icon_state = "hydrocrate";
-	name = "produce fridge"
-	},
-/obj/item/food/grown/cabbage,
-/obj/item/food/grown/pumpkin,
-/obj/item/food/grown/potato,
-/obj/item/food/grown/koibeans,
-/obj/item/food/grown/onion,
-/obj/item/food/grown/watermelon,
-/obj/item/food/grown/cucumber,
-/obj/item/food/grown/eggplant,
-/obj/item/food/grown/berries,
-/obj/item/food/grown/apple,
-/obj/item/food/grown/tomato,
-/obj/item/food/grown/wheat,
-/obj/item/food/grown/carrot,
-/obj/structure/window,
+/obj/structure/closet/crate/hydroponics,
+/obj/item/seeds/carrot,
+/obj/item/seeds/wheat,
+/obj/item/seeds/tomato,
+/obj/item/seeds/apple,
+/obj/item/seeds/berry,
+/obj/item/seeds/eggplant,
+/obj/item/seeds/cucumber,
+/obj/item/seeds/watermelon,
+/obj/item/seeds/onion,
+/obj/item/seeds/soya,
+/obj/item/seeds/potato,
+/obj/item/seeds/pumpkin,
+/obj/item/seeds/cabbage,
 /obj/structure/sign/poster/contraband/ambrosia_vulgaris{
 	pixel_x = -30
 	},
+/obj/structure/window,
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
 "pgo" = (
@@ -64636,14 +64639,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
-"pKD" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/dish_drive/bullet{
-	succrange = 6
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "pKM" = (
 /obj/effect/turf_decal/siding/white,
 /obj/effect/turf_decal/tile/neutral{
@@ -73148,7 +73143,6 @@
 /area/station/engineering/storage/tech)
 "rOS" = (
 /obj/structure/table/reinforced,
-/obj/machinery/recharger,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -73156,6 +73150,14 @@
 	id = "armouryaccess";
 	name = "Armoury Access";
 	req_access = list("armory")
+	},
+/obj/machinery/recharger{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/machinery/recharger{
+	pixel_x = 6;
+	pixel_y = 2
 	},
 /obj/item/key/security,
 /turf/open/floor/iron/dark,
@@ -78658,34 +78660,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"tdv" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/suit/armor/bulletproof,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/storage/secure/safe/directional/east,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "tdC" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/bot,
@@ -78699,25 +78673,8 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "teo" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/item/clothing/head/helmet/sec{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/sec,
-/obj/item/clothing/head/helmet/sec{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/suit/armor/vest/alt/sec{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/suit/armor/vest/alt/sec,
-/obj/item/clothing/suit/armor/vest/alt/sec{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
@@ -79973,6 +79930,29 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"tuV" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/clothing/head/helmet/sec{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/sec,
+/obj/item/clothing/head/helmet/sec{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/armor/vest/alt/sec{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/armor/vest/alt/sec,
+/obj/item/clothing/suit/armor/vest/alt/sec{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "tuW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -80592,6 +80572,20 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"tDr" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/item/melee/hammer,
+/obj/item/melee/hammer,
+/obj/item/melee/hammer,
+/obj/item/storage/box/firingpins,
+/obj/item/storage/box/firingpins,
+/obj/item/gun/energy/e_gun/dragnet{
+	pixel_y = 6
+	},
+/obj/item/gun/energy/e_gun/dragnet,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "tDs" = (
 /turf/closed/wall,
 /area/station/service/electronic_marketing_den)
@@ -84617,6 +84611,33 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
+"uAx" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/bulletproof/old{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/armor/bulletproof/old{
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/armor/bulletproof/old{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet/alt{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/alt{
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/alt{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "uAA" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/table/reinforced,
@@ -88645,6 +88666,45 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
+"vym" = (
+/obj/item/storage/secure/safe/directional/east,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/rack,
+/obj/item/clothing/glasses/hud/security/sunglasses/redsec{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/glasses/hud/security/sunglasses/redsec{
+	pixel_y = 3
+	},
+/obj/item/clothing/glasses/hud/security/sunglasses/redsec{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/sec/redsec{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/sec/redsec{
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/sec/redsec{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/item/clothing/suit/armor/vest/alt/sec/redsec{
+	pixel_x = -7;
+	pixel_y = -5
+	},
+/obj/item/clothing/suit/armor/vest/alt/sec/redsec{
+	pixel_y = -5
+	},
+/obj/item/clothing/suit/armor/vest/alt/sec/redsec{
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "vyn" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -90607,6 +90667,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
+/obj/machinery/vending/wardrobe/sec_wardrobe/red,
 /turf/open/floor/iron,
 /area/station/security/lockers)
 "vYE" = (
@@ -92028,9 +92089,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "wow" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/turf_decal/bot,
+/obj/structure/rack/gunrack,
+/obj/effect/spawner/armory_spawn/shotguns,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "wox" = (
@@ -92538,19 +92599,8 @@
 /obj/machinery/camera/directional/south{
 	c_tag = "Armory - Interior"
 	},
-/obj/structure/table/reinforced,
-/obj/item/gun/energy/e_gun/dragnet,
-/obj/item/gun/energy/e_gun/dragnet,
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/item/melee/hammer,
-/obj/item/melee/hammer,
-/obj/item/melee/hammer,
-/obj/item/storage/box/firingpins,
-/obj/item/storage/box/firingpins,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "wtE" = (
@@ -99937,6 +99987,33 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"ylz" = (
+/obj/structure/rack,
+/obj/structure/sign/nanotrasen{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/flashlight/seclite{
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/obj/item/flashlight/seclite{
+	pixel_x = 2
+	},
+/obj/item/flashlight/seclite{
+	pixel_x = 2;
+	pixel_y = -7
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "ylB" = (
 /obj/machinery/light/small/directional/west,
 /obj/item/clothing/suit/caution,
@@ -152248,8 +152325,8 @@ aaa
 qYo
 aaa
 qYo
-fiO
-fiO
+dax
+dax
 lTv
 omW
 nbw
@@ -152505,7 +152582,7 @@ aaa
 qYo
 vVc
 vVc
-fiO
+dax
 mAA
 lTv
 lTv
@@ -152762,7 +152839,7 @@ aaa
 qYo
 aaa
 qYo
-fiO
+dax
 nOz
 oHS
 uWT
@@ -154090,11 +154167,11 @@ jNM
 sRd
 bLs
 aqW
-aEs
+wTu
 wow
-wow
-wow
-wow
+uAx
+neb
+tDr
 dwU
 wtB
 bLs
@@ -154349,10 +154426,10 @@ bLs
 hXZ
 abw
 teo
-tdv
-jUS
-oYX
-pKD
+teo
+teo
+teo
+teo
 pbN
 bLs
 hEF
@@ -154604,12 +154681,12 @@ aaa
 aad
 bLs
 bLs
-bLs
-bLs
-bLs
-bLs
-bLs
-bLs
+aEs
+tuV
+vym
+ylz
+haB
+iGl
 bLs
 bLs
 aaa

--- a/_maps/map_files/Deltastation/DeltaStation2_bubber.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_bubber.dmm
@@ -2693,6 +2693,20 @@
 /obj/item/clothing/under/rank/civilian/lawyer/black/skirt,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
+"aFl" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/item/melee/hammer,
+/obj/item/melee/hammer,
+/obj/item/melee/hammer,
+/obj/item/storage/box/firingpins,
+/obj/item/storage/box/firingpins,
+/obj/item/gun/energy/e_gun/dragnet{
+	pixel_y = 6
+	},
+/obj/item/gun/energy/e_gun/dragnet,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "aFo" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -29269,14 +29283,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
-"haB" = (
-/obj/structure/rack,
-/obj/item/gun/energy/ionrifle,
-/obj/item/clothing/suit/hooded/ablative,
-/obj/item/gun/energy/temperature/security,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "haF" = (
 /obj/structure/sign/warning/secure_area/directional/west,
 /turf/open/space/basic,
@@ -35736,14 +35742,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"iGl" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/dish_drive/bullet{
-	succrange = 6
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "iGm" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -41825,6 +41823,14 @@
 	dir = 1
 	},
 /area/station/medical/morgue)
+"kbM" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/dish_drive/bullet{
+	succrange = 6
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "kbN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -47770,6 +47776,44 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/theater)
+"lzS" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = -7;
+	pixel_y = -6
+	},
+/obj/item/clothing/suit/armor/riot{
+	pixel_y = -6
+	},
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = 7;
+	pixel_y = -6
+	},
+/obj/item/clothing/head/helmet/toggleable/riot{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/toggleable/riot{
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/toggleable/riot{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/shield/riot{
+	pixel_x = -8;
+	pixel_y = -8
+	},
+/obj/item/shield/riot{
+	pixel_y = -8
+	},
+/obj/item/shield/riot{
+	pixel_x = 8;
+	pixel_y = -8
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "lAg" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -54239,44 +54283,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
-"neb" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = -7;
-	pixel_y = -6
-	},
-/obj/item/clothing/suit/armor/riot{
-	pixel_y = -6
-	},
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = 7;
-	pixel_y = -6
-	},
-/obj/item/clothing/head/helmet/toggleable/riot{
-	pixel_x = -6;
-	pixel_y = 8
-	},
-/obj/item/clothing/head/helmet/toggleable/riot{
-	pixel_y = 8
-	},
-/obj/item/clothing/head/helmet/toggleable/riot{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/item/shield/riot{
-	pixel_x = -8;
-	pixel_y = -8
-	},
-/obj/item/shield/riot{
-	pixel_y = -8
-	},
-/obj/item/shield/riot{
-	pixel_x = 8;
-	pixel_y = -8
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "nei" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -59400,6 +59406,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/firealarm/directional/west,
 /obj/structure/closet/secure_closet/smartgun,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "ouc" = (
@@ -62258,6 +62265,33 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/service/theater)
+"phf" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/bulletproof/old{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/armor/bulletproof/old{
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/armor/bulletproof/old{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet/alt{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/alt{
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/alt{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "phn" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -67669,6 +67703,33 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"qwp" = (
+/obj/structure/rack,
+/obj/structure/sign/nanotrasen{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/flashlight/seclite{
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/obj/item/flashlight/seclite{
+	pixel_x = 2
+	},
+/obj/item/flashlight/seclite{
+	pixel_x = 2;
+	pixel_y = -7
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "qwv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -72872,6 +72933,14 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/fitness/recreation)
+"rLv" = (
+/obj/structure/rack,
+/obj/item/gun/energy/ionrifle,
+/obj/item/clothing/suit/hooded/ablative,
+/obj/item/gun/energy/temperature/security,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "rLx" = (
 /obj/machinery/status_display/evac/directional/east,
 /obj/structure/chair{
@@ -78552,6 +78621,45 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/vault,
 /area/station/commons/fitness/recreation)
+"tcw" = (
+/obj/item/storage/secure/safe/directional/east,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/rack,
+/obj/item/clothing/glasses/hud/security/sunglasses/redsec{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/glasses/hud/security/sunglasses/redsec{
+	pixel_y = 3
+	},
+/obj/item/clothing/glasses/hud/security/sunglasses/redsec{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/sec/redsec{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/sec/redsec{
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/sec/redsec{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/item/clothing/suit/armor/vest/alt/sec/redsec{
+	pixel_x = -7;
+	pixel_y = -5
+	},
+/obj/item/clothing/suit/armor/vest/alt/sec/redsec{
+	pixel_y = -5
+	},
+/obj/item/clothing/suit/armor/vest/alt/sec/redsec{
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "tcx" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -79930,29 +80038,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"tuV" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/item/clothing/head/helmet/sec{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/sec,
-/obj/item/clothing/head/helmet/sec{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/suit/armor/vest/alt/sec{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/suit/armor/vest/alt/sec,
-/obj/item/clothing/suit/armor/vest/alt/sec{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "tuW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -80572,20 +80657,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"tDr" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/rack,
-/obj/item/melee/hammer,
-/obj/item/melee/hammer,
-/obj/item/melee/hammer,
-/obj/item/storage/box/firingpins,
-/obj/item/storage/box/firingpins,
-/obj/item/gun/energy/e_gun/dragnet{
-	pixel_y = 6
-	},
-/obj/item/gun/energy/e_gun/dragnet,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "tDs" = (
 /turf/closed/wall,
 /area/station/service/electronic_marketing_den)
@@ -84611,33 +84682,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
-"uAx" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/bulletproof/old{
-	pixel_x = -7;
-	pixel_y = -3
-	},
-/obj/item/clothing/suit/armor/bulletproof/old{
-	pixel_y = -3
-	},
-/obj/item/clothing/suit/armor/bulletproof/old{
-	pixel_x = 7;
-	pixel_y = -3
-	},
-/obj/item/clothing/head/helmet/alt{
-	pixel_x = -7;
-	pixel_y = 6
-	},
-/obj/item/clothing/head/helmet/alt{
-	pixel_y = 6
-	},
-/obj/item/clothing/head/helmet/alt{
-	pixel_x = 7;
-	pixel_y = 6
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "uAA" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/table/reinforced,
@@ -88666,45 +88710,6 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
-"vym" = (
-/obj/item/storage/secure/safe/directional/east,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/rack,
-/obj/item/clothing/glasses/hud/security/sunglasses/redsec{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/glasses/hud/security/sunglasses/redsec{
-	pixel_y = 3
-	},
-/obj/item/clothing/glasses/hud/security/sunglasses/redsec{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/sec/redsec{
-	pixel_x = -7;
-	pixel_y = 6
-	},
-/obj/item/clothing/head/helmet/sec/redsec{
-	pixel_y = 6
-	},
-/obj/item/clothing/head/helmet/sec/redsec{
-	pixel_x = 7;
-	pixel_y = 6
-	},
-/obj/item/clothing/suit/armor/vest/alt/sec/redsec{
-	pixel_x = -7;
-	pixel_y = -5
-	},
-/obj/item/clothing/suit/armor/vest/alt/sec/redsec{
-	pixel_y = -5
-	},
-/obj/item/clothing/suit/armor/vest/alt/sec/redsec{
-	pixel_x = 7;
-	pixel_y = -5
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "vyn" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -95711,6 +95716,29 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
+"xjE" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/clothing/head/helmet/sec{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/sec,
+/obj/item/clothing/head/helmet/sec{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/armor/vest/alt/sec{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/armor/vest/alt/sec,
+/obj/item/clothing/suit/armor/vest/alt/sec{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "xjF" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -99987,33 +100015,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
-"ylz" = (
-/obj/structure/rack,
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/item/clothing/mask/gas/sechailer{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/mask/gas/sechailer{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/flashlight/seclite{
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/obj/item/flashlight/seclite{
-	pixel_x = 2
-	},
-/obj/item/flashlight/seclite{
-	pixel_x = 2;
-	pixel_y = -7
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "ylB" = (
 /obj/machinery/light/small/directional/west,
 /obj/item/clothing/suit/caution,
@@ -154169,9 +154170,9 @@ bLs
 aqW
 wTu
 wow
-uAx
-neb
-tDr
+phf
+lzS
+aFl
 dwU
 wtB
 bLs
@@ -154682,11 +154683,11 @@ aad
 bLs
 bLs
 aEs
-tuV
-vym
-ylz
-haB
-iGl
+xjE
+tcw
+qwp
+rLv
+kbM
 bLs
 bLs
 aaa

--- a/_maps/map_files/Deltastation/DeltaStation2_bubber.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_bubber.dmm
@@ -126,7 +126,16 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "aby" = (
 /turf/open/floor/wood,
@@ -1480,7 +1489,6 @@
 /area/station/commons/dorms)
 "aqW" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/item/storage/barricade{
 	pixel_y = -5
 	},
@@ -1488,6 +1496,7 @@
 /obj/item/storage/barricade{
 	pixel_y = 5
 	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "arc" = (
@@ -2631,12 +2640,15 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "aEs" = (
-/obj/structure/closet/secure_closet/contraband/armory,
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/spawner/random/maintenance/three,
-/obj/effect/spawner/random/contraband/armory,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/siding/dark_red,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "aEz" = (
 /obj/structure/disposalpipe/segment{
@@ -2693,20 +2705,6 @@
 /obj/item/clothing/under/rank/civilian/lawyer/black/skirt,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
-"aFl" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/rack,
-/obj/item/melee/hammer,
-/obj/item/melee/hammer,
-/obj/item/melee/hammer,
-/obj/item/storage/box/firingpins,
-/obj/item/storage/box/firingpins,
-/obj/item/gun/energy/e_gun/dragnet{
-	pixel_y = 6
-	},
-/obj/item/gun/energy/e_gun/dragnet,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "aFo" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -7934,12 +7932,12 @@
 /turf/open/floor/iron/diagonal,
 /area/station/medical/break_room)
 "bOT" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/closet/ammunitionlocker/useful,
 /obj/item/storage/box/lethalshot,
 /obj/item/storage/box/lethalshot,
 /obj/item/storage/box/lethalshot,
 /obj/item/storage/box/lethalshot,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "bOU" = (
@@ -14718,7 +14716,13 @@
 /area/station/service/hydroponics)
 "dwU" = (
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "dwV" = (
 /obj/machinery/door/firedoor,
@@ -15787,6 +15791,20 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"dLt" = (
+/obj/structure/rack,
+/obj/item/melee/hammer,
+/obj/item/melee/hammer,
+/obj/item/melee/hammer,
+/obj/item/storage/box/firingpins,
+/obj/item/storage/box/firingpins,
+/obj/item/gun/energy/e_gun/dragnet{
+	pixel_y = 6
+	},
+/obj/item/gun/energy/e_gun/dragnet,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "dLu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/delivery,
@@ -21863,6 +21881,14 @@
 /obj/item/pen,
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
+"fjB" = (
+/obj/structure/closet/secure_closet/contraband/armory,
+/obj/machinery/light/directional/east,
+/obj/effect/spawner/random/maintenance/three,
+/obj/effect/spawner/random/contraband/armory,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "fjQ" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27234,7 +27260,6 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
 "gzP" = (
-/obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -27248,6 +27273,7 @@
 /obj/item/gun/energy/disabler{
 	pixel_y = -2
 	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "gzQ" = (
@@ -27740,7 +27766,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "gFK" = (
 /obj/machinery/vending/hydroseeds,
@@ -29136,12 +29168,14 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel)
 "gYv" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/mob/living/simple_animal/bot/secbot/beepsky/armsky,
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/mob/living/simple_animal/bot/secbot/beepsky/armsky,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "gYz" = (
 /obj/structure/cable,
@@ -30585,6 +30619,33 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/aft)
+"hrB" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/bulletproof/old{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/armor/bulletproof/old{
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/armor/bulletproof/old{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet/alt{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/alt{
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/alt{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "hrG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -32898,8 +32959,8 @@
 	pixel_y = -3
 	},
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/item/gun/grenadelauncher,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "hYa" = (
@@ -34843,6 +34904,28 @@
 /obj/structure/table/glass,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"iuT" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/herringbone,
+/area/station/ai_monitored/security/armory)
 "iuU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -36482,8 +36565,8 @@
 	},
 /obj/item/storage/lockbox/loyalty,
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "iRm" = (
@@ -41583,7 +41666,16 @@
 	dir = 1
 	},
 /obj/machinery/holopad,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "jYM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41823,14 +41915,6 @@
 	dir = 1
 	},
 /area/station/medical/morgue)
-"kbM" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/dish_drive/bullet{
-	succrange = 6
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "kbN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -44781,7 +44865,6 @@
 /turf/open/floor/iron,
 /area/station/security/detectives_office/private_investigators_office)
 "kNk" = (
-/obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -44793,6 +44876,7 @@
 /obj/item/gun/energy/e_gun{
 	pixel_y = -7
 	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "kNw" = (
@@ -45229,6 +45313,44 @@
 /obj/effect/turf_decal/tile/neutral/full,
 /turf/open/floor/iron/large,
 /area/station/medical/virology)
+"kSZ" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = -7;
+	pixel_y = -6
+	},
+/obj/item/clothing/suit/armor/riot{
+	pixel_y = -6
+	},
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = 7;
+	pixel_y = -6
+	},
+/obj/item/clothing/head/helmet/toggleable/riot{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/toggleable/riot{
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/toggleable/riot{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/shield/riot{
+	pixel_x = -8;
+	pixel_y = -8
+	},
+/obj/item/shield/riot{
+	pixel_y = -8
+	},
+/obj/item/shield/riot{
+	pixel_x = 8;
+	pixel_y = -8
+	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "kTd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47776,44 +47898,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/theater)
-"lzS" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = -7;
-	pixel_y = -6
-	},
-/obj/item/clothing/suit/armor/riot{
-	pixel_y = -6
-	},
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = 7;
-	pixel_y = -6
-	},
-/obj/item/clothing/head/helmet/toggleable/riot{
-	pixel_x = -6;
-	pixel_y = 8
-	},
-/obj/item/clothing/head/helmet/toggleable/riot{
-	pixel_y = 8
-	},
-/obj/item/clothing/head/helmet/toggleable/riot{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/item/shield/riot{
-	pixel_x = -8;
-	pixel_y = -8
-	},
-/obj/item/shield/riot{
-	pixel_y = -8
-	},
-/obj/item/shield/riot{
-	pixel_x = 8;
-	pixel_y = -8
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "lAg" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -50800,7 +50884,6 @@
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos/pumproom)
 "mnT" = (
-/obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -50812,6 +50895,7 @@
 /obj/item/gun/energy/laser{
 	pixel_y = -7
 	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "mnW" = (
@@ -54842,7 +54926,6 @@
 /area/station/security/brig)
 "nlZ" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/item/radio/intercom/directional/north,
 /obj/item/storage/box/firingpins,
 /obj/item/grenade/barrier{
@@ -54852,6 +54935,7 @@
 /obj/item/grenade/barrier{
 	pixel_x = 6
 	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "nma" = (
@@ -56608,7 +56692,12 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/siding/dark_red,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "nIY" = (
 /obj/machinery/duct,
@@ -59403,10 +59492,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "otJ" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/firealarm/directional/west,
 /obj/structure/closet/secure_closet/smartgun,
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "ouc" = (
@@ -61445,6 +61534,14 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/station/service/chapel)
+"oWx" = (
+/obj/structure/rack,
+/obj/item/gun/energy/ionrifle,
+/obj/item/clothing/suit/hooded/ablative,
+/obj/item/gun/energy/temperature/security,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "oWA" = (
 /obj/structure/bed,
 /obj/item/bedsheet/mime,
@@ -61740,7 +61837,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "pbP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -62265,33 +62365,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/service/theater)
-"phf" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/bulletproof/old{
-	pixel_x = -7;
-	pixel_y = -3
-	},
-/obj/item/clothing/suit/armor/bulletproof/old{
-	pixel_y = -3
-	},
-/obj/item/clothing/suit/armor/bulletproof/old{
-	pixel_x = 7;
-	pixel_y = -3
-	},
-/obj/item/clothing/head/helmet/alt{
-	pixel_x = -7;
-	pixel_y = 6
-	},
-/obj/item/clothing/head/helmet/alt{
-	pixel_y = 6
-	},
-/obj/item/clothing/head/helmet/alt{
-	pixel_x = 7;
-	pixel_y = 6
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "phn" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -64027,7 +64100,7 @@
 /area/station/science/circuits)
 "pDt" = (
 /obj/machinery/flasher/portable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "pDy" = (
@@ -64511,10 +64584,7 @@
 /area/station/cargo/blacksmith)
 "pIX" = (
 /obj/structure/chair/office,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "pJf" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -64673,6 +64743,21 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
+"pKD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/herringbone,
+/area/station/ai_monitored/security/armory)
 "pKM" = (
 /obj/effect/turf_decal/siding/white,
 /obj/effect/turf_decal/tile/neutral{
@@ -65907,6 +65992,45 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel)
+"pYb" = (
+/obj/item/storage/secure/safe/directional/east,
+/obj/structure/rack,
+/obj/item/clothing/glasses/hud/security/sunglasses/redsec{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/glasses/hud/security/sunglasses/redsec{
+	pixel_y = 3
+	},
+/obj/item/clothing/glasses/hud/security/sunglasses/redsec{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/sec/redsec{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/sec/redsec{
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/sec/redsec{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/item/clothing/suit/armor/vest/alt/sec/redsec{
+	pixel_x = -7;
+	pixel_y = -5
+	},
+/obj/item/clothing/suit/armor/vest/alt/sec/redsec{
+	pixel_y = -5
+	},
+/obj/item/clothing/suit/armor/vest/alt/sec/redsec{
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "pYh" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
@@ -67066,6 +67190,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den/gaming)
+"qnm" = (
+/obj/machinery/light/directional/east,
+/obj/machinery/dish_drive/bullet{
+	succrange = 6
+	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "qnr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -67703,33 +67835,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"qwp" = (
-/obj/structure/rack,
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/item/clothing/mask/gas/sechailer{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/mask/gas/sechailer{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/flashlight/seclite{
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/obj/item/flashlight/seclite{
-	pixel_x = 2
-	},
-/obj/item/flashlight/seclite{
-	pixel_x = 2;
-	pixel_y = -7
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "qwv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -72933,14 +73038,6 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/commons/fitness/recreation)
-"rLv" = (
-/obj/structure/rack,
-/obj/item/gun/energy/ionrifle,
-/obj/item/clothing/suit/hooded/ablative,
-/obj/item/gun/energy/temperature/security,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "rLx" = (
 /obj/machinery/status_display/evac/directional/east,
 /obj/structure/chair{
@@ -73212,9 +73309,6 @@
 /area/station/engineering/storage/tech)
 "rOS" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
 /obj/machinery/button/door/directional/south{
 	id = "armouryaccess";
 	name = "Armoury Access";
@@ -73229,6 +73323,7 @@
 	pixel_y = 2
 	},
 /obj/item/key/security,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "rOU" = (
@@ -73824,6 +73919,29 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"rUP" = (
+/obj/structure/rack,
+/obj/item/clothing/head/helmet/sec{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/sec,
+/obj/item/clothing/head/helmet/sec{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/armor/vest/alt/sec{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/armor/vest/alt/sec,
+/obj/item/clothing/suit/armor/vest/alt/sec{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "rUV" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -78621,45 +78739,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/vault,
 /area/station/commons/fitness/recreation)
-"tcw" = (
-/obj/item/storage/secure/safe/directional/east,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/rack,
-/obj/item/clothing/glasses/hud/security/sunglasses/redsec{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/glasses/hud/security/sunglasses/redsec{
-	pixel_y = 3
-	},
-/obj/item/clothing/glasses/hud/security/sunglasses/redsec{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/sec/redsec{
-	pixel_x = -7;
-	pixel_y = 6
-	},
-/obj/item/clothing/head/helmet/sec/redsec{
-	pixel_y = 6
-	},
-/obj/item/clothing/head/helmet/sec/redsec{
-	pixel_x = 7;
-	pixel_y = 6
-	},
-/obj/item/clothing/suit/armor/vest/alt/sec/redsec{
-	pixel_x = -7;
-	pixel_y = -5
-	},
-/obj/item/clothing/suit/armor/vest/alt/sec/redsec{
-	pixel_y = -5
-	},
-/obj/item/clothing/suit/armor/vest/alt/sec/redsec{
-	pixel_x = 7;
-	pixel_y = -5
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "tcx" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -78784,7 +78863,16 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "teA" = (
 /obj/structure/displaycase/captain,
@@ -85383,6 +85471,33 @@
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
+"uKR" = (
+/obj/structure/rack,
+/obj/structure/sign/nanotrasen{
+	pixel_x = 32
+	},
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/flashlight/seclite{
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/obj/item/flashlight/seclite{
+	pixel_x = 2
+	},
+/obj/item/flashlight/seclite{
+	pixel_x = 2;
+	pixel_y = -7
+	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "uKY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -86290,7 +86405,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/dark_red/corner,
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "uVZ" = (
 /obj/structure/cable,
@@ -88612,7 +88732,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/siding/dark_red,
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "vxi" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -92094,9 +92216,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "wow" = (
-/obj/effect/turf_decal/bot,
 /obj/structure/rack/gunrack,
 /obj/effect/spawner/armory_spawn/shotguns,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "wox" = (
@@ -92606,7 +92728,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "wtE" = (
 /obj/effect/landmark/start/hangover,
@@ -94621,7 +94743,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "wTF" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -95716,29 +95841,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
-"xjE" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/item/clothing/head/helmet/sec{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/sec,
-/obj/item/clothing/head/helmet/sec{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/suit/armor/vest/alt/sec{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/suit/armor/vest/alt/sec,
-/obj/item/clothing/suit/armor/vest/alt/sec{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "xjF" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -97812,12 +97914,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "xHR" = (
-/obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/structure/rack/gunrack,
 /obj/effect/spawner/armory_spawn/cmg,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "xHW" = (
@@ -99727,7 +99829,16 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "yhH" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -153659,7 +153770,7 @@ yhE
 yhE
 yhE
 jYK
-vxf
+iuT
 gYv
 cdr
 jhr
@@ -154168,11 +154279,11 @@ jNM
 sRd
 bLs
 aqW
-wTu
+aEs
 wow
-phf
-lzS
-aFl
+hrB
+kSZ
+dLt
 dwU
 wtB
 bLs
@@ -154430,7 +154541,7 @@ teo
 teo
 teo
 teo
-teo
+pKD
 pbN
 bLs
 hEF
@@ -154682,12 +154793,12 @@ aaa
 aad
 bLs
 bLs
-aEs
-xjE
-tcw
-qwp
-rLv
-kbM
+fjB
+rUP
+pYb
+uKR
+oWx
+qnm
 bLs
 bLs
 aaa

--- a/_maps/map_files/IceBoxStation/IceBoxStation_bubber.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_bubber.dmm
@@ -924,13 +924,17 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "apS" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 4
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory/upper)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/siding/dark_red/corner,
+/turf/open/floor/iron/herringbone,
+/area/station/ai_monitored/security/armory)
 "apT" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
@@ -1333,17 +1337,14 @@
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "auT" = (
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/closet/secure_closet/contraband/armory,
-/obj/machinery/firealarm/directional/north,
 /obj/effect/spawner/random/maintenance/three,
 /obj/effect/spawner/random/contraband/armory,
-/obj/effect/turf_decal/tile/red/half{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory/upper)
+/area/station/ai_monitored/security/armory)
 "avb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -1399,10 +1400,15 @@
 /turf/open/openspace,
 /area/station/science/ordnance)
 "awd" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/large,
+/obj/effect/spawner/random/medical/medkit,
+/obj/effect/spawner/random/medical/surgery_tool,
+/obj/item/surgical_drapes,
+/obj/item/grenade/barrier,
+/obj/item/grenade/smokebomb,
 /turf/open/floor/plating,
-/area/station/ai_monitored/security/armory/upper)
+/area/station/security/prison)
 "awh" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -3058,12 +3064,17 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/office)
 "aWk" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "armory";
-	name = "Armory Shutter"
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/brigdoor{
+	name = "Armory Desk";
+	req_access = list("armory")
 	},
-/turf/open/floor/iron,
-/area/station/ai_monitored/security/armory/upper)
+/obj/machinery/door/window/left/directional/north{
+	name = "Armory Desk"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/ai_monitored/security/armory)
 "aWs" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix{
 	dir = 4
@@ -3218,7 +3229,6 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/brig/upper)
 "aZq" = (
@@ -4472,6 +4482,7 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "brx" = (
+/obj/structure/sign/warning,
 /turf/closed/wall,
 /area/station/security/warden)
 "bry" = (
@@ -4625,14 +4636,6 @@
 /obj/item/flashlight/lantern,
 /turf/open/floor/plating,
 /area/mine/eva/lower)
-"btI" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Armory - Internal - Lower"
-	},
-/obj/effect/turf_decal/tile/red/half,
-/obj/structure/closet/secure_closet/smartgun,
-/turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory)
 "btQ" = (
 /obj/machinery/modular_computer/console/preset/curator{
 	dir = 8
@@ -4679,16 +4682,30 @@
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
 "buS" = (
-/obj/effect/turf_decal/tile/red/half{
-	dir = 4
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor/border_only{
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory/upper)
+/obj/effect/turf_decal/siding/dark_red/corner,
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/herringbone,
+/area/station/ai_monitored/security/armory)
 "buW" = (
 /obj/structure/lattice,
 /obj/structure/sign/warning/directional/south,
@@ -6698,8 +6715,22 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "bXy" = (
-/turf/open/openspace,
-/area/station/ai_monitored/security/armory/upper)
+/obj/machinery/light/directional/west,
+/obj/machinery/camera/motion/directional/west{
+	c_tag = "Security - Armory"
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/siding/dark_red/corner,
+/obj/structure/closet/secure_closet/smartgun,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/wall/peppertank/directional/west,
+/turf/open/floor/iron/herringbone,
+/area/station/ai_monitored/security/armory)
 "bXF" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/ai_all,
@@ -8012,9 +8043,11 @@
 /turf/closed/wall,
 /area/station/service/kitchen)
 "cqb" = (
-/obj/effect/turf_decal/tile/red/half,
-/turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory/upper)
+/obj/structure/rack/gunrack,
+/obj/effect/spawner/armory_spawn/cmg,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "cqh" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Library Maintenance"
@@ -8432,9 +8465,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/command/heads_quarters/captain/private/nt_rep)
-"cxO" = (
-/turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory)
 "cxP" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4
@@ -9006,6 +9036,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/north,
+/obj/machinery/vending/wardrobe/sec_wardrobe/red,
 /turf/open/floor/iron/smooth_edge,
 /area/station/security/lockers)
 "cFc" = (
@@ -9299,9 +9330,11 @@
 /turf/open/floor/iron,
 /area/mine/laborcamp)
 "cJi" = (
-/obj/structure/sign/warning,
-/turf/closed/wall/r_wall,
-/area/station/security/warden)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plating,
+/area/station/security/prison)
 "cJs" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -9337,13 +9370,6 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
-"cJO" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/iron/dark/textured,
-/area/station/security/warden)
 "cJY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/sorting/mail{
@@ -9546,13 +9572,15 @@
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
 "cMA" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control"
+/obj/structure/closet/secure_closet/security/sec,
+/obj/structure/cable,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/head/helmet/sec/peacekeeper,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/smooth_edge{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark/textured,
-/area/station/security/warden)
+/area/station/security/lockers)
 "cMI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining/glass{
@@ -9847,10 +9875,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
-"cRg" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/station/security/warden)
 "cRo" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
@@ -10444,6 +10468,10 @@
 /obj/machinery/computer/crew{
 	dir = 8
 	},
+/obj/machinery/computer/security/telescreen/prison{
+	pixel_x = 26;
+	pixel_y = 24
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "dat" = (
@@ -10958,9 +10986,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
-"diC" = (
-/turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory/upper)
 "diH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13377,7 +13402,7 @@
 /turf/open/floor/iron,
 /area/mine/production)
 "dUd" = (
-/obj/structure/closet/secure_closet/warden,
+/obj/machinery/flasher/portable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "dUe" = (
@@ -13777,6 +13802,12 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"eaj" = (
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/obj/vehicle/ridden/secway,
+/obj/item/key/security,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "eaq" = (
 /obj/structure/table,
 /obj/item/paper_bin/carbon,
@@ -15099,9 +15130,8 @@
 	dir = 4
 	},
 /obj/structure/rack/gunrack,
-/obj/effect/spawner/armory_spawn/microfusion,
 /turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory)
+/area/station/security/prison)
 "evk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16362,30 +16392,12 @@
 /turf/open/floor/carpet/green,
 /area/command/heads_quarters/captain/private/nt_rep)
 "eOJ" = (
-/obj/structure/rack,
-/obj/item/clothing/head/helmet/sec{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/sec,
-/obj/item/clothing/head/helmet/sec{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/suit/armor/vest/alt/sec{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/suit/armor/vest/alt/sec,
-/obj/item/clothing/suit/armor/vest/alt/sec{
-	pixel_x = -3;
-	pixel_y = 3
-	},
 /obj/effect/turf_decal/tile/red/half{
 	dir = 8
 	},
+/obj/item/rack_parts,
 /turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory)
+/area/station/security/prison)
 "eOK" = (
 /obj/effect/turf_decal/trimline/neutral/mid_joiner{
 	dir = 4
@@ -17409,8 +17421,18 @@
 /turf/open/floor/carpet/executive,
 /area/command/heads_quarters/captain/private/nt_rep)
 "feJ" = (
-/turf/closed/wall/r_wall,
-/area/station/ai_monitored/security/armory/upper)
+/obj/machinery/door/poddoor/shutters{
+	id = "armory";
+	name = "Armory Shutter"
+	},
+/obj/machinery/button/door/directional/east{
+	id = "armory";
+	name = "Armory Shutters";
+	pixel_x = 22;
+	req_access = list("armory")
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/ai_monitored/security/armory)
 "feQ" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -17775,29 +17797,20 @@
 /turf/open/floor/iron/white,
 /area/mine/living_quarters)
 "fjW" = (
-/obj/machinery/button/door/directional/east{
-	id = "armory";
-	name = "Armory Shutters";
-	pixel_x = -9;
-	pixel_y = 30;
-	req_access = list("armory")
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 8
 	},
-/obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/tile/red/half{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory/upper)
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/turf/open/floor/iron/herringbone,
+/area/station/ai_monitored/security/armory)
 "fkj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -18915,9 +18928,6 @@
 	pixel_y = -3;
 	req_access = list("brig")
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
 	},
@@ -18951,6 +18961,7 @@
 /area/station/medical/medbay/lobby)
 "fCW" = (
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/processing)
 "fDc" = (
@@ -19485,10 +19496,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
-"fLs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall/r_wall,
-/area/station/ai_monitored/security/armory/upper)
 "fLP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 10
@@ -20613,15 +20620,22 @@
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "gbJ" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Armory"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory/upper)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/turf/open/floor/iron/herringbone,
+/area/station/ai_monitored/security/armory)
 "gbK" = (
 /obj/machinery/ticket_machine/directional/east,
 /obj/effect/turf_decal/tile/blue,
@@ -21508,7 +21522,7 @@
 "grh" = (
 /obj/machinery/vending/security,
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron/smooth_edge,
+/turf/open/floor/iron/smooth,
 /area/station/security/lockers)
 "grk" = (
 /obj/structure/cable,
@@ -22067,10 +22081,6 @@
 	dir = 1
 	},
 /area/station/service/hydroponics)
-"gAR" = (
-/obj/structure/falsewall,
-/turf/open/floor/plating,
-/area/station/security/prison)
 "gAY" = (
 /obj/structure/sign/warning/cold_temp/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22579,8 +22589,8 @@
 /area/station/science/lab)
 "gIk" = (
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory)
+/turf/open/floor/plating,
+/area/station/security/prison)
 "gIl" = (
 /obj/structure/fence/corner{
 	dir = 6
@@ -23013,13 +23023,17 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/armory,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/ai_monitored/security/armory/upper)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured,
+/area/station/ai_monitored/security/armory)
 "gPp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/machinery/light_switch/directional/south,
+/obj/item/radio/intercom/prison/directional/south{
+	pixel_y = -40
+	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "gPE" = (
@@ -24696,19 +24710,24 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "hqS" = (
-/obj/structure/railing,
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun/dragnet{
-	pixel_y = 4
+/obj/structure/rack/gunrack,
+/obj/item/storage/box/teargas{
+	pixel_y = -4
 	},
-/obj/item/gun/energy/e_gun/dragnet,
-/obj/effect/turf_decal/tile/red/half{
-	dir = 1
+/obj/item/storage/box/flashbangs{
+	pixel_y = 3
 	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory/upper)
+/obj/item/gun/grenadelauncher{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/gun/energy/temperature/security,
+/obj/item/gun/energy/ionrifle{
+	pixel_y = -8
+	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "hqV" = (
 /obj/structure/sign/warning/radiation/rad_area,
 /turf/closed/wall/r_wall,
@@ -25019,12 +25038,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
 "hvR" = (
-/obj/machinery/recharger,
-/obj/structure/table,
 /obj/effect/turf_decal/tile/red/half,
-/obj/machinery/light/directional/north,
+/obj/structure/table_frame,
+/obj/item/stack/sheet/iron,
 /turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory)
+/area/station/security/prison)
 "hvS" = (
 /obj/effect/landmark/start/depsec/engineering,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -25587,9 +25605,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "hEC" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/obj/machinery/light/directional/south,
 /obj/machinery/light_switch/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -25598,14 +25613,14 @@
 	},
 /area/station/security/lockers)
 "hEG" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/security/glass{
+	name = "Armory"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/warden)
 "hEI" = (
@@ -26744,13 +26759,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
-"hYu" = (
-/obj/machinery/light/directional/west,
-/obj/machinery/camera/motion/directional/south{
-	c_tag = "Armory - Internal - Upper"
-	},
-/turf/open/openspace,
-/area/station/ai_monitored/security/armory/upper)
 "hYy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -27350,7 +27358,17 @@
 /area/station/engineering/atmos)
 "igB" = (
 /obj/machinery/firealarm/directional/west,
-/turf/open/floor/glass,
+/obj/structure/rack,
+/obj/item/storage/barricade{
+	pixel_y = 5
+	},
+/obj/item/storage/barricade,
+/obj/item/storage/barricade{
+	pixel_y = -5
+	},
+/turf/open/floor/iron/smooth_edge{
+	dir = 4
+	},
 /area/station/security/lockers)
 "igL" = (
 /obj/effect/turf_decal/stripes/box,
@@ -27402,13 +27420,20 @@
 /turf/open/floor/iron,
 /area/station/science/explab)
 "ihx" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Armory"
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun{
+	pixel_y = 7
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/armory,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory/upper)
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun{
+	pixel_y = -7
+	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "ihz" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/recharge_floor,
@@ -28310,19 +28335,14 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "iuS" = (
-/obj/machinery/airalarm/directional/north,
-/obj/structure/rack,
-/obj/item/gun/energy/disabler{
-	pixel_y = 6
-	},
-/obj/item/gun/energy/disabler{
-	pixel_y = 2
-	},
-/obj/item/gun/energy/disabler{
-	pixel_y = -2
-	},
-/turf/open/floor/glass/reinforced,
-/area/station/ai_monitored/security/armory/upper)
+/obj/machinery/light/directional/north,
+/obj/structure/closet/ammunitionlocker/useful,
+/obj/item/storage/box/rubbershot,
+/obj/item/storage/box/rubbershot,
+/obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark/textured,
+/area/station/ai_monitored/security/armory)
 "ivj" = (
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/plating,
@@ -28455,10 +28475,8 @@
 /turf/open/floor/iron/large,
 /area/station/engineering/main)
 "ixV" = (
-/obj/structure/bed/dogbed/mcgriff,
-/obj/item/food/beef_wellington_slice,
 /obj/structure/cable,
-/mob/living/basic/pet/dog/pug/mcgriff,
+/obj/machinery/flasher/portable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "ixZ" = (
@@ -28738,12 +28756,17 @@
 	},
 /area/station/science/explab)
 "iCa" = (
-/obj/machinery/light/directional/north,
-/obj/structure/rack/gunrack,
-/obj/effect/spawner/armory_spawn/cmg,
 /obj/effect/turf_decal/tile/red/half,
+/obj/structure/table,
+/obj/machinery/computer/arcade/orion_trail{
+	desc = "For gamers only. Casuals need not apply.";
+	icon_screen = "library";
+	icon_state = "oldcomp";
+	name = "Gamer Computer";
+	pixel_y = 8
+	},
 /turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory)
+/area/station/security/prison)
 "iCg" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -31379,16 +31402,6 @@
 /obj/structure/transit_tube/crossing/horizontal,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"jqB" = (
-/obj/structure/railing,
-/obj/machinery/flasher/portable,
-/obj/effect/turf_decal/tile/red/half{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory/upper)
 "jqE" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -31877,15 +31890,12 @@
 /area/station/service/bar)
 "jyM" = (
 /obj/structure/rack,
-/obj/item/gun/energy/ionrifle,
-/obj/item/gun/energy/temperature/security,
-/obj/item/clothing/suit/hooded/ablative,
 /obj/effect/turf_decal/tile/red/half{
 	dir = 8
 	},
-/obj/item/gun/grenadelauncher,
+/obj/effect/spawner/random/contraband/narcotics,
 /turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory)
+/area/station/security/prison)
 "jyR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -31970,11 +31980,22 @@
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "jAk" = (
+/obj/structure/rack,
+/obj/item/gun/energy/disabler{
+	pixel_y = 6
+	},
+/obj/item/gun/energy/disabler{
+	pixel_y = 2
+	},
+/obj/item/gun/energy/disabler{
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/textured,
-/area/station/security/warden)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "jAu" = (
 /obj/structure/rack,
 /obj/structure/cable,
@@ -32557,8 +32578,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "jJM" = (
-/turf/open/floor/glass,
-/area/station/security/lockers)
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/siding/dark_red,
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/iron/herringbone,
+/area/station/ai_monitored/security/armory)
 "jJU" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/effect/turf_decal/tile/blue/opposingcorners,
@@ -33364,19 +33391,15 @@
 /area/mine/laborcamp)
 "jUn" = (
 /obj/structure/table,
-/obj/item/folder/red{
-	pixel_x = 7;
-	pixel_y = 6
-	},
-/obj/item/folder/red{
-	pixel_x = 7;
-	pixel_y = 7
-	},
 /obj/item/storage/box/evidence{
 	pixel_x = -6;
 	pixel_y = 9
 	},
-/obj/item/radio/intercom/directional/north,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/recharger{
+	pixel_x = 6;
+	pixel_y = 2
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "jUr" = (
@@ -34036,6 +34059,7 @@
 /area/station/engineering/atmos)
 "kfy" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/brig/upper)
 "kfz" = (
@@ -34776,6 +34800,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"krM" = (
+/obj/machinery/holopad,
+/turf/open/floor/iron/herringbone,
+/area/station/ai_monitored/security/armory)
 "krQ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -35061,6 +35089,13 @@
 "kvI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
+	},
+/obj/structure/rack,
+/obj/item/gun/energy/laser/practice{
+	pixel_y = 5
+	},
+/obj/item/gun/energy/laser/practice{
+	pixel_y = -5
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
@@ -35821,17 +35856,6 @@
 /obj/structure/flora/bush/jungle/a/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
-"kIa" = (
-/obj/item/gun/energy/laser/practice{
-	pixel_y = 5
-	},
-/obj/item/gun/energy/laser/practice,
-/obj/item/gun/energy/laser/practice{
-	pixel_y = -5
-	},
-/obj/structure/rack,
-/turf/open/floor/iron/dark/textured,
-/area/station/security/office)
 "kIi" = (
 /obj/machinery/door/airlock{
 	name = "Perma Overlook Entrance"
@@ -35958,14 +35982,22 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "kJO" = (
-/obj/structure/table,
-/obj/item/storage/box/firingpins,
-/obj/item/storage/box/firingpins,
-/obj/item/key/security,
 /obj/machinery/light/directional/east,
 /obj/item/radio/intercom/prison/directional/east,
+/obj/structure/cable,
+/obj/structure/table,
+/obj/item/storage/box/firingpins{
+	pixel_x = -7;
+	pixel_y = 12
+	},
+/obj/item/storage/box/firingpins{
+	pixel_x = 7;
+	pixel_y = 12
+	},
+/obj/item/storage/lockbox/loyalty,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory/upper)
+/area/station/ai_monitored/security/armory)
 "kJP" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -36798,21 +36830,13 @@
 /area/station/maintenance/fore/lesser)
 "kUj" = (
 /obj/structure/rack,
-/obj/item/storage/box/teargas{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/handcuffs,
-/obj/item/storage/box/flashbangs{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/effect/turf_decal/tile/red/half{
 	dir = 8
 	},
-/obj/item/storage/toolbox/drone,
+/obj/item/modular_computer/pda/clear,
+/obj/item/modular_computer/pda/clear,
 /turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory)
+/area/station/security/prison)
 "kUu" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 4
@@ -38078,14 +38102,15 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/central/lesser)
 "lok" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 6
 	},
-/turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory/upper)
+/turf/open/floor/iron/herringbone,
+/area/station/ai_monitored/security/armory)
 "lop" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -38655,8 +38680,14 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/treatment_center)
 "lyG" = (
-/turf/open/floor/glass/reinforced,
-/area/station/ai_monitored/security/armory/upper)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
+/turf/open/floor/iron/herringbone,
+/area/station/ai_monitored/security/armory)
 "lyH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible/layer2,
@@ -39876,14 +39907,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "lTN" = (
-/obj/structure/table,
-/obj/machinery/recharger,
 /obj/machinery/light/directional/south,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
-/turf/open/floor/iron/smooth_edge{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_x = -6;
+	pixel_y = 2
 	},
+/obj/machinery/recharger{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/turf/open/floor/iron/smooth,
 /area/station/security/lockers)
 "lUb" = (
 /obj/machinery/door/firedoor,
@@ -42413,9 +42449,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/computer/security/telescreen/prison{
-	pixel_y = 32
-	},
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "mNE" = (
@@ -43461,6 +43495,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
+"ndm" = (
+/obj/machinery/space_heater,
+/turf/open/floor/iron/dark/textured,
+/area/station/security/processing)
 "ndu" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -44788,37 +44826,13 @@
 /area/station/maintenance/solars/port/aft)
 "nxy" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/head/helmet/toggleable/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/toggleable/riot,
-/obj/item/clothing/head/helmet/toggleable/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/shield/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/shield/riot,
-/obj/item/shield/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/effect/turf_decal/tile/red/half,
 /obj/machinery/airalarm/directional/north,
+/obj/effect/spawner/random/decoration/carpet,
+/obj/effect/spawner/random/decoration/carpet,
+/obj/effect/spawner/random/decoration/carpet,
 /turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory)
+/area/station/security/prison)
 "nxM" = (
 /turf/closed/wall,
 /area/station/maintenance/department/medical/morgue)
@@ -46822,6 +46836,17 @@
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/white,
 /area/station/cargo/miningdock)
+"nYi" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/herringbone,
+/area/station/ai_monitored/security/armory)
 "nYn" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet,
@@ -46920,13 +46945,16 @@
 /obj/machinery/computer/secure_data{
 	dir = 1
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "oaw" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Security - Equipment Room"
 	},
-/turf/open/floor/glass/reinforced,
+/turf/open/floor/iron/smooth_edge{
+	dir = 4
+	},
 /area/station/security/lockers)
 "oaG" = (
 /obj/effect/turf_decal/tile/dark{
@@ -47935,11 +47963,10 @@
 /turf/open/floor/iron/kitchen/small,
 /area/station/security/prison/mess)
 "oqb" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/station/security/prison)
 "oqc" = (
 /obj/effect/turf_decal/trimline/dark_green/arrow_ccw{
 	dir = 4
@@ -50363,9 +50390,20 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/execution/transfer)
 "pdK" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory/upper)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/herringbone,
+/area/station/ai_monitored/security/armory)
 "pdO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/engine,
@@ -50557,11 +50595,9 @@
 	},
 /area/icemoon/underground/explored)
 "pgL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory)
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/station/security/prison)
 "pgN" = (
 /obj/item/organ/external/tail/monkey,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -51883,10 +51919,6 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/maintenance/disposal/incinerator)
-"pBN" = (
-/obj/structure/flora/tree/jungle/small/style_random,
-/turf/open/floor/grass,
-/area/station/security/warden)
 "pBV" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/iron/dark,
@@ -52487,13 +52519,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"pLT" = (
-/obj/machinery/space_heater,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/security/warden)
 "pMg" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
@@ -52766,9 +52791,17 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "pPK" = (
-/obj/structure/stairs/east,
-/turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory)
+/obj/structure/closet/crate/large,
+/obj/item/seeds/bamboo,
+/obj/item/seeds/kiri,
+/obj/item/seeds/wheat/meat,
+/obj/effect/spawner/random/contraband/permabrig_gear,
+/obj/item/instrument/eguitar,
+/obj/item/secateurs,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/security/prison)
 "pPN" = (
 /obj/machinery/porta_turret/ai{
 	dir = 8
@@ -52951,6 +52984,10 @@
 "pSz" = (
 /turf/open/openspace,
 /area/station/maintenance/starboard/upper)
+"pSY" = (
+/obj/structure/cable,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "pTd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -53011,8 +53048,20 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark/textured,
-/area/station/security/warden)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/turf/open/floor/iron/herringbone,
+/area/station/ai_monitored/security/armory)
 "pTU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/corner{
@@ -53059,19 +53108,32 @@
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "pUK" = (
-/obj/item/grenade/barrier{
-	pixel_x = 4
+/obj/structure/rack,
+/obj/item/melee/hammer{
+	pixel_x = -7
 	},
-/obj/item/grenade/barrier,
-/obj/item/grenade/barrier{
-	pixel_x = -4
+/obj/item/melee/hammer,
+/obj/item/melee/hammer{
+	pixel_x = 7
 	},
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red/half{
-	dir = 8
+/obj/item/melee/baton/security/loaded{
+	pixel_x = -7
 	},
-/turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory/upper)
+/obj/item/melee/baton/security/loaded,
+/obj/item/melee/baton/security/loaded{
+	pixel_x = 7
+	},
+/obj/item/flashlight/seclite{
+	pixel_x = 2
+	},
+/obj/item/flashlight/seclite{
+	pixel_x = 2;
+	pixel_y = -7
+	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "pUN" = (
 /obj/structure/chair/stool/directional/south,
 /obj/machinery/flasher/directional/west{
@@ -54010,7 +54072,6 @@
 /area/station/construction)
 "qlw" = (
 /obj/machinery/disposal/bin,
-/obj/item/radio/intercom/prison/directional/north,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/camera/directional/north{
 	c_tag = "Warden's Office"
@@ -54418,12 +54479,32 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "qsn" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/bulletproof/old{
+	pixel_x = -7;
+	pixel_y = -3
 	},
-/obj/structure/flora/bush/sunny/style_random,
-/turf/open/floor/grass,
-/area/station/security/warden)
+/obj/item/clothing/suit/armor/bulletproof/old{
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/armor/bulletproof/old{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet/alt{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/alt{
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/alt{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "qsu" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil,
@@ -54531,17 +54612,8 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "qum" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/brigdoor{
-	name = "Armory Desk";
-	req_access = list("armory")
-	},
-/obj/machinery/door/window/left/directional/north{
-	name = "Armory Desk"
-	},
-/turf/open/floor/iron,
-/area/station/ai_monitored/security/armory/upper)
+/turf/closed/wall/r_wall,
+/area/station/ai_monitored/security/armory)
 "quB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -56707,7 +56779,6 @@
 	pixel_x = -4;
 	pixel_y = -6
 	},
-/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "ras" = (
@@ -58926,6 +58997,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
+"rMX" = (
+/obj/structure/rack/gunrack,
+/obj/effect/spawner/armory_spawn/shotguns,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "rMY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -59377,13 +59455,9 @@
 /obj/effect/turf_decal/tile/red/half{
 	dir = 8
 	},
-/obj/structure/closet/ammunitionlocker/useful,
-/obj/item/storage/box/lethalshot,
-/obj/item/storage/box/lethalshot,
-/obj/item/storage/box/lethalshot,
-/obj/item/storage/box/lethalshot,
+/obj/structure/closet,
 /turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory)
+/area/station/security/prison)
 "rUo" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -60387,31 +60461,10 @@
 /area/station/engineering/atmos/pumproom)
 "sjv" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/suit/armor/bulletproof,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/effect/turf_decal/tile/red/half,
+/obj/item/radio/headset,
 /turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory)
+/area/station/security/prison)
 "sjX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -61072,6 +61125,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/security/sec,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/head/helmet/sec/peacekeeper,
 /turf/open/floor/iron/smooth_edge{
 	dir = 1
 	},
@@ -61197,8 +61253,20 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/textured,
-/area/station/security/warden)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/turf/open/floor/iron/herringbone,
+/area/station/ai_monitored/security/armory)
 "svP" = (
 /obj/machinery/light/directional/south,
 /obj/structure/disposalpipe/segment{
@@ -62479,16 +62547,6 @@
 /turf/open/floor/iron/large,
 /area/station/engineering/main)
 "sPK" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_x = -6
-	},
-/obj/machinery/button/door{
-	id = "BrigLock";
-	name = "Cell Shutters";
-	pixel_x = 7;
-	pixel_y = 9
-	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "sPV" = (
@@ -62659,6 +62717,16 @@
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/port/fore)
+"sTo" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/turf/open/floor/iron/herringbone,
+/area/station/ai_monitored/security/armory)
 "sTO" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restroom"
@@ -63438,9 +63506,8 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/science/genetics)
 "tgP" = (
-/mob/living/simple_animal/bot/secbot/beepsky/armsky,
-/turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory)
+/turf/open/floor/plating,
+/area/station/security/prison)
 "thD" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
@@ -64230,7 +64297,14 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "tuc" = (
-/turf/closed/wall,
+/obj/structure/rack,
+/obj/item/clothing/suit/hooded/ablative,
+/obj/item/gun/energy/e_gun/dragnet{
+	pixel_y = 6
+	},
+/obj/item/gun/energy/e_gun/dragnet,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
 "tue" = (
 /turf/closed/wall,
@@ -64371,9 +64445,8 @@
 	dir = 4
 	},
 /obj/structure/rack/gunrack,
-/obj/effect/spawner/armory_spawn/shotguns,
 /turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory)
+/area/station/security/prison)
 "tvX" = (
 /obj/effect/landmark/start/depsec/engineering,
 /obj/structure/cable,
@@ -64417,23 +64490,10 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "twP" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_x = -6
-	},
-/obj/machinery/button/door{
-	id = "Secure Gate";
-	name = "Cell Shutters";
-	pixel_x = 7;
-	pixel_y = 9
-	},
-/obj/machinery/button/door{
-	id = "Prison Gate";
-	name = "Prison Wing Lockdown";
-	pixel_x = 7;
-	req_access = list("brig")
-	},
 /obj/structure/cable,
+/obj/structure/bed/dogbed/mcgriff,
+/obj/item/food/beef_wellington_slice,
+/mob/living/basic/pet/dog/pug/mcgriff,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "twU" = (
@@ -64953,12 +65013,15 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
 "tDL" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory/upper)
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 5
+	},
+/turf/open/floor/iron/herringbone,
+/area/station/ai_monitored/security/armory)
 "tDN" = (
 /obj/structure/chair{
 	name = "Defense"
@@ -65140,7 +65203,24 @@
 /obj/machinery/computer/prisoner/management{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/south,
+/obj/machinery/button/door{
+	id = "BrigLock";
+	name = "Cell Shutters";
+	pixel_x = -11;
+	pixel_y = -23
+	},
+/obj/machinery/button/door{
+	id = "Prison Gate";
+	name = "Prison Wing Lockdown";
+	pixel_y = -23;
+	req_access = list("brig")
+	},
+/obj/machinery/button/door{
+	id = "Secure Gate";
+	name = "Cell Shutters";
+	pixel_x = 11;
+	pixel_y = -23
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "tGr" = (
@@ -67803,6 +67883,47 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/cargo/office)
+"uvg" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = -7;
+	pixel_y = -6
+	},
+/obj/item/clothing/suit/armor/riot{
+	pixel_y = -6
+	},
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = 7;
+	pixel_y = -6
+	},
+/obj/item/clothing/head/helmet/toggleable/riot{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/toggleable/riot{
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/toggleable/riot{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/shield/riot{
+	pixel_x = -8;
+	pixel_y = -8
+	},
+/obj/item/shield/riot{
+	pixel_y = -8
+	},
+/obj/item/shield/riot{
+	pixel_x = 8;
+	pixel_y = -8
+	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "uvi" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68120,12 +68241,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"uBs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory)
 "uBt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -68565,6 +68680,12 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
+"uIu" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/dark_red,
+/turf/open/floor/iron/herringbone,
+/area/station/ai_monitored/security/armory)
 "uIx" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
@@ -70766,21 +70887,26 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "vrS" = (
+/obj/structure/cable,
 /obj/structure/table,
+/obj/item/storage/box/trackimp{
+	pixel_x = -7;
+	pixel_y = 5
+	},
 /obj/item/storage/box/chemimp{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/item/grenade/barrier{
+	pixel_x = -6
+	},
+/obj/item/grenade/barrier,
+/obj/item/grenade/barrier{
 	pixel_x = 6
 	},
-/obj/item/storage/box/trackimp{
-	pixel_x = -3
-	},
-/obj/item/storage/lockbox/loyalty,
-/obj/effect/turf_decal/tile/red/half{
-	dir = 1
-	},
-/obj/machinery/light_switch/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory/upper)
+/area/station/ai_monitored/security/armory)
 "vrX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -71362,6 +71488,9 @@
 /obj/item/book/manual/wiki/security_space_law{
 	pixel_x = -4;
 	pixel_y = 5
+	},
+/obj/machinery/light_switch/directional/south{
+	pixel_x = 20
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
@@ -73731,6 +73860,7 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "wkr" = (
+/obj/structure/closet/secure_closet/warden,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "wks" = (
@@ -75373,8 +75503,25 @@
 /area/station/science/ordnance/burnchamber)
 "wHe" = (
 /obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory/upper)
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red,
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/herringbone,
+/area/station/ai_monitored/security/armory)
 "wHg" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/trimline/yellow/warning{
@@ -76022,7 +76169,9 @@
 /area/station/maintenance/aft/greater)
 "wRs" = (
 /obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/glass/reinforced,
+/turf/open/floor/iron/smooth_edge{
+	dir = 4
+	},
 /area/station/security/lockers)
 "wRx" = (
 /obj/structure/cable,
@@ -76477,8 +76626,18 @@
 /turf/open/floor/plating,
 /area/station/security/courtroom)
 "wZj" = (
-/turf/open/floor/iron/dark/textured,
-/area/station/security/warden)
+/obj/structure/rack,
+/obj/item/gun/energy/laser{
+	pixel_y = 7
+	},
+/obj/item/gun/energy/laser,
+/obj/item/gun/energy/laser{
+	pixel_y = -7
+	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "wZp" = (
 /obj/item/storage/toolbox/electrical{
 	pixel_x = 4;
@@ -76606,12 +76765,10 @@
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "xaH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/ai_monitored/security/armory)
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "xaI" = (
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
@@ -77761,11 +77918,11 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal)
 "xsQ" = (
-/obj/vehicle/ridden/secway,
-/obj/effect/turf_decal/tile/red/half,
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/obj/machinery/flasher/portable,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory/upper)
+/area/station/ai_monitored/security/armory)
 "xtc" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
@@ -77874,9 +78031,9 @@
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "xuA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/station/security/prison)
 "xuJ" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 4
@@ -79488,12 +79645,44 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "xVx" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/rack,
+/obj/item/clothing/glasses/hud/security/sunglasses/redsec{
+	pixel_x = -3;
+	pixel_y = 3
 	},
+/obj/item/clothing/glasses/hud/security/sunglasses/redsec{
+	pixel_y = 3
+	},
+/obj/item/clothing/glasses/hud/security/sunglasses/redsec{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/sec/redsec{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/sec/redsec{
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/sec/redsec{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/item/clothing/suit/armor/vest/alt/sec/redsec{
+	pixel_x = -7;
+	pixel_y = -5
+	},
+/obj/item/clothing/suit/armor/vest/alt/sec/redsec{
+	pixel_y = -5
+	},
+/obj/item/clothing/suit/armor/vest/alt/sec/redsec{
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/station/security/warden)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "xVB" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -80157,10 +80346,10 @@
 /turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "yfs" = (
-/obj/machinery/flasher/portable,
-/obj/effect/turf_decal/tile/red/half,
-/turf/open/floor/iron/dark/textured,
-/area/station/ai_monitored/security/armory/upper)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/ai_monitored/security/armory)
 "yfF" = (
 /obj/structure/flora/grass/green/style_random,
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -80345,8 +80534,12 @@
 	},
 /area/station/medical/medbay/central)
 "yiL" = (
-/turf/closed/wall/r_wall,
-/area/station/ai_monitored/security/armory)
+/obj/effect/spawner/random/structure/girder{
+	loot = list(/obj/structure/falsewall = 50, /turf/closed/wall = 50);
+	name = "falsewall or wall spawner"
+	},
+/turf/open/floor/plating,
+/area/station/security/prison)
 "yjh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -171073,7 +171266,7 @@ mlX
 oVY
 nyP
 tVf
-gAR
+yiL
 lgK
 dSJ
 nKL
@@ -171329,7 +171522,7 @@ cIc
 xtz
 oVY
 pez
-tVf
+yiL
 izn
 lgK
 pfn
@@ -171586,13 +171779,13 @@ cIc
 kqn
 oVY
 pez
+tVf
 yiL
-yiL
-yiL
-yiL
-yiL
-yiL
-yiL
+mMM
+mMM
+mMM
+mMM
+mMM
 eDq
 eGz
 dAZ
@@ -171843,13 +172036,13 @@ cIc
 dHw
 qhS
 jaW
-yiL
+tVf
 sjv
 oqb
-uBs
-uBs
-uBs
-xaH
+xuA
+cJi
+tgP
+mMM
 fCd
 nDp
 ubo
@@ -172100,13 +172293,13 @@ xEI
 oZR
 oVY
 pez
-yiL
+tVf
 nxy
-cxO
 xuA
-tuc
+xuA
+tVf
 pPK
-yiL
+mMM
 dOF
 nSk
 bSk
@@ -172359,11 +172552,11 @@ oVY
 pez
 yiL
 hvR
-cxO
-xuA
-tuc
-tuc
-yiL
+pgL
+awd
+tVf
+tVf
+mMM
 pRB
 cGl
 hgM
@@ -172614,13 +172807,13 @@ vVH
 mlX
 oVY
 pez
-yiL
+tVf
 iCa
-cxO
 xuA
+tgP
 tvS
 evj
-yiL
+mMM
 qLD
 bbY
 hgM
@@ -172871,13 +173064,13 @@ vVH
 sFu
 oVY
 vHU
-yiL
-btI
+tVf
+iCa
 tgP
 pgL
-cxO
+xuA
 gIk
-yiL
+mMM
 aym
 iti
 hgM
@@ -173128,13 +173321,13 @@ vVH
 xtz
 oVY
 pez
-yiL
-yiL
+tVf
+tVf
 kUj
 eOJ
 rUl
 jyM
-yiL
+mMM
 szz
 rnb
 hgM
@@ -173385,13 +173578,13 @@ vVH
 kqn
 oVY
 tjC
+tVf
+tVf
+tVf
+tVf
+tVf
 yiL
-yiL
-yiL
-yiL
-yiL
-yiL
-yiL
+mMM
 xHE
 xHE
 hgM
@@ -236102,7 +236295,7 @@ bln
 rwt
 lBD
 ntK
-bln
+xaH
 tCj
 xAs
 xAs
@@ -236353,13 +236546,13 @@ bDu
 bDu
 bDu
 xAs
-xAs
-bln
-bln
-lSu
-bln
-bln
-bln
+xaH
+xaH
+xaH
+xaH
+xaH
+xaH
+xaH
 lSu
 cuq
 itE
@@ -236610,7 +236803,7 @@ wRs
 lTN
 bDu
 dvl
-cuq
+pSY
 jRS
 jRS
 dlt
@@ -236862,12 +237055,12 @@ tGr
 bDu
 jgG
 mAe
-jJM
+mAe
 mAe
 dfz
 dnX
 bln
-abb
+pSY
 tDg
 tDg
 ooL
@@ -237119,19 +237312,19 @@ tGr
 bDu
 nGU
 mAe
-jJM
 mAe
-dfz
-feJ
-feJ
-awd
-awd
-awd
-feJ
-feJ
-kyy
-kyy
-cJi
+mAe
+cMA
+bDu
+lSu
+lSu
+lSu
+lSu
+lSu
+lSu
+lSu
+lSu
+lSu
 abb
 oFI
 gnZ
@@ -237376,18 +237569,18 @@ lbc
 bDu
 jgG
 mAe
-jJM
+mAe
 mAe
 stt
 qum
-diC
+qum
 yfs
-lyG
-jqB
-hYu
-feJ
-cRg
-pBN
+yfs
+yfs
+qum
+yfs
+yfs
+yfs
 brx
 kyy
 kyy
@@ -237633,19 +237826,19 @@ lbc
 bDu
 cFb
 mAe
-jJM
+mAe
 mAe
 uVP
 aWk
-diC
+jJM
 cqb
-lyG
+rMX
 hqS
 bXy
-feJ
+uvg
 xVx
 qsn
-brx
+kyy
 rai
 twP
 sPK
@@ -237896,7 +238089,7 @@ hEC
 feJ
 fjW
 pdK
-lyG
+sTo
 apS
 buS
 gbJ
@@ -238150,16 +238343,16 @@ qkL
 cLD
 qkL
 hGH
-feJ
+qum
 iuS
 lyG
-lyG
-lyG
-lyG
+krM
+uIu
+eaj
 ihx
 wZj
 jAk
-cMA
+kyy
 wkr
 eRO
 ven
@@ -238407,15 +238600,15 @@ vDS
 ijj
 uLV
 weT
-feJ
+qum
 auT
 tDL
-lyG
+nYi
 lok
 pUK
-feJ
-pLT
-cJO
+qum
+yfs
+yfs
 iDq
 jUn
 eRO
@@ -238664,16 +238857,16 @@ omk
 omk
 jeF
 ctE
-feJ
-feJ
+qum
+tuc
 xsQ
 wHe
 vrS
 kJO
-feJ
+yfs
 uGr
 uGr
-iDq
+kyy
 qlw
 cFZ
 uaP
@@ -238921,16 +239114,16 @@ egm
 rzr
 wGW
 tJN
-kIa
-feJ
-feJ
+qum
+qum
+qum
 gPn
-fLs
-feJ
-feJ
+qum
+qum
+qum
 uGr
 uGr
-iDq
+kyy
 mNj
 lAL
 gPp
@@ -243295,7 +243488,7 @@ bln
 sEB
 ykw
 rVy
-lEj
+ndm
 fCW
 nUg
 dKP

--- a/_maps/map_files/IceBoxStation/IceBoxStation_bubber.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_bubber.dmm
@@ -13488,6 +13488,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/locker)
+"dVk" = (
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/obj/vehicle/ridden/secway,
+/obj/item/key/security,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "dVq" = (
 /obj/machinery/space_heater,
 /obj/structure/sign/poster/random/directional/east,
@@ -13802,12 +13808,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"eaj" = (
-/obj/effect/turf_decal/tile/dark_red/fourcorners,
-/obj/vehicle/ridden/secway,
-/obj/item/key/security,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "eaq" = (
 /obj/structure/table,
 /obj/item/paper_bin/carbon,
@@ -14483,6 +14483,12 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
+"ekF" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/dark_red,
+/turf/open/floor/iron/herringbone,
+/area/station/ai_monitored/security/armory)
 "elf" = (
 /obj/machinery/rnd/production/circuit_imprinter/department/science,
 /obj/machinery/button/door/directional/north{
@@ -18319,6 +18325,16 @@
 "fsv" = (
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"fsx" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/turf/open/floor/iron/herringbone,
+/area/station/ai_monitored/security/armory)
 "fsF" = (
 /obj/effect/spawner/structure/window,
 /obj/effect/mapping_helpers/broken_floor,
@@ -28511,6 +28527,10 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
+"iyi" = (
+/obj/machinery/space_heater,
+/turf/open/floor/iron/dark/textured,
+/area/station/security/processing)
 "iyE" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
 	dir = 4
@@ -34800,10 +34820,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"krM" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron/herringbone,
-/area/station/ai_monitored/security/armory)
 "krQ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -38851,6 +38867,47 @@
 	dir = 10
 	},
 /area/station/science/research)
+"lAW" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = -7;
+	pixel_y = -6
+	},
+/obj/item/clothing/suit/armor/riot{
+	pixel_y = -6
+	},
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = 7;
+	pixel_y = -6
+	},
+/obj/item/clothing/head/helmet/toggleable/riot{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/toggleable/riot{
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/toggleable/riot{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/shield/riot{
+	pixel_x = -8;
+	pixel_y = -8
+	},
+/obj/item/shield/riot{
+	pixel_y = -8
+	},
+/obj/item/shield/riot{
+	pixel_x = 8;
+	pixel_y = -8
+	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "lBb" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/vending/autodrobe,
@@ -38930,6 +38987,10 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"lCa" = (
+/obj/machinery/holopad,
+/turf/open/floor/iron/herringbone,
+/area/station/ai_monitored/security/armory)
 "lCb" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/cable,
@@ -40683,6 +40744,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
+"mhi" = (
+/obj/structure/rack/gunrack,
+/obj/effect/spawner/armory_spawn/shotguns,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "mhq" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
@@ -43495,10 +43563,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
-"ndm" = (
-/obj/machinery/space_heater,
-/turf/open/floor/iron/dark/textured,
-/area/station/security/processing)
 "ndu" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -46836,17 +46900,6 @@
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/white,
 /area/station/cargo/miningdock)
-"nYi" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/dark_red/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/herringbone,
-/area/station/ai_monitored/security/armory)
 "nYn" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet,
@@ -52984,10 +53037,6 @@
 "pSz" = (
 /turf/open/openspace,
 /area/station/maintenance/starboard/upper)
-"pSY" = (
-/obj/structure/cable,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
 "pTd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -58997,13 +59046,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
-"rMX" = (
-/obj/structure/rack/gunrack,
-/obj/effect/spawner/armory_spawn/shotguns,
-/obj/effect/turf_decal/tile/dark_red/fourcorners,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "rMY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62717,16 +62759,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/port/fore)
-"sTo" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/dark_red{
-	dir = 8
-	},
-/turf/open/floor/iron/herringbone,
-/area/station/ai_monitored/security/armory)
 "sTO" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restroom"
@@ -67246,6 +67278,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/virology)
+"ula" = (
+/obj/structure/cable,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "ulj" = (
 /obj/structure/flora/tree/pine/style_random,
 /obj/structure/flora/grass/green/style_random,
@@ -67883,47 +67919,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/cargo/office)
-"uvg" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = -7;
-	pixel_y = -6
-	},
-/obj/item/clothing/suit/armor/riot{
-	pixel_y = -6
-	},
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = 7;
-	pixel_y = -6
-	},
-/obj/item/clothing/head/helmet/toggleable/riot{
-	pixel_x = -6;
-	pixel_y = 8
-	},
-/obj/item/clothing/head/helmet/toggleable/riot{
-	pixel_y = 8
-	},
-/obj/item/clothing/head/helmet/toggleable/riot{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/item/shield/riot{
-	pixel_x = -8;
-	pixel_y = -8
-	},
-/obj/item/shield/riot{
-	pixel_y = -8
-	},
-/obj/item/shield/riot{
-	pixel_x = 8;
-	pixel_y = -8
-	},
-/obj/effect/turf_decal/tile/dark_red/fourcorners,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "uvi" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68263,6 +68258,17 @@
 "uBA" = (
 /turf/closed/wall,
 /area/station/engineering/atmos/project)
+"uBB" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/herringbone,
+/area/station/ai_monitored/security/armory)
 "uBP" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
@@ -68680,12 +68686,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
-"uIu" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/dark_red,
-/turf/open/floor/iron/herringbone,
-/area/station/ai_monitored/security/armory)
 "uIx" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
@@ -76169,6 +76169,7 @@
 /area/station/maintenance/aft/greater)
 "wRs" = (
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/ammo_workbench,
 /turf/open/floor/iron/smooth_edge{
 	dir = 4
 	},
@@ -236803,7 +236804,7 @@ wRs
 lTN
 bDu
 dvl
-pSY
+ula
 jRS
 jRS
 dlt
@@ -237060,7 +237061,7 @@ mAe
 dfz
 dnX
 bln
-pSY
+ula
 tDg
 tDg
 ooL
@@ -237832,10 +237833,10 @@ uVP
 aWk
 jJM
 cqb
-rMX
+mhi
 hqS
 bXy
-uvg
+lAW
 xVx
 qsn
 kyy
@@ -238089,7 +238090,7 @@ hEC
 feJ
 fjW
 pdK
-sTo
+fsx
 apS
 buS
 gbJ
@@ -238346,9 +238347,9 @@ hGH
 qum
 iuS
 lyG
-krM
-uIu
-eaj
+lCa
+ekF
+dVk
 ihx
 wZj
 jAk
@@ -238603,7 +238604,7 @@ weT
 qum
 auT
 tDL
-nYi
+uBB
 lok
 pUK
 qum
@@ -243488,7 +243489,7 @@ bln
 sEB
 ykw
 rVy
-ndm
+iyi
 fCW
 nUg
 dKP

--- a/_maps/map_files/MetaStation/MetaStation_bubber.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_bubber.dmm
@@ -287,8 +287,7 @@
 /area/station/science/research)
 "agc" = (
 /obj/effect/turf_decal/bot,
-/mob/living/simple_animal/bot/secbot/beepsky/armsky,
-/obj/machinery/holopad,
+/obj/machinery/ammo_workbench,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "ago" = (
@@ -15169,6 +15168,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/mob/living/simple_animal/bot/secbot/beepsky/armsky,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "fzl" = (
@@ -31609,6 +31609,13 @@
 "kZx" = (
 /turf/closed/wall,
 /area/station/science/lab)
+"kZF" = (
+/obj/effect/turf_decal/trimline/dark_red/filled/corner,
+/obj/machinery/holopad{
+	pixel_y = 16
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "kZG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39510,11 +39517,9 @@
 /area/station/science/xenobiology)
 "nJu" = (
 /obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
 /obj/item/clothing/mask/gas/sechailer,
 /obj/item/clothing/head/helmet/sec/peacekeeper,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "nJA" = (
@@ -44331,10 +44336,15 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
 "pti" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/head/helmet/sec/peacekeeper,
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/machinery/recharger{
+	pixel_x = 6;
+	pixel_y = 2
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "ptE" = (
@@ -59112,14 +59122,13 @@
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
 "upR" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/security/sec,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/head/helmet/sec/peacekeeper,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "upT" = (
@@ -59876,15 +59885,14 @@
 	},
 /area/station/medical/medbay/lobby)
 "uBP" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
 /obj/structure/cable,
 /obj/machinery/newscaster/directional/east,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/security/sec,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/head/helmet/sec/peacekeeper,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "uCq" = (
@@ -97660,7 +97668,7 @@ tms
 kVU
 tJE
 kVU
-tJE
+kZF
 fzi
 wTp
 jxV

--- a/_maps/map_files/MetaStation/MetaStation_bubber.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_bubber.dmm
@@ -288,6 +288,7 @@
 "agc" = (
 /obj/effect/turf_decal/bot,
 /mob/living/simple_animal/bot/secbot/beepsky/armsky,
+/obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "ago" = (
@@ -503,12 +504,12 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "akE" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_red/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "akG" = (
@@ -6606,13 +6607,17 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "cuY" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 4
 	},
-/obj/item/melee/hammer,
-/obj/item/melee/hammer,
-/obj/item/melee/hammer,
+/obj/structure/rack,
+/obj/item/gun/energy/laser{
+	pixel_y = 7
+	},
+/obj/item/gun/energy/laser,
+/obj/item/gun/energy/laser{
+	pixel_y = -7
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "cuZ" = (
@@ -8322,20 +8327,19 @@
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "daO" = (
-/obj/item/grenade/barrier{
-	pixel_x = -3;
-	pixel_y = 1
-	},
-/obj/item/grenade/barrier,
-/obj/item/grenade/barrier{
-	pixel_x = 3;
-	pixel_y = -1
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 6;
-	pixel_y = -2
-	},
 /obj/structure/rack,
+/obj/effect/turf_decal/trimline/dark_red/filled/warning{
+	dir = 8
+	},
+/obj/item/storage/box/flashes{
+	pixel_y = -3
+	},
+/obj/item/storage/box/firingpins{
+	pixel_y = 4
+	},
+/obj/item/gun/energy/temperature/security,
+/obj/item/gun/energy/ionrifle,
+/obj/item/clothing/suit/hooded/ablative,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "daS" = (
@@ -11189,7 +11193,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+/obj/effect/turf_decal/trimline/dark_red/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
@@ -11455,17 +11459,31 @@
 /turf/open/floor/iron,
 /area/station/security/warden)
 "eew" = (
-/obj/structure/rack,
-/obj/item/gun/energy/ionrifle,
-/obj/item/gun/energy/temperature/security,
-/obj/item/clothing/suit/hooded/ablative,
-/obj/item/gun/grenadelauncher,
-/obj/item/storage/box/teargas{
-	pixel_x = 1;
-	pixel_y = -2
+/obj/effect/turf_decal/tile/dark_red/half/contrasted{
+	dir = 8
 	},
-/obj/item/storage/box/flashes{
-	pixel_x = 3
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/bulletproof/old{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/armor/bulletproof/old{
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/armor/bulletproof/old{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet/alt{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/alt{
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/alt{
+	pixel_x = 7;
+	pixel_y = 6
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
@@ -20756,9 +20774,45 @@
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/entry)
 "hxF" = (
-/obj/effect/turf_decal/bot_blue,
-/obj/structure/closet/secure_closet/smartgun,
 /obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/dark_red/anticorner/contrasted{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = -7;
+	pixel_y = -6
+	},
+/obj/item/clothing/suit/armor/riot{
+	pixel_y = -6
+	},
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = 7;
+	pixel_y = -6
+	},
+/obj/item/clothing/head/helmet/toggleable/riot{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/toggleable/riot{
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/toggleable/riot{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/shield/riot{
+	pixel_x = -8;
+	pixel_y = -8
+	},
+/obj/item/shield/riot{
+	pixel_y = -8
+	},
+/obj/item/shield/riot{
+	pixel_x = 8;
+	pixel_y = -8
+	},
+/obj/structure/window/reinforced,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "hxV" = (
@@ -20930,17 +20984,29 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
 "hBR" = (
+/obj/effect/turf_decal/tile/dark_red/anticorner/contrasted,
 /obj/structure/rack,
-/obj/item/shield/riot{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/item/melee/hammer{
+	pixel_x = -7
 	},
-/obj/item/shield/riot,
-/obj/item/shield/riot{
-	pixel_x = 3;
-	pixel_y = -3
+/obj/item/melee/hammer,
+/obj/item/melee/hammer{
+	pixel_x = 7
 	},
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/obj/item/melee/baton/security/loaded{
+	pixel_x = -7
+	},
+/obj/item/melee/baton/security/loaded,
+/obj/item/melee/baton/security/loaded{
+	pixel_x = 7
+	},
+/obj/item/flashlight/seclite{
+	pixel_x = 2
+	},
+/obj/item/flashlight/seclite{
+	pixel_x = 2;
+	pixel_y = -7
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "hBY" = (
@@ -22128,13 +22194,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
 "hXJ" = (
-/obj/structure/closet/secure_closet/security/sec,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/head/helmet/sec/peacekeeper,
+/obj/machinery/vending/wardrobe/sec_wardrobe/red,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "hXK" = (
@@ -25193,36 +25257,31 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
 "iRG" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/item/clothing/suit/armor/riot{
-	pixel_y = 2
-	},
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 3;
-	pixel_y = -2
-	},
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_y = -2
-	},
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = -3;
-	pixel_y = -2
-	},
 /obj/machinery/requests_console/directional/north{
 	assistance_requestable = 1;
 	department = "Security";
 	name = "Security Requests Console";
 	supplies_requestable = 1
 	},
-/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/effect/turf_decal/tile/dark_red/half/contrasted,
+/obj/structure/rack,
+/obj/item/grenade/barrier{
+	pixel_x = -6
+	},
+/obj/item/grenade/barrier,
+/obj/item/grenade/barrier{
+	pixel_x = 6
+	},
+/obj/item/storage/box/teargas{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/flashbangs{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/gun/grenadelauncher,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "iRO" = (
@@ -25456,10 +25515,10 @@
 /turf/open/floor/plating,
 /area/station/commons/dorms)
 "iVO" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/trimline/dark_red/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "iWc" = (
@@ -28692,6 +28751,9 @@
 	succrange = 2
 	},
 /obj/machinery/light_switch/directional/east,
+/obj/effect/turf_decal/trimline/dark_red/filled/warning{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "kaF" = (
@@ -31547,9 +31609,6 @@
 "kZx" = (
 /turf/closed/wall,
 /area/station/science/lab)
-"kZF" = (
-/turf/closed/wall,
-/area/station/security/prison)
 "kZG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34701,10 +34760,10 @@
 /turf/open/floor/iron,
 /area/station/common/cryopods)
 "mgc" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/dark_red/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "mgh" = (
@@ -39293,7 +39352,7 @@
 "nEZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/security/prison)
+/area/station/security/prison/rec)
 "nFa" = (
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
@@ -39610,9 +39669,8 @@
 /area/station/maintenance/starboard/aft)
 "nMw" = (
 /obj/machinery/airalarm/directional/north,
-/obj/structure/rack/gunrack,
-/obj/effect/spawner/armory_spawn/microfusion,
 /obj/effect/turf_decal/delivery/red,
+/obj/structure/closet/secure_closet/smartgun,
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/security/armory)
 "nMz" = (
@@ -41680,7 +41738,7 @@
 /obj/structure/bed/maint,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/security/prison)
+/area/station/security/prison/rec)
 "ovX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -46235,11 +46293,6 @@
 "qcd" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/pumproom)
-"qcf" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/space)
 "qcC" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -51688,18 +51741,20 @@
 /turf/open/floor/iron/pool,
 /area/station/security/prison/rec)
 "rRf" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/effect/turf_decal/tile/dark_red/anticorner/contrasted{
 	dir = 4
 	},
-/obj/item/gun/energy/disabler{
-	pixel_y = 6
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
 	},
-/obj/item/gun/energy/disabler{
-	pixel_y = 2
+/obj/item/gun/energy/e_gun{
+	pixel_y = 7
 	},
-/obj/item/gun/energy/disabler{
-	pixel_y = -2
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun{
+	pixel_y = -7
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
@@ -53951,13 +54006,46 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "sDw" = (
+/obj/effect/turf_decal/tile/dark_red/anticorner/contrasted{
+	dir = 1
+	},
 /obj/structure/rack,
-/obj/item/storage/barricade{
+/obj/item/clothing/glasses/hud/security/sunglasses/redsec{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/glasses/hud/security/sunglasses/redsec{
+	pixel_y = 3
+	},
+/obj/item/clothing/glasses/hud/security/sunglasses/redsec{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/sec/redsec{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/sec/redsec{
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/sec/redsec{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/item/clothing/suit/armor/vest/alt/sec/redsec{
+	pixel_x = -7;
 	pixel_y = -5
 	},
-/obj/item/storage/barricade,
-/obj/item/storage/barricade{
-	pixel_y = 5
+/obj/item/clothing/suit/armor/vest/alt/sec/redsec{
+	pixel_y = -5
+	},
+/obj/item/clothing/suit/armor/vest/alt/sec/redsec{
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
@@ -55089,7 +55177,7 @@
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/security/prison)
+/area/station/security/prison/rec)
 "sWO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -55654,29 +55742,23 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "tgy" = (
-/obj/structure/rack,
-/obj/item/clothing/glasses/hud/security/sunglasses/gars{
-	pixel_x = 3;
-	pixel_y = -2
-	},
-/obj/item/clothing/glasses/hud/security/sunglasses/gars{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/item/clothing/glasses/hud/security/sunglasses{
-	pixel_x = -3;
-	pixel_y = -2
-	},
-/obj/item/clothing/glasses/hud/security/sunglasses{
-	pixel_x = -3;
-	pixel_y = 2
-	},
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/camera/motion/directional/west{
 	c_tag = "Armory - Internal"
 	},
 /obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/obj/effect/turf_decal/tile/dark_red/anticorner/contrasted,
+/obj/structure/rack,
+/obj/structure/window/reinforced,
+/obj/item/gun/energy/disabler{
+	pixel_y = 6
+	},
+/obj/item/gun/energy/disabler{
+	pixel_y = 2
+	},
+/obj/item/gun/energy/disabler{
+	pixel_y = -2
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "tgC" = (
@@ -55971,10 +56053,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "tms" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/corner,
-/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+/obj/effect/turf_decal/trimline/dark_red/filled/warning{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/dark_red/filled/corner,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "tmz" = (
@@ -57223,7 +57305,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "tJE" = (
-/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/dark_red/filled/corner,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "tJF" = (
@@ -59426,32 +59508,24 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "uwg" = (
-/obj/structure/rack,
 /obj/machinery/light/directional/west,
-/obj/item/clothing/head/helmet/toggleable/riot{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/item/clothing/head/helmet/toggleable/riot{
-	pixel_y = 2
-	},
-/obj/item/clothing/head/helmet/toggleable/riot{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/clothing/head/helmet/alt{
-	pixel_x = 3;
-	pixel_y = -2
-	},
-/obj/item/clothing/head/helmet/alt{
-	pixel_y = -2
-	},
-/obj/item/clothing/head/helmet/alt{
-	pixel_x = -3;
-	pixel_y = -2
-	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/effect/turf_decal/tile/dark_red/half/contrasted,
+/obj/structure/rack,
+/obj/item/storage/barricade{
+	pixel_y = 5
+	},
+/obj/item/storage/barricade,
+/obj/item/storage/barricade{
+	pixel_y = -5
+	},
+/obj/item/storage/box/chemimp{
+	pixel_x = 6
+	},
+/obj/item/storage/box/trackimp{
+	pixel_x = -3
+	},
+/obj/item/storage/lockbox/loyalty,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "uwh" = (
@@ -61124,13 +61198,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"uZa" = (
-/obj/effect/spawner/random/structure/girder{
-	loot = list(/obj/structure/falsewall = 50, /turf/closed/wall = 50);
-	name = "falsewall or wall spawner"
-	},
-/turf/open/floor/plating,
-/area/station/security/prison)
 "uZj" = (
 /obj/structure/sign/directions/security{
 	dir = 1;
@@ -61158,9 +61225,6 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
-"uZF" = (
-/turf/closed/wall/r_wall,
-/area/space)
 "uZK" = (
 /obj/structure/sign/warning/vacuum/external/directional/north,
 /obj/effect/turf_decal/stripes/line{
@@ -65464,7 +65528,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "wzF" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/warning{
+/obj/effect/turf_decal/trimline/dark_red/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
@@ -89101,7 +89165,7 @@ sbX
 irh
 wyn
 iOr
-uZF
+iOr
 raz
 aaa
 aaa
@@ -89358,7 +89422,7 @@ qDS
 tVo
 ese
 rAW
-qcf
+cmB
 raz
 raz
 raz
@@ -90130,7 +90194,7 @@ dHQ
 jjM
 vfy
 iOr
-uZF
+iOr
 mji
 aaa
 aaa
@@ -90387,7 +90451,7 @@ fbX
 cnk
 wFY
 qox
-uZF
+iOr
 aUn
 aaa
 aaa
@@ -92179,8 +92243,8 @@ gQT
 gQT
 mMQ
 gQT
-kZF
-kZF
+gQT
+gQT
 wZz
 wZz
 wZz
@@ -92436,7 +92500,7 @@ gQT
 mAe
 odB
 nyf
-uZa
+mou
 nEZ
 tYo
 bmX
@@ -92693,7 +92757,7 @@ hOR
 ybs
 nNB
 wuh
-kZF
+gQT
 ovL
 wZz
 dXA
@@ -92950,7 +93014,7 @@ gQT
 lUY
 cfa
 otM
-kZF
+gQT
 sWF
 wZz
 wOm
@@ -98862,7 +98926,7 @@ aaa
 aaa
 aaa
 aaa
-aav
+aaa
 aaa
 aaa
 aaa
@@ -101174,7 +101238,7 @@ aaa
 aaa
 aaa
 aaa
-aav
+aaa
 aaa
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation_bubber.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_bubber.dmm
@@ -11484,6 +11484,7 @@
 	pixel_x = 7;
 	pixel_y = 6
 	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "efa" = (
@@ -21007,6 +21008,7 @@
 	pixel_x = 2;
 	pixel_y = -7
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "hBY" = (
@@ -55756,7 +55758,6 @@
 /obj/machinery/camera/motion/directional/west{
 	c_tag = "Armory - Internal"
 	},
-/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/dark_red/anticorner/contrasted,
 /obj/structure/rack,
 /obj/structure/window/reinforced,
@@ -59517,7 +59518,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "uwg" = (
-/obj/machinery/light/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/dark_red/half/contrasted,
 /obj/structure/rack,

--- a/_maps/map_files/VoidRaptor/VoidRaptor_bubber.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor_bubber.dmm
@@ -13355,21 +13355,17 @@
 /area/station/commons/dorms)
 "dSa" = (
 /obj/structure/rack,
-/obj/item/clothing/head/helmet/alt{
-	pixel_x = -6;
-	pixel_y = -4
-	},
-/obj/item/clothing/head/helmet/alt{
-	pixel_y = 6
-	},
-/obj/item/clothing/head/helmet/alt{
-	pixel_x = 6;
-	pixel_y = -4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/item/gun/energy/laser{
+	pixel_y = 7
+	},
+/obj/item/gun/energy/laser,
+/obj/item/gun/energy/laser{
+	pixel_y = -7
+	},
 /turf/open/floor/engine,
 /area/station/ai_monitored/security/armory)
 "dSc" = (
@@ -22052,11 +22048,11 @@
 /area/station/medical/medbay/central)
 "gra" = (
 /obj/structure/rack/gunrack,
-/obj/effect/spawner/armory_spawn/microfusion,
 /obj/effect/turf_decal/tile/dark_red/half{
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/spawner/armory_spawn/shotguns,
 /turf/open/floor/engine,
 /area/station/ai_monitored/security/armory)
 "grg" = (
@@ -40068,17 +40064,22 @@
 /turf/open/floor/carpet/royalblack,
 /area/station/command/heads_quarters/hos)
 "lqX" = (
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun/dragnet,
-/obj/item/gun/energy/e_gun/dragnet,
-/obj/item/melee/hammer,
-/obj/item/melee/hammer,
-/obj/item/melee/hammer,
 /obj/effect/turf_decal/tile/dark_red/half,
 /obj/machinery/camera/directional/south{
 	c_tag = "Armory - Interior"
 	},
 /obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/item/storage/box/teargas{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/flashbangs{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/gun/grenadelauncher,
 /turf/open/floor/engine,
 /area/station/ai_monitored/security/armory)
 "lqY" = (
@@ -46652,16 +46653,6 @@
 /turf/open/floor/wood/large,
 /area/station/service/library)
 "nbs" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_y = 6
-	},
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = -4
-	},
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -46671,6 +46662,40 @@
 /obj/item/storage/secure/safe/directional/east,
 /obj/machinery/light/warm/directional/east,
 /obj/effect/turf_decal/delivery,
+/obj/structure/rack,
+/obj/item/clothing/glasses/hud/security/sunglasses/redsec{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/glasses/hud/security/sunglasses/redsec{
+	pixel_y = 3
+	},
+/obj/item/clothing/glasses/hud/security/sunglasses/redsec{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/sec/redsec{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/sec/redsec{
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/sec/redsec{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/item/clothing/suit/armor/vest/alt/sec/redsec{
+	pixel_x = -7;
+	pixel_y = -5
+	},
+/obj/item/clothing/suit/armor/vest/alt/sec/redsec{
+	pixel_y = -5
+	},
+/obj/item/clothing/suit/armor/vest/alt/sec/redsec{
+	pixel_x = 7;
+	pixel_y = -5
+	},
 /turf/open/floor/engine,
 /area/station/ai_monitored/security/armory)
 "nbt" = (
@@ -48507,18 +48532,6 @@
 	},
 /area/station/hallway/primary/fore)
 "nzM" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = -7;
-	pixel_y = 5
-	},
-/obj/item/clothing/suit/armor/riot{
-	pixel_y = 5
-	},
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = 7;
-	pixel_y = 5
-	},
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -48530,6 +48543,40 @@
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = -7;
+	pixel_y = -6
+	},
+/obj/item/clothing/suit/armor/riot{
+	pixel_y = -6
+	},
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = 7;
+	pixel_y = -6
+	},
+/obj/item/clothing/head/helmet/toggleable/riot{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/toggleable/riot{
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/toggleable/riot{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/shield/riot{
+	pixel_x = -8;
+	pixel_y = -8
+	},
+/obj/item/shield/riot{
+	pixel_y = -8
+	},
+/obj/item/shield/riot{
+	pixel_x = 8;
+	pixel_y = -8
+	},
 /turf/open/floor/engine,
 /area/station/ai_monitored/security/armory)
 "nzP" = (
@@ -59468,12 +59515,6 @@
 /area/station/cargo/blacksmith)
 "qBO" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/suit/hooded/ablative{
-	pixel_y = 7
-	},
-/obj/item/gun/energy/temperature/security{
-	pixel_y = 5
-	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -59484,6 +59525,13 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
+/obj/item/storage/box/firingpins,
+/obj/item/clothing/suit/hooded/ablative{
+	pixel_y = 7
+	},
+/obj/item/gun/energy/temperature/security{
+	pixel_y = 5
+	},
 /turf/open/floor/engine,
 /area/station/ai_monitored/security/armory)
 "qBR" = (
@@ -60113,18 +60161,6 @@
 	},
 /area/station/science/ordnance/testlab)
 "qKP" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/suit/armor/vest/alt/sec{
-	pixel_y = 2
-	},
-/obj/item/clothing/suit/armor/vest/alt/sec{
-	pixel_x = -4;
-	pixel_y = -6
-	},
-/obj/item/clothing/suit/armor/vest/alt/sec{
-	pixel_x = 4;
-	pixel_y = -6
-	},
 /obj/structure/window/reinforced{
 	dir = 1;
 	pixel_y = 1
@@ -60139,6 +60175,29 @@
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/bulletproof/old{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/armor/bulletproof/old{
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/armor/bulletproof/old{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet/alt{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/alt{
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/alt{
+	pixel_x = 7;
+	pixel_y = 6
+	},
 /turf/open/floor/engine,
 /area/station/ai_monitored/security/armory)
 "qLf" = (
@@ -67267,9 +67326,9 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/landmark/secequipment,
 /obj/effect/turf_decal/tile/red/diagonal_centre,
 /obj/effect/turf_decal/bot,
+/obj/machinery/vending/wardrobe/sec_wardrobe/red,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/security/office)
 "sJk" = (
@@ -72915,25 +72974,31 @@
 /area/station/maintenance/starboard/aft)
 "ult" = (
 /obj/structure/rack,
-/obj/item/melee/baton/security/loaded,
-/obj/item/melee/baton/security/loaded,
-/obj/item/melee/baton/security/loaded,
-/obj/item/shield/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/shield/riot,
-/obj/item/shield/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/dark_red/half,
 /obj/machinery/light/warm/directional/south,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/south,
 /obj/effect/turf_decal/bot,
+/obj/item/melee/hammer{
+	pixel_x = -7
+	},
+/obj/item/melee/hammer,
+/obj/item/melee/hammer{
+	pixel_x = 7
+	},
+/obj/item/melee/baton/security/loaded{
+	pixel_x = -7
+	},
+/obj/item/melee/baton/security/loaded,
+/obj/item/melee/baton/security/loaded{
+	pixel_x = 7
+	},
+/obj/item/flashlight/seclite{
+	pixel_x = 2
+	},
+/obj/item/flashlight/seclite{
+	pixel_x = 2;
+	pixel_y = -7
+	},
 /turf/open/floor/engine,
 /area/station/ai_monitored/security/armory)
 "ulA" = (
@@ -77398,16 +77463,6 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/sorting)
 "vwn" = (
-/obj/item/gun/energy/disabler{
-	pixel_y = -2
-	},
-/obj/item/gun/energy/disabler{
-	pixel_y = 2
-	},
-/obj/item/gun/energy/disabler{
-	pixel_y = 6
-	},
-/obj/structure/rack,
 /obj/effect/turf_decal/tile/dark_red/anticorner{
 	dir = 1
 	},
@@ -80632,17 +80687,6 @@
 /area/station/service/chapel)
 "wrA" = (
 /obj/structure/rack,
-/obj/item/clothing/head/helmet/sec{
-	pixel_y = 6
-	},
-/obj/item/clothing/head/helmet/sec{
-	pixel_x = -6;
-	pixel_y = -4
-	},
-/obj/item/clothing/head/helmet/sec{
-	pixel_x = 6;
-	pixel_y = -4
-	},
 /obj/structure/window/reinforced{
 	dir = 1;
 	pixel_y = 1
@@ -80651,6 +80695,13 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/item/gun/energy/e_gun{
+	pixel_y = 7
+	},
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun{
+	pixel_y = -7
+	},
 /turf/open/floor/engine,
 /area/station/ai_monitored/security/armory)
 "wrH" = (
@@ -80871,20 +80922,20 @@
 /area/station/medical/coldroom)
 "wtg" = (
 /obj/structure/rack,
-/obj/item/clothing/head/helmet/toggleable/riot{
-	pixel_y = 8
-	},
-/obj/item/clothing/head/helmet/toggleable/riot{
-	pixel_x = -5
-	},
-/obj/item/clothing/head/helmet/toggleable/riot{
-	pixel_x = 6
-	},
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/item/gun/energy/disabler{
+	pixel_y = 6
+	},
+/obj/item/gun/energy/disabler{
+	pixel_y = 2
+	},
+/obj/item/gun/energy/disabler{
+	pixel_y = -2
+	},
 /turf/open/floor/engine,
 /area/station/ai_monitored/security/armory)
 "wtJ" = (
@@ -85545,8 +85596,6 @@
 /turf/open/floor/plating,
 /area/station/security/execution/transfer)
 "xMF" = (
-/obj/structure/rack/gunrack,
-/obj/effect/spawner/armory_spawn/shotguns,
 /obj/effect/turf_decal/tile/dark_red/half{
 	dir = 1
 	},

--- a/_maps/map_files/tramstation/tramstation_bubber.dmm
+++ b/_maps/map_files/tramstation/tramstation_bubber.dmm
@@ -1929,10 +1929,29 @@
 /turf/open/misc/asteroid/airless,
 /area/station/asteroid)
 "aeX" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
 /mob/living/simple_animal/bot/secbot/beepsky/armsky,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red/corner,
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "aeY" = (
 /obj/effect/turf_decal/trimline/white/warning{
@@ -4518,15 +4537,42 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "avf" = (
-/obj/item/storage/toolbox/drone,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron,
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9;
+	pixel_x = 4
+	},
+/obj/item/gun/energy/disabler{
+	pixel_y = 6
+	},
+/obj/item/gun/energy/disabler{
+	pixel_y = 2
+	},
+/obj/item/gun/energy/disabler{
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "avg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/structure/rack/gunrack,
+/obj/item/storage/box/teargas{
+	pixel_y = -4
 	},
-/turf/open/floor/iron,
+/obj/item/storage/box/flashbangs{
+	pixel_y = 3
+	},
+/obj/item/gun/grenadelauncher{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/gun/energy/temperature/security,
+/obj/item/gun/energy/ionrifle{
+	pixel_y = -8
+	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "avj" = (
 /obj/structure/table,
@@ -5790,17 +5836,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "aFA" = (
-/obj/structure/table,
-/obj/item/storage/box/rubbershot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot{
+/obj/structure/table/reinforced,
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/flashbangs{
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "aFP" = (
@@ -6428,7 +6470,6 @@
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/bot,
 /obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/head/helmet/sec/redsec,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/lockers)
 "aJC" = (
@@ -7602,7 +7643,7 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "aRk" = (
-/obj/machinery/vending/security,
+/obj/machinery/vending/wardrobe/sec_wardrobe/red,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/lockers)
 "aRo" = (
@@ -9172,7 +9213,6 @@
 /obj/machinery/status_display/evac/directional/east,
 /obj/effect/turf_decal/bot,
 /obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/head/helmet/sec/redsec,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/lockers)
 "buW" = (
@@ -10054,13 +10094,16 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "bKl" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/hooded/ablative,
-/obj/item/gun/energy/ionrifle,
-/obj/item/gun/energy/temperature/security,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/north,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/siding/dark_red,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "bKt" = (
 /turf/open/floor/engine,
@@ -14785,9 +14828,25 @@
 	},
 /area/station/service/chapel)
 "dst" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/siding/dark_red,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/arrows{
+	dir = 1
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "dsF" = (
 /turf/open/floor/iron/smooth,
@@ -15946,17 +16005,17 @@
 /turf/open/floor/carpet,
 /area/station/service/chapel/monastery)
 "dQd" = (
-/obj/structure/table,
-/obj/item/storage/box/teargas{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_x = -6;
+	pixel_y = 2
 	},
-/obj/item/storage/box/handcuffs,
-/obj/item/storage/box/flashbangs{
-	pixel_x = 3;
-	pixel_y = -3
+/obj/machinery/recharger{
+	pixel_x = 6;
+	pixel_y = 2
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "dQn" = (
@@ -16388,6 +16447,7 @@
 /area/station/service/library)
 "dYe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/vending/security,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/lockers)
 "dYh" = (
@@ -16960,8 +17020,7 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "ekh" = (
 /obj/structure/cable,
@@ -17217,12 +17276,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
-"epT" = (
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/ai_monitored/security/armory)
 "eqi" = (
 /obj/effect/landmark/navigate_destination/tcomms,
 /turf/open/floor/iron,
@@ -17566,11 +17619,16 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/station/commons/vacant_room)
 "exx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9;
+	pixel_x = 4
+	},
+/obj/item/clothing/suit/hooded/ablative,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "exD" = (
 /obj/effect/turf_decal/stripes/white/line{
@@ -18567,18 +18625,41 @@
 /area/station/medical/treatment_center)
 "eRq" = (
 /obj/structure/rack,
-/obj/item/gun/ballistic/shotgun/riot{
+/obj/item/clothing/glasses/hud/security/sunglasses/redsec{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/gun/ballistic/shotgun/riot,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_x = 3;
-	pixel_y = -3
+/obj/item/clothing/glasses/hud/security/sunglasses/redsec{
+	pixel_y = 3
 	},
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner,
-/turf/open/floor/iron,
+/obj/item/clothing/glasses/hud/security/sunglasses/redsec{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/sec/redsec{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/sec/redsec{
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/sec/redsec{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/item/clothing/suit/armor/vest/alt/sec/redsec{
+	pixel_x = -7;
+	pixel_y = -5
+	},
+/obj/item/clothing/suit/armor/vest/alt/sec/redsec{
+	pixel_y = -5
+	},
+/obj/item/clothing/suit/armor/vest/alt/sec/redsec{
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "eRw" = (
 /obj/machinery/firealarm/directional/west,
@@ -18617,11 +18698,8 @@
 /turf/open/floor/carpet,
 /area/station/service/chapel/monastery)
 "eSj" = (
-/obj/structure/table,
-/obj/item/storage/box/firingpins,
-/obj/item/storage/box/firingpins,
-/obj/item/key/security,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/vehicle/ridden/secway,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "eSv" = (
@@ -22729,7 +22807,7 @@
 /area/station/engineering/supermatter/room)
 "gxf" = (
 /obj/machinery/flasher/portable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "gxk" = (
@@ -23591,11 +23669,31 @@
 /turf/open/floor/iron,
 /area/station/cargo/blacksmith)
 "gNe" = (
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/bulletproof/old{
+	pixel_x = -7;
+	pixel_y = -3
 	},
-/turf/open/floor/iron,
+/obj/item/clothing/suit/armor/bulletproof/old{
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/armor/bulletproof/old{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet/alt{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/alt{
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/alt{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "gNk" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -24444,8 +24542,19 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction/engineering)
 "hgn" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "hgI" = (
 /obj/machinery/camera/directional/south{
@@ -25125,12 +25234,11 @@
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "htq" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/structure/rack/gunrack,
+/obj/effect/spawner/armory_spawn/shotguns,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "htr" = (
 /obj/effect/turf_decal/delivery,
@@ -26128,10 +26236,29 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "hPs" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red/corner,
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "hPA" = (
 /obj/structure/chair/office{
@@ -27122,10 +27249,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom/holding)
 "ihc" = (
-/obj/structure/table,
-/obj/machinery/recharger,
 /obj/machinery/status_display/evac/directional/north,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/closet/secure_closet/smartgun,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "ihi" = (
@@ -27657,6 +27783,17 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/service/library/lounge)
+"isi" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/siding/dark_red,
+/turf/open/floor/iron/herringbone,
+/area/station/ai_monitored/security/armory)
 "isM" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Break Room"
@@ -27744,10 +27881,18 @@
 /turf/open/floor/iron,
 /area/station/security/processing)
 "iub" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9;
+	pixel_x = 4
 	},
-/turf/open/floor/iron,
+/obj/item/gun/energy/e_gun/dragnet{
+	pixel_y = 6
+	},
+/obj/item/gun/energy/e_gun/dragnet,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "iuc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
@@ -27779,6 +27924,24 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
+"iuv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9;
+	pixel_x = 4
+	},
+/obj/item/gun/energy/e_gun{
+	pixel_y = 7
+	},
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun{
+	pixel_y = -7
+	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "iuz" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 1";
@@ -30080,12 +30243,15 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "jlQ" = (
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun/dragnet,
-/obj/item/gun/energy/e_gun/dragnet,
 /obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "jmb" = (
 /obj/machinery/door/window/left/directional/north{
@@ -32749,7 +32915,8 @@
 /area/station/service/library)
 "kkV" = (
 /obj/machinery/suit_storage_unit/security,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light_switch/directional/south,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "klg" = (
@@ -37503,12 +37670,15 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "lUo" = (
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "lUr" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -37922,10 +38092,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "mcU" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "mcX" = (
 /obj/structure/disposalpipe/segment{
@@ -38463,18 +38632,20 @@
 /area/station/science/lab)
 "mlS" = (
 /obj/structure/rack,
-/obj/item/gun/energy/disabler{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9;
+	pixel_x = 4
 	},
-/obj/item/gun/energy/disabler,
-/obj/item/gun/energy/disabler{
-	pixel_x = 3;
-	pixel_y = -3
+/obj/item/gun/energy/laser{
+	pixel_y = 7
 	},
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner,
-/turf/open/floor/iron,
+/obj/item/gun/energy/laser,
+/obj/item/gun/energy/laser{
+	pixel_y = -7
+	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "mma" = (
 /obj/structure/table/glass,
@@ -39248,7 +39419,7 @@
 "mzH" = (
 /obj/machinery/suit_storage_unit/security,
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "mzJ" = (
@@ -39826,9 +39997,21 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "mKP" = (
-/obj/vehicle/ridden/secway,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/siding/dark_red,
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "mKQ" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -41305,18 +41488,7 @@
 	req_access = list("armory")
 	},
 /obj/machinery/status_display/ai/directional/north,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/rack,
-/obj/item/gun/energy/disabler{
-	pixel_y = 6
-	},
-/obj/item/gun/energy/disabler{
-	pixel_y = 2
-	},
-/obj/item/gun/energy/disabler{
-	pixel_y = -2
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "noI" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -41946,6 +42118,23 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/security/office)
+"nBr" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/turf/open/floor/iron/herringbone,
+/area/station/ai_monitored/security/armory)
 "nBt" = (
 /obj/machinery/holopad/secure,
 /obj/structure/cable,
@@ -43337,9 +43526,20 @@
 	name = "Armory";
 	req_access = list("armory")
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "obz" = (
 /obj/machinery/door/firedoor,
@@ -43871,32 +44071,16 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science)
 "olh" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/suit/armor/bulletproof,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/siding/dark_red,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "olw" = (
 /obj/structure/industrial_lift/tram/white,
@@ -44300,13 +44484,35 @@
 /turf/open/floor/glass/reinforced,
 /area/station/security/warden)
 "ouM" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9;
+	pixel_x = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+/obj/item/melee/hammer{
+	pixel_x = -7
 	},
-/turf/open/floor/iron,
+/obj/item/melee/hammer,
+/obj/item/melee/hammer{
+	pixel_x = 7
+	},
+/obj/item/melee/baton/security/loaded{
+	pixel_x = -7
+	},
+/obj/item/melee/baton/security/loaded,
+/obj/item/melee/baton/security/loaded{
+	pixel_x = 7
+	},
+/obj/item/flashlight/seclite{
+	pixel_x = 2
+	},
+/obj/item/flashlight/seclite{
+	pixel_x = 2;
+	pixel_y = -7
+	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "ovi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44563,11 +44769,11 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "oBY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/structure/rack/gunrack,
+/obj/effect/spawner/armory_spawn/cmg,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "oCd" = (
 /obj/machinery/camera/motion{
@@ -44739,6 +44945,22 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
+"oFN" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Security - Armory";
+	network = list("ss13","Security")
+	},
+/obj/structure/rack,
+/obj/item/storage/barricade{
+	pixel_y = 5
+	},
+/obj/item/storage/barricade,
+/obj/item/storage/barricade{
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "oFY" = (
 /obj/structure/rack,
 /obj/item/storage/box/gloves{
@@ -46060,25 +46282,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
-"pgq" = (
-/obj/structure/rack,
-/obj/item/gun/energy/laser{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/laser,
-/obj/item/gun/energy/laser{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/ai_monitored/security/armory)
 "pgz" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 6
@@ -46925,10 +47128,20 @@
 /turf/open/floor/wood,
 /area/station/service/theater)
 "pvi" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "pvk" = (
 /obj/machinery/camera/directional/west{
@@ -47909,6 +48122,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"pKw" = (
+/obj/machinery/flasher/portable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "pKI" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -50238,36 +50458,16 @@
 /turf/closed/wall,
 /area/station/solars/port)
 "qEM" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = 3;
-	pixel_y = -3
+/obj/machinery/light_switch/directional/north,
+/obj/effect/turf_decal/siding/dark_red/corner,
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 8
 	},
-/obj/item/clothing/head/helmet/toggleable/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/toggleable/riot,
-/obj/item/clothing/head/helmet/toggleable/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/shield/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/shield/riot,
-/obj/item/shield/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "qEW" = (
 /obj/structure/table,
@@ -51392,26 +51592,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
-"rah" = (
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Security - Armory";
-	network = list("ss13","Security")
-	},
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/ai_monitored/security/armory)
 "ram" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/violet/visible{
 	dir = 4
@@ -52021,6 +52201,12 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/garden)
+"rlc" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/drone,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "rlo" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -53982,14 +54168,23 @@
 /area/station/service/hydroponics)
 "sab" = (
 /obj/structure/table,
+/obj/item/storage/box/trackimp{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/item/storage/box/chemimp{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/item/storage/lockbox/loyalty,
 /obj/item/grenade/barrier{
-	pixel_x = 4
+	pixel_x = -6
 	},
 /obj/item/grenade/barrier,
 /obj/item/grenade/barrier{
-	pixel_x = -4
+	pixel_x = 6
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "saj" = (
@@ -54660,9 +54855,14 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "sne" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "snp" = (
 /obj/effect/turf_decal/trimline/yellow/arrow_cw,
@@ -57890,11 +58090,22 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "trm" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "trr" = (
 /obj/machinery/exodrone_launcher,
@@ -57927,7 +58138,8 @@
 /obj/structure/closet/secure_closet/contraband/armory,
 /obj/effect/spawner/random/contraband/armory,
 /obj/effect/spawner/random/maintenance/three,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/storage/secure/safe/directional/west,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "trZ" = (
@@ -60422,6 +60634,15 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"uqt" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/turf/open/floor/iron/herringbone,
+/area/station/ai_monitored/security/armory)
 "uqA" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
 /obj/machinery/duct,
@@ -61737,14 +61958,17 @@
 /area/station/hallway/secondary/service)
 "uPZ" = (
 /obj/structure/table,
-/obj/item/storage/box/chemimp{
-	pixel_x = 6
+/obj/item/storage/box/firingpins{
+	pixel_x = -7;
+	pixel_y = 12
 	},
-/obj/item/storage/box/trackimp{
-	pixel_x = -3
+/obj/item/storage/box/firingpins{
+	pixel_x = 7;
+	pixel_y = 12
 	},
-/obj/item/storage/lockbox/loyalty,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/storage/fancy/donut_box,
+/obj/item/key/security,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "uQb" = (
@@ -61986,9 +62210,16 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "uVA" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark_red/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/siding/dark_red,
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "uVO" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -67525,10 +67756,11 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/oresilo)
 "wYE" = (
-/obj/structure/table,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/west,
-/obj/machinery/recharger,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/closet/ammunitionlocker/useful,
+/obj/item/storage/box/rubbershot,
+/obj/item/storage/box/rubbershot,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "wYO" = (
@@ -69840,11 +70072,43 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "xYC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = -7;
+	pixel_y = -6
+	},
+/obj/item/clothing/suit/armor/riot{
+	pixel_y = -6
+	},
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = 7;
+	pixel_y = -6
+	},
+/obj/item/clothing/head/helmet/toggleable/riot{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/toggleable/riot{
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/toggleable/riot{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/shield/riot{
+	pixel_x = -8;
+	pixel_y = -8
+	},
+/obj/item/shield/riot{
+	pixel_y = -8
+	},
+/obj/item/shield/riot{
+	pixel_x = 8;
+	pixel_y = -8
+	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "xYU" = (
 /obj/effect/landmark/blobstart,
@@ -70386,9 +70650,20 @@
 /turf/closed/wall/r_wall,
 /area/station/security/brig)
 "yjm" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/ai_monitored/security/armory)
 "yjp" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
@@ -153684,7 +153959,7 @@ aaa
 dEv
 qEM
 trm
-epT
+hgn
 hgn
 mKP
 aFA
@@ -153943,7 +154218,7 @@ olh
 exx
 ouM
 iub
-hgn
+isi
 dQd
 dEv
 avQ
@@ -154194,14 +154469,14 @@ aaa
 aaa
 dEv
 gxf
-gxf
+pKw
 gxf
 dst
 xYC
 eRq
 gNe
-iub
-hgn
+isi
+oFN
 lAC
 avR
 agZ
@@ -154454,9 +154729,9 @@ pvi
 yjm
 yjm
 hPs
-pgq
-lAC
-rah
+yjm
+nBr
+yjm
 aeX
 yjm
 oby
@@ -154711,11 +154986,11 @@ sab
 uPZ
 eSj
 dst
-xYC
+iuv
 mlS
 avf
-avg
-hgn
+isi
+rlc
 lAC
 ktA
 agZ
@@ -154971,7 +155246,7 @@ bKl
 oBY
 htq
 avg
-hgn
+isi
 mzH
 dEv
 jPc
@@ -155227,7 +155502,7 @@ dEv
 jlQ
 sne
 lUo
-hgn
+uqt
 uVA
 kkV
 dEv

--- a/_maps/map_files/tramstation/tramstation_bubber.dmm
+++ b/_maps/map_files/tramstation/tramstation_bubber.dmm
@@ -14402,6 +14402,13 @@
 "dkO" = (
 /turf/open/floor/iron,
 /area/station/security/brig)
+"dlg" = (
+/obj/machinery/flasher/portable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "dlJ" = (
 /obj/structure/table,
 /obj/structure/cable,
@@ -23992,6 +23999,24 @@
 	},
 /turf/open/floor/circuit,
 /area/station/science/robotics/mechbay)
+"gTf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9;
+	pixel_x = 4
+	},
+/obj/item/gun/energy/e_gun{
+	pixel_y = 7
+	},
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun{
+	pixel_y = -7
+	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "gTu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -25375,6 +25400,23 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
+"hwz" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/turf/open/floor/iron/herringbone,
+/area/station/ai_monitored/security/armory)
 "hwG" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/effect/spawner/random/aimodule/neutral,
@@ -27507,6 +27549,22 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/qm)
+"inz" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Security - Armory";
+	network = list("ss13","Security")
+	},
+/obj/structure/rack,
+/obj/item/storage/barricade{
+	pixel_y = 5
+	},
+/obj/item/storage/barricade,
+/obj/item/storage/barricade{
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "inG" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -27783,17 +27841,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/service/library/lounge)
-"isi" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/dark_red{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/siding/dark_red,
-/turf/open/floor/iron/herringbone,
-/area/station/ai_monitored/security/armory)
 "isM" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Break Room"
@@ -27818,6 +27865,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/ammo_workbench,
 /turf/open/floor/iron,
 /area/station/security/office)
 "isW" = (
@@ -27924,24 +27972,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
-"iuv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/rack,
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9;
-	pixel_x = 4
-	},
-/obj/item/gun/energy/e_gun{
-	pixel_y = 7
-	},
-/obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun{
-	pixel_y = -7
-	},
-/obj/effect/turf_decal/tile/dark_red/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "iuz" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 1";
@@ -42118,23 +42148,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/security/office)
-"nBr" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/dark_red{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/dark_red{
-	dir = 4
-	},
-/obj/machinery/holopad,
-/turf/open/floor/iron/herringbone,
-/area/station/ai_monitored/security/armory)
 "nBt" = (
 /obj/machinery/holopad/secure,
 /obj/structure/cable,
@@ -44945,22 +44958,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
-"oFN" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Security - Armory";
-	network = list("ss13","Security")
-	},
-/obj/structure/rack,
-/obj/item/storage/barricade{
-	pixel_y = 5
-	},
-/obj/item/storage/barricade,
-/obj/item/storage/barricade{
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/tile/dark_red/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "oFY" = (
 /obj/structure/rack,
 /obj/item/storage/box/gloves{
@@ -48122,13 +48119,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
-"pKw" = (
-/obj/machinery/flasher/portable,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/dark_red/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "pKI" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -52201,12 +52191,6 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/garden)
-"rlc" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/drone,
-/obj/effect/turf_decal/tile/dark_red/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "rlo" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -57407,6 +57391,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"tfa" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 8
+	},
+/turf/open/floor/iron/herringbone,
+/area/station/ai_monitored/security/armory)
 "tfc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -59933,6 +59926,17 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
+"ucy" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark_red{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/siding/dark_red,
+/turf/open/floor/iron/herringbone,
+/area/station/ai_monitored/security/armory)
 "ucA" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -60634,15 +60638,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"uqt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/dark_red{
-	dir = 8
-	},
-/turf/open/floor/iron/herringbone,
-/area/station/ai_monitored/security/armory)
 "uqA" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
 /obj/machinery/duct,
@@ -63673,6 +63668,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"vwV" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/drone,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "vwZ" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
@@ -154218,7 +154219,7 @@ olh
 exx
 ouM
 iub
-isi
+ucy
 dQd
 dEv
 avQ
@@ -154469,14 +154470,14 @@ aaa
 aaa
 dEv
 gxf
-pKw
+dlg
 gxf
 dst
 xYC
 eRq
 gNe
-isi
-oFN
+ucy
+inz
 lAC
 avR
 agZ
@@ -154730,7 +154731,7 @@ yjm
 yjm
 hPs
 yjm
-nBr
+hwz
 yjm
 aeX
 yjm
@@ -154986,11 +154987,11 @@ sab
 uPZ
 eSj
 dst
-iuv
+gTf
 mlS
 avf
-isi
-rlc
+ucy
+vwV
 lAC
 ktA
 agZ
@@ -155246,7 +155247,7 @@ bKl
 oBY
 htq
 avg
-isi
+ucy
 mzH
 dEv
 jPc
@@ -155502,7 +155503,7 @@ dEv
 jlQ
 sne
 lUo
-uqt
+tfa
 uVA
 kkV
 dEv

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -67,7 +67,8 @@
 	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/clothing/head/helmet/sec = 3)
 	crate_name = "helmet crate"
-
+*/
+// SKYRAT EDIT REMOVAL END
 /datum/supply_pack/security/laser
 	name = "Lasers Crate"
 	desc = "Contains three lethal, high-energy laser guns. Requires Security access to open."
@@ -75,8 +76,6 @@
 	access_view = ACCESS_ARMORY
 	contains = list(/obj/item/gun/energy/laser = 3)
 	crate_name = "laser crate"
-*/
-// SKYRAT EDIT REMOVAL END
 
 /datum/supply_pack/security/securitybarriers
 	name = "Security Barrier Grenades"
@@ -242,7 +241,8 @@
 	cost = CARGO_CRATE_VALUE * 5
 	contains = list(/obj/item/gun/energy/e_gun/dragnet = 3)
 	crate_name = "\improper DRAGnet crate"
-
+*/
+// SKYRAT EDIT REMOVAL END
 /datum/supply_pack/security/armory/energy
 	name = "Energy Guns Crate"
 	desc = "Contains two Energy Guns, capable of firing both nonlethal and lethal \
@@ -251,8 +251,6 @@
 	contains = list(/obj/item/gun/energy/e_gun = 2)
 	crate_name = "energy gun crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
-*/
-// SKYRAT EDIT REMOVAL END
 
 /datum/supply_pack/security/armory/exileimp
 	name = "Exile Implants Crate"


### PR DESCRIPTION
## About The Pull Request
• All of the core five maps we're running get a reworked armoury.
• Removal of roundstart MCRs, replaced with lasers & e_guns.
• Readdition of lasers and e_gun cargo packs.
• Redsec vendor for all security departments.
• Icebox armory is now single-z. It was a bit of a meme with just how pointless it was to bother defending it before.
• Holopads for all armouries.
• Ammo workbench for all maps.

## Media
![image](https://user-images.githubusercontent.com/53862927/231196791-e717d63f-b050-4e3b-9547-d862a3cd59b4.png)
![image](https://user-images.githubusercontent.com/53862927/231196835-7ed02d6c-9c77-407f-b456-3dce3b63606f.png)
![image](https://user-images.githubusercontent.com/53862927/231196899-e2cb64e9-8a0d-4195-8ae3-3eede0d4554d.png)
![image](https://user-images.githubusercontent.com/53862927/231198152-37dbcf9f-943f-401e-9673-63acdb2b5363.png)


## Changelog
:cl:
qol: Reworked armouries for all maps.
qol: Ammo workbenches for security on all maps.
balance: Roundstart MCRs replaced with energy weapons in the armoury.
fix: A few area bugs on Metastation.
/:cl:
