### PR TITLE
Removes borer egg from uplink

### DIFF
--- a/modular_skyrat/modules/skyrat-uplinks/code/categories/dangerous.dm
+++ b/modular_skyrat/modules/skyrat-uplinks/code/categories/dangerous.dm
@@ -4,13 +4,3 @@
 	item = /obj/item/gun/ballistic/automatic/c20r/toy/unrestricted/riot
 	cost = 4
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
-
-/datum/uplink_item/dangerous/cortical_borer
-	name = "Cortical Borer Egg"
-	desc = "The egg of a cortical borer. The cortical borer is a parasite that can produce chemicals upon command, as well as \
-			learn new chemicals through the blood if old enough. Be careful as there is no way to get the borer to pledge allegiance \
-			to yourself. The egg is extremely fragile, do not crush it in your hand nor throw it. \
-			The egg is required to sit out in the open in order to hatch. (Cannot be hidden in closets, etc.)"
-	progression_minimum = 20 MINUTES
-	item = /obj/effect/mob_spawn/ghost_role/borer_egg/traitor
-	cost = 20


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This removes the ability for traitors to purchase borer eggs from the uplink.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game
As it stands, borers are too powerful as a 2nd tool to traitors. Unlike Holoparasites which dust you upon death, borers come with no downsides other than their steep cost. A cost which can easily be recouped with the help of the borer in your head helping you do side objectives.

A good traitor with a borer in their head is a terrifying force to be reckoned with. A borer-empowered traitor at their prime cannot be dealt with by any means possible. One such example was 3 weeks ago when Weiss Ii used a borer egg as their first purchase to accumulate a total of 63 TC while running permanently mach 3 around the station. After their TC hoarding, they used it all to buy an elite syndi modsuit, double e-sword and glue alongside bits and bobs. With the assistance of the borer's speed and overpowered wound recovery chems, they were essentially taking no damage and being able to revive. This is on top of their very heavily armored suit and the 75% block chance d-sword that cannot be disarmed.

That is one such example. I will admit that this is by all means a salt PR and I will not shy away from it. But I will also note that Borers are an unbalanced antagonist and factor into the round. They come from a codebase that only uses them for flavor and roleplay, not for actual balanced gameplay.

It's my hope that borers either get completely removed or overhauled to become actually balanced, but I do not see anyone picking up the latter and the former will piss off too many people. So this is my compromise, traitors cannot purchase them anymore and everyone is happy. A round will happen where they both spawn but to that I just say thanks dynamic. 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removes borer egg from traitor uplink.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
