### PR TITLE
Hugboxes pierced realities

### DIFF
--- a/code/modules/antagonists/heretic/influences.dm
+++ b/code/modules/antagonists/heretic/influences.dm
@@ -136,6 +136,7 @@
 /obj/effect/visible_heretic_influence/proc/show_presence()
 	animate(src, alpha = 255, time = 15 SECONDS)
 
+/* Bubberstation change: hugboxes heretic stuff
 /obj/effect/visible_heretic_influence/attack_hand(mob/living/user, list/modifiers)
 	. = ..()
 	if(.)
@@ -182,6 +183,7 @@
 	var/datum/effect_system/reagents_explosion/explosion = new()
 	explosion.set_up(1, get_turf(human_user), TRUE, 0)
 	explosion.start(src)
+*/
 
 /obj/effect/visible_heretic_influence/examine(mob/user)
 	. = ..()
@@ -191,7 +193,7 @@
 	var/mob/living/carbon/human/human_user = user
 	to_chat(human_user, span_userdanger("Your mind burns as you stare at the tear!"))
 	human_user.adjustOrganLoss(ORGAN_SLOT_BRAIN, 10, 190)
-	human_user.add_mood_event("gates_of_mansus", /datum/mood_event/gates_of_mansus)
+	// human_user.add_mood_event("gates_of_mansus", /datum/mood_event/gates_of_mansus) Bubberstation change: Hugboxes heretics.
 
 /obj/effect/heretic_influence
 	name = "reality smash"


### PR DESCRIPTION

## About The Pull Request

- Pierced realities no longer gib your entire head when you click on them with TK.
- Pierced realities no longer dismember your arms when you click on them without TK.
- Pierced realities no longer make you want to die when you examine them (still give drain bamage).

## Justification

New players won't get baited into clicking on the pierced reality. This is funny, but it's just annoying for medical.
Veteran players won't get baited into clicking on the pierced reality with TK because they're curious to see what would happen.
The mood debuff is ultimately pointless and no one ever takes it seriously anyways.

## Changelog

:cl: BurgerBB
del: Hugboxes pierced realities by removing some non-heretic functionality.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
