### PR TITLE
Adds mutant colors to dwarf

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/dwarf.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/dwarf.dm
@@ -3,6 +3,7 @@
 	id = SPECIES_DWARF
 	examine_limb_id = SPECIES_HUMAN
 	species_traits = list(
+		MUTCOLORS,
 		EYECOLOR,
 		HAIR,
 		FACEHAIR,
@@ -16,7 +17,7 @@
 		TRAIT_LITERATE,
 	)
 	mutanttongue = /obj/item/organ/internal/tongue/dwarven
-	use_skintones = 1
+	use_skintones = 0
 	skinned_type = /obj/item/stack/sheet/animalhide/human
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	payday_modifier = 0.75


### PR DESCRIPTION
I wanna be able to make small dwarf guys that have different colors!

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This changes dwarves from having human skin color to mutant colors like other races
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->
## Changelog

🆑 
add: mutant colors for dwarves
/:cl:

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
