### PR TITLE
[MODULAR] Crew Monitor Console Alarm

### DIFF
--- a/modular_zubbers/code/game/machinery/crew_monitor.dm
+++ b/modular_zubbers/code/game/machinery/crew_monitor.dm
@@ -5,19 +5,14 @@
 	luminosity = 1
 	light_power = 3
 	var/canalarm = FALSE
-	var/obj/item/radio/radio
 
 
 /obj/machinery/computer/crew/Initialize(mapload, obj/item/circuitboard/C)
 	. = ..()
-
-	radio = new/obj/item/radio(src)
-	radio.set_listening(FALSE)
 	alarm()
 
 /obj/machinery/computer/crew/proc/alarm()
 	canalarm = FALSE
-	var/injuredcount = 0
 
 	for(var/tracked_mob in GLOB.suit_sensors_list)
 		var/mob/living/carbon/human/mob = tracked_mob
@@ -25,10 +20,8 @@
 			continue
 		var/obj/item/clothing/under/uniform = mob.w_uniform
 		if(uniform.sensor_mode >= SENSOR_VITALS && HAS_TRAIT(mob, TRAIT_CRITICAL_CONDITION) || mob.stat == DEAD && mob.mind)
-			injuredcount++
 			canalarm = TRUE
 		else if(uniform.sensor_mode == SENSOR_LIVING && mob.stat == DEAD)
-			injuredcount++
 			canalarm = TRUE
 
 
@@ -38,7 +31,7 @@
 
 	else
 		set_light((initial(light_range)), initial(light_power), initial(light_color), TRUE)
-	addtimer(CALLBACK(src, .proc/alarm), SENSORS_UPDATE_PERIOD)
+	addtimer(CALLBACK(src, .proc/alarm), SENSORS_UPDATE_PERIOD) // Fix this for 515
 
 	return canalarm
 

--- a/modular_zubbers/code/game/machinery/crew_monitor.dm
+++ b/modular_zubbers/code/game/machinery/crew_monitor.dm
@@ -1,4 +1,4 @@
-#define SENSORS_UPDATE_PERIOD 10 SECONDS //Why is this not a global define, why do I have to define it again
+#define SENSORS_UPDATE_PERIOD 15 SECONDS //Why is this not a global define, why do I have to define it again
 
 
 /obj/machinery/computer/crew

--- a/modular_zubbers/code/game/machinery/crew_monitor.dm
+++ b/modular_zubbers/code/game/machinery/crew_monitor.dm
@@ -1,0 +1,45 @@
+#define SENSORS_UPDATE_PERIOD 10 SECONDS //Why is this not a global define, why do I have to define it again
+
+
+/obj/machinery/computer/crew
+	luminosity = 1
+	light_power = 3
+	var/canalarm = FALSE
+	var/obj/item/radio/radio
+
+
+/obj/machinery/computer/crew/Initialize(mapload, obj/item/circuitboard/C)
+	. = ..()
+
+	radio = new/obj/item/radio(src)
+	radio.set_listening(FALSE)
+	alarm()
+
+/obj/machinery/computer/crew/proc/alarm()
+	canalarm = FALSE
+	var/injuredcount = 0
+
+	for(var/tracked_mob in GLOB.suit_sensors_list)
+		var/mob/living/carbon/human/mob = tracked_mob
+		if(mob.z != src.z  && !HAS_TRAIT(mob, TRAIT_MULTIZ_SUIT_SENSORS))
+			continue
+		var/obj/item/clothing/under/uniform = mob.w_uniform
+		if(uniform.sensor_mode >= SENSOR_VITALS && HAS_TRAIT(mob, TRAIT_CRITICAL_CONDITION) || mob.stat == DEAD && mob.mind)
+			injuredcount++
+			canalarm = TRUE
+		else if(uniform.sensor_mode == SENSOR_LIVING && mob.stat == DEAD)
+			injuredcount++
+			canalarm = TRUE
+
+
+	if(canalarm)
+		playsound(src, 'sound/machines/twobeep.ogg', 50, TRUE)
+		set_light((initial(light_range) + 3), 3, CIRCUIT_COLOR_SECURITY, TRUE)
+
+	else
+		set_light((initial(light_range)), initial(light_power), initial(light_color), TRUE)
+	addtimer(CALLBACK(src, .proc/alarm), SENSORS_UPDATE_PERIOD)
+
+	return canalarm
+
+#undef SENSORS_UPDATE_PERIOD

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7486,6 +7486,7 @@
 #include "modular_zubbers\code\game\area\areas\station.dm"
 #include "modular_zubbers\code\game\brain_damage\severe.dm"
 #include "modular_zubbers\code\game\Items\plushes.dm"
+#include "modular_zubbers\code\game\machinery\crew_monitor.dm"
 #include "modular_zubbers\code\game\machinery\computer\arcade.dm"
 #include "modular_zubbers\code\game\machinery\computer\crew.dm"
 #include "modular_zubbers\code\game\objects\effects\decals.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

An example PR for showing how to do modular additions of functionality. 
This PR adds a red glow and a ping when the crew monitor has people in critical on the station. 

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
https://user-images.githubusercontent.com/77420409/165019092-4f4ed12f-dbd1-49ff-b5e9-016e8680a8f5.mp4
:cl:
add: Crew monitor now has a suit sensors alarm, like baylikes!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
