### PR TITLE
Improves HoS gear armour values

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -114,9 +114,9 @@
 	strip_delay = 80
 
 /datum/armor/armor_hos
-	melee = 40
-	bullet = 35
-	laser = 40
+	melee = 40 // BUBBER EDIT - OG: 30
+	bullet = 35 // BUBBER EDIT - OG: 30
+	laser = 40 // BUBBER EDIT - OG: 30
 	energy = 40
 	bomb = 25
 	fire = 70

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -114,9 +114,9 @@
 	strip_delay = 80
 
 /datum/armor/armor_hos
-	melee = 30
-	bullet = 30
-	laser = 30
+	melee = 40
+	bullet = 35
+	laser = 40
 	energy = 40
 	bomb = 25
 	fire = 70


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Buffs HoS armour so that it's not **worse** than regular security vests.

## Changelog
HoS armor now has 40 melee, 35 bullet, and 40 laser protection. For reference, it used to be 30 armor for all of them.
For comparison, security vests are 35, 30, 30. Captain's carapace is 50, 40, 50.

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: HoS armor now has slightly better protection values than regular security gear, instead of being worse.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
