### PR TITLE
Adds a fax machine to the MetaStation Bridge

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -24385,6 +24385,10 @@
 "iNB" = (
 /obj/machinery/firealarm/directional/east,
 /obj/structure/table/glass,
+/obj/machinery/fax{
+	fax_name = "Station Bridge";
+	name = "Bridge Fax Machine"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "iNC" = (


### PR DESCRIPTION
Does what it says on the tin. there's now a fax machine on the bridge, as requested in issue #114 I might be a little late on this one? idk which map actually gets used, the metastation one or metastation bubbers, but either way there's a fax there now!

## About The Pull Request

All i did was add a fax machine to the bridge on the MetaStation Map. I ran my test server and everything to make sure it was set up correctly and everything seems fine.

This one's probably a little late, but I did it anyway just to get a feel for using the mapping tools.