### PR TITLE
Makes Skyrat donor items normal items instead of OC items.

### DIFF
--- a/modular_skyrat/modules/customization/game/objects/items/plushes.dm
+++ b/modular_skyrat/modules/customization/game/objects/items/plushes.dm
@@ -319,13 +319,13 @@
 	squeak_override = list('sound/effects/crunchybushwhack1.ogg' = 1)
 
 /obj/item/toy/plush/skyrat/fox/mia
-	name = "Mia’s fox plushie"
-	desc = "A small stuffed silver fox with a collar tag that says “Eavy” and a tiny bell in its fluffy tail."
+	name = "Strange fox plushie"
+	desc = "A small stuffed silver fox with a collar, looks strange."
 	icon_state = "miafox"
 
 /obj/item/toy/plush/skyrat/fox/kailyn
 	name = "teasable fox plushie"
-	desc = "A familiar looking vixen in a peacekeeper attire, perfect for everyone who intends on venturing in the dark alone! There's a little tag which tells you to not boop its nose."
+	desc = "A vixen in a peacekeeper attire, perfect for everyone who intends on venturing in the dark alone! There's a little tag which tells you to boop its nose."
 	icon_state = "teasefox"
 	attack_verb_continuous = list("sneezes on", "detains", "tazes")
 	attack_verb_simple = list("sneeze on", "detain", "taze")
@@ -518,7 +518,7 @@
 // Donation reward for shyshadow
 /obj/item/toy/plush/skyrat/plushie_winrow
 	name = "dark and brooding lizard plush"
-	desc = "An almost intimidating black lizard plush, this one's got a little beret to come with it! Best not to separate the two. Its eyes shine with suggestion, no maidens?"
+	desc = "An almost intimidating black lizard plush, this one's got a little beret to come with it! Best not to separate the two. It sorta smells bad."
 	icon_state = "plushie_shyshadow"
 
 // Donation reward for Dudewithatude

--- a/modular_skyrat/modules/customization/modules/clothing/suits/misc.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/suits/misc.dm
@@ -90,7 +90,7 @@
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/suits.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/suit.dmi'
 	name = "aerostatic bomber jacket"
-	desc = "A jacket once worn by the Air Force during the Antecentennial Revolution, there are quite a few pockets on the inside, mostly for storing notebooks and compasses."
+	desc = "A jacket once popular by the Air Force during the Antecentennial Revolution, there are quite a few pockets on the inside, helpful for keeping that emergency oxygen tank close by."
 	icon_state = "aerostatic_bomber_jacket"
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 

--- a/modular_skyrat/modules/customization/modules/clothing/~donator/donator_clothing.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/~donator/donator_clothing.dm
@@ -77,8 +77,8 @@
 
 // Donation reward for Grunnyyy
 /obj/item/clothing/suit/jacket/ryddid
-	name = "Ryddid"
-	desc = "An old worn out piece of clothing belonging to a certain small demon."
+	name = "The Rizz"
+	desc = "An old worn out piece of clothing, not very Rizzy."
 	icon = 'modular_skyrat/master_files/icons/donator/obj/clothing/suits.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/donator/mob/clothing/suit.dmi'
 	icon_state = "darkcoat"
@@ -88,7 +88,7 @@
 // Donation reward for Grunnyyy
 /obj/item/clothing/neck/cloak/grunnyyy
 	name = "black and red cloak"
-	desc = "The design on this seems a little too familiar."
+	desc = "The design on this seems a tad basic, but welcome."
 	icon = 'modular_skyrat/master_files/icons/donator/obj/custom.dmi'
 	icon_state = "infcloak"
 	worn_icon = 'modular_skyrat/master_files/icons/donator/mob/clothing/custom_w.dmi'
@@ -266,8 +266,8 @@
 
 // Donation reward for Farsighted Nightlight
 /obj/item/clothing/mask/gas/nightlight
-	name = "FIR-36 Rebreather"
-	desc = "A close-fitting respirator designed by Forestfel Intersystem Industries and originally meant for Ixian Tajarans, the FIR-36 Rebreather is commonly used by Military and Civilian Personnel alike. It reeks of Militarism."
+	name = "Heavy Duty Rebreather"
+	desc = "An ultra heavy duty rebreather, often used by those who need them for medical reasons."
 	icon = 'modular_skyrat/master_files/icons/donator/obj/clothing/masks.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/donator/mob/clothing/mask.dmi'
 	icon_state = "far14c"
