### PR TITLE
[non-modular] Space Ninja no longer spawns in BALD. 

### DIFF
--- a/code/modules/antagonists/space_ninja/space_ninja.dm
+++ b/code/modules/antagonists/space_ninja/space_ninja.dm
@@ -108,15 +108,23 @@
 	to_chat(owner.current, span_notice("The station is located to your [dir2text(get_dir(owner.current, locate(world.maxx/2, world.maxy/2, owner.current.z)))]. A thrown ninja star will be a great way to get there."))
 	owner.announce_objectives()
 
-/datum/antagonist/ninja/on_gain()
+/datum/antagonist/ninja/on_gain() // BUBBER EDIT BEGIN- WHOLE PROC EDITS
+	var/mob/living/carbon/human/operative = owner.current
 	if(give_objectives)
 		addObjectives()
 	addMemories()
+	operative.client?.prefs?.safe_transfer_prefs_to(operative)
+	operative.dna.update_dna_identity()
+	operative.dna.species.pre_equip_species_outfit(null, operative)
+	operative.regenerate_icons()
+	SSquirks.AssignQuirks(operative, operative.client, TRUE, TRUE, null, FALSE, operative)
+
 	if(give_equipment)
 		equip_space_ninja(owner.current)
 
 	owner.current.mind.set_assigned_role(SSjob.GetJobType(/datum/job/space_ninja))
 	owner.current.mind.special_role = ROLE_NINJA
+	operative.mind.active = TRUE // BUBBED EDIT END
 	return ..()
 
 /datum/antagonist/ninja/admin_add(datum/mind/new_owner,mob/admin)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

No more randomgen. Still random names, though. 
Note: It's intended to be this way on SR, but it's tgui prompt is broken. 

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

Everything else is this way, this is just conformity with the standards of midround humanoids. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: space ninja now spawns properly as intended
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
