### PR TITLE
SyndieViro remap (off-station)

### DIFF
--- a/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
@@ -155,12 +155,12 @@
 /obj/structure/table/reinforced,
 /obj/machinery/light/directional/south,
 /obj/effect/spawner/random/food_or_drink/donkpockets{
-	pixel_y = 7;
-	pixel_x = 10
+	pixel_x = 10;
+	pixel_y = 7
 	},
 /obj/item/storage/box/donkpockets{
-	pixel_y = 5;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 5
 	},
 /turf/open/floor/iron/kitchen,
 /area/ruin/syndicate_lava_base/bar)
@@ -366,6 +366,18 @@
 	dir = 8
 	},
 /area/ruin/syndicate_lava_base/main)
+"cs" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/effect/turf_decal/stripes/red/full,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "cu" = (
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 4
@@ -525,22 +537,13 @@
 /area/ruin/syndicate_lava_base/virology)
 "dw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8;
 	external_pressure_bound = 140;
 	name = "server vent";
-	pressure_checks = 0;
-	dir = 8
+	pressure_checks = 0
 	},
 /turf/open/floor/circuit/telecomms,
 /area/ruin/syndicate_lava_base/testlab)
-"dy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/chair/plastic{
-	dir = 4
-	},
-/turf/open/floor/plating/icemoon,
-/area/ruin/syndicate_lava_base/medbay)
 "dz" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Bar"
@@ -610,8 +613,8 @@
 "dT" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/rndboards{
-	pixel_y = 15;
-	pixel_x = 2
+	pixel_x = 2;
+	pixel_y = 15
 	},
 /obj/item/storage/part_replacer{
 	pixel_y = 6
@@ -729,8 +732,8 @@
 	},
 /obj/machinery/button/door/directional/south{
 	id = "interdynecargo";
-	req_access = list("syndicate");
-	pixel_y = 24
+	pixel_y = 24;
+	req_access = list("syndicate")
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/cargo)
@@ -899,9 +902,9 @@
 /area/ruin/syndicate_lava_base/bar)
 "gA" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	name = "euthanization chamber freezer";
 	dir = 4;
-	initialize_directions = 4
+	initialize_directions = 4;
+	name = "euthanization chamber freezer"
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/testlab)
@@ -912,6 +915,7 @@
 /obj/structure/chair/office/light{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/dark_green/full,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/virology)
 "gF" = (
@@ -1094,8 +1098,8 @@
 "iw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor{
-	id = "interdynedisp";
-	dir = 1
+	dir = 1;
+	id = "interdynedisp"
 	},
 /turf/open/floor/plating,
 /area/ruin/syndicate_lava_base/bar)
@@ -1134,15 +1138,19 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/bar)
-"iQ" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
+"iP" = (
+/obj/effect/turf_decal/tile/dark_green/half{
+	dir = 4
 	},
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
+"iQ" = (
+/obj/effect/turf_decal/tile/dark_green/full,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/ruin/syndicate_lava_base/medbay)
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "iS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1263,12 +1271,12 @@
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/toy/crayon/spraycan{
-	pixel_y = 9;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 9
 	},
 /obj/item/toy/crayon/spraycan{
-	pixel_y = 9;
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = 9
 	},
 /obj/structure/sign/painting/large/library{
 	dir = 4
@@ -1298,6 +1306,15 @@
 	dir = 4
 	},
 /area/ruin/syndicate_lava_base/bar)
+"jO" = (
+/obj/effect/turf_decal/tile/dark_green,
+/obj/structure/table/glass,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 10
+	},
+/obj/item/restraints/handcuffs/cable/zipties,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "jR" = (
 /turf/open/floor/iron/white,
 /area/ruin/syndicate_lava_base/medbay)
@@ -1319,6 +1336,10 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
+	},
+/obj/structure/sink/kitchen/directional{
+	dir = 8;
+	pixel_x = 16
 	},
 /turf/open/floor/iron/white,
 /area/ruin/syndicate_lava_base/medbay)
@@ -1359,14 +1380,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood,
 /area/ruin/syndicate_lava_base/testlab)
-"kp" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/dark_blue,
-/turf/open/floor/iron/white,
-/area/ruin/syndicate_lava_base/medbay)
 "kr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1389,12 +1402,10 @@
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/testlab)
 "kE" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/lava/plasma/ice_moon,
-/area/ruin/syndicate_lava_base/medbay)
+/obj/effect/turf_decal/tile/dark_green/full,
+/obj/effect/turf_decal/stripes/red/line,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "kL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1431,16 +1442,11 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/syndicate_lava_base/bar)
 "lb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/toy/cards/deck/cas/black{
-	pixel_x = 3;
-	pixel_y = 11
-	},
-/turf/open/floor/plating/icemoon,
-/area/ruin/syndicate_lava_base/medbay)
+/obj/structure/window/reinforced/survival_pod/spawner/directional/east,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/obj/effect/turf_decal/tile/dark_red/full,
+/turf/open/floor/engine,
+/area/ruin/syndicate_lava_base/virology)
 "lj" = (
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -1449,6 +1455,14 @@
 /obj/machinery/smartfridge/extract/preloaded,
 /turf/open/floor/wood,
 /area/ruin/syndicate_lava_base/testlab)
+"lt" = (
+/obj/structure/bodycontainer/crematorium{
+	dir = 4;
+	id = "cremasynd"
+	},
+/obj/machinery/light/small/red/dim/directional/west,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "lu" = (
 /obj/structure/railing{
 	dir = 6
@@ -1595,8 +1609,8 @@
 /obj/item/assembly/igniter,
 /obj/structure/frame/machine{
 	anchored = 1;
-	state = 2;
-	icon_state = "box_1"
+	icon_state = "box_1";
+	state = 2
 	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/cargo)
@@ -1815,9 +1829,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/door/window/survival_pod{
-	req_access = list("syndicate")
-	},
+/obj/effect/turf_decal/tile/dark_green/full,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/virology)
 "pe" = (
@@ -1933,6 +1945,17 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/misc/grass,
 /area/ruin/syndicate_lava_base/bar)
+"pS" = (
+/obj/effect/turf_decal/stripes/red/line,
+/obj/machinery/button/crematorium{
+	id = "cremasynd";
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/tile/dark_green/half{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "pU" = (
 /obj/machinery/camera/autoname/directional/west{
 	network = list("intd13")
@@ -1946,11 +1969,18 @@
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/syndicate_lava_base/virology)
 "qd" = (
-/obj/machinery/door/airlock/maintenance/external,
-/obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/medbay)
+/obj/effect/turf_decal/tile/dark_green/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/structure/closet/l3closet/virology,
+/obj/item/clothing/shoes/galoshes,
+/obj/item/clothing/mask/gas/glass,
+/obj/item/tank/internals/oxygen,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "qe" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
@@ -2037,6 +2067,16 @@
 "rg" = (
 /turf/open/floor/carpet/orange,
 /area/ruin/syndicate_lava_base/cargo)
+"rh" = (
+/obj/structure/window/reinforced/survival_pod/spawner/directional/east,
+/obj/machinery/door/window/survival_pod{
+	dir = 1;
+	name = "Subject A";
+	req_access = list("syndicate")
+	},
+/obj/effect/turf_decal/tile/dark_red/full,
+/turf/open/floor/engine,
+/area/ruin/syndicate_lava_base/virology)
 "rv" = (
 /obj/effect/turf_decal/tile/dark_red{
 	dir = 1
@@ -2048,11 +2088,10 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/table/glass,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 10
+/obj/machinery/smartfridge/chemistry/virology/preloaded,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 8
 	},
-/obj/item/healthanalyzer,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/virology)
 "rG" = (
@@ -2091,6 +2130,7 @@
 	},
 /obj/item/storage/pill_bottle/mannitol,
 /obj/item/reagent_containers/dropper,
+/obj/item/storage/box/bodybags,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/medbay)
 "sa" = (
@@ -2330,9 +2370,9 @@
 	network = list("fsci")
 	},
 /obj/machinery/door/window/survival_pod{
-	req_access = list("syndicate");
 	dir = 1;
-	name = "Slime Pacification Chamber"
+	name = "Slime Pacification Chamber";
+	req_access = list("syndicate")
 	},
 /obj/effect/turf_decal/tile/dark_red{
 	dir = 8
@@ -2354,6 +2394,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
 /area/ruin/syndicate_lava_base/dormitories)
+"ur" = (
+/obj/effect/turf_decal/tile/dark_green/half,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/mapping_helpers/apc/syndicate_access,
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/infections{
+	pixel_y = 7
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "us" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2451,15 +2502,15 @@
 /area/ruin/syndicate_lava_base/cargo)
 "vw" = (
 /obj/structure/frame/computer{
-	dir = 4;
-	anchored = 1
+	anchored = 1;
+	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/syndicate_lava_base/testlab)
 "vy" = (
 /obj/machinery/button/door/directional/north{
-	pixel_y = 34;
-	id = "interdyneobservation"
+	id = "interdyneobservation";
+	pixel_y = 34
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/carpet/royalblack,
@@ -2688,15 +2739,14 @@
 /turf/open/floor/iron/white,
 /area/ruin/syndicate_lava_base/medbay)
 "xA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/mob/living/carbon/human/species/felinid/primitive{
+	name = "lobotomized local primitive"
 	},
-/obj/structure/table,
-/obj/item/toy/cards/deck/cas{
-	pixel_y = 6
-	},
-/turf/open/floor/plating/icemoon,
-/area/ruin/syndicate_lava_base/medbay)
+/obj/effect/turf_decal/tile/dark_red/full,
+/turf/open/floor/engine,
+/area/ruin/syndicate_lava_base/virology)
 "xJ" = (
 /obj/effect/turf_decal/tile/dark_blue,
 /obj/effect/turf_decal/tile/blue{
@@ -2719,8 +2769,8 @@
 "xS" = (
 /obj/structure/frame/machine{
 	anchored = 1;
-	state = 2;
-	icon_state = "box_1"
+	icon_state = "box_1";
+	state = 2
 	},
 /obj/item/circuitboard/machine/stacking_machine,
 /turf/open/floor/plating,
@@ -2746,8 +2796,8 @@
 /area/ruin/syndicate_lava_base/cargo)
 "yi" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Toilet";
-	id_tag = "interdynerec1"
+	id_tag = "interdynerec1";
+	name = "Unisex Toilet"
 	},
 /turf/open/floor/iron/checker,
 /area/ruin/syndicate_lava_base/bar)
@@ -2802,8 +2852,8 @@
 "yF" = (
 /obj/structure/frame/machine{
 	anchored = 1;
-	state = 2;
-	icon_state = "box_1"
+	icon_state = "box_1";
+	state = 2
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/syndicate_lava_base/testlab)
@@ -2911,6 +2961,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/bar)
+"zJ" = (
+/obj/structure/window/reinforced/survival_pod/spawner/directional/east,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
+/obj/effect/turf_decal/tile/dark_red/full,
+/turf/open/floor/engine,
+/area/ruin/syndicate_lava_base/virology)
 "zP" = (
 /obj/machinery/button/door{
 	id = "syndie_lavaland_vault";
@@ -2951,6 +3007,23 @@
 	},
 /turf/open/floor/engine,
 /area/ruin/syndicate_lava_base/testlab)
+"Ah" = (
+/obj/effect/turf_decal/tile/dark_green/half,
+/obj/structure/table/glass,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 5
+	},
+/obj/item/stack/sheet/mineral/gold{
+	amount = 10
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 10
+	},
+/obj/machinery/light/directional/north,
+/obj/item/food/monkeycube,
+/obj/item/food/monkeycube,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "Am" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -2983,6 +3056,12 @@
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/syndicate_lava_base/main)
+"AQ" = (
+/obj/effect/turf_decal/tile/dark_green/half,
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "AR" = (
 /obj/machinery/camera/autoname/directional/south{
 	network = list("intd13")
@@ -3020,6 +3099,21 @@
 /obj/structure/flora/rock,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/ruin/syndicate_lava_base/cargo)
+"By" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod/spawner/directional/east,
+/obj/effect/turf_decal/stripes/red/full,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
+/obj/structure/sign/warning/biohazard/directional/north{
+	layer = 3.3
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "BA" = (
 /turf/open/floor/engine,
 /area/ruin/syndicate_lava_base/testlab)
@@ -3029,7 +3123,9 @@
 /area/ruin/syndicate_lava_base/bar)
 "BC" = (
 /obj/machinery/computer/pandemic,
-/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/obj/effect/turf_decal/tile/dark_green/half{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/virology)
 "BE" = (
@@ -3166,15 +3262,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/structure/reagent_dispensers/wall/virusfood/directional/west,
-/obj/item/book/manual/wiki/infections{
-	pixel_y = 7
-	},
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/storage/box/syringes,
+/obj/structure/reagent_dispensers/wall/virusfood/directional/north,
+/obj/effect/turf_decal/tile/dark_green/half,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/virology)
 "CM" = (
@@ -3212,8 +3301,7 @@
 /turf/open/floor/wood,
 /area/ruin/syndicate_lava_base/dormitories)
 "Df" = (
-/obj/machinery/smartfridge/chemistry/virology/preloaded,
-/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/obj/effect/turf_decal/tile/dark_green/full,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/virology)
 "Dn" = (
@@ -3324,9 +3412,15 @@
 /turf/open/floor/carpet/royalblack,
 /area/ruin/syndicate_lava_base/telecomms)
 "Er" = (
-/obj/structure/lattice/catwalk,
-/turf/open/lava/plasma/ice_moon,
-/area/ruin/syndicate_lava_base/medbay)
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
+/obj/machinery/light/floor{
+	pixel_x = 16;
+	pixel_y = -16
+	},
+/obj/effect/turf_decal/tile/dark_red/full,
+/turf/open/floor/engine,
+/area/ruin/syndicate_lava_base/virology)
 "EA" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
@@ -3476,6 +3570,12 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/syndicate_lava_base/dormitories)
+"Ft" = (
+/obj/effect/turf_decal/tile/dark_green/half{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "Fu" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3615,11 +3715,15 @@
 /turf/open/floor/iron/smooth_large,
 /area/ruin/syndicate_lava_base/cargo)
 "Gr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/mob/living/carbon/human/species/monkey{
+	ai_controller = null;
+	faction = list("neutral","Syndicate")
 	},
-/turf/open/floor/plating/icemoon,
-/area/ruin/syndicate_lava_base/medbay)
+/obj/effect/turf_decal/tile/dark_red/full,
+/turf/open/floor/engine,
+/area/ruin/syndicate_lava_base/virology)
 "Gs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_corner,
@@ -3684,6 +3788,16 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/kitchen,
 /area/ruin/syndicate_lava_base/bar)
+"Hm" = (
+/obj/effect/turf_decal/tile/dark_green/half,
+/obj/structure/table/glass,
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/storage/box/syringes,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "Hn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3696,8 +3810,8 @@
 /area/ruin/syndicate_lava_base/medbay)
 "Hs" = (
 /obj/machinery/door/window/survival_pod{
-	req_access = list("syndicate");
-	name = "Slime Euthanization Chamber"
+	name = "Slime Euthanization Chamber";
+	req_access = list("syndicate")
 	},
 /turf/open/floor/circuit/telecomms,
 /area/ruin/syndicate_lava_base/testlab)
@@ -3868,12 +3982,15 @@
 /obj/machinery/firealarm/directional/south{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/machinery/door/window/survival_pod{
+	dir = 4;
+	name = "Virology airlock";
+	req_access = list("syndicate")
 	},
-/obj/effect/turf_decal/tile/dark_blue,
-/turf/open/floor/iron/white,
-/area/ruin/syndicate_lava_base/medbay)
+/obj/effect/turf_decal/stripes/red/full,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "Jd" = (
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/dormitories)
@@ -3962,6 +4079,9 @@
 	},
 /obj/machinery/airalarm/directional/east{
 	req_access = list("syndicate")
+	},
+/obj/effect/turf_decal/tile/dark_green/half{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/virology)
@@ -4065,8 +4185,8 @@
 "Lc" = (
 /obj/structure/frame/machine{
 	anchored = 1;
-	state = 2;
-	icon_state = "box_1"
+	icon_state = "box_1";
+	state = 2
 	},
 /obj/item/circuitboard/machine/recycler,
 /obj/machinery/conveyor{
@@ -4143,6 +4263,18 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/syndicate_lava_base/bar)
+"LB" = (
+/obj/effect/turf_decal/tile/dark_green/half{
+	dir = 1
+	},
+/obj/machinery/button/door/directional/east{
+	id = "interdynemedbay";
+	pixel_x = 0;
+	pixel_y = -24;
+	req_access = list("syndicate")
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "LC" = (
 /obj/machinery/conveyor{
 	id = "interdynedisp"
@@ -4297,19 +4429,12 @@
 /turf/open/floor/engine/n2,
 /area/ruin/syndicate_lava_base/engineering)
 "Ns" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/dark_green/full,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/mob/living/carbon/human/species/monkey{
-	ai_controller = null;
-	faction = list("neutral","Syndicate")
-	},
-/obj/structure/chair/office/light,
-/turf/open/floor/iron/white,
-/area/ruin/syndicate_lava_base/medbay)
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "Nv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_edge{
@@ -4364,6 +4489,11 @@
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/bar)
+"Ob" = (
+/obj/effect/turf_decal/tile/dark_green/full,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "Oc" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -4440,6 +4570,29 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/dormitories)
+"OK" = (
+/obj/effect/turf_decal/tile/dark_green/half{
+	dir = 4
+	},
+/obj/structure/table/glass,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/healthanalyzer,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
+"OL" = (
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/machinery/door/window/survival_pod{
+	dir = 1;
+	name = "Subject B";
+	req_access = list("syndicate")
+	},
+/obj/machinery/light/floor{
+	pixel_x = 16;
+	pixel_y = -16
+	},
+/obj/effect/turf_decal/tile/dark_red/full,
+/turf/open/floor/engine,
+/area/ruin/syndicate_lava_base/virology)
 "ON" = (
 /obj/machinery/limbgrower,
 /obj/effect/turf_decal/tile/blue{
@@ -4594,10 +4747,10 @@
 /obj/machinery/light/directional/north,
 /obj/structure/table/glass,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/item/clothing/glasses/hud/health,
 /obj/item/reagent_containers/dropper{
 	pixel_y = -6
 	},
+/obj/effect/turf_decal/tile/dark_green/half,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/virology)
 "PW" = (
@@ -4893,8 +5046,8 @@
 /area/ruin/syndicate_lava_base/medbay)
 "Tf" = (
 /obj/machinery/camera/autoname/directional/west{
-	pixel_y = -18;
-	network = list("intd13")
+	network = list("intd13");
+	pixel_y = -18
 	},
 /turf/open/lava/plasma/ice_moon,
 /area/ruin/syndicate_lava_base/medbay)
@@ -4936,19 +5089,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/effect/mapping_helpers/apc/syndicate_access,
+/obj/effect/turf_decal/tile/dark_green/full,
 /obj/structure/table/glass,
-/obj/machinery/reagentgrinder,
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 5
-	},
-/obj/item/stack/sheet/mineral/uranium{
-	amount = 10
-	},
-/obj/item/stack/sheet/mineral/gold{
-	amount = 10
-	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/virology)
 "Tv" = (
@@ -5090,8 +5232,8 @@
 /obj/item/circuitboard/machine/ore_silo,
 /obj/structure/frame/machine{
 	anchored = 1;
-	state = 2;
-	icon_state = "box_1"
+	icon_state = "box_1";
+	state = 2
 	},
 /turf/open/floor/iron/corner,
 /area/ruin/syndicate_lava_base/main)
@@ -5293,14 +5435,12 @@
 	},
 /area/ruin/syndicate_lava_base/cargo)
 "WF" = (
-/obj/machinery/door/airlock/maintenance/external,
-/obj/structure/fans/tiny,
-/obj/effect/turf_decal/stripes/corner{
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/corner{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/main)
+/turf/open/lava/plasma/ice_moon,
+/area/ruin/syndicate_lava_base/cargo)
 "WK" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
@@ -5321,8 +5461,8 @@
 "Xa" = (
 /obj/structure/frame/machine{
 	anchored = 1;
-	state = 2;
-	icon_state = "box_1"
+	icon_state = "box_1";
+	state = 2
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5453,6 +5593,16 @@
 	},
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/syndicate_lava_base/medbay)
+"Yi" = (
+/obj/machinery/door/window/survival_pod{
+	dir = 8;
+	name = "Virology airlock";
+	req_access = list("syndicate")
+	},
+/obj/effect/turf_decal/stripes/red/full,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "Yl" = (
 /obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate,
 /obj/machinery/light/directional/north,
@@ -6802,7 +6952,7 @@ RV
 Zl
 Zo
 Zo
-Zo
+Kz
 Zo
 JA
 Zo
@@ -7385,18 +7535,18 @@ bN
 RV
 RV
 WC
-WC
-WC
-WC
-RV
-Zl
+WF
+Mt
+Mt
+Mt
+Mt
 sg
 Zo
 ux
 Zo
 cV
 Zo
-Zo
+ux
 Zo
 Zo
 Zl
@@ -7444,13 +7594,13 @@ RV
 RV
 ab
 ab
-ab
-ab
-ab
-ab
-ZU
-ZU
-WF
+Mt
+Mt
+Mt
+lt
+Mt
+Mt
+Mt
 yQ
 Oz
 pg
@@ -7503,11 +7653,11 @@ BE
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-kE
+Mt
+jO
+OK
+iP
+pS
 Er
 Gr
 NB
@@ -7562,13 +7712,13 @@ BE
 ab
 ab
 ab
-ab
-ab
-ab
-ab
+Mt
+Ah
+Df
+Df
 kE
-Er
-dy
+rh
+lb
 NB
 xc
 Yf
@@ -7621,12 +7771,12 @@ BE
 ab
 ab
 ab
-ab
-ab
-ab
-ab
+Mt
+AQ
+Df
+Df
 kE
-Er
+OL
 xA
 NB
 xc
@@ -7680,12 +7830,12 @@ BE
 ab
 ab
 ab
-ab
-ab
-ab
-ab
+Mt
+Hm
+Df
+Df
 kE
-Er
+zJ
 lb
 NB
 xc
@@ -7740,10 +7890,10 @@ ab
 ab
 sR
 Mt
-Mt
-Mt
-Mt
-yQ
+ur
+Ob
+Df
+Df
 qd
 yQ
 yQ
@@ -7803,7 +7953,7 @@ CK
 Tu
 Df
 Ns
-ZH
+LB
 yQ
 KC
 Gv
@@ -7862,7 +8012,7 @@ PQ
 gB
 pc
 iQ
-kp
+Ft
 yQ
 Ib
 Gv
@@ -7920,8 +8070,8 @@ qa
 rD
 Kg
 BC
-iQ
-ZH
+cs
+Yi
 yQ
 of
 Gv
@@ -7979,7 +8129,7 @@ ds
 Mt
 Mt
 Mt
-Tk
+By
 IS
 yQ
 Ko

--- a/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
@@ -35,6 +35,28 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/syndicate_lava_base/cargo)
+"at" = (
+/obj/effect/turf_decal/tile/dark_green/full,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
+"au" = (
+/obj/effect/turf_decal/tile/dark_green/half,
+/obj/structure/table/glass,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 5
+	},
+/obj/item/stack/sheet/mineral/gold{
+	amount = 10
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 10
+	},
+/obj/machinery/light/directional/north,
+/obj/item/food/monkeycube,
+/obj/item/food/monkeycube,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "aw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
@@ -145,11 +167,8 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/table/glass,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 10
-	},
-/obj/item/healthanalyzer,
+/obj/machinery/smartfridge/chemistry/virology/preloaded,
+/obj/effect/turf_decal/tile/dark_green,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/virology)
 "bv" = (
@@ -184,8 +203,8 @@
 /obj/structure/fans/tiny,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/machinery/door/window/survival_pod{
-	req_access = list("syndicate");
-	name = "Slime Pacification Chamber"
+	name = "Slime Pacification Chamber";
+	req_access = list("syndicate")
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/testlab)
@@ -361,12 +380,12 @@
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/toy/crayon/spraycan{
-	pixel_y = 9;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 9
 	},
 /obj/item/toy/crayon/spraycan{
-	pixel_y = 9;
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = 9
 	},
 /obj/structure/sign/painting/large/library{
 	dir = 4
@@ -388,9 +407,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/door/window/survival_pod{
-	req_access = list("syndicate")
-	},
+/obj/effect/turf_decal/tile/dark_green/full,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/virology)
 "dA" = (
@@ -877,6 +894,7 @@
 /obj/structure/chair/office/light{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/dark_green/full,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/virology)
 "iw" = (
@@ -1154,6 +1172,18 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/main)
+"lB" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/effect/turf_decal/stripes/red/full,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "lE" = (
 /obj/structure/table/reinforced,
 /obj/item/kitchen/rollingpin,
@@ -1192,6 +1222,16 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/cargo)
+"lT" = (
+/obj/effect/turf_decal/tile/dark_green/half,
+/obj/structure/table/glass,
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/storage/box/syringes,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "lX" = (
 /obj/structure/window/reinforced/survival_pod/spawner/directional/north,
 /obj/structure/table/reinforced,
@@ -1204,6 +1244,14 @@
 /obj/structure/dresser,
 /turf/open/floor/wood,
 /area/ruin/syndicate_lava_base/cargo)
+"md" = (
+/obj/structure/bodycontainer/crematorium{
+	dir = 4;
+	id = "cremasynd"
+	},
+/obj/machinery/light/small/red/dim/directional/west,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "mk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1341,6 +1389,15 @@
 /obj/structure/dresser,
 /turf/open/floor/wood,
 /area/ruin/syndicate_lava_base/dormitories)
+"nr" = (
+/obj/effect/turf_decal/tile/dark_green,
+/obj/structure/table/glass,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 10
+	},
+/obj/item/restraints/handcuffs/cable/zipties,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "nt" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -1360,6 +1417,16 @@
 /obj/item/stack/rods/ten,
 /turf/open/floor/plating/lavaland_atmos,
 /area/ruin/syndicate_lava_base/cargo)
+"nI" = (
+/obj/machinery/door/window/survival_pod{
+	dir = 8;
+	name = "Virology airlock";
+	req_access = list("syndicate")
+	},
+/obj/effect/turf_decal/stripes/red/full,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "nT" = (
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/syndicate_lava_base/bar)
@@ -1416,8 +1483,8 @@
 /area/ruin/syndicate_lava_base/cargo)
 "oA" = (
 /obj/machinery/door/window/survival_pod{
-	req_access = list("syndicate");
-	name = "Slime Euthanization Chamber"
+	name = "Slime Euthanization Chamber";
+	req_access = list("syndicate")
 	},
 /turf/open/floor/circuit/telecomms,
 /area/ruin/syndicate_lava_base/testlab)
@@ -1447,8 +1514,7 @@
 /turf/open/floor/plating,
 /area/ruin/syndicate_lava_base/bar)
 "oM" = (
-/obj/machinery/smartfridge/chemistry/virology/preloaded,
-/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/obj/effect/turf_decal/tile/dark_green/full,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/virology)
 "oP" = (
@@ -1512,19 +1578,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/effect/mapping_helpers/apc/syndicate_access,
+/obj/effect/turf_decal/tile/dark_green/full,
 /obj/structure/table/glass,
-/obj/machinery/reagentgrinder,
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 5
-	},
-/obj/item/stack/sheet/mineral/uranium{
-	amount = 10
-	},
-/obj/item/stack/sheet/mineral/gold{
-	amount = 10
-	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/virology)
 "pD" = (
@@ -1686,6 +1741,12 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/syndicate_lava_base/testlab)
+"qY" = (
+/obj/structure/window/reinforced/survival_pod/spawner/directional/east,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
+/obj/effect/turf_decal/tile/dark_red/full,
+/turf/open/floor/engine,
+/area/ruin/syndicate_lava_base/virology)
 "rf" = (
 /obj/structure/railing{
 	dir = 4
@@ -2013,8 +2074,8 @@
 "vR" = (
 /obj/structure/frame/machine{
 	anchored = 1;
-	state = 2;
-	icon_state = "box_1"
+	icon_state = "box_1";
+	state = 2
 	},
 /obj/item/circuitboard/machine/stacking_machine,
 /turf/open/floor/plating,
@@ -2022,8 +2083,8 @@
 "vX" = (
 /obj/structure/frame/machine{
 	anchored = 1;
-	state = 2;
-	icon_state = "box_1"
+	icon_state = "box_1";
+	state = 2
 	},
 /obj/item/circuitboard/machine/ore_redemption,
 /obj/item/assembly/igniter,
@@ -2042,8 +2103,8 @@
 "wf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor{
-	id = "interdynedisp";
-	dir = 1
+	dir = 1;
+	id = "interdynedisp"
 	},
 /turf/open/floor/plating,
 /area/ruin/syndicate_lava_base/bar)
@@ -2109,12 +2170,12 @@
 /obj/structure/table/reinforced,
 /obj/machinery/light/directional/south,
 /obj/effect/spawner/random/food_or_drink/donkpockets{
-	pixel_y = 7;
-	pixel_x = 10
+	pixel_x = 10;
+	pixel_y = 7
 	},
 /obj/item/storage/box/donkpockets{
-	pixel_y = 5;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 5
 	},
 /turf/open/floor/iron/kitchen,
 /area/ruin/syndicate_lava_base/bar)
@@ -2241,12 +2302,10 @@
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/main)
 "xR" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/lava/smooth/lava_land_surface,
-/area/ruin/syndicate_lava_base/medbay)
+/obj/effect/turf_decal/tile/dark_green/full,
+/obj/effect/turf_decal/stripes/red/line,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "xT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -2286,8 +2345,8 @@
 "yf" = (
 /obj/structure/frame/machine{
 	anchored = 1;
-	state = 2;
-	icon_state = "box_1"
+	icon_state = "box_1";
+	state = 2
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2380,19 +2439,12 @@
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/dormitories)
 "zo" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/dark_green/full,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/mob/living/carbon/human/species/monkey{
-	ai_controller = null;
-	faction = list("neutral","Syndicate")
-	},
-/obj/structure/chair/office/light,
-/turf/open/floor/iron/white,
-/area/ruin/syndicate_lava_base/medbay)
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "zt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -2447,14 +2499,20 @@
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/bar)
 "zE" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/ruin/syndicate_lava_base/medbay)
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod/spawner/directional/east,
+/obj/effect/turf_decal/stripes/red/full,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
+/obj/structure/sign/warning/biohazard/directional/north{
+	layer = 3.3
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "zF" = (
 /obj/machinery/atmospherics/miner/nitrogen,
 /turf/open/floor/engine/n2,
@@ -2590,11 +2648,18 @@
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/medbay)
 "AT" = (
-/obj/machinery/door/airlock/maintenance/external,
-/obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/medbay)
+/obj/effect/turf_decal/tile/dark_green/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/structure/closet/l3closet/virology,
+/obj/item/clothing/shoes/galoshes,
+/obj/item/clothing/mask/gas/glass,
+/obj/item/tank/internals/oxygen,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "AU" = (
 /obj/machinery/griddle,
 /obj/machinery/airalarm/directional/north{
@@ -2623,15 +2688,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/ruin/syndicate_lava_base/medbay)
-"Bo" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/white,
-/area/ruin/syndicate_lava_base/medbay)
 "Bp" = (
 /obj/structure/frame/machine{
 	anchored = 1;
-	state = 2;
-	icon_state = "box_1"
+	icon_state = "box_1";
+	state = 2
 	},
 /obj/item/circuitboard/machine/recycler,
 /obj/machinery/conveyor{
@@ -2652,6 +2713,12 @@
 /obj/item/storage/backpack/duffelbag/syndie/surgery,
 /turf/open/floor/plating,
 /area/ruin/syndicate_lava_base/medbay)
+"BC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/syndicate_lava_base/virology)
 "BH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -2705,14 +2772,12 @@
 /turf/open/floor/circuit/telecomms,
 /area/ruin/syndicate_lava_base/testlab)
 "BT" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/dark_green/full,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/ruin/syndicate_lava_base/medbay)
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "BW" = (
 /obj/machinery/button/door{
 	id = "syndie_lavaland_vault";
@@ -2799,14 +2864,12 @@
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/engineering)
 "CM" = (
-/obj/machinery/door/airlock/maintenance/external,
-/obj/structure/fans/tiny,
-/obj/effect/turf_decal/stripes/corner{
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/corner{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/turf/open/floor/plating,
-/area/ruin/syndicate_lava_base/main)
+/turf/open/lava/smooth/lava_land_surface,
+/area/ruin/syndicate_lava_base/cargo)
 "CN" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 8
@@ -2923,11 +2986,15 @@
 /turf/open/floor/plating,
 /area/ruin/syndicate_lava_base/bar)
 "DZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/mob/living/carbon/human/species/monkey{
+	ai_controller = null;
+	faction = list("neutral","Syndicate")
 	},
-/turf/open/floor/plating/lavaland_atmos,
-/area/ruin/syndicate_lava_base/medbay)
+/obj/effect/turf_decal/tile/dark_red/full,
+/turf/open/floor/engine,
+/area/ruin/syndicate_lava_base/virology)
 "Em" = (
 /obj/machinery/light/directional/west,
 /obj/structure/sign/painting/library{
@@ -3034,10 +3101,10 @@
 /area/ruin/syndicate_lava_base/bar)
 "Fq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8;
 	external_pressure_bound = 140;
 	name = "server vent";
-	pressure_checks = 0;
-	dir = 8
+	pressure_checks = 0
 	},
 /turf/open/floor/circuit/telecomms,
 /area/ruin/syndicate_lava_base/testlab)