@@ -328,7 +328,7 @@
 
 // Donation reward for TheOOZ
 /obj/item/clothing/mask/animal/kindle
-	name = "wolf mask"
+	name = "Cheap wolf mask"
 	desc = "A dark mask in the shape of a wolf's head.<br>The material feels like it's made entirely out of inexpensive plastic."
 	icon = 'modular_skyrat/master_files/icons/donator/obj/clothing/masks.dmi'
 	icon_state = "kindle"
@@ -367,15 +367,15 @@
 
 // Donation reward for Random516
 /obj/item/clothing/gloves/fingerless/blutigen_wraps
-	name = "Blutigen wraps"
-	desc = "The one who wears these had everything and yet lost it all..."
+	name = "Bandage like wraps"
+	desc = "The one who wears these had quite a tussle"
 	icon = 'modular_skyrat/master_files/icons/donator/obj/clothing/gloves.dmi'
 	icon_state = "blutigen_wraps"
 	worn_icon = 'modular_skyrat/master_files/icons/donator/mob/clothing/hands.dmi'
 
 // Donation reward for Random516
 /obj/item/clothing/suit/blutigen_kimono
-	name = "Blutigen kimono"
+	name = "Fancy blue kimono"
 	desc = "For the eyes bestowed upon this shall seek adventure..."
 	icon = 'modular_skyrat/master_files/icons/donator/obj/clothing/suits.dmi'
 	icon_state = "blutigen_kimono"
@@ -399,14 +399,14 @@
 
 // Donation reward for CoffeePot
 /obj/item/clothing/gloves/ring/hypno/coffeepot
-	name = "hypnodemon's ring"
-	desc = "A pallid, softly desaturated-looking gold ring that doesn't look like it belongs. It's hard to put one's finger on why it feels at odds with the world around it - the shine coming off it looks like it could be a mismatch with the lighting in the room, or it could be that it seems to glint and twinkle occasionally when there's no obvious reason for it to - though only when you're not really looking."
+	name = "Liquid gold ring"
+	desc = "A strange glass ring with liquid gold moving around inside of it. Watching it flow within the glass is almost calming, far... to calming..."
 	spans = list("velvet")
 
 // Donation reward for Bippys
 /obj/item/clothing/gloves/ring/hypno/bippys
-	name = "hypnobot hexnut"
-	desc = "A silver bolt component that once belonged to a very peculiar IPC. It's large enough to be worn as a ring on nearly any finger, and is said to amplify the voice of one's mind to another's in the softness of a Whisper..."
+	name = "Liquid silver ring"
+	desc = "A strange glass ring with liquid gold moving around inside of it. Watching it flow within the glass is almost calming, far... to calming..."
 	icon_state = "ringsilver"
 	worn_icon_state = "sring"
 	spans = list("hexnut")
@@ -503,7 +503,7 @@
 /****************LEGACY REWARDS***************/
 // Donation reward for inferno707
 /obj/item/clothing/neck/cloak/inferno
-	name = "Kiara's cloak"
+	name = "Cloner cloak"
 	desc = "The design on this seems a little too familiar."
 	icon = 'modular_skyrat/master_files/icons/donator/obj/custom.dmi'
 	icon_state = "infcloak"
@@ -513,7 +513,7 @@
 
 // Donation reward for inferno707
 /obj/item/clothing/neck/inferno_collar
-	name = "Kiara's collar"
+	name = "Inferno collar"
 	desc = "A soft black collar that seems to stretch to fit whoever wears it."
 	icon_state = "infcollar"
 	icon = 'modular_skyrat/master_files/icons/donator/obj/custom.dmi'
@@ -537,16 +537,16 @@
 
 // Donation reward for inferno707
 /obj/item/clothing/accessory/medal/steele
-	name = "Insignia Of Steele"
-	desc = "An intricate pendant given to those who help a key member of the Steele Corporation."
+	name = "Insignia Of Swag"
+	desc = "An intricate pendant given to those who have swag out the wazzoo."
 	icon = 'modular_skyrat/master_files/icons/donator/obj/custom.dmi'
 	icon_state = "steele"
 	medaltype = "medal-silver"
 
 // Donation reward for inferno707
 /obj/item/toy/darksabre
