### PR TITLE
fixes quartermaster's supply remote not having access to blacksmith doors

### DIFF
--- a/code/__DEFINES/access.dm
+++ b/code/__DEFINES/access.dm
@@ -499,6 +499,7 @@
 	ACCESS_MINING_STATION, \
 	ACCESS_QM, \
 	ACCESS_SHIPPING, \
+	ACCESS_BLACKSMITH, \
 	ACCESS_VAULT, \
 )
 /// Name for the Command region.


### PR DESCRIPTION
## About The Pull Request

see title

## Changelog

:cl:
fix: The supply door remote can now access the blacksmithing office's doors, as intended.
/:cl:
