### PR TITLE
removes BUG that causes DAMAGE to ANTAG

### DIFF
--- a/modular_zubbers/code/game/objects/items/reshirevolver.dm
+++ b/modular_zubbers/code/game/objects/items/reshirevolver.dm
@@ -1,3 +1,5 @@
+#define AMMO_GIVEN_ON_START 24
+
 /obj/item/gun/ballistic/revolver/hos_revolver
 	name = "\improper HR-460MS 'Tracker'"
 	desc = "A brutally effectve revolver by Romulus officers prior to destruction of the planet, if the initial damage did not kill, the bleedout would. Uses the brutal .460 Rowland ammo."
@@ -35,30 +37,8 @@
 
 /obj/item/storage/bag/b460reloadpouch/PopulateContents()
 	. = ..()
-	new /obj/item/ammo_casing/b460(src)
-	new /obj/item/ammo_casing/b460(src)
-	new /obj/item/ammo_casing/b460(src)
-	new /obj/item/ammo_casing/b460(src)
-	new /obj/item/ammo_casing/b460(src)
-	new /obj/item/ammo_casing/b460(src)
-	new /obj/item/ammo_casing/b460(src)
-	new /obj/item/ammo_casing/b460(src)
-	new /obj/item/ammo_casing/b460(src)
-	new /obj/item/ammo_casing/b460(src)
-	new /obj/item/ammo_casing/b460(src)
-	new /obj/item/ammo_casing/b460(src)
-	new /obj/item/ammo_casing/b460(src)
-	new /obj/item/ammo_casing/b460(src)
-	new /obj/item/ammo_casing/b460(src)
-	new /obj/item/ammo_casing/b460(src)
-	new /obj/item/ammo_casing/b460(src)
-	new /obj/item/ammo_casing/b460(src)
-	new /obj/item/ammo_casing/b460(src)
-	new /obj/item/ammo_casing/b460(src)
-	new /obj/item/ammo_casing/b460(src)
-	new /obj/item/ammo_casing/b460(src)
-	new /obj/item/ammo_casing/b460(src)
-	new /obj/item/ammo_casing/b460(src)
+	for(var/i in 1 to AMMO_GIVEN_ON_START)
+		new /obj/item/ammo_casing/b460(src)
 
 /obj/item/storage/box/gunset/hos_revolver/PopulateContents()
 	. = ..()

--- a/modular_zubbers/code/game/objects/items/reshirevolver.dm
+++ b/modular_zubbers/code/game/objects/items/reshirevolver.dm
@@ -1,9 +1,12 @@
 /obj/item/gun/ballistic/revolver/hos_revolver
 	name = "\improper HR-460MS 'Tracker'"
 	desc = "A brutally effectve revolver by Romulus officers prior to destruction of the planet, if the initial damage did not kill, the bleedout would. Uses the brutal .460 Rowland ammo."
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/cylinder/rowland
 	icon = 'modular_zubbers/icons/obj/reshirevolver.dmi'
 	icon_state = "tracker"
 	fire_sound = 'modular_skyrat/modules/sec_haul/sound/hpistol_fire.ogg'
+	projectile_damage_multiplier = 1.6 //48 Damages, still a lot but not too much
+//With the damage multipler, it would crit in 4, kill in 6. Does not take into account armours.
 
 /obj/item/ammo_box/magazine/internal/cylinder/rowland
 	name = "\improper rowland revolver cylinder"

--- a/modular_zubbers/code/game/objects/items/reshirevolver.dm
+++ b/modular_zubbers/code/game/objects/items/reshirevolver.dm
@@ -44,3 +44,5 @@
 	. = ..()
 	new /obj/item/gun/ballistic/revolver/hos_revolver(src)
 	new /obj/item/storage/bag/b460reloadpouch(src)
+
+#undef AMMO_GIVEN_ON_START

--- a/modular_zubbers/code/game/objects/items/reshirevolver.dm
+++ b/modular_zubbers/code/game/objects/items/reshirevolver.dm
@@ -4,8 +4,6 @@
 	icon = 'modular_zubbers/icons/obj/reshirevolver.dmi'
 	icon_state = "tracker"
 	fire_sound = 'modular_skyrat/modules/sec_haul/sound/hpistol_fire.ogg'
-	projectile_damage_multiplier = 1.6 //48 Damages, still a lot but not too much
-//With the damage multipler, it would crit in 4, kill in 6. Does not take into account armours.
 
 /obj/item/ammo_box/magazine/internal/cylinder/rowland
 	name = "\improper rowland revolver cylinder"


### PR DESCRIPTION
so errrrm the HoS revolver had its internal mag set wrong
so it just spawned with a .357 mag instead
which with the 1.6x proj. multiplier meant it was just an objectively more powerful .357. For free. Roundstart guaranteed.
 oh and couldn't be reloaded with the ammo you got supplied with
Ruh roh!

![image](https://github.com/Bubberstation/Bubberstation/assets/8881105/7bf67e29-1bfc-49d6-bd13-227cb58bb1c2)

:cl:
fix: The HoS revolver can now be reloaded
fix: The HoS revolver is no longer an objectively better .357
/:cl: