### PR TITLE
Attempts to band aid spine wagging

### DIFF
--- a/code/modules/surgery/organs/external/tails.dm
+++ b/code/modules/surgery/organs/external/tails.dm
@@ -117,11 +117,14 @@
 	///A reference to the paired_spines, since for some fucking reason tail spines are tied to the spines themselves.
 	var/obj/item/organ/external/spines/paired_spines
 
-/obj/item/organ/external/tail/lizard/Insert(mob/living/carbon/reciever, special, drop_if_replaced)
+//BUBBER FIX START
+//This edit atempts to bandaid the spine wagging issue and should be overriden the moment someone else figures it out
+/obj/item/organ/external/tail/lizard/Insert(mob/living/carbon/receiver, special, drop_if_replaced)
 	. = ..()
-	if(.)
-		paired_spines = ownerlimb.owner.get_organ_slot(ORGAN_SLOT_EXTERNAL_SPINES)
-		paired_spines?.paired_tail = src
+	paired_spines = ownerlimb.owner.get_organ_slot(ORGAN_SLOT_EXTERNAL_SPINES)
+	if(!paired_spines)
+		return ..()
+	paired_spines?.paired_tail = src
 
 /obj/item/organ/external/tail/lizard/Remove(mob/living/carbon/organ_owner, special, moving)
 	. = ..()
@@ -131,10 +134,12 @@
 
 /obj/item/organ/external/tail/lizard/start_wag()
 	. = ..()
-
+	if(!paired_spines) //The insert proc is not getting called, and I can't find the missing implementation
+		paired_spines = ownerlimb.owner.get_organ_slot(ORGAN_SLOT_EXTERNAL_SPINES)
 	if(paired_spines)
 		var/datum/bodypart_overlay/mutant/spines/accessory = paired_spines.bodypart_overlay
 		accessory.wagging = TRUE
+//BUBBER FIX END
 
 /obj/item/organ/external/tail/lizard/stop_wag()
 	. = ..()

--- a/modular_skyrat/modules/customization/modules/surgery/organs/spines.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/spines.dm
@@ -12,6 +12,14 @@
 /datum/bodypart_overlay/mutant/spines/can_draw_on_bodypart(mob/living/carbon/human/human)
 	return !sprite_datum.is_hidden(human)
 
+//BUBBER FIX START
+/datum/bodypart_overlay/mutant/spines/get_feature_key_for_overlay()
+	return (wagging ? "wagging" : "") + feature_key
+
+/datum/bodypart_overlay/mutant/spines/get_base_icon_state()
+	return sprite_datum.icon_state
+//BUBBER FIX END
+
 /// We overwrite this just because we need to change the layer to be ever so slightly above the tails.
 /// It sucks, but it's the best I could do without refactoring a lot more.
 /datum/bodypart_overlay/mutant/spines/get_images(image_layer, obj/item/bodypart/limb)

--- a/modular_skyrat/modules/customization/modules/surgery/organs/tails.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/tails.dm
@@ -40,8 +40,9 @@
 
 	return TRUE
 
-
-/obj/item/organ/external/tail/Insert(mob/living/carbon/reciever, special, drop_if_replaced)
+//BUBBER FIX START
+/obj/item/organ/external/tail/Insert(mob/living/carbon/receiver, special, drop_if_replaced)
+//BUBBER FIX END
 	if(sprite_accessory_flags & SPRITE_ACCESSORY_WAG_ABLE)
 		wag_flags |= WAG_ABLE
 	return ..()


### PR DESCRIPTION
## About The Pull Request

closes: #252

### Quick rundown of what is broken
For some reason, someone somewhere deleted the Insert proc call for lizard tails. I have looked through about 50 different files, ran through the last 3 months of PRs that touched organ/customization code, and found nothing out of place, be it for my inexperience or influence of a higher power.

Thus I have put together this QoL quickfix: Spines are now checked again when trying to wag, which works.

(Please someone who knows more about this try to point me in the right direction so I don't have to do this)

- [x] Searched for the error
- [x] Found the issue
- [x] Cried a lot trying to fix it
- [x] Tested the fix
- [ ] Make the spines not disappear


## Changelog
:cl:
fix: Lizard spines no longer disconnect from the rest of the body upon wagging
/:cl:
