### PR TITLE
Reset the Gateway to TGstation, allowing cyborgs to enter

### DIFF
--- a/modular_skyrat/modules/black_mesa/code/gateway.dm
+++ b/modular_skyrat/modules/black_mesa/code/gateway.dm
@@ -1,2 +1,3 @@
-/obj/machinery/gateway/away/required_key
+/* /obj/machinery/gateway/away/required_key
 	requires_key = TRUE
+ */ // BUBBER EDIT DISABLE - TG GATEWAY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Very short sighted to mess up the gateway like this only because black mesa is the only gatway ran upstream
Why should be suffer mediocrity? 
Merge only after update from upstream
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Gateway now functions as it does on TGstation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
