### PR TITLE
(Non-Modular) Requested addition to be able to hide seed packets and cards in shoe storage.

### DIFF
--- a/code/datums/storage/subtypes/pockets.dm
+++ b/code/datums/storage/subtypes/pockets.dm
@@ -105,9 +105,10 @@
 		list(/obj/item/screwdriver/power,
 		/obj/item/ammo_casing/caseless/rocket,
 		/obj/item/clothing/mask/cigarette/pipe,
-		/obj/item/toy/crayon/spraycan,
-		/obj/item/seeds,
-		/obj/item/card)
+		/obj/item/toy/crayon/spraycan, // BUBBER EDIT ADDITION
+		/obj/item/seeds, // BUBBER EDIT ADDITION
+		/obj/item/card, // BUBBER EDIT ADDITION
+		)
 		)
 
 /datum/storage/pockets/shoes/clown/New()

--- a/code/datums/storage/subtypes/pockets.dm
+++ b/code/datums/storage/subtypes/pockets.dm
@@ -143,9 +143,10 @@
 		list(/obj/item/screwdriver/power,
 		/obj/item/ammo_casing/caseless/rocket,
 		/obj/item/clothing/mask/cigarette/pipe,
-		/obj/item/toy/crayon/spraycan,
-		/obj/item/seeds,
-		/obj/item/card)
+		/obj/item/toy/crayon/spraycan, // BUBBER EDIT ADDITION
+		/obj/item/seeds, // BUBBER EDIT ADDITION
+		/obj/item/card, // BUBBER EDIT ADDITION
+		)
 		)
 
 /datum/storage/pockets/pocketprotector

--- a/code/datums/storage/subtypes/pockets.dm
+++ b/code/datums/storage/subtypes/pockets.dm
@@ -105,7 +105,9 @@
 		list(/obj/item/screwdriver/power,
 		/obj/item/ammo_casing/caseless/rocket,
 		/obj/item/clothing/mask/cigarette/pipe,
-		/obj/item/toy/crayon/spraycan)
+		/obj/item/toy/crayon/spraycan,
+		/obj/item/seeds,
+		/obj/item/card)
 		)
 
 /datum/storage/pockets/shoes/clown/New()
@@ -140,7 +142,9 @@
 		list(/obj/item/screwdriver/power,
 		/obj/item/ammo_casing/caseless/rocket,
 		/obj/item/clothing/mask/cigarette/pipe,
-		/obj/item/toy/crayon/spraycan)
+		/obj/item/toy/crayon/spraycan,
+		/obj/item/seeds,
+		/obj/item/card)
 		)
 
 /datum/storage/pockets/pocketprotector


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Another request from BurningCold, allowing you to slip seeds and card-shaped objects into shoe storage.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: adds seeds and card types to the list of things you can hide in shoes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
