### PR TITLE
(Modular) Alt recipes for makeshift tools

### DIFF
--- a/modular_zubbers/modules/modular_items/code/recipes_misc.dm
+++ b/modular_zubbers/modules/modular_items/code/recipes_misc.dm
@@ -1,0 +1,53 @@
+
+/datum/crafting_recipe/makeshift/crowbar_alt
+	name = "Makeshift Crowbar"
+	result = /obj/item/crowbar/makeshift
+	reqs = list(/obj/item/stack/sheet/iron = 4,
+				/obj/item/stack/sheet/cloth = 1,
+				/obj/item/weaponcrafting/silkstring = 1)
+	time = 120
+	category = CAT_MISC
+
+/datum/crafting_recipe/makeshift/screwdriver_alt
+	name = "Makeshift Screwdriver"
+	tool_paths = list(/obj/item/crowbar/makeshift)
+	result = /obj/item/screwdriver/makeshift
+	reqs = list(/obj/item/weaponcrafting/silkstring = 1,
+				/obj/item/stack/sheet/cloth = 2,
+				/obj/item/stack/rods = 2)
+	time = 80
+	category = CAT_MISC
+
+/datum/crafting_recipe/makeshift/welder_alt
+	name = "Makeshift Welder"
+	tool_paths = list(/obj/item/crowbar/makeshift)
+	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	result = /obj/item/weldingtool/makeshift
+	reqs = list(/obj/item/tank/internals/emergency_oxygen = 1,
+				/obj/item/stack/sheet/iron = 6,
+				/obj/item/stack/sheet/glass = 2,
+				/obj/item/weaponcrafting/silkstring = 2)
+	time = 160
+	category = CAT_MISC
+
+/datum/crafting_recipe/makeshift/wirecutters_alt
+	name = "Makeshift Wirecutters"
+	tool_paths = list(/obj/item/crowbar/makeshift)
+	tool_behaviors = list(TOOL_SCREWDRIVER)
+	result = /obj/item/wirecutters/makeshift
+	reqs = list(/obj/item/weaponcrafting/silkstring = 2,
+				/obj/item/stack/rods = 4)
+	time = 80
+	category = CAT_MISC
+
+/datum/crafting_recipe/makeshift/wrench_alt
+	name = "Makeshift Wrench"
+	tool_paths = list(/obj/item/crowbar/makeshift)
+	tool_behaviors = list(TOOL_SCREWDRIVER)
+	result = /obj/item/wrench/makeshift
+	reqs = list(/obj/item/weaponcrafting/silkstring = 1,
+				/obj/item/stack/sheet/iron = 3,
+				/obj/item/stack/rods = 1,
+				/obj/item/stack/sheet/cloth = 2)
+	time = 80
+	category = CAT_MISC


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Another request from BurningCold, this PR adds alternative recipes for makeshift tools, allowing string from weapon-crafting to be used for the tools as an alternative to cable coil.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added alternative recipes for the five makeshift tools. This does not include the makeshift MFC cell or cable layer. These recipes use silk string instead of cable coil.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
