### PR TITLE
Removes Hand Teleporter Portal Dispelling

### DIFF
--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -134,6 +134,7 @@
 	. = ..()
 	active_portal_pairs = list()
 
+/* Bubberstation change: Removes portal dispelling.
 /obj/item/hand_tele/pre_attack(atom/target, mob/user, params)
 	if(try_dispel_portal(target, user))
 		return TRUE
@@ -149,6 +150,7 @@
 /obj/item/hand_tele/afterattack(atom/target, mob/user)
 	try_dispel_portal(target, user)
 	. = ..()
+*/
 
 /obj/item/hand_tele/pre_attack_secondary(atom/target, mob/user, proximity_flag, click_parameters)
 	var/portal_location = last_portal_location


### PR DESCRIPTION

## About The Pull Request

You can no longer dispel portals with the Hand Teleporter.

# Why this is good for the game

While hand teleporters should be strong, I feel that giving the ability to immediately close portals after you traveled through them is perhaps too strong for the item in question. Currently, there is nothing stopping a Head of Staff or an antagonist from taking the hand teleporter round start and then using it to teleport away constantly to evade threats.

## Changelog

:cl: BurgerBB
balance: The hand teleporter can no longer dispel portals.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