@@ -3075,15 +3142,6 @@
 	dir = 4
 	},
 /area/ruin/syndicate_lava_base/main)
-"FE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/chair/plastic{
-	dir = 4
-	},
-/turf/open/floor/plating/lavaland_atmos,
-/area/ruin/syndicate_lava_base/medbay)
 "FF" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/door/airlock{
@@ -3181,6 +3239,17 @@
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/testlab)
+"Gx" = (
+/obj/effect/turf_decal/tile/dark_green/half,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/mapping_helpers/apc/syndicate_access,
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/infections{
+	pixel_y = 7
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "GB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -3250,8 +3319,8 @@
 /obj/item/circuitboard/machine/ore_silo,
 /obj/structure/frame/machine{
 	anchored = 1;
-	state = 2;
-	icon_state = "box_1"
+	icon_state = "box_1";
+	state = 2
 	},
 /turf/open/floor/iron/corner,
 /area/ruin/syndicate_lava_base/main)
@@ -3276,15 +3345,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/structure/reagent_dispensers/wall/virusfood/directional/west,
-/obj/item/book/manual/wiki/infections{
-	pixel_y = 7
-	},
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/storage/box/syringes,
+/obj/structure/reagent_dispensers/wall/virusfood/directional/north,
+/obj/effect/turf_decal/tile/dark_green/half,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/virology)
 "HV" = (
@@ -3384,8 +3446,8 @@
 /area/ruin/syndicate_lava_base/dormitories)
 "IZ" = (
 /obj/structure/frame/computer{
-	dir = 4;
-	anchored = 1
+	anchored = 1;
+	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/syndicate_lava_base/testlab)
@@ -3603,6 +3665,15 @@
 	},
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/syndicate_lava_base/main)
+"KR" = (
+/obj/effect/turf_decal/tile/dark_green/half{
+	dir = 4
+	},
+/obj/structure/table/glass,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/healthanalyzer,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "KS" = (
 /obj/structure/filingcabinet,
 /obj/item/folder/syndicate/mining,
@@ -3812,8 +3883,8 @@
 /area/ruin/syndicate_lava_base/main)
 "MP" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Toilet";
-	id_tag = "interdynerec1"
+	id_tag = "interdynerec1";
+	name = "Unisex Toilet"
 	},
 /turf/open/floor/iron/checker,
 /area/ruin/syndicate_lava_base/bar)
@@ -4065,6 +4136,9 @@
 /obj/machinery/airalarm/directional/east{
 	req_access = list("syndicate")
 	},
+/obj/effect/turf_decal/tile/dark_green/half{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/virology)
 "PE" = (
@@ -4275,8 +4349,8 @@
 "Ru" = (
 /obj/structure/frame/machine{
 	anchored = 1;
-	state = 2;
-	icon_state = "box_1"
+	icon_state = "box_1";
+	state = 2
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/syndicate_lava_base/testlab)
@@ -4288,6 +4362,18 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/dormitories)
+"RC" = (
+/obj/effect/turf_decal/tile/dark_green/half{
+	dir = 1
+	},
+/obj/machinery/button/door/directional/east{
+	id = "interdynemedbay";
+	pixel_x = 0;
+	pixel_y = -24;
+	req_access = list("syndicate")
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "RJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -4345,6 +4431,16 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/testlab)
+"Sa" = (
+/obj/structure/window/reinforced/survival_pod/spawner/directional/east,
+/obj/machinery/door/window/survival_pod{
+	dir = 1;
+	name = "Subject A";
+	req_access = list("syndicate")
+	},
+/obj/effect/turf_decal/tile/dark_red/full,
+/turf/open/floor/engine,
+/area/ruin/syndicate_lava_base/virology)
 "Sc" = (
 /obj/machinery/vending/hydroseeds{
 	onstation = 0
@@ -4407,6 +4503,12 @@
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
 /turf/open/floor/engine/n2,
 /area/ruin/syndicate_lava_base/engineering)
+"SS" = (
+/obj/effect/turf_decal/tile/dark_green/half,
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "SU" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay"
@@ -4424,8 +4526,15 @@
 /obj/machinery/firealarm/directional/south{
 	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/ruin/syndicate_lava_base/medbay)
+/obj/machinery/door/window/survival_pod{
+	dir = 4;
+	name = "Virology airlock";
+	req_access = list("syndicate")
+	},
+/obj/effect/turf_decal/stripes/red/full,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "Tf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4460,6 +4569,7 @@
 	pixel_x = -6;
 	pixel_y = 10
 	},
+/obj/item/storage/box/bodybags,
 /turf/open/floor/iron/white,
 /area/ruin/syndicate_lava_base/medbay)
 "Tw" = (
@@ -4480,6 +4590,12 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/checker,
 /area/ruin/syndicate_lava_base/bar)
+"TF" = (
+/obj/effect/turf_decal/tile/dark_green/half{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "TJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -4560,6 +4676,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/catwalk_floor/iron,
 /area/ruin/syndicate_lava_base/dormitories)
+"UK" = (
+/obj/effect/turf_decal/tile/dark_green/half{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "UO" = (
 /turf/open/floor/plating,
 /area/ruin/syndicate_lava_base/engineering)
@@ -4601,9 +4723,15 @@
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/bar)
 "Vj" = (
-/obj/structure/lattice/catwalk,
-/turf/open/lava/smooth/lava_land_surface,
-/area/ruin/syndicate_lava_base/medbay)
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
+/obj/machinery/light/floor{
+	pixel_x = 16;
+	pixel_y = -16
+	},
+/obj/effect/turf_decal/tile/dark_red/full,
+/turf/open/floor/engine,
+/area/ruin/syndicate_lava_base/virology)
 "Vm" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/south,
 /obj/structure/window/reinforced/tinted/spawner/directional/north,
@@ -4649,6 +4777,20 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/white,
 /area/ruin/syndicate_lava_base/medbay)
+"Vz" = (
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/machinery/door/window/survival_pod{
+	dir = 1;
+	name = "Subject B";
+	req_access = list("syndicate")
+	},
+/obj/machinery/light/floor{
+	pixel_x = 16;
+	pixel_y = -16
+	},
+/obj/effect/turf_decal/tile/dark_red/full,
+/turf/open/floor/engine,
+/area/ruin/syndicate_lava_base/virology)
 "VI" = (
 /obj/machinery/firealarm/directional/east{
 	dir = 8
@@ -4783,7 +4925,9 @@
 /area/ruin/syndicate_lava_base/testlab)
 "Xd" = (
 /obj/machinery/computer/pandemic,
-/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/obj/effect/turf_decal/tile/dark_green/half{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/virology)
 "Xf" = (
@@ -4798,10 +4942,10 @@
 /obj/machinery/light/directional/north,
 /obj/structure/table/glass,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/item/clothing/glasses/hud/health,
 /obj/item/reagent_containers/dropper{
 	pixel_y = -6
 	},
+/obj/effect/turf_decal/tile/dark_green/half,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/virology)
 "Xn" = (
@@ -4815,6 +4959,10 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
+	},
+/obj/structure/sink/kitchen/directional{
+	dir = 8;
+	pixel_x = 16
 	},
 /turf/open/floor/iron/white,
 /area/ruin/syndicate_lava_base/medbay)
@@ -4894,6 +5042,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/ruin/syndicate_lava_base/bar)
+"XP" = (
+/obj/effect/turf_decal/tile/dark_green/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line,
+/obj/machinery/button/crematorium{
+	id = "cremasynd";
+	pixel_x = -24
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/syndicate_lava_base/virology)
 "XR" = (
 /obj/structure/table/wood,
 /obj/item/modular_computer/laptop/preset/syndicate,
@@ -4991,15 +5150,12 @@
 /turf/open/floor/iron/white,
 /area/ruin/syndicate_lava_base/medbay)
 "YD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/toy/cards/deck/cas{
-	pixel_y = 6
-	},
-/turf/open/floor/plating/lavaland_atmos,
-/area/ruin/syndicate_lava_base/medbay)
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/mob/living/carbon/human/species/lizard/ashwalker,
+/obj/effect/turf_decal/tile/dark_red/full,
+/turf/open/floor/engine,
+/area/ruin/syndicate_lava_base/virology)
 "YF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5085,9 +5241,9 @@
 /area/ruin/syndicate_lava_base/medbay)
 "Zn" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	name = "euthanization chamber freezer";
 	dir = 4;
-	initialize_directions = 4
+	initialize_directions = 4;
+	name = "euthanization chamber freezer"
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/testlab)
@@ -5119,16 +5275,11 @@
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/main)
 "ZC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/toy/cards/deck/cas/black{
-	pixel_x = 3;
-	pixel_y = 11
-	},
-/turf/open/floor/plating/lavaland_atmos,
-/area/ruin/syndicate_lava_base/medbay)
+/obj/structure/window/reinforced/survival_pod/spawner/directional/east,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/obj/effect/turf_decal/tile/dark_red/full,
+/turf/open/floor/engine,
+/area/ruin/syndicate_lava_base/virology)
 "ZG" = (
 /obj/structure/window/reinforced/survival_pod/spawner/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
@@ -6337,7 +6488,7 @@ Zz
 JB
 Zq
 Zq
-Zq
+Tl
 Zq
 MO
 Zq
@@ -6920,18 +7071,18 @@ jS
 Zz
 Zz
 np
-np
-np
-np
-Zz
-JB
+CM
+rq
+rq
+rq
+rq
 AH
 Zq
 Ih
 Zq
 OM
 Zq
-Zq
+Ih
 Zq
 Zq
 JB
@@ -6979,13 +7130,13 @@ OC
 Zz
 ab
 ab
-ab
-ab
-ab
-ab
-Wx
-Wx
-CM
+rq
+rq
+rq
+md
+rq
+rq
+rq
 ZX
 HM
 Lw
@@ -7038,11 +7189,11 @@ OC
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-xR
+rq
+nr
+KR
+UK
+XP
 Vj
 DZ
 VO
@@ -7097,13 +7248,13 @@ OC
 ab
 ab
 ab
-ab
-ab
-ab
-ab
+rq
+au
+oM
+oM
 xR
-Vj
-FE
+Sa
+ZC
 VO
 Wq
 jK
@@ -7156,12 +7307,12 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
+rq
+SS
+oM
+oM
 xR
-Vj
+Vz
 YD
 VO
 Wq
@@ -7215,12 +7366,12 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
+rq
+lT
+oM
+oM
 xR
-Vj
+qY
 ZC
 VO
 Wq
@@ -7274,11 +7425,11 @@ ab
 ab
 ab
 ab
-Va
 rq
-rq
-rq
-ZX
+Gx
+at
+oM
+oM
 AT
 ZX
 ZX
@@ -7338,7 +7489,7 @@ HT
 py
 oM
 zo
-Yp
+RC
 ZX
 Zc
 KX
@@ -7397,7 +7548,7 @@ Xl
 is
 dy
 BT
-Bo
+TF
 ZX
 fs
 KX
@@ -7455,8 +7606,8 @@ zt
 bu
 PC
 Xd
-BT
-Yp
+lB
+nI
 ZX
 uX
 KX
@@ -7509,11 +7660,11 @@ ab
 ab
 ab
 ab
-ab
-kD
-ZX
-ZX
-ZX
+Va
+BC
+rq
+rq
+rq
 zE
 Tb
 ZX


### PR DESCRIPTION
## About The Pull Request

The Interdyne/Syndie base virology is low-effort, it needs some bling. Having the test monkey in a chair in the hallway is not cool. This tiny map edit PR fixes this.

* Virology section redone in the icemoon/lavaland syndie base so its a bit more fun.
* More space, airlock to enter, signs, more table room, less cramped. Test subject glass cages. Ability for passers by to see into viro and be amused by test subjects if the shutters are open.
* Additions - couple monkey cubes. One catatonic test subject from the appropriate map native population added. Viro equipment locker added with some internals and a fricking bio suit. Crematorium added. Box of body bags and a sink.  
* Atmos/APC/Wiring functionally unchanged. Eastern smoking gallery mostly sacrificed to make room.

how it looks (new is above, screenshot is from the icemoon version, lavaland is pretty much identical)
![viro](https://github.com/Bubberstation/Bubberstation/assets/110836368/b1fc99cd-1d3d-4a07-b08c-fa812e6a0288)

## Changelog

:cl:
add: Viro section redone in syndie base on lavaland/icemoon
/:cl:

