### PR TITLE
Oversized quirk changes

### DIFF
--- a/code/__DEFINES/~skyrat_defines/combat.dm
+++ b/code/__DEFINES/~skyrat_defines/combat.dm
@@ -17,7 +17,7 @@
 #define CLICK_CD_RANGE_TIRED 5 //#define CLICK_CD_RANGE 4, so 25% slower
 
 //Grab breakout odds
-#define OVERSIZED_GRAB_RESIST_BONUS 10 /// For those with the oversized trait, they get this.
+#define OVERSIZED_GRAB_RESIST_BONUS 0 // BUBBER EDIT- With this oversized are just as good at grabs as anyone else.
 
 // Damage modifiers
 #define OVERSIZED_HARM_DAMAGE_BONUS 5 /// Those with the oversized trait do 5 more damage.

--- a/code/modules/vehicles/sealed.dm
+++ b/code/modules/vehicles/sealed.dm
@@ -50,9 +50,9 @@
 	if(!istype(M))
 		return FALSE
 	//SKYRAT EDIT ADDITION
-	if(HAS_TRAIT(M, TRAIT_OVERSIZED))
+	/*if(HAS_TRAIT(M, TRAIT_OVERSIZED))
 		to_chat(M, span_warning("You are far too big for this!"))
-		return FALSE
+		return FALSE*/                                   //BUBBER EDIT: commented out this Skyrat change.
 	//SKYRAT EDIT END
 	if(do_after(M, get_enter_delay(M), src, timed_action_flags = IGNORE_HELD_ITEM, extra_checks = CALLBACK(src, PROC_REF(enter_checks), M)))
 		mob_enter(M)

--- a/modular_skyrat/modules/oversized/code/door.dm
+++ b/modular_skyrat/modules/oversized/code/door.dm
@@ -1,3 +1,5 @@
+//BUBBER EDIT: Commenting out this whole file, we don't want this.
+/*
 /obj/machinery/door/airlock/Initialize(mapload)
 	. = ..()
 	var/static/list/loc_connections = list(
@@ -18,4 +20,4 @@
 			crossing_human.visible_message(span_warning("[crossing_human] slams their head into the frame of [src] with a sickening thud!"), \
 				span_userdanger("You slam your head against [src]!")
 			)
-			playsound(crossed_atom, 'sound/effects/bang.ogg', 50, TRUE)
+			playsound(crossed_atom, 'sound/effects/bang.ogg', 50, TRUE)*/


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Yeah so 15 brain damage for forgetting to toggle walk intent when walking through an airlock is really harsh. They have various benefits and disadvantages, I think even with these changes the are weaker.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Oversized people no longer get bonuses to their grabs/their chance to break out of being grabbed
add: Vehicle bays have been expanded to allow oversized people inside!
del: Oversized people, Nanotrasen has heard you: We've introduced a brand new line of airlocks, extra tall- And yes it's definitely our compassion and not the medical bills your brain injuries have caused you... fucking hell, can't even look out for themselves... oh fuck this thing is still on!!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
