### PR TITLE
[MODULAR] Adds a hud to being a cortical borer.

### DIFF
--- a/modular_zubbers/code/modules/borer_hud/borer.dm
+++ b/modular_zubbers/code/modules/borer_hud/borer.dm
@@ -1,0 +1,54 @@
+/mob/living/basic/cortical_borer
+	hud_type = /datum/hud/borer
+///Hud type with targetting dol and a nutrition bar
+/datum/hud/borer/New(mob/living/owner)
+	. = ..()
+	var/atom/movable/screen/using
+
+	action_intent = new /atom/movable/screen/combattoggle/flashy()
+	action_intent.hud = src
+	action_intent.icon = ui_style
+	action_intent.screen_loc = ui_combat_toggle
+	static_inventory += action_intent
+
+	using = new /atom/movable/screen/language_menu()
+	using.icon = ui_style
+	using.hud = src
+	using.update_appearance()
+	static_inventory += using
+
+	using = new /atom/movable/screen/navigate
+	using.screen_loc = ui_alien_navigate_menu
+	using.hud = src
+	static_inventory += using
+
+	healthdoll = new /atom/movable/screen/healthdoll/living()
+	healthdoll.hud = src
+	infodisplay += healthdoll
+/mob/living/basic/cortical_borer/Life(seconds_per_tick, times_fired)
+	. = ..()
+	update_health_hud() // it literally won't otherwise.
+
+/mob/living/basic/cortical_borer/update_health_hud()
+	. = ..()
+
+	var/string = ""
+	string += "Your health: [health] / [maxHealth] \n"
+	string += "CHEM: [chemical_storage] / [max_chemical_storage] | [chemical_evolution ? chemical_evolution : null] \n"
+	if(stat_evolution)
+		string += "STAT AVAIL: [stat_evolution] \n"
+	if(human_host)
+		var/brute = "<span style=color:red>[human_host.bruteloss]</span>"
+		var/burn = "<span style=color:white>[human_host.fireloss]</span>"
+		var/tox = "<span style=color:green>[human_host.toxloss]</span>"
+		var/oxy = "<span style=color:blue>[human_host.oxyloss]</span>"
+		var/blood = "<span style=color:magenta>[human_host.blood_volume]</span>"
+		string += "[brute] | [burn] | [tox] | [oxy] | [blood]u"
+	if(hud_used?.action_intent)
+		hud_used.action_intent.maptext = MAPTEXT(string)
+		hud_used.action_intent.maptext_height = 400
+		hud_used.action_intent.maptext_width = 400
+		hud_used.action_intent.maptext_y = 64
+		hud_used.action_intent.maptext_x = -64
+
+

--- a/modular_zubbers/code/modules/borer_hud/borer.dm
+++ b/modular_zubbers/code/modules/borer_hud/borer.dm
@@ -38,8 +38,8 @@
 	if(stat_evolution)
 		string += "STAT AVAIL: [stat_evolution] \n"
 	if(human_host)
-		var/brute = "<span style=color:red>[human_host.bruteloss]</span>"
-		var/burn = "<span style=color:white>[human_host.fireloss]</span>"
+		var/brute = "<span style=color:red>[human_host.getBruteLoss()]</span>" // Limbs
+		var/burn = "<span style=color:white>[human_host.getFireLoss()]</span>" // Limbs
 		var/tox = "<span style=color:green>[human_host.toxloss]</span>"
 		var/oxy = "<span style=color:blue>[human_host.oxyloss]</span>"
 		var/blood = "<span style=color:magenta>[human_host.blood_volume]</span>"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7099,6 +7099,7 @@
 #include "modular_zubbers\code\game\objects\items\food\misc.dm"
 #include "modular_zubbers\code\modules\_defines.dm"
 #include "modular_zubbers\code\modules\asset_cache\assets\arcade.dm"
+#include "modular_zubbers\code\modules\borer_hud\borer.dm"
 #include "modular_zubbers\code\modules\clothing\head\helmet.dm"
 #include "modular_zubbers\code\modules\clothing\head\jobs.dm"
 #include "modular_zubbers\code\modules\clothing\head\wig.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Does as the title says. I hate spamming the healthscan button. 

http://hosts-the-files.weh.gay/dreamseeker_EHRUagDAal.mp4
![dreamseeker_RAk7GdxHHl](https://github.com/Bubberstation/Bubberstation/assets/77420409/bc8f4c7d-874d-487e-8315-ce19b9bb664d)
![dreamseeker_WGR7dk81dl](https://github.com/Bubberstation/Bubberstation/assets/77420409/5199a67c-785a-4a48-b2ae-ec28b0e16d5b)


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Cortical Borers now have a HUD. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
