### PR TITLE
Adds Hemophage Organs to the Limbgrower

### DIFF
--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -21,7 +21,7 @@
 	/// Our internal techweb for limbgrower designs.
 	var/datum/techweb/autounlocking/stored_research
 	/// All the categories of organs we can print.
-	var/list/categories = list(SPECIES_HUMAN, SPECIES_LIZARD, SPECIES_MOTH, SPECIES_PLASMAMAN, SPECIES_ETHEREAL, RND_CATEGORY_LIMBS_OTHER, RND_CATEGORY_LIMBS_DIGITIGRADE)
+	var/list/categories = list(SPECIES_HUMAN, SPECIES_LIZARD, SPECIES_MOTH, SPECIES_PLASMAMAN, SPECIES_ETHEREAL, RND_CATEGORY_LIMBS_OTHER, RND_CATEGORY_LIMBS_DIGITIGRADE, SPECIES_HEMOPHAGE)//BUBBER EDIT-Adds Hemophage to the list.
 	///Designs imported from technology disks that we can print.
 	var/list/imported_designs = list()
 

--- a/code/modules/research/designs/limbgrower_designs.dm
+++ b/code/modules/research/designs/limbgrower_designs.dm
@@ -197,6 +197,39 @@
 	build_path = /obj/item/organ/internal/lungs/ethereal
 	category = list(SPECIES_ETHEREAL)
 
+//Hemophage organs. Bubber Edit.
+/datum/design/hemophage_heart
+	name = "Pulsating Tumor"
+	id = "hemophageheart"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/blood = 10)
+	build_path = /obj/item/organ/internal/heart/hemophage
+	category = list(SPECIES_HEMOPHAGE)
+
+/datum/design/hemophage_liver
+	name = "Corrupted Liver"
+	id = "hemophageliver"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/blood = 10)
+	build_path = /obj/item/organ/internal/liver/hemophage
+	category = list(SPECIES_HEMOPHAGE)
+
+/datum/design/hemophage_stomach
+	name = "Corrupted Stomach"
+	id = "hemophagestomach"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/blood = 10)
+	build_path = /obj/item/organ/internal/stomach/hemophage
+	category = list(SPECIES_HEMOPHAGE)
+
+/datum/design/hemophage_tongue
+	name = "Corrupted Tongue"
+	id = "hemophagetongue"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/blood = 10)
+	build_path = /obj/item/organ/internal/tongue/hemophage
+	category = list(SPECIES_HEMOPHAGE)
+
 // Intentionally not growable by normal means - for balance conerns.
 /datum/design/ethereal_heart
 	name = "Crystal Core"
@@ -279,3 +312,13 @@
 	desc = "Contains designs for ethereal organs for the limbgrower - Ethereal tongue and stomach."
 	id = "limbdesign_ethereal"
 	build_path = /obj/item/disk/design_disk/limbs/ethereal
+
+/obj/item/disk/design_disk/limbs/hemophage
+	name = "Hemophage Organ Design Disk"
+	limb_designs = list(/datum/design/hemophage_heart, /datum/design/hemophage_liver, /datum/design/hemophage_stomach, /datum/design/hemophage_tongue)
+
+/datum/design/limb_disk/hemophage
+	name = "Hemophage Organ Design Disk"
+	desc = "Contains designs for hemophage organs for the limbgrower - Tounges, livers, tumors, and stomachs."
+	id = "limbdesign_hemophage"
+	build_path = /obj/item/disk/design_disk/limbs/hemophage

--- a/code/modules/research/designs/limbgrower_designs.dm
+++ b/code/modules/research/designs/limbgrower_designs.dm
@@ -197,39 +197,6 @@
 	build_path = /obj/item/organ/internal/lungs/ethereal
 	category = list(SPECIES_ETHEREAL)
 
-//Hemophage organs. Bubber Edit.
-/datum/design/hemophage_heart
-	name = "Pulsating Tumor"
-	id = "hemophageheart"
-	build_type = LIMBGROWER
-	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/blood = 10)
-	build_path = /obj/item/organ/internal/heart/hemophage
-	category = list(SPECIES_HEMOPHAGE)
-
-/datum/design/hemophage_liver
-	name = "Corrupted Liver"
-	id = "hemophageliver"
-	build_type = LIMBGROWER
-	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/blood = 10)
-	build_path = /obj/item/organ/internal/liver/hemophage
-	category = list(SPECIES_HEMOPHAGE)
-
-/datum/design/hemophage_stomach
-	name = "Corrupted Stomach"
-	id = "hemophagestomach"
-	build_type = LIMBGROWER
-	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/blood = 10)
-	build_path = /obj/item/organ/internal/stomach/hemophage
-	category = list(SPECIES_HEMOPHAGE)
-
-/datum/design/hemophage_tongue
-	name = "Corrupted Tongue"
-	id = "hemophagetongue"
-	build_type = LIMBGROWER
-	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/blood = 10)
-	build_path = /obj/item/organ/internal/tongue/hemophage
-	category = list(SPECIES_HEMOPHAGE)
-
 // Intentionally not growable by normal means - for balance conerns.
 /datum/design/ethereal_heart
 	name = "Crystal Core"