-	name = "Kiara's sabre"
-	desc = "This blade looks as dangerous as its owner."
+	name = "Dark sabre"
+	desc = "This blade looks to be made out of a heavy metal foam."
 	icon = 'modular_skyrat/master_files/icons/donator/obj/custom.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/donator/mob/clothing/custom_w.dmi'
 	icon_state = "darksabre"
@@ -559,7 +559,7 @@
 // Donation reward for inferno707
 /obj/item/storage/belt/sabre/darksabre
 	name = "ornate sheathe"
-	desc = "An ornate and rather sinister looking sabre sheathe."
+	desc = "An ornate and sabre sheath seemingly made to keep a certain ritualistic sabre safe."
 	icon = 'modular_skyrat/master_files/icons/donator/obj/custom.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/donator/mob/clothing/custom_w.dmi'
 	icon_state = "darksheath"
@@ -590,7 +590,7 @@
 // Donation reward for inferno707
 /obj/item/clothing/mask/hheart
 	name = "Hollow Heart"
-	desc = "It's an odd ceramic mask. Set in the internal side are several suspicious electronics branded by Steele Tech."
+	desc = "It's an odd ceramic mask."
 	icon = 'modular_skyrat/master_files/icons/donator/obj/clothing/masks.dmi'
 	icon_state = "hheart"
 	worn_icon = 'modular_skyrat/master_files/icons/donator/mob/clothing/mask.dmi'
@@ -631,8 +631,8 @@
 
 // Donation reward for asky / Zulie
 /obj/item/clothing/suit/hooded/cloak/zuliecloak
-	name = "Project: Zul-E"
-	desc = "A standard version of a prototype cloak given out by Nanotrasen higher ups. It's surprisingly thick and heavy for a cloak despite having most of it's tech stripped. It also comes with a bluespace trinket which calls it's accompanying hat onto the user. A worn inscription on the inside of the cloak reads 'Fleuret' ...the rest is faded away."
+	name = "Project: Upright"
+	desc = "A strange but wonderful bit of technology that allows those who wear this cloak to summon a swarm of nanites as a hat."
 	icon_state = "zuliecloak"
 	icon = 'modular_skyrat/master_files/icons/donator/obj/clothing/cloaks.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/donator/mob/clothing/neck.dmi'
@@ -689,8 +689,8 @@
 
 // Donation reward for Enzoman
 /obj/item/clothing/mask/luchador/enzo
-	name = "mask of El Red Templar"
-	desc = "A mask belonging to El Red Templar, a warrior of lucha. Taking it from him is not recommended."
+	name = "mask of A Lucha Warror"
+	desc = "A mask belonging to a warrior of lucha. Taking it from them is not recommended."
 	icon = 'modular_skyrat/master_files/icons/donator/obj/clothing/masks.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/donator/mob/clothing/mask.dmi'
 	icon_state = "luchador"
@@ -751,8 +751,8 @@
 
 // Donation reward for CandleJax
 /obj/item/clothing/head/helmet/space/plasmaman/candlejax
-	name = "emission's helmet"
-	desc = "A special containment helmet designed for heavy usage. Multiple dings and notches are on this one."
+	name = "Specialised helmet"
+	desc = "A specialised helmet designed for heavy usage. Designed for Plasmamen who fancy a new look."
 	icon = 'modular_skyrat/master_files/icons/donator/obj/clothing/hats.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/donator/mob/clothing/head.dmi'
 	icon_state = "emissionhelm"
@@ -760,31 +760,31 @@
 
 // Donation reward for CandleJax
 /obj/item/clothing/head/helmet/space/plasmaman/candlejax2
-	name = "azulean's environment helmet"
-	desc = "An Azulean-made Enviro-Helmet, adjusted for the unique skull shape typical of the species. Alongside the standard features, it includes an embossment of the Azulean Crest on the back of the helmet."
+	name = "Skullshape environment helmet"
+	desc = "A new Enviro-Helmet, adjusted for the unique skull shape typical of some Plasmamen."
 	icon = 'modular_skyrat/master_files/icons/donator/obj/clothing/hats.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/donator/mob/clothing/head.dmi'
 	icon_state = "anahead"
 
 // Donation reward for CandleJax
 /obj/item/clothing/under/plasmaman/candlejax
