### PR TITLE
Redoes the DNR trait

### DIFF
--- a/code/__DEFINES/~skyrat_defines/mobs.dm
+++ b/code/__DEFINES/~skyrat_defines/mobs.dm
@@ -14,7 +14,7 @@
 #define UNDERWEAR_HIDE_UNDIES (1<<2)
 
 //Appends to the bottom of Defib fails - DNR TRAIT
-#define DEFIB_FAIL_DNR (1<<11)
+//#define DEFIB_FAIL_DNR (1<<11) //BUBBER EDIT REMOVAL
 
 ///Defines for icons used for modular bodyparts, created to make it easier to relocate the module or files if necessary.
 #define BODYPART_ICON_HUMAN 'modular_skyrat/modules/bodyparts/icons/human_parts_greyscale.dmi'

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -624,11 +624,10 @@
 						fail_reason = "Patient's brain is missing. Further attempts futile."
 					if (DEFIB_FAIL_BLACKLISTED)
 						fail_reason = "Patient has been blacklisted from revival. Further attempts futile."
-					//SKYRAT EDIT ADDITION - DNR TRAIT
-					if (DEFIB_FAIL_DNR)
-						fail_reason = "Patient has been flagged as Do Not Resuscitate. Further attempts futile."
-					//SKYRAT EDIT ADDITION END - DNR TRAIT
-
+					//SKYRAT EDIT ADDITION - DNR TRAIT // BUBBED EDIT REMOVAL BEGIN
+//					if (DEFIB_FAIL_DNR)
+//						fail_reason = "Patient has been flagged as Do Not Resuscitate. Further attempts futile."
+					//SKYRAT EDIT ADDITION END - DNR TRAIT // BUBBER EDIT REMOVAL BEGIN
 				if(fail_reason)
 					user.visible_message(span_warning("[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - [fail_reason]"))
 					playsound(src, 'sound/machines/defib_failed.ogg', 50, FALSE)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -924,17 +924,16 @@
 /mob/living/carbon/can_be_revived()
 	if(!get_organ_by_type(/obj/item/organ/internal/brain) && (!mind || !mind.has_antag_datum(/datum/antagonist/changeling)) || HAS_TRAIT(src, TRAIT_HUSK))
 		return FALSE
-//SKYRAT EDIT ADDITION - DNR TRAIT
-	if(HAS_TRAIT(src, TRAIT_DNR))
-		return FALSE
-//SKYRAT EDIT ADDITION END - DNR TRAIT
-
+//SKYRAT EDIT ADDITION - DNR TRAIT // BUBBER EDIT REMOVAL
+//	if(HAS_TRAIT(src, TRAIT_DNR))
+//		return FALSE
+//SKYRAT EDIT ADDITION END - DNR TRAIT // BUBBER EDIT REMOVAL
 	return ..()
 
 /mob/living/carbon/proc/can_defib()
 //SKYRAT EDIT ADDITION - DNR TRAIT
-	if(HAS_TRAIT(src, TRAIT_DNR)) //This is also added when a ghost DNR's!
-		return DEFIB_FAIL_DNR
+//	if(HAS_TRAIT(src, TRAIT_DNR)) //This is also added when a ghost DNR's! // BUBBER EDIT REMOVAL
+//		return DEFIB_FAIL_DNR
 //SKYRAT EDIT ADDITION END - DNR TRAIT
 	if (HAS_TRAIT(src, TRAIT_SUICIDED))
 		return DEFIB_FAIL_SUICIDE

--- a/code/modules/surgery/revival.dm
+++ b/code/modules/surgery/revival.dm
@@ -96,12 +96,13 @@
 			morbid_weirdo.add_mood_event("morbid_revival_success", /datum/mood_event/morbid_revival_success)
 		return TRUE
 	else
-	//SKYRAT EDIT ADDITION - DNR TRAIT - need this so that people dont just keep spamming the revival surgery; it runs success just bc the surgery steps are done
-		if(HAS_TRAIT(target, TRAIT_DNR))
-			target.visible_message(span_warning("...[target.p_they()] lies still, unaffected. Further attempts are futile, they're gone."))
-		else
-			target.visible_message(span_warning("...[target.p_they()] convulses, then lies still."))
-	//SKYRAT EDIT ADDITION END - DNR TRAIT - ORIGINAL: target.visible_message(span_warning("...[target.p_they()] convulses, then lies still."))
+	//SKYRAT EDIT ADDITION - DNR TRAIT - need this so that people dont just keep spamming the revival surgery; it runs success just bc the surgery steps are done // BUBBER EDIT REMOVAL
+//		if(HAS_TRAIT(target, TRAIT_DNR))
+//			target.visible_message(span_warning("...[target.p_they()] lies still, unaffected. Further attempts are futile, they're gone."))
+//		else
+//			target.visible_message(span_warning("...[target.p_they()] convulses, then lies still."))
+	//SKYRAT EDIT ADDITION END - DNR TRAIT - ORIGINAL: target.visible_message(span_warning("...[target.p_they()] convulses, then lies still.")) // BUBBER EDIT REMOVAL
+		target.visible_message(span_warning("...[target.p_they()] convulses, then lies still.")) // BUBBER TG RESTORE
 		return FALSE
 
 /datum/surgery_step/revive/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/modular_skyrat/modules/assault_operatives/code/interrogator.dm
