### PR TITLE
Health scanner now displays allergies more visibly

### DIFF
--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -911,7 +911,7 @@
 		allergy_chem_names += initial(chem_type.name)
 
 	allergy_string = allergy_chem_names.Join(", ")
-	name = "Extreme [allergy_string] Allergies"
+	//name = "Extreme [allergy_string] Allergies"
 	medical_record_text = "Patient's immune system responds violently to [allergy_string]"
 
 	var/mob/living/carbon/human/human_holder = quirk_holder

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -189,6 +189,13 @@
 			render_list += "<span class='info ml-1'>Subject Major Disabilities: [carbontarget.get_quirk_string(FALSE, CAT_QUIRK_MAJOR_DISABILITY)].</span>\n"
 			if(advanced)
 				render_list += "<span class='info ml-1'>Subject Minor Disabilities: [carbontarget.get_quirk_string(FALSE, CAT_QUIRK_MINOR_DISABILITY)].</span>\n"
+				// Allergies
+			for(var/datum/quirk/quirky as anything in target.quirks)
+				if(istype(quirky, /datum/quirk/item_quirk/allergic))
+					var/datum/quirk/item_quirk/allergic/allergies_quirk = quirky
+					var/allergies = allergies_quirk.allergy_string
+					render_list += "<span class='alert ml-1'><b>Subject is extremely allergic to the following chemicals:</b></span>\n"
+					render_list += "<span class='alert ml-2'><b>[allergies]</b></span>\n"
 
 	if (HAS_TRAIT(target, TRAIT_IRRADIATED))
 		render_list += "<span class='alert ml-1'>Subject is irradiated. Supply toxin healing.</span>\n"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As per [Suggestion y863l1zt](https://ptb.discord.com/channels/1059199070016655462/1097317084909817936), makes allergies have their own section on left click medical scanning, and makes the whole thing bold text
Before: 
![image](https://user-images.githubusercontent.com/60290575/232613049-01e0fc42-8fca-417e-9f80-ab2099d8e074.png)
After:
![image](https://user-images.githubusercontent.com/60290575/232613089-2db5b575-f912-49e4-8a01-fd16494b43a7.png)


:cl:
qol: Health scanner now displays allergies more visibly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