-	name = "emission's containment suit"
-	desc = "A modified envirosuit featuring a reserved color scheme."
+	name = "Specialised suit"
+	desc = "A modified envirosuit featuring a reserved color scheme for plasmamen looking to try on something new."
 	icon = 'modular_skyrat/master_files/icons/donator/obj/clothing/uniform.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/donator/mob/clothing/uniform.dmi'
 	icon_state = "emissionsuit"
 
 // Donation reward for CandleJax
 /obj/item/clothing/under/plasmaman/candlejax2
-	name = "azulean's environment suit"
-	desc = "An Azulean-made Enviro-Suit. Fitted to the Azulean form, it has surplus containment fabric designed to give the solidified mass of plasma that was once a tail some breathing room."
+	name = "skeleton shame environment suit"
+	desc = "An Enviro-Suit. Fitted to the the form of some other species who fell into plasma."
 	icon = 'modular_skyrat/master_files/icons/donator/obj/clothing/uniform.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/donator/mob/clothing/uniform.dmi'
 	icon_state = "ana_envirosuit"
 
 // Donation reward for CandleJax
 /obj/item/clothing/under/plasmaman/jax2
-	name = "xuracorp hazard underfitting"
+	name = "Custom hazard underfitting"
 	desc = "A hazard suit fitted with bio-resistant fibers. Utilizes self-sterilizing pumps fitted in the back."
 	icon = 'modular_skyrat/master_files/icons/donator/obj/clothing/uniform.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/donator/mob/clothing/uniform.dmi'
@@ -818,7 +818,7 @@
 // Donation reward for Raxraus
 /obj/item/clothing/under/rank/security/rax
 	name = "banded uniform"
-	desc = "Personalized and tailored to fit, this uniform is designed to protect without compromising its stylishness."
+	desc = "This uniform is designed to protect without compromising its stylishness."
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/under/security.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/under/security.dmi'
 	worn_icon_digi = 'modular_skyrat/master_files/icons/donator/mob/clothing/uniform_digi.dmi'
@@ -868,7 +868,7 @@
 // Donation reward for GoldenAlpharex
 /obj/item/clothing/glasses/welding/steampunk_goggles
 	name = "steampunk goggles"
-	desc = "This really feels like something you'd expect to see sitting on top of a certain ginger's head... They have a rather fancy brass trim around the lenses."
+	desc = "This really feels like something you'd expect to see sitting on top of a cosplayers head... They have a rather fancy brass trim around the lenses."
 	icon = 'modular_skyrat/master_files/icons/donator/obj/clothing/glasses.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/donator/mob/clothing/eyes.dmi'
 	icon_state = "goldengoggles"
@@ -1097,7 +1097,7 @@
 // Donation reward for 1ceres
 /obj/item/clothing/glasses/rosecolored
 	name = "rose-colored glasses"
-	desc = "Goggle-shaped glasses that seem to have a HUD-like feed in some odd line-based script. It doesn’t look like they were made by NT."
+	desc = "Goggle-shaped glasses that seem to have a HUD-like feed in some odd line-based script."
 	icon = 'modular_skyrat/master_files/icons/donator/obj/clothing/glasses.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/donator/mob/clothing/eyes.dmi'
 	icon_state = "rose"
@@ -1144,7 +1144,7 @@
 // Donation reward for 1ceres
 /obj/item/clothing/suit/jacket/gorlex_harness
 	name = "engine technician harness"
-	desc = "A blood-red engineering technician harness. You can't seem to figure out a use to it, but it seems to seal magnetically in some places."
+	desc = "A blood-red engineering technician harness, it seems to seal magnetically in some places."
 	icon = 'modular_skyrat/master_files/icons/donator/obj/clothing/suits.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/donator/mob/clothing/suit.dmi'
 	icon_state = "gorlexharness"
@@ -1175,8 +1175,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/korpstech, 32)
 
 // Donation reward for Cimika
 /obj/item/clothing/suit/toggle/labcoat/skyrat/tenrai
