### PR TITLE
[Modular] Makes all techwebs generate points

### DIFF
--- a/modular_zubbers/code/modules/research/techweb/_techweb.dm
+++ b/modular_zubbers/code/modules/research/techweb/_techweb.dm
@@ -1,0 +1,2 @@
+/datum/techweb
+	var/should_generate_points = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it so that all new techwebs (including the station techweb) generate points by DEFAULT. This is to make techwebs compatible with ghost roles making new servers.
Coupled with turning on NO_DEFAULT_TECHWEB_LINK, this will solve ghost roles being connected to the station research network by default, while still allowing them to research.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
Add: Techwebs generate points by default.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
