### PR TITLE
Senstive Snout DLC - Snout Bapping Reborn

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -492,7 +492,7 @@
 	else if(helper.zone_selected == BODY_ZONE_PRECISE_MOUTH)
 		nosound = TRUE
 		playsound(src, 'modular_skyrat/modules/emotes/sound/emotes/Nose_boop.ogg', 50, 0)
-		if(HAS_TRAIT(src, TRAIT_SENSITIVESNOUT) && get_location_accessible(src, BODY_ZONE_PRECISE_MOUTH))
+		if(HAS_TRAIT(src, TRAIT_SENSITIVESNOUT))
 			to_chat(src, span_warning("[helper] boops you on your sensitive nose, sending you to the ground!"))
 			src.Knockdown(20)
 			src.apply_damage(30, STAMINA)

--- a/modular_skyrat/master_files/code/datums/traits/negative.dm
+++ b/modular_skyrat/master_files/code/datums/traits/negative.dm
@@ -65,3 +65,27 @@
 	value = -6
 	mob_trait = TRAIT_NOGUNS
 	icon = "none"
+
+/datum/quirk/sensitivesnout
+	name = "Sensitive Snout"
+	desc = "Your snout has always been sensitive, and it really hurts when someone pokes it!"
+	gain_text = span_notice("Your snout is awfully sensitive.")
+	lose_text = span_notice("Your snout feels numb.")
+	medical_record_text = "Patient's snout seems to have a cluster of nerves in the tip, would advise against direct contact."
+	value = -2
+	mob_trait = TRAIT_SENSITIVESNOUT
+	icon = "fingerprint"
+
+/datum/quirk/sensitivesnout/post_add()
+	quirk_holder.apply_status_effect(/datum/status_effect/sensitivesnout)
+
+/datum/quirk/sensitivesnout/remove()
+	quirk_holder.remove_status_effect(/datum/status_effect/sensitivesnout)
+
+/datum/status_effect/sensitivesnout
+	id = "sensitivesnout"
+	duration = -1
+	alert_type = null
+
+/datum/status_effect/sensitivesnout/get_examine_text()
+	return span_warning("[owner.p_their(TRUE)] snout is rather bappable...")

--- a/modular_skyrat/master_files/code/datums/traits/neutral.dm
+++ b/modular_skyrat/master_files/code/datums/traits/neutral.dm
@@ -191,12 +191,3 @@
 	var/obj/item/organ/internal/tongue/dog/new_tongue = new(get_turf(human_holder))
 	new_tongue.Insert(human_holder)
 
-/datum/quirk/sensitivesnout
-	name = "Sensitive Snout"
-	desc = "Your face has always been sensitive, and it really hurts when someone pokes it!"
-	gain_text = span_notice("Your face is awfully sensitive.")
-	lose_text = span_notice("Your face feels numb.")
-	medical_record_text = "Patient's nose seems to have a cluster of nerves in the tip, would advise against direct contact."
-	value = 0
-	mob_trait = TRAIT_SENSITIVESNOUT
-	icon = "fingerprint"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR makes Sensitive Snout a Negative trait again, and makes it incredibly obvious that you are bulliable when you have it. It also makes Sensitive snout ignore masks now, so, there is no escape. For -2 TC, you can be bullied relentlessly for having a really bappable snout. 

## How This Contributes To The Skyrat Roleplay Experience

Makes sensitive snout users have the "theoretical" downsides. Plus, masks fucking hurt? How would getting bapped in the mask BLOCK painful things? Doesn't make sense. 
![dreamseeker_n4vNsJ6fXy](https://user-images.githubusercontent.com/77420409/210023495-09eb94b4-5dd4-4aef-a6d7-8e4a6b293fbe.png)

![dreamseeker_hVzeyA8IUy](https://user-images.githubusercontent.com/77420409/210023412-18f88557-d420-4e5f-b7bf-070d14d61913.png)

https://user-images.githubusercontent.com/77420409/210023415-dac46dda-c562-44ba-a40e-b8e8c5a9a509.mp4




## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  

https://user-images.githubusercontent.com/77420409/210023400-1c02aebf-ef67-46ec-b8fc-8c344347baeb.mp4


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: sensitive snout is now visible on examine! bullies take note.
balance: sensitive snout is now not blocked by masks. masks hurt to wear. makes sense. 
spellcheck: changed the word nose to snout and similar for sensitive snoute
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