-	name = "Tenrai labcoat"
-	desc = "A labcoat crafted from a variety of pristine materials, sewn together with a frightening amount of skill. The fabric is aery, smooth as silk, and exceptionally pleasant to the touch. The golden stripes are visible in the dark, working as a beacon to the injured. A small label on the inside of it reads \"Tenrai Kitsunes Supremacy\"."
+	name = "Kitsune labcoat"
+	desc = "A labcoat crafted from a variety of pristine materials, sewn together with a frightening amount of skill. The fabric is aery, smooth as silk, and exceptionally pleasant to the touch. The golden stripes are visible in the dark, working as a beacon to the injured. A small label on the inside of it reads \"Kitsunes Supremacy\"."
 	base_icon_state = "tenraicoat"
 	icon_state = "tenraicoat"
 	icon = 'modular_skyrat/master_files/icons/donator/obj/clothing/suits.dmi'
@@ -1191,7 +1191,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/korpstech, 32)
 //Donation reward for RealWinterFrost
 /obj/item/clothing/neck/cloak/fluffycloak
 	name = "Cloak of the Fluffy One"
-	desc = "Hugs and kisses is only what this one knows, may their hugs be for all and not for their own \"For Fuffy Use Only\"."
+	desc = "A cloak that feels almost cold to the touch, although its actually just the colors."
 	icon_state = "fluffycloak"
 	icon = 'modular_skyrat/master_files/icons/donator/obj/clothing/cloaks.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/donator/mob/clothing/neck.dmi'
@@ -1213,7 +1213,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/korpstech, 32)
 // Donation reward for Cimika, on behalf of tf4
 /obj/item/clothing/neck/fishpendant
 	name = "fish necklace"
-	desc = "A simple, silver necklace with a blue tuna pendant.\n\"L. Alazawi\" is inscribed on the back. You get the feeling it would go well with potatoes and green beans."
+	desc = "A simple, silver necklace with a blue tuna pendant. May it bless your next cast."
 	icon = 'modular_skyrat/master_files/icons/donator/obj/clothing/necklaces.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/donator/mob/clothing/neck.dmi'
 	icon_state = "fishpendant"
@@ -1247,7 +1247,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/korpstech, 32)
 //Donation reward for Konstyantyn
 /obj/item/clothing/accessory/badge/holo/jade
 	name = "jade holobadge"
-	desc = "A strangely green holobadge. 'Lieutenant Uriah' is stamped onto it, above the letters JS."
+	desc = "A strangely green holobadge. Seems shiny and expensive"
 	icon = 'modular_skyrat/master_files/icons/donator/obj/custom.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/donator/mob/clothing/custom_w.dmi'
 	icon_state = "greenbadge"
@@ -1564,7 +1564,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/korpstech, 32)
 
 /obj/item/clothing/suit/armor/hos/elofy
 	name = "solar admiral coat"
-	desc = "A traditional naval officer uniform of the late 63rd Expeditionary Fleet. This faithful recreation bears the admiral's crest of the Luna Wolves Legion. It is uniquely tailored to the form of a certain wolf girl."
+	desc = "A traditional naval officer uniform of some expeditionary fleet..."
 	icon = 'modular_skyrat/master_files/icons/donator/obj/clothing/suits.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/donator/mob/clothing/suit.dmi'
 	icon_state = "coat_blackblue"
@@ -1591,7 +1591,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/korpstech, 32)
 
 /obj/item/clothing/suit/armor/hos/elofy/examine_more(mob/user)
 	. = ..()
-	. += "It seems particularly soft and has subtle ballistic fibers intwined with the soft fabric that is perfectedly tailored to the body that wears it. Each golden engraving seems to reflect against your eyes with a slightly blinding flare. This is part of a full set of Luna Wolves Legion battle garb."
+	. += "It seems particularly soft and has subtle ballistic fibers intwined with the soft fabric that is perfectedly tailored to the body that wears it."
 
 /obj/item/clothing/gloves/elofy
 	name = "solar admiral gloves"

--- a/modular_skyrat/modules/customization/modules/clothing/~donator/donator_items.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/~donator/donator_items.dm
@@ -65,8 +65,8 @@
 #define SLAP_SIDE		4
 
 /obj/item/donator/transponder
-	name = "broken Helian transponder"
-	desc = "Used by Helians to communicate with their mothership, the screen is cracked and its edges scuffed. This one has seen better days."
+	name = "broken transponder"
+	desc = "Used by aliens to communicate with their home planet, the screen is cracked and its edges scuffed. This one has seen better days."
 	icon = 'modular_skyrat/master_files/icons/donator/obj/custom.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/donator/mob/clothing/custom_w.dmi'
 	lefthand_file = 'modular_skyrat/master_files/icons/donator/mob/inhands/donator_left.dmi'