@@ -312,13 +279,3 @@
 	desc = "Contains designs for ethereal organs for the limbgrower - Ethereal tongue and stomach."
 	id = "limbdesign_ethereal"
 	build_path = /obj/item/disk/design_disk/limbs/ethereal
-
-/obj/item/disk/design_disk/limbs/hemophage
-	name = "Hemophage Organ Design Disk"
-	limb_designs = list(/datum/design/hemophage_heart, /datum/design/hemophage_liver, /datum/design/hemophage_stomach, /datum/design/hemophage_tongue)
-
-/datum/design/limb_disk/hemophage
-	name = "Hemophage Organ Design Disk"
-	desc = "Contains designs for hemophage organs for the limbgrower - Tounges, livers, tumors, and stomachs."
-	id = "limbdesign_hemophage"
-	build_path = /obj/item/disk/design_disk/limbs/hemophage

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -473,6 +473,7 @@
 		"limbdesign_felinid",
 		"limbdesign_lizard",
 		"limbdesign_plasmaman",
+		"limbdesign_hemophage",//bubber addition
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 6500)
 	discount_experiments = list(

--- a/modular_zubbers/code/modules/designs/limbgrower_designs.dm
+++ b/modular_zubbers/code/modules/designs/limbgrower_designs.dm
@@ -1,0 +1,41 @@
+/datum/design/hemophage_heart
+	name = "Pulsating Tumor"
+	id = "hemophageheart"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/blood = 10)
+	build_path = /obj/item/organ/internal/heart/hemophage
+	category = list(SPECIES_HEMOPHAGE)
+
+/datum/design/hemophage_liver
+	name = "Corrupted Liver"
+	id = "hemophageliver"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/blood = 10)
+	build_path = /obj/item/organ/internal/liver/hemophage
+	category = list(SPECIES_HEMOPHAGE)
+
+/datum/design/hemophage_stomach
+	name = "Corrupted Stomach"
+	id = "hemophagestomach"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/blood = 10)
+	build_path = /obj/item/organ/internal/stomach/hemophage
+	category = list(SPECIES_HEMOPHAGE)
+
+/datum/design/hemophage_tongue
+	name = "Corrupted Tongue"
+	id = "hemophagetongue"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/blood = 10)
+	build_path = /obj/item/organ/internal/tongue/hemophage
+	category = list(SPECIES_HEMOPHAGE)
+
+/obj/item/disk/design_disk/limbs/hemophage
+	name = "Hemophage Organ Design Disk"
+	limb_designs = list(/datum/design/hemophage_heart, /datum/design/hemophage_liver, /datum/design/hemophage_stomach, /datum/design/hemophage_tongue)
+
+/datum/design/limb_disk/hemophage
+	name = "Hemophage Organ Design Disk"
+	desc = "Contains designs for hemophage organs for the limbgrower - Tounges, livers, tumors, and stomachs."
+	id = "limbdesign_hemophage"
+	build_path = /obj/item/disk/design_disk/limbs/hemophage

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7072,6 +7072,7 @@
 #include "modular_zubbers\code\modules\customization\sprite_accessories\snouts.dm"
 #include "modular_zubbers\code\modules\customization\sprite_accessories\tails.dm"
 #include "modular_zubbers\code\modules\customization\sprite_accessories\taurs.dm"
+#include "modular_zubbers\code\modules\designs\limbgrower_designs.dm"
 #include "modular_zubbers\code\modules\dynamic\midround_rulesets.dm"
 #include "modular_zubbers\code\modules\fluff\flora\ash_flora.dm"
 #include "modular_zubbers\code\modules\food_and_drinks\recipes\tablecraft\recipes_seafood.dm"


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the Hemophage organs to the limbgrower, requiring the xeno-biology research node and a custom organ design disk. Each organ requires a small amount of synthflesh and blood. Also adds a Hemophage tab to the limbgrower. Tested in game!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Adds Hemophage(Corrupted) Organs to the Limbgrower
add: Adds Hemophage Organ Design Disk to the Xeno-Biology research Node
add: Adds Hemophage tab to Limbgrower
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
