### PR TITLE
(Modular) Adds a proc to the SAD to restore character quirks

### DIFF
--- a/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
+++ b/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
@@ -145,7 +145,7 @@
 		Original Name: [original_name], New Name: [patient.dna.real_name]. \
 		This may be a false positive from changing from a humanized monkey into a character, so be careful.")
 
-	SSquirks.AssignQuirks(patient, patient.client)
+	SSquirks.AssignQuirks(patient, patient.client) // BUBBER EDIT ADDITON
 
 	open_machine()
 	playsound(src, 'sound/machines/microwave/microwave-end.ogg', 100, FALSE)

--- a/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
+++ b/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
@@ -145,6 +145,8 @@
 		Original Name: [original_name], New Name: [patient.dna.real_name]. \
 		This may be a false positive from changing from a humanized monkey into a character, so be careful.")
 
+	SSquirks.AssignQuirks(patient, patient.client)
+
 	open_machine()
 	playsound(src, 'sound/machines/microwave/microwave-end.ogg', 100, FALSE)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The S.A.D. currently does not restore quirks when it reads character preferences. This adds a proc to fix it
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Self Actualization Device will now restore your quirks when restoring your character preferences.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