--- a/modular_skyrat/modules/loadouts/loadout_items/donator/personal/donator_personal.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/donator/personal/donator_personal.dm
@@ -1,5 +1,5 @@
 /datum/loadout_item/toys/miafoxplush
-	name = "Mia’s fox plushie"
+	name = "Strange fox plushie"
 	item_path = /obj/item/toy/plush/skyrat/fox/mia
 //ckeywhitelist = list("fuzlet")
 
@@ -30,7 +30,7 @@
 	//ckeywhitelist = list("thedragmeme")
 
 /datum/loadout_item/suit/ryddid
-	name = "The Ryddid"
+	name = "The Rizz"
 	item_path = /obj/item/clothing/suit/jacket/ryddid
 	//ckeywhitelist = list("grunnyyy")
 
@@ -45,12 +45,12 @@
 	//ckeywhitelist = list("grunnyyy")
 
 /datum/loadout_item/gloves/hypnoring_coffee
-	name = "Hypnodemon's Ring"
+	name = "Liquid Gold Ring"
 	item_path = /obj/item/clothing/gloves/ring/hypno/coffeepot
 	//ckeywhitelist = list("coffeepot")
 
 /datum/loadout_item/gloves/hypnoring_bippy
-	name = "Hypnodemon's Ring"
+	name = "Liquid Silver Ring"
 	item_path = /obj/item/clothing/gloves/ring/hypno/bippys
 	//ckeywhitelist = list("bippys")
 
@@ -97,28 +97,28 @@
 	//ckeywhitelist = list("goldenalpharex")
 
 /datum/loadout_item/under/jumpsuit/plasmaman_jax
-	name = "XuraCorp Biohazard Underfitting"
+	name = "Custom Biohazard Underfitting"
 	item_path = /obj/item/clothing/under/plasmaman/jax2
 	//ckeywhitelist = list("candlejax")
 	restricted_roles = list(JOB_RESEARCH_DIRECTOR, JOB_SCIENTIST, JOB_SCIENCE_GUARD, JOB_VIROLOGIST, JOB_GENETICIST)
 
 /datum/loadout_item/head/emissionhelm
-	name = "Emission's Helmet"
+	name = "Specialised Helmet"
 	item_path = /obj/item/clothing/head/helmet/space/plasmaman/candlejax
 	//ckeywhitelist = list("candlejax")
 
 /datum/loadout_item/head/anahelm
-	name = "Azulean's Enviro-Helmet"
+	name = "Skullshape Enviro-Helmet"
 	item_path = /obj/item/clothing/head/helmet/space/plasmaman/candlejax2
 //	ckeywhitelist = list("candlejax")
 
 /datum/loadout_item/under/jumpsuit/emissionsuit
-	name = "Emission's Suit"
+	name = "Specialised Suit"
 	item_path = /obj/item/clothing/under/plasmaman/candlejax
 	//ckeywhitelist = list("candlejax")
 
 /datum/loadout_item/under/jumpsuit/anasuit
-	name = "Azulean's Enviro-Suit"
+	name = "Skeleton shape Enviro-Suit"
 	item_path = /obj/item/clothing/under/plasmaman/candlejax2
 //	ckeywhitelist = list("candlejax")
 
@@ -133,27 +133,27 @@
 	//ckeywhitelist = list("slippyjoe")
 
 /datum/loadout_item/shoes/britches_shoes
-	name = "Britches' shoes"
+	name = "Cute clown shoes"
 	item_path = /obj/item/clothing/shoes/clown_shoes/britches
 	//ckeywhitelist = list("bloodrite")
 
 /datum/loadout_item/under/jumpsuit/britches_dress
-	name = "Britches' dress"
+	name = "Cute clown dress"
 	item_path = /obj/item/clothing/under/rank/civilian/clown/britches
 	//ckeywhitelist = list("bloodrite")
 
 /datum/loadout_item/mask/britches_mask
-	name = "Britches' mask"
+	name = "Cute clown mask"
 	item_path = /obj/item/clothing/mask/gas/britches
 	//ckeywhitelist = list("bloodrite")
 
 /datum/loadout_item/mask/luchador_mask
-	name = "Mask of El Red Templar"
+	name = "Mask of A Lucha Warror"
 	item_path = /obj/item/clothing/mask/luchador/enzo
 	//ckeywhitelist = list("enzoman")
 
 /datum/loadout_item/mask/nightlight_mask
