### PR TITLE
Adds crew monitors to Advanced biotech and lathes

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -455,6 +455,10 @@
 		"bodymedicell",
 		"clotmedicell",
 		//SKYRAT EDIT END  -
+
+		//BUBBER EDIT START
+		"crewmonitor",
+		//BUBBER EDIT END
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 	required_experiments = list(/datum/experiment/dissection/nonhuman)

--- a/modular_zubbers/code/modules/research/designs/medical_designs.dm
+++ b/modular_zubbers/code/modules/research/designs/medical_designs.dm
@@ -2,6 +2,7 @@
 	name = "Handheld crew monitor"
 	desc = "A miniature machine that tracks suit sensors across the station."
 	id = "crewmonitor"
+	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT * 1.5, /datum/material/silver = SMALL_MATERIAL_AMOUNT*5)
 	build_path = /obj/item/sensor_device
 	category = list(

--- a/modular_zubbers/code/modules/research/designs/medical_designs.dm
+++ b/modular_zubbers/code/modules/research/designs/medical_designs.dm
@@ -1,0 +1,10 @@
+/datum/design/crewmonitor
+	name = "Handheld crew monitor"
+	desc = "A miniature machine that tracks suit sensors across the station."
+	id = "crewmonitor"
+	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT * 1.5, /datum/material/silver = SMALL_MATERIAL_AMOUNT*5)
+	build_path = /obj/item/sensor_device
+	category = list(
+		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_MEDICAL
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7142,6 +7142,7 @@
 #include "modular_zubbers\code\modules\pai\ghost_pai.dm"
 #include "modular_zubbers\code\modules\projectiles\guns\energy\pulse.dm"
 #include "modular_zubbers\code\modules\research\designs\comp_board_designs.dm"
+#include "modular_zubbers\code\modules\research\designs\medical_designs.dm"
 #include "modular_zubbers\code\modules\status_indicators\status_indicator.dm"
 #include "modular_zubbers\code\modules\status_indicators\status_indicator_pref.dm"
 #include "modular_zubbers\code\modules\surgery\bodyparts\species_parts\misc_bodyparts.dm"


### PR DESCRIPTION
## About The Pull Request
Rationale: Both this and the pinpointer can be purchased for the same price from the vendor, but only one gets to be printable, which feels kinda stupid.

Well not anymore, this adds the Handheld crew monitor under the Advanced biotech node.

- [x] Tested

## Changelog
:cl:
add: You can now print pinpointers
/:cl: