### PR TITLE
Fixes ore redemtion windows

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -37043,7 +37043,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/left/directional/east{
-	name = "Ore Redemtion Window";
+	name = "Ore Redemption Window";
 	req_access = list("mineral_storeroom")
 	},
 /turf/open/floor/iron/dark,

--- a/_maps/map_files/IceBoxStation/IceBoxStation_bubber.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_bubber.dmm
@@ -38015,7 +38015,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/left/directional/east{
-	name = "Ore Redemtion Window";
+	name = "Ore Redemption Window";
 	req_access = list("mineral_storeroom")
 	},
 /turf/open/floor/iron/dark,

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -69855,7 +69855,7 @@
 	},
 /obj/machinery/door/window/left/directional/east{
 	dir = 8;
-	name = "Ore Redemtion Window";
+	name = "Ore Redemption Window";
 	req_access = list("mineral_storeroom")
 	},
 /turf/open/floor/plating,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -35680,7 +35680,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/left/directional/east{
-	name = "Ore Redemtion Window"
+	name = "Ore Redemption Window"
 	},
 /turf/open/floor/iron,
 /area/station/construction/storage_wing)

--- a/_maps/map_files/MetaStation/MetaStation_bubber.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_bubber.dmm
@@ -36566,7 +36566,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/left/directional/east{
-	name = "Ore Redemtion Window"
+	name = "Ore Redemption Window"
 	},
 /turf/open/floor/iron,
 /area/station/construction/storage_wing)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ore redemtion windows were spelled incorrectly in the code. This PR fixes the spelling error. Fully modular.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
Fix: spells Ore Redemption Window correctly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