+++ b/modular_skyrat/modules/assault_operatives/code/interrogator.dm
@@ -97,7 +97,7 @@
 		return FALSE
 	if(!is_station_level(z))
 		return FALSE
-	if(human_occupant.stat == DEAD && !HAS_TRAIT(human_occupant, TRAIT_DNR))
+	if(human_occupant.stat == DEAD) // BUBBER EDIT - DNR TRAIT REWORK
 		return FALSE
 	return TRUE
 
@@ -115,7 +115,7 @@
 		balloon_alert_to_viewers("invalid target DNA!")
 		return
 	human_occupant = occupant
-	if(human_occupant.stat == DEAD && !HAS_TRAIT(human_occupant, TRAIT_DNR))
+	if(human_occupant.stat == DEAD)
 		balloon_alert_to_viewers("occupant is dead!")
 		return
 	if(!SSgoldeneye.check_goldeneye_target(human_occupant.mind)) // Preventing abuse by method of duplication.

--- a/modular_skyrat/modules/primitive_catgirls/code/smelling_salts.dm
+++ b/modular_skyrat/modules/primitive_catgirls/code/smelling_salts.dm
@@ -42,7 +42,7 @@
 	var/fail_reason
 
 	switch (defib_result)
-		if (DEFIB_FAIL_SUICIDE, DEFIB_FAIL_DNR, DEFIB_FAIL_BLACKLISTED, DEFIB_FAIL_NO_INTELLIGENCE)
+		if (DEFIB_FAIL_SUICIDE, DEFIB_FAIL_BLACKLISTED, DEFIB_FAIL_NO_INTELLIGENCE) // BUBBER EDIT - DNR REWORK
 			fail_reason = "[carbon_target] doesn't respond at all... You don't think they're coming back."
 		if (DEFIB_FAIL_NO_HEART, DEFIB_FAIL_FAILING_HEART, DEFIB_FAIL_FAILING_BRAIN)
 			fail_reason = "[carbon_target] seems to respond just a little, but something you can't see must be wrong about them..."

--- a/modular_zubbers/code/game/traits/neutral.dm
+++ b/modular_zubbers/code/game/traits/neutral.dm
@@ -1,0 +1,35 @@
+/datum/quirk/dnr/post_add()
+	quirk_holder.AddElement(/datum/element/dnr)
+
+/datum/quirk/dnr/remove()
+	quirk_holder.RemoveElement(/datum/element/dnr)
+
+/datum/element/dnr/
+	element_flags = ELEMENT_DETACH_ON_HOST_DESTROY
+
+/datum/element/dnr/proc/apply_dnr(mob/living/holder)
+	holder.ghostize()
+	var/mob/dead/observer/dnr_person = holder.mind.get_ghost(even_if_they_cant_reenter = TRUE)
+	dnr_person.can_reenter_corpse = FALSE
+	holder.med_hud_set_status()
+	dnr_person.stay_dead()
+	dnr_person.log_message("had their player ([key_name(src)]) do-not-resuscitate / DNR automatically via trait.", LOG_GAME, color = COLOR_GREEN, log_globally = FALSE)
+	if(!holder.has_quirk(/datum/quirk/dnr))
+		holder.add_quirk(/datum/quirk/dnr)
+	addtimer(CALLBACK(src, PROC_REF(cleanup), holder), 60 SECONDS)
+	message_admins("[holder] has died with DNR trait & element, releasing job slot in 60 seconds.")
+
+/datum/element/dnr/proc/cleanup(mob/living/holder) // What if they gib, though?
+	var/datum/job/job_to_free = SSjob.GetJob(holder.mind.assigned_role.title)
+	job_to_free.current_positions--
+	holder.log_message("has been released via their current body via DNR trait - ([holder])", LOG_GAME, color = COLOR_GREEN)
+	holder.mind = null
+
+/datum/element/dnr/Attach(mob/living/target)
+	. = ..()
+	if(!isliving(target))
+		return ELEMENT_INCOMPATIBLE
+	RegisterSignal(target, COMSIG_LIVING_DEATH, PROC_REF(apply_dnr))
+/datum/element/dnr/Detach(mob/living/target, ...)
+	. = ..()
+	UnregisterSignal(target, COMSIG_LIVING_DEATH)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7500,6 +7500,7 @@
 #include "modular_zubbers\code\game\objects\items\food\misc.dm"
 #include "modular_zubbers\code\game\objects\items\storage\boxes.dm"
 #include "modular_zubbers\code\game\traits\negative.dm"
+#include "modular_zubbers\code\game\traits\neutral.dm"
 #include "modular_zubbers\code\game\turf\space.dm"
 #include "modular_zubbers\code\modules\_defines.dm"
 #include "modular_zubbers\code\modules\admin\verbs\debug.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR makes the DNR trait act consistently with the DNR verb. The timer for releasing your job is a bit longer, however. 

## How This Contributes To The Skyrat Roleplay Experience

Less of a jank experience. 

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  

https://user-images.githubusercontent.com/77420409/210154927-f339ec5d-3024-4702-a019-9203a14b22fc.mp4


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
refactor: changed the DNR trait to do what the TG DNR verb does
code: removed skyrat DNR trait nonmodular edits
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
