### PR TITLE
Virus Cost Changes

### DIFF
--- a/code/modules/antagonists/disease/disease_abilities.dm
+++ b/code/modules/antagonists/disease/disease_abilities.dm
@@ -294,7 +294,7 @@ new /datum/disease_ability/symptom/powerful/youth
 
 /datum/disease_ability/symptom/medium
 	cost = 4
-	required_total_points =6
+	required_total_points =6//Bubber edit, orginally 8
 	category = "Symptom"
 
 /datum/disease_ability/symptom/medium/heal
@@ -303,7 +303,7 @@ new /datum/disease_ability/symptom/powerful/youth
 
 /datum/disease_ability/symptom/powerful
 	cost = 4
-	required_total_points = 10
+	required_total_points = 10//Bubber edit, orginally 16
 	category = "Symptom (Strong)"
 
 /datum/disease_ability/symptom/powerful/heal

--- a/code/modules/antagonists/disease/disease_abilities.dm
+++ b/code/modules/antagonists/disease/disease_abilities.dm
@@ -294,7 +294,7 @@ new /datum/disease_ability/symptom/powerful/youth
 
 /datum/disease_ability/symptom/medium
 	cost = 4
-	required_total_points = 8
+	required_total_points =6
 	category = "Symptom"
 
 /datum/disease_ability/symptom/medium/heal
@@ -303,7 +303,7 @@ new /datum/disease_ability/symptom/powerful/youth
 
 /datum/disease_ability/symptom/powerful
 	cost = 4
-	required_total_points = 16
+	required_total_points = 10
 	category = "Symptom (Strong)"
 
 /datum/disease_ability/symptom/powerful/heal


### PR DESCRIPTION
Important balances for Bubber's current pop levels.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Lowers the required total points for Sentient Viruses, useful for balancing with Bubber's population. The actual costs for the symptoms aren't changed, only the amount of hosts required to unlock each level of symptom. Untested as of now.
Does not change the requirements for mild symptoms.
<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Lowers Required Hosts for virus symptoms.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
