### PR TITLE
Adds Death Penalty 2

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -309,6 +309,9 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_BLOOD_DEFICIENCY "blood_deficiency"
 #define TRAIT_JOLLY "jolly"
 #define TRAIT_NOCRITDAMAGE "no_crit"
+//Modular zubbers change start.
+#define TRAIT_I_DO_NOT_FEAR_DEATH "i_do_not_fear_death"
+//Modular zubbers change end.
 
 /// Stops the mob from slipping on water, or banana peels, or pretty much anything that doesn't have [GALOSHES_DONT_HELP] set
 #define TRAIT_NO_SLIP_WATER "noslip_water"

--- a/code/datums/mood.dm
+++ b/code/datums/mood.dm
@@ -94,6 +94,11 @@
 			set_sanity(sanity + 0.6 * seconds_per_tick, SANITY_NEUTRAL, SANITY_MAXIMUM)
 	handle_nutrition()
 
+	//Bubberstation change start: Adds death mood event.
+	if(mood_level >= MOOD_LEVEL_HAPPY2 && sanity_level >= SANITY_GREAT)
+		clear_mood_event("death")
+	//Bubberstation change end: Adds death mood event.
+
 	// 0.416% is 15 successes / 3600 seconds. Calculated with 2 minute
 	// mood runtime, so 50% average uptime across the hour.
 	if(HAS_TRAIT(mob_parent, TRAIT_DEPRESSION) && SPT_PROB(0.416, seconds_per_tick))
@@ -106,6 +111,10 @@
 	SIGNAL_HANDLER
 
 	if (last_stat == DEAD && mob_parent.stat != DEAD)
+		//Bubberstation change start: Adds death mood event.
+		if(!HAS_TRAIT(mob_parent, TRAIT_I_DO_NOT_FEAR_DEATH))
+			add_mood_event("death",/datum/mood_event/death)
+		//Bubberstation change end: Adds death mood event.
 		START_PROCESSING(SSmood, src)
 	else if (last_stat != DEAD && mob_parent.stat == DEAD)
 		STOP_PROCESSING(SSmood, src)

--- a/modular_zubbers/code/datums/mood_events/death_events.dm
+++ b/modular_zubbers/code/datums/mood_events/death_events.dm
@@ -1,0 +1,4 @@
+/datum/mood_event/death
+	description = "I died! I really need to find a way to get over this..."
+	mood_change = -9
+	timeout = 0

--- a/modular_zubbers/code/datums/quirks/positive_quirks/i_do_not_fear_death.dm
+++ b/modular_zubbers/code/datums/quirks/positive_quirks/i_do_not_fear_death.dm
@@ -1,0 +1,10 @@
+/datum/quirk/i_do_not_fear_death
+	name = "Accepted Mortality"
+	desc = "You've accepted your own mortality (or perhaps the miracles of modern healthcare), and do not suffer a mood penalty when dying."
+	icon = FA_ICON_HAND_MIDDLE_FINGER
+	value = 4
+	mob_trait = TRAIT_I_DO_NOT_FEAR_DEATH
+	gain_text = span_notice("Death is inevitable. Our fear of it makes us play safe, blocks out emotion. It's a losing game.")
+	lose_text = span_danger("Wait a minute... what if I die, and there is no one competent enough to save me? Oh god.")
+	medical_record_text = "Patient demonstrates a complete lack of caring on the subject of dying."
+	quirk_flags = QUIRK_HUMAN_ONLY|QUIRK_MOODLET_BASED


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a mood penalty for death. The mood penalty can be removed by having a great sanity, and a good mood.
Adds a quirk that prevents the mood penalty from being applied.

## Why It's Good For The Game

Needs more penalties for death, even if it's minor like mood.

## Changelog

:cl: BurgerBB
add: Adds a mood penalty for death, plus new quirk that negates it. The mood penalty for death can be removed by having a great sanity and a good mood.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
