### PR TITLE
Dynamic Config Overhaul

### DIFF
--- a/config/dynamic.json
+++ b/config/dynamic.json
@@ -3,164 +3,323 @@
 	"Roundstart": {
 		"Traitors": {
 			"cost": 8,
-			"scaling_cost": 9,
-			"weight": 0,
+			"scaling_cost": 8,
+			"weight": 100,
 			"required_candidates": 1,
-			"minimum_required_age": 0,
-			"requirements": [
-				10,
-				10,
-				10,
-				10,
-				10,
-				10,
-				10,
-				10,
-				10,
-				10
-			],
-			"antag_cap": {
-				"denominator": 24
-			},
-			"protected_roles": [
-				"Prisoner",
-				"Blueshield",
-				"Corrections Officer",
-				"Security Officer",
-				"Warden",
-				"Detective",
-				"Head of Security",
-				"Captain",
-				"Nanotrasen Consultant",
-				"Head of Personnel",
-				"Chief Engineer",
-				"Chief Medical Officer",
-				"Research Director",
-				"Quartermaster"
-			],
-			"restricted_roles": [
-				"Cyborg"
-			]
-		},
-
-		"Blood Brothers": {
-			"weight": 0
-		},
-
-		"Changelings": {
-			"weight": 0
-		},
-
-		"Heretics": {
-			"weight": 0
-		},
-
-		"Wizard": {
-			"weight": 0
-		},
-
-		"Blood Cult": {
-			"weight": 0
-		},
-
-		"Nuclear Emergency": {
-			"weight": 0
-		},
-
-		"Revolution": {
-			"weight": 0
-		}
-	},
-
-	"Midround": {
-		"Syndicate Sleeper Agent": {
-			"weight": 0
+			"antag_cap": 5,
+			"minimum_players": 0
 		},
 
 		"Malfunctioning AI": {
-			"weight": 0
+			"cost": 30,
+			"scaling_cost": 30,
+			"weight": 0,
+			"required_candidates": 1,
+			"antag_cap": 1,
+			"minimum_players": 40
 		},
-
+		
+		"Blood Brothers": {
+			"cost": 8,
+			"scaling_cost": 16,
+			"weight": 25,
+			"required_candidates": 2,
+			"antag_cap": 4,
+			"minimum_players": 30
+		},
+		
+		"Changelings": {
+			"cost": 12,
+			"scaling_cost": 18,
+			"weight": 10,
+			"required_candidates": 1,
+			"antag_cap": 4,
+			"minimum_players": 30
+		},
+		
+		"Heretics": {
+			"cost": 12,
+			"scaling_cost": 12,
+			"weight": 25,
+			"required_candidates": 1,
+			"antag_cap": 4,
+			"minimum_players": 20
+		},
+		
 		"Wizard": {
+			"cost": 36,
+			"scaling_cost": 64,
+			"weight": 0,
+			"required_candidates": 1,
+			"antag_cap": 1,
+			"minimum_players": 40
+		},
+		
+		"Blood Cult": {
+			"cost": 24,
+			"scaling_cost": 12,
+			"weight": 0,
+			"required_candidates": 2,
+			"antag_cap": 4,
+			"minimum_players": 30
+		},
+		
+		"Nuclear Emergency": {
+			"cost": 36,
+			"scaling_cost": 8,
+			"weight": 0,
+			"required_candidates": 4,
+			"antag_cap": 6,
+			"minimum_players": 40
+		},
+		
+		"Revolution": {
+			"cost": 20,
+			"scaling_cost": 8,
+			"weight": 10,
+			"required_candidates": 1,
+			"antag_cap": 2,
+			"minimum_players": 30
+		},
+		
+		"Extended": {
 			"weight": 0
 		},
-
-		"Nuclear Assault": {
-			"weight": 0
+		
+		"Clown Operatives": {
+			"cost": 36,
+			"scaling_cost": 8,
+			"weight": 0,
+			"required_candidates": 4,
+			"antag_cap": 6,
+			"minimum_players": 40
 		},
-
-		"Blob": {
-			"weight": 0
+		
+		"Meteor": {
+			"cost": 50,
+			"scaling_cost": 50,
+			"weight": 0,
+			"minimum_players": 40
 		},
-
-		"Blob Infection": {
-			"weight": 0
-		},
-
-		"Alien Infestation": {
-			"weight": 0
-		},
-
-		"Nightmare": {
-			"weight": 0
-		},
-
-		"Space Dragon": {
-			"weight": 0
-		},
-
-		"Abductors": {
-			"weight": 0
-		},
-
-		"Space Ninja": {
-			"weight": 0
-		},
-
-		"Spiders": {
-			"weight": 0
-		},
-
-		"Revenant": {
-			"weight": 0
-		},
-
-		"Sentient Disease": {
-			"weight": 0
-		},
-
-		"Space Pirates": {
-			"weight": 0
-		},
-
-		"Obsessed": {
-			"weight": 0
-		},
-
-		"Space Changeling": {
-			"weight": 0
-		},
-
-		"Paradox Clone": {
-			"weight": 0
+		
+		"Nations": {
+			"cost": 50,
+			"scaling_cost": 0,
+			"weight": 0,
+			"minimum_players": 50
 		}
+
+	},
+
+	"Midround": {		
+		"Syndicate Sleeper Agent": {
+			"cost": 8,
+			"scaling_cost": 8,
+			"weight": 100,
+			"required_candidates": 1,
+			"antag_cap": 5,
+			"minimum_players": 0
+		},	
+		
+		"Malfunctioning AI": {
+			"cost": 30,
+			"scaling_cost": 30,
+			"weight": 0,
+			"required_candidates": 1,
+			"antag_cap": 1,
+			"minimum_players": 50
+		},	
+		
+		"Wizard": {
+			"cost": 36,
+			"scaling_cost": 64,
+			"weight": 0,
+			"required_candidates": 1,
+			"antag_cap": 1,
+			"minimum_players": 40
+		},
+		
+		"Nuclear Assault": {
+			"cost": 36,
+			"scaling_cost": 8,
+			"weight": 0,
+			"required_candidates": 4,
+			"antag_cap": 6,
+			"minimum_players": 40
+		},
+		
+		"Blob": {
+			"cost": 24,
+			"scaling_cost": 24,
+			"weight": 3,
+			"required_candidates": 1,
+			"antag_cap": 1,
+			"minimum_players": 40
+		},	
+		
+		"Blob Infection": {
+			"cost": 24,
+			"scaling_cost": 24,
+			"weight": 5,
+			"required_candidates": 1,
+			"antag_cap": 1,
+			"minimum_players": 40
+		},	
+		
+		"Alien Infestation": {
+			"cost": 36,
+			"scaling_cost": 24,
+			"weight": 0,
+			"required_candidates": 1,
+			"antag_cap": 3,
+			"minimum_players": 50
+		},		
+		
+		"Nightmare": {
+			"cost": 12,
+			"scaling_cost": 12,
+			"weight": 20,
+			"required_candidates": 1,
+			"antag_cap": 3,
+			"minimum_players": 30
+		},	
+		
+		"Space Dragon": {
+			"cost": 36,
+			"scaling_cost": 36,
+			"weight": 5,
+			"required_candidates": 1,
+			"antag_cap": 2,
+			"minimum_players": 40
+		},
+		
+		"Abductors": {
+			"cost": 8,
+			"scaling_cost": 8,
+			"weight": 25,
+			"required_candidates": 2,
+			"antag_cap": 3,
+			"minimum_players": 30
+		},
+		
+		"Space Ninja": {
+			"cost": 24,
+			"scaling_cost": 24,
+			"weight": 10,
+			"required_candidates": 1,
+			"antag_cap": 2,
+			"minimum_players": 40
+		},
+		
+		"Spiders": {
+			"cost": 30,
+			"scaling_cost": 24,
+			"weight": 0,
+			"required_candidates": 1,
+			"antag_cap": 4,
+			"minimum_players": 50
+		},	
+		
+		"Revenant": {
+			"cost": 12,
+			"scaling_cost": 12,
+			"weight": 20,
+			"required_candidates": 1,
+			"antag_cap": 3,
+			"minimum_players": 30
+		},	
+		
+		"Sentient Disease": {
+			"cost": 18,
+			"scaling_cost": 18,
+			"weight": 10,
+			"required_candidates": 1,
+			"antag_cap": 2,
+			"minimum_players": 40
+		},	
+		
+		"Space Pirates": {
+			"cost": 8,
+			"scaling_cost": 8,
+			"weight": 10,
+			"required_candidates": 3,
+			"antag_cap": 5,
+			"minimum_players": 40
+		},		
+		
+		"Dangerous Space Pirates": {
+			"cost": 16,
+			"scaling_cost": 8,
+			"weight": 10,
+			"required_candidates": 3,
+			"antag_cap": 4,
+			"minimum_players": 40		
+		},
+		
+		"Obsessed": {
+			"cost": 4,
+			"scaling_cost": 4,
+			"weight": 20,
+			"required_candidates": 1,
+			"antag_cap": 4,
+			"minimum_players": 10		
+		},	
+		
+		"Space Changeling": {
+			"cost": 8,
+			"scaling_cost": 8,
+			"weight": 20,
+			"required_candidates": 1,
+			"antag_cap": 3,
+			"minimum_players": 30		
+		},
+		
+		"Paradox Clone": {
+			"cost": 8,
+			"scaling_cost": 8,
+			"weight": 0,
+			"required_candidates": 1,
+			"antag_cap": 5,
+			"minimum_players": 0		
+		}
+	
 	},
 
 	"Latejoin": {
 		"Syndicate Infiltrator": {
-			"weight": 0
+			"cost": 8,
+			"scaling_cost": 8,
+			"weight": 100,
+			"required_candidates": 1,
+			"antag_cap": 5,
+			"minimum_players": 0		
 		},
-
+		
 		"Provocateur": {
-			"weight": 0
+			"cost": 8,
+			"scaling_cost": 8,
+			"weight": 0,
+			"required_candidates": 1,
+			"antag_cap": 1,
+			"minimum_players": 40		
 		},
-
+		
 		"Heretic Smuggler": {
-			"weight": 0
+			"cost": 12,
+			"scaling_cost": 12,
+			"weight": 10,
+			"required_candidates": 1,
+			"antag_cap": 4,
+			"minimum_players": 30		
 		},
-
+		
 		"Stowaway Changeling": {
-			"weight": 0
+			"cost": 12,
+			"scaling_cost": 12,
+			"weight": 25,
+			"required_candidates": 1,
+			"antag_cap": 3,
+			"minimum_players": 30		
 		}
 	}
 }

--- a/modular_zubbers/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/modular_zubbers/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -1,0 +1,36 @@
+/datum/dynamic_ruleset
+
+	protected_roles = list( /// If set, and config flag protect_roles_from_antagonist is true, then the rule will not pick players from these roles.
+		JOB_CAPTAIN,
+		JOB_HEAD_OF_PERSONNEL,
+		JOB_HEAD_OF_SECURITY,
+		JOB_RESEARCH_DIRECTOR,
+		JOB_CHIEF_ENGINEER,
+		JOB_CHIEF_MEDICAL_OFFICER,
+		JOB_CYBORG,
+		JOB_WARDEN,
+		JOB_DETECTIVE,
+		JOB_SECURITY_OFFICER,
+		JOB_SECURITY_OFFICER_MEDICAL,
+		JOB_SECURITY_OFFICER_ENGINEERING,
+		JOB_SECURITY_OFFICER_SCIENCE,
+		JOB_SECURITY_OFFICER_SUPPLY,
+		JOB_CORRECTIONS_OFFICER,
+		JOB_QUARTERMASTER,
+		JOB_BLUESHIELD,
+		JOB_NT_REP
+	)
+
+	enemy_roles = list( //The roles the ruleset considers an enemy. This is used for "required_enemies" calculations. Basically put all validhunters here. :^)
+		JOB_CAPTAIN,
+		JOB_DETECTIVE,
+		JOB_HEAD_OF_SECURITY,
+		JOB_WARDEN,
+		JOB_SECURITY_OFFICER,
+		JOB_SECURITY_OFFICER_MEDICAL,
+		JOB_SECURITY_OFFICER_ENGINEERING,
+		JOB_SECURITY_OFFICER_SCIENCE,
+		JOB_SECURITY_OFFICER_SUPPLY,
+		JOB_AI,
+		JOB_BLUESHIELD
+	)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7145,6 +7145,7 @@
 #include "modular_zubbers\code\datums\bubber_quirks\hydrophilic.dm"
 #include "modular_zubbers\code\datums\id_trim\jobs.dm"
 #include "modular_zubbers\code\game\area\areas\station.dm"
+#include "modular_zubbers\code\game\gamemodes\dynamic\dynamic_rulesets.dm"
 #include "modular_zubbers\code\game\machinery\computer\arcade.dm"
 #include "modular_zubbers\code\game\objects\effects\decals.dm"
 #include "modular_zubbers\code\game\objects\effects\landmarks.dm"


### PR DESCRIPTION

## About The Pull Request

This PR basically includes every current ruleset into the config and assigns them weights, costs, and other stuff per my personal opinion on what is good.

Some gamemodes still have 0 weight (not possible to pick) but still have costs and requirements assigned.

Missing Skyrat + Bubberstation roles, like blueshield, are protected from enemy roles for dynamic. All heads cannot role antag either.


## Changelog

:cl: BurgerBB
config: Redoes the Dynamic config settings
balance: Adds missing Skyrat + Bubberstation roles to protected and enemy roles for dynamic.
/:cl:
