### PR TITLE
[DO NOT MERGE] silicons now require power to do door actions

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1693,8 +1693,9 @@
 			user_toggle_open(usr)
 			. = TRUE
 
-/obj/machinery/door/airlock/proc/user_allowed(mob/user)
-	return (issilicon(user) && canAIControl(user)) || isAdminGhostAI(user)
+/obj/machinery/door/airlock/proc/user_allowed(mob/living/silicon/user) // BUBBER EDIT - Whole Proc Replaced For Silicon Interaction Power Draw
+	if(user.get_power(demand = 350, distance = (get_dist(src,user)), atom = src))
+		return (issilicon(user) && canAIControl(user)) || isAdminGhostAI(user)
 
 /obj/machinery/door/airlock/proc/shock_restore(mob/user)
 	if(!user_allowed(user))

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -150,8 +150,8 @@
 		return FALSE
 	if(!local_apc.cell)
 		return FALSE
-	local_apc.cell.use(amount)
-	return TRUE
+	if(local_apc.cell.use(amount))// BUBBER EDIT - Fix this code so it returns properly
+		return TRUE
 
 /**
  * Attempts to draw power directly from the APC's Powernet rather than the APC's battery. For high-draw machines, like the cell charger

--- a/modular_zubbers/code/modules/silicon_powerdraw/powerdraw.dm
+++ b/modular_zubbers/code/modules/silicon_powerdraw/powerdraw.dm
@@ -1,0 +1,26 @@
+/mob/living/silicon/proc/get_power(demand, uses, distance, atom)
+	var/mob/living/silicon/robot/robot
+	var/obj/item/stock_parts/cell/cell
+	var/area/siliconarea
+	if(iscyborg(src)) // if we're a cyborg, we have a cell.
+		robot = src
+		cell = robot.cell
+	if(cell && cell.use(demand * distance)) // More distance means more draw
+		balloon_alert(robot, "used [demand * distance]")
+		Beam(BeamTarget = atom, time = 1 SECONDS)
+		. = TRUE
+	else // Use the area power, if we need to.
+		siliconarea = get_area(src)
+		var/obj/machinery/power/apc/theAPC
+		for(var/obj/machinery/power/apc/APC in siliconarea)
+			if(!(APC.machine_stat & BROKEN))
+				theAPC = APC
+		//Don't go lower than 4000 units on an APC. Also, no distance multi because the room is doing it now.
+		if((theAPC.cell.charge) <= 4000 && theAPC.directly_use_power(demand))
+			Beam(BeamTarget = theAPC, time = 1 SECONDS)
+			Beam(BeamTarget = atom, time = 1 SECONDS) // beam me up, scotty!
+			. = TRUE
+		else
+			to_chat(src, "Not enough APC power for this action!")
+
+	return .

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7448,6 +7448,7 @@
 #include "modular_zubbers\code\modules\research\designs\medical_designs.dm"
 #include "modular_zubbers\code\modules\sec_haul\code\security_medic\secmed_clothes.dm"
 #include "modular_zubbers\code\modules\sec_haul\code\security_medic\security_medic.dm"
+#include "modular_zubbers\code\modules\silicon_powerdraw\powerdraw.dm"
 #include "modular_zubbers\code\modules\status_indicators\status_indicator.dm"
 #include "modular_zubbers\code\modules\status_indicators\status_indicator_pref.dm"
 #include "modular_zubbers\code\modules\surgery\bodyparts\species_parts\misc_bodyparts.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so that silicons require a power source to remotely operate doors. The further the door, the bigger the draw. It first draws from your internal cell, then your areas APC. Also creates a visible blootoof beam that shows who did it. 

https://github.com/Bubberstation/Bubberstation/assets/77420409/9ac0c162-9a95-4a75-b7fa-e5aef81b672f


https://github.com/Bubberstation/Bubberstation/assets/77420409/2337784e-7791-43b8-af5e-a452b02badc6




<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

This PR lets us have our cake (secborgs) and eat it too. 
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: silicons now show wireless beams on door operations. 
balance: silicons now draw power from themselves or APC's when operating doors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
