### PR TITLE
Legalizes nuking from space

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
@@ -536,9 +536,13 @@ GLOBAL_VAR(station_nuke_source)
 
 	// The nuke was on the station zlevel
 	if(bomb_location && is_station_level(bomb_location.z))
+//BUBBER EDIT REMOVAL
+/* who.
 		// Nuke missed, it's in space
 		if(istype(nuke_area, /area/space))
 			detonation_status = DETONATION_NEAR_MISSED_STATION
+*/
+//BUBBER EDIT END
 
 		// Nuke missed, it'stoo far from the station
 		else if((bomb_location.x < (128 - NUKE_RADIUS)) \

--- a/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
@@ -545,7 +545,7 @@ GLOBAL_VAR(station_nuke_source)
 //BUBBER EDIT END
 
 		// Nuke missed, it'stoo far from the station
-		else if((bomb_location.x < (128 - NUKE_RADIUS)) \
+		if((bomb_location.x < (128 - NUKE_RADIUS)) \
 			|| (bomb_location.x > (128 + NUKE_RADIUS)) \
 			|| (bomb_location.y < (128 - NUKE_RADIUS)) \
 			|| (bomb_location.y > (128 + NUKE_RADIUS)))


### PR DESCRIPTION
## About The Pull Request

So apparently if you detonate the nuclear device from outside of Delta's bridge, it doesn't count as "blowing up the station".
This fixes that.

## Changelog

:cl:
fix: legalizes nuking from space
/:cl: