### PR TITLE
Prevent admins from pressing buttons that cause the server to reach out to external services and fail.

### DIFF
--- a/code/controllers/subsystem/tts.dm
+++ b/code/controllers/subsystem/tts.dm
@@ -89,7 +89,9 @@ SUBSYSTEM_DEF(tts)
 	rustg_file_write(json_encode(available_speakers), "data/cached_tts_voices.json")
 	rustg_file_write("rustg HTTP requests can't write to folders that don't exist, so we need to make it exist.", "tmp/tts/init.txt")
 	return TRUE
-
+/datum/controller/subsystem/tts/establish_connection_to_tts() // BUBBER EDIT BEGIN - CRASH BANDAID
+	message_admins("a naughty admin was prevented from hanging the server sending an external query.")
+	return // BUBBER EDIT END
 /datum/controller/subsystem/tts/Initialize()
 	if(!CONFIG_GET(string/tts_http_url))
 		return SS_INIT_NO_NEED

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1456,6 +1456,9 @@
 		usr << browse(dat.Join("<br>"), "window=related_[C];size=420x300")
 
 	else if(href_list["centcomlookup"])
+		if(href_list) // BUBBER EDIT BEGIN - Crash Bandaid
+			message_admins("a naughty admin was prevented from hanging the server sending an external query.")
+			return // BUBBER EDIT END - Crash Bandaid
 		if(!check_rights(R_ADMIN))
 			return
 


### PR DESCRIPTION
AAAAAA.

...

AHHHHHHHHH.

Locks up the server waiting for responses it will never get. 