### PR TITLE
Buffids

### DIFF
--- a/code/__DEFINES/id_cards.dm
+++ b/code/__DEFINES/id_cards.dm
@@ -11,13 +11,13 @@
  */
 
 /// Wildcard slot define for basic grey cards. Only hold 2 common wildcards.
-#define WILDCARD_LIMIT_GREY list(WILDCARD_NAME_COMMON = list(limit = 2, usage = list()))
-/// Wildcard slot define for Head of Staff silver cards. Can hold 3 common, 1 command and 1 private command.
-#define WILDCARD_LIMIT_SILVER list( \
-	WILDCARD_NAME_COMMON = list(limit = 3, usage = list()), \
-	WILDCARD_NAME_COMMAND = list(limit = 1, usage = list()), \
+#define WILDCARD_LIMIT_GREY list( \
+	WILDCARD_NAME_COMMON = list(limit = 12, usage = list()), \
+	WILDCARD_NAME_COMMAND = list(limit = 2, usage = list()), \
 	WILDCARD_NAME_PRV_COMMAND = list(limit = 1, usage = list()) \
-)
+) //BUBBER EDITS: Much more slots.
+/// Wildcard slot define for Head of Staff silver cards. Can hold 3 common, 1 command and 1 private command.
+#define WILDCARD_LIMIT_SILVER list(WILDCARD_NAME_CAPTAIN = list(limit = -1, usage = list())) //BUBBER EDIT: Infinite slots, like a gold ID
 /// Wildcard slot define for Captain gold cards. Can hold infinite of any Captain level wildcard.
 #define WILDCARD_LIMIT_GOLD list(WILDCARD_NAME_CAPTAIN = list(limit = -1, usage = list()))
 /// Wildcard slot define for select Syndicate-affiliated cards. Can hold infinite of any Syndicate level wildcard. Syndicate includes all station accesses.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Regular IDs get more wildcard slots than silver IDs
Silver IDs get infinite slots, making them identical to gold IDs.

Happy to discuss these values and hear what you think!

## Changelog

:cl:
balance: ID cards can hold a lot more accesses now: Silver IDs can hold anything like Gold IDs, and regular IDs have a lot more wildcard slots
/:cl:
