### PR TITLE
racism.exe

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -357,7 +357,7 @@ ROUNDSTART_RACES moth
 ROUNDSTART_RACES plasmaman
 #ROUNDSTART_RACES shadow
 ROUNDSTART_RACES teshari
-ROUNDSTART_RACES hemophage
+#ROUNDSTART_RACES hemophage
 ROUNDSTART_RACES snail
 
 ## Races that are better than humans in some ways, but worse in others
@@ -410,7 +410,7 @@ ROUNDSTART_RACES akula
 ROUNDSTART_RACES unathi
 ROUNDSTART_RACES skrell
 ROUNDSTART_RACES humanoid
-ROUNDSTART_RACES xeno
+#ROUNDSTART_RACES xeno
 ROUNDSTART_RACES slimeperson
 ROUNDSTART_RACES podweak
 ROUNDSTART_RACES dwarf


### PR DESCRIPTION
## About The Pull Request

Sooner or later some of the cringe and hugbox stuff that helped make Skyrat bad has to go.
Might as well start here.

Roundstart races commented out
Hemophage & Xeno hybrid

## Why It's Good For The Game

Both are far better as antags. Having them neutered on station crew that act exactly like any other crew is cringe.
Been tried for ages, never seen it done well, let it die. Or just keep adding cringe in endless layers of absolute garbo.
I'm doing my part, are you doing yours?

## Changelog

:cl:
del: Comments out roundstart hemophage and xeno hybrid
/:cl:
