### PR TITLE
(Non-modular) Removes the majority of Interdyne's snipers.

### DIFF
--- a/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -318,7 +318,7 @@
 	ears = /obj/item/radio/headset/syndicate/alt
 	shoes = /obj/item/clothing/shoes/combat
 	r_pocket = /obj/item/gun/ballistic/automatic/pistol
-	r_hand = /obj/item/gun/ballistic/rifle/sniper_rifle
+	// r_hand = /obj/item/gun/ballistic/rifle/sniper_rifle //Bubberstation Edit
 
 	implants = list(/obj/item/implant/weapons_auth)
 	id_trim = /datum/id_trim/syndicom/skyrat/interdyne //SKYRAT EDIT

--- a/modular_skyrat/modules/mapping/code/lavaland_ruin_code.dm
+++ b/modular_skyrat/modules/mapping/code/lavaland_ruin_code.dm
@@ -70,6 +70,7 @@
 	ears = /obj/item/radio/headset/interdyne/command
 	id = /obj/item/card/id/advanced/silver/generic
 	id_trim = /datum/id_trim/syndicom/skyrat/interdyne/deckofficer
+	r_hand = /obj/item/gun/ballistic/rifle/sniper_rifle //Bubberstation Edit
 
 /obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate/deckofficer
 	name = "Interdyne Deck Officer"


### PR DESCRIPTION
## About The Pull Request

This removes the majority of Interdyne's sniper rifles. Only the Deck Officer will spawn with one. 

## Why It's Good For The Game

These snipers can literally two-shot ERT. The only way to deal with Interdyne, outside of bwoinking them, is to send a code red ERT. This will perhaps let me consider accepting Interdyne opfors. They are literally untouchable with the amount of snipers they're flooded with. It's either they lose access to the surrounding lavaland like on TG, or they lose access to most of their snipers. Miners are still weak to ballistics. The outside turrets shred still. Everyone still has Markov pistols. You can make combat mechs if things get too heated.

## Testing
![image](https://github.com/Bubberstation/Bubberstation/assets/95130227/fccb5b91-691d-4601-9372-ba9a17f3a494)
![image](https://github.com/Bubberstation/Bubberstation/assets/95130227/56139e48-5c23-4630-9f4c-4a0a0ec67bc3)

## Changelog

:cl: StrangeWeirdKitten
balance: Removes all but one sniper from Interdyne
/:cl:
