### PR TITLE
Removes Birdshot and Northstar from map vote rotation

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -16,7 +16,7 @@ endmap
 map birdshot
 	#default
 	maxplayers 66
-	votable
+	#votable
 endmap
 
 map metastation
@@ -39,7 +39,7 @@ endmap
 
 map northstar
 	minplayers 50
-	votable
+	#votable
 endmap
 
 


### PR DESCRIPTION
## About The Pull Request

Removes Birdshot and Northstar from map vote rotation

## Why is this good for the game

While it is nice that there are extra map options, and while there has been some significant effort put into these maps, the general consensus on discord, in ooc, and even in game that people really don't like these two maps.

Some of the problems include clientside lag, very confusing and waypoint-unfriendly layout, excessive use of multi-z, and way too spacious for the pop.

## Changelog

:cl: BurgerBB
del: Removes Birdshot and Northstar from map vote rotation
/:cl: