### PR TITLE
Adds a BlueShield office to Icebox

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation_bubber.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_bubber.dmm
@@ -6075,6 +6075,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"bNc" = (
+/turf/closed/wall,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/blueshield)
 "bNo" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -7349,6 +7353,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
+"cfr" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/carpet/executive,
+/area/blueshield)
 "cfC" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
@@ -7506,6 +7514,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"cir" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/commons/storage/emergency)
 "ciG" = (
 /obj/machinery/door/airlock/external{
 	name = "Security Yard";
@@ -10733,6 +10747,10 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/hallway/secondary/entry)
+"ddY" = (
+/obj/structure/table/wood,
+/turf/open/floor/carpet/executive,
+/area/blueshield)
 "ddZ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/green{
@@ -15841,6 +15859,11 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/station/science/xenobiology)
+"eGO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/blueshield)
 "eGW" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -18366,6 +18389,23 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"fth" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/camera/directional/south{
+	c_tag = "NT Consultant's Hallway";
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/blueshield)
 "ftt" = (
 /obj/structure/sign/warning/secure_area/directional/south{
 	desc = "A warning sign which reads 'SERVER ROOM'.";
@@ -26500,6 +26540,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"hTj" = (
+/obj/structure/closet/secure_closet/blueshield,
+/obj/machinery/light/directional/south,
+/turf/open/floor/carpet/royalblue,
+/area/blueshield)
 "hTm" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/meter,
@@ -26507,6 +26552,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"hTp" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblue,
+/area/blueshield)
 "hTt" = (
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
@@ -26787,6 +26838,14 @@
 /obj/machinery/telecomms/relay/preset/mining,
 /turf/open/floor/circuit,
 /area/mine/living_quarters)
+"hYD" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	name = "Window Shutters";
+	id = "blu_shutters"
+	},
+/turf/open/floor/plating,
+/area/blueshield)
 "hYI" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -31391,6 +31450,12 @@
 "jpS" = (
 /turf/closed/wall/r_wall,
 /area/station/cargo/warehouse)
+"jpW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood/large,
+/area/blueshield)
 "jqc" = (
 /obj/machinery/door/airlock/external{
 	glass = 1;
@@ -32059,6 +32124,9 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
+"jBf" = (
+/turf/open/floor/wood/large,
+/area/blueshield)
 "jBh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -32200,6 +32268,10 @@
 /obj/machinery/pdapainter/security,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/hos)
+"jDv" = (
+/obj/structure/chair/office,
+/turf/open/floor/wood/large,
+/area/blueshield)
 "jDG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32772,6 +32844,9 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"jLL" = (
+/turf/closed/wall,
+/area/blueshield)
 "jLO" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -39574,6 +39649,13 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library)
+"lNm" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/landmark/start/blueshield,
+/turf/open/floor/carpet/executive,
+/area/blueshield)
 "lNn" = (
 /obj/machinery/bluespace_vendor/directional/north,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -40596,6 +40678,15 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/plating,
 /area/station/science/ordnance)
+"meJ" = (
+/obj/machinery/power/apc/highcap/five_k/directional/east{
+	auto_name = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/wood/large,
+/area/blueshield)
 "meL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -54058,6 +54149,12 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/grimy,
 /area/station/commons/vacant_room/office)
+"qky" = (
+/obj/machinery/computer/crew{
+	dir = 4
+	},
+/turf/open/floor/carpet/executive,
+/area/blueshield)
 "qkB" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
@@ -56242,11 +56339,9 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "qRR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /obj/structure/cable,
-/obj/structure/chair/stool/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency)
 "qRT" = (
@@ -59017,6 +59112,14 @@
 /obj/structure/sign/warning/cold_temp,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"rMk" = (
+/obj/machinery/door/airlock/command{
+	name = "Blueshield's Office"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/blueshield)
 "rMr" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -66177,6 +66280,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"tUd" = (
+/obj/machinery/door/airlock/command{
+	name = "Blueshield's Office"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood/large,
+/area/blueshield)
 "tUh" = (
 /obj/item/chair/wood,
 /obj/effect/mapping_helpers/broken_floor,
@@ -67178,6 +67292,14 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/lobby)
+"ujF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/north,
+/turf/open/floor/wood/large,
+/area/blueshield)
 "ujI" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/light/directional/west,
@@ -67197,9 +67319,8 @@
 "uke" = (
 /obj/machinery/airalarm/directional/south,
 /obj/structure/cable,
-/obj/effect/spawner/random/entertainment/arcade{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency)
 "ukf" = (
@@ -67935,6 +68056,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage)
+"uuJ" = (
+/obj/structure/bed/double,
+/obj/item/bedsheet/nanotrasen/double,
+/turf/open/floor/carpet/royalblue,
+/area/blueshield)
 "uuP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -72497,6 +72623,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/mining)
+"vQI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/landmark/start/blueshield,
+/turf/open/floor/carpet/royalblue,
+/area/blueshield)
 "vQL" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -78671,6 +78805,23 @@
 /obj/machinery/requests_console/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/station/service/bar/backroom)
+"xEG" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin/carbon{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/obj/item/pen/fourcolor{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/obj/machinery/button/door/directional/west{
+	id = "blu_shutters";
+	name = "Window Shutters";
+	pixel_y = -8
+	},
+/turf/open/floor/carpet/executive,
+/area/blueshield)
 "xEI" = (
 /obj/machinery/door/airlock/security{
 	name = "Private Cell"
@@ -170062,9 +170213,9 @@ iDt
 iDt
 scw
 iDt
-nfG
-udC
-udC
+jLL
+jLL
+jLL
 udC
 iDt
 iDt
@@ -170316,12 +170467,12 @@ xMq
 xMq
 iDt
 iDt
-ijY
-xMq
-udC
-udC
-udC
-udC
+bNc
+hYD
+hYD
+jLL
+qky
+jLL
 udC
 nfG
 iDt
@@ -170573,12 +170724,12 @@ udC
 xMq
 xMq
 scw
-xMq
-xMq
-udC
-udC
-udC
-udC
+jLL
+fth
+jDv
+xEG
+lNm
+jLL
 udC
 xMq
 iDt
@@ -170831,14 +170982,14 @@ xvZ
 wkf
 iCC
 lOY
-udC
-udC
-udC
-udC
-udC
-udC
-udC
-udC
+ujF
+jBf
+ddY
+cfr
+jLL
+jLL
+jLL
+jLL
 iDt
 iDt
 iDt
@@ -171088,14 +171239,14 @@ fyC
 wkf
 iEK
 txI
-udC
-udC
-udC
-udC
-udC
-udC
-xMq
-xMq
+jpW
+meJ
+eGO
+eGO
+rMk
+vQI
+hTp
+jLL
 ijY
 iDt
 iDt
@@ -171345,14 +171496,14 @@ fyZ
 wkf
 kzq
 txI
-qnX
-txI
-txI
-txI
-udC
-xMq
-xMq
-xMq
+tUd
+jLL
+jLL
+jLL
+jLL
+uuJ
+hTj
+jLL
 xMq
 iDt
 iDt
@@ -171607,9 +171758,9 @@ txI
 uMl
 txI
 txI
-udC
-udC
-xMq
+jLL
+jLL
+jLL
 psb
 scw
 psb
@@ -171858,7 +172009,7 @@ feB
 fRQ
 hPJ
 lab
-lpb
+cir
 qRR
 qSw
 uPd


### PR DESCRIPTION
I've heard a few people complaining about the lack of blueshield offices on the maps, so I decided to start fixing it.

## About The Pull Request
 This adds a blueshield office just south of the NT-Rep's office, in that same little hallway. There is a small attached bedroom, and the windows have working shutters, like the other outward facing offices. This also means that icebox now has a spawn for the blueshield's locker, which is always handy.