-	name = "FIR-36 Rebreather"
+	name = "Heavy Duty Rebreather"
 	item_path = /obj/item/clothing/mask/gas/nightlight
 //	ckeywhitelist = list("farsightednightlight", "raxraus", "1ceres", "marcoalbaredaa", "itzshift_yt", "drifter7371", "AvianAviator", "Katty Kat", "Investigator77", "Dalao Azure", "Socialistion", "ChillyLobster", "Sylvara", "AmZee")
 
@@ -173,7 +173,7 @@
 	ckeywhitelist = list("ChillyLobster")
 
 /datum/loadout_item/mask/kindle_mask
-	name = "Kindle's mask"
+	name = "Cheap wolf mask"
 	item_path = /obj/item/clothing/mask/animal/kindle
 	//ckeywhitelist = list("theooz")
 
@@ -183,12 +183,12 @@
 	//ckeywhitelist = list("random516")
 
 /datum/loadout_item/gloves/blutigen_wraps
-	name = "Blutigen Wraps"
+	name = "Bandage like Wraps"
 	item_path = /obj/item/clothing/gloves/fingerless/blutigen_wraps
 	//ckeywhitelist = list("random516")
 
 /datum/loadout_item/suit/blutigen_kimono
-	name = "Blutigen Kimono"
+	name = "Fancy Blue Kimono"
 	item_path = /obj/item/clothing/suit/blutigen_kimono
 	//ckeywhitelist = list("random516")
 
@@ -220,17 +220,17 @@
 	//ckeywhitelist = list("netrakyram")
 
 /datum/loadout_item/neck/kiaracloak
-	name = "Kiara's cloak"
+	name = "Cloner cloak"
 	item_path = /obj/item/clothing/neck/cloak/inferno
 	//ckeywhitelist = list("inferno707")
 
 /datum/loadout_item/neck/kiaracollar
-	name = "Kiara's collar"
+	name = "Inferno collar"
 	item_path = /obj/item/clothing/neck/inferno_collar
 	//ckeywhitelist = list("inferno707")
 
 /datum/loadout_item/pocket_items/kiaramedal
-	name = "Insignia of Steele"
+	name = "Insignia of Swag"
 	item_path = /obj/item/clothing/accessory/medal/steele
 	//ckeywhitelist = list("inferno707")
 
@@ -255,7 +255,7 @@
 	//ckeywhitelist = list("inferno707")
 
 /datum/loadout_item/neck/zuliecloak
-	name = "Project: Zul-E"
+	name = "Project: Upright"
 	item_path = /obj/item/clothing/suit/hooded/cloak/zuliecloak
 	//ckeywhitelist = list("asky")
 
@@ -393,12 +393,12 @@
 	//ckeywhitelist = list("kaynite")
 
 /datum/loadout_item/suit/tenrai_coat
-	name = "Tenrai Coat"
+	name = "Kitsunes Labcoat"
 	item_path = /obj/item/clothing/suit/toggle/labcoat/skyrat/tenrai
 	//ckeywhitelist = list("cimika")
 
 /datum/loadout_item/neck/fluffycloak
-	name = "Fluffy Cloak"
+	name = "Minty Cloak"
 	item_path = /obj/item/clothing/neck/cloak/fluffycloak
 	//ckeywhitelist = list("realwinterfrost")
 
@@ -599,7 +599,7 @@
 //	ckeywhitelist = list("october23")
 
 /datum/loadout_item/pocket_items/transponder
-	name = "Broken Helian Transponder"
+	name = "Broken Transponder"
 	item_path = /obj/item/donator/transponder
 //	ckeywhitelist = list("glacii")
 


### PR DESCRIPTION
Naturally there is nothing wrong with skyrat donors having their own items on skyrat, but as we are a downstream we have their items and have unlocked them for everyone to use. Thing is, a lot of items are made for a certain OC that someone has on skyrat and that makes it a rather odd item to use here. No one wants to wear "DJ Phonky beats jacket" when they are playing as a chill librarian who just likes the way the jacket looks. This changes that by removing DIRECT references to players on skyrat and makes the description for some outfits more generic. This is both to give our players more options without feeling weird about wearing an outfit named "John's t-shirt" as well as respecting the players on skyrat who may not want people wearing items named after them, or made for them. 