### PR TITLE
Blob laser resistance buff

### DIFF
--- a/code/modules/antagonists/blob/structures/_blob.dm
+++ b/code/modules/antagonists/blob/structures/_blob.dm
@@ -35,6 +35,7 @@
 /datum/armor/structure_blob
 	fire = 80
 	acid = 70
+        laser = 50
 
 /obj/structure/blob/Initialize(mapload, owner_overmind)
 	. = ..()

--- a/code/modules/antagonists/blob/structures/factory.dm
+++ b/code/modules/antagonists/blob/structures/factory.dm
@@ -7,6 +7,7 @@
 	health_regen = BLOB_FACTORY_HP_REGEN
 	point_return = BLOB_REFUND_FACTORY_COST
 	resistance_flags = LAVA_PROOF
+        armor_type = /datum/armor/structure_blob/factory
 	///How many spores this factory can have.
 	var/max_spores = BLOB_FACTORY_MAX_SPORES
 	///The list of spores
@@ -17,6 +18,9 @@
 	var/mob/living/simple_animal/hostile/blob/blobbernaut/blobbernaut
 	///Used in blob/powers.dm, checks if it's already trying to spawn a blobbernaut to prevent issues.
 	var/is_creating_blobbernaut = FALSE
+
+/datum/armor/structure_blob/factory
+	laser = 25
 
 /obj/structure/blob/special/factory/scannerreport()
 	if(blobbernaut)

--- a/code/modules/antagonists/blob/structures/node.dm
+++ b/code/modules/antagonists/blob/structures/node.dm
@@ -17,6 +17,7 @@
 /datum/armor/special_node
 	fire = 65
 	acid = 90
+        laser = 25
 
 /obj/structure/blob/special/node/Initialize(mapload)
 	GLOB.blob_nodes += src

--- a/code/modules/antagonists/blob/structures/resource.dm
+++ b/code/modules/antagonists/blob/structures/resource.dm
@@ -6,7 +6,11 @@
 	max_integrity = BLOB_RESOURCE_MAX_HP
 	point_return = BLOB_REFUND_RESOURCE_COST
 	resistance_flags = LAVA_PROOF
+        armor_type = /datum/armor/structure_blob/resource
 	var/resource_delay = 0
+
+/datum/armor/structure_blob/resource
+	laser = 25
 
 /obj/structure/blob/special/resource/scannerreport()
 	return "Gradually supplies the blob with resources, increasing the rate of expansion."

--- a/code/modules/antagonists/blob/structures/shield.dm
+++ b/code/modules/antagonists/blob/structures/shield.dm
@@ -15,6 +15,7 @@
 /datum/armor/blob_shield
 	fire = 90
 	acid = 90
+        laser = 25
 
 /obj/structure/blob/shield/Initialize(mapload, owner_overmind)
 	AddElement(/datum/element/blocks_explosives)


### PR DESCRIPTION
## Original PR: https://github.com/tgstation/tgstation/pull/76458 and https://github.com/Skyrat-SS13/Skyrat-tg/pull/22191

## About The Pull Request
Regular blob tiles take half as much damage from lasers, all others take 25% less. They already have a lot of health and I think anything more than that makes it feel like a slog to kill.

## Why It's Good For The Game

Blobs feel like Swiss cheese right now if you have a laser. Enough lasers makes it completely trivial, so this should help level the playing field a little. This should only impact lasers, so emitters will also get hit but other sources of heat will not.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Vekter
balance: Increased blob tiles' resistance to lasers to compensate for the recent buff to laser damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
