### PR TITLE
Reebe touchups

### DIFF
--- a/_maps/skyrat/lazy_templates/reebe.dmm
+++ b/_maps/skyrat/lazy_templates/reebe.dmm
@@ -18,6 +18,10 @@
 /obj/item/paper/crumpled/bloody/reebe2,
 /turf/open/floor/bronze,
 /area/ruin/powered/reebe)
+"cN" = (
+/obj/machinery/door/airlock/bronze,
+/turf/open/floor/bronze/flat,
+/area/ruin/powered/reebe)
 "en" = (
 /obj/structure/deployable_barricade/wooden,
 /turf/open/floor/bronze/flat,
@@ -112,6 +116,32 @@
 "mL" = (
 /turf/open/indestructible/reebe_void,
 /area/ruin/powered/reebe/space)
+"nh" = (
+/obj/structure/destructible/clockwork/gear_base/powered/prosperity_prism,
+/turf/open/floor/bronze/flat,
+/area/ruin/powered/reebe)
+"nx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/bronze,
+/obj/item/stack/sheet/bronze/thirty{
+	pixel_y = 10;
+	pixel_x = 10
+	},
+/obj/item/stack/sheet/bronze/thirty{
+	pixel_y = 5;
+	pixel_x = 5
+	},
+/obj/item/stack/sheet/bronze/thirty,
+/obj/item/clockwork/replica_fabricator{
+	pixel_x = -10;
+	pixel_y = 10
+	},
+/turf/open/floor/bronze,
+/area/ruin/powered/reebe)
+"ny" = (
+/obj/structure/destructible/clockwork/gear_base/powered/tinkerers_cache,
+/turf/open/floor/bronze/flat,
+/area/ruin/powered/reebe)
 "oh" = (
 /obj/effect/mob_spawn/corpse/human/clock_cultist,
 /turf/open/floor/bronze,
@@ -156,6 +186,10 @@
 /obj/effect/rune/blood_boil,
 /turf/open/floor/bronze/flat,
 /area/ruin/powered/reebe)
+"sw" = (
+/obj/effect/decal/cleanable/blood/splatter/over_window,
+/turf/closed/wall/mineral/bronze,
+/area/ruin/powered/reebe)
 "tr" = (
 /obj/structure/table/bronze,
 /obj/item/clothing/suit/clockwork/speed{
@@ -170,6 +204,10 @@
 "tH" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/landmark/late_cog_portals,
+/turf/open/floor/bronze/flat,
+/area/ruin/powered/reebe)
+"uT" = (
+/obj/structure/fluff/clockwork/alloy_shards,
 /turf/open/floor/bronze/flat,
 /area/ruin/powered/reebe)
 "ve" = (
@@ -214,8 +252,8 @@
 /turf/open/floor/bronze/flat,
 /area/ruin/powered/reebe)
 "xm" = (
-/obj/structure/destructible/clockwork/gear_base/powered/interdiction_lens/free,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/clockwork/gear_base/powered/interdiction_lens,
 /turf/open/floor/bronze/filled,
 /area/ruin/powered/reebe)
 "yd" = (
@@ -240,6 +278,10 @@
 "Bm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/bronze/filled,
+/area/ruin/powered/reebe)
+"BP" = (
+/obj/structure/table/bronze,
+/turf/open/floor/bronze,
 /area/ruin/powered/reebe)
 "BT" = (
 /obj/structure/fluff/clockwork/alloy_shards/medium{
@@ -286,6 +328,10 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/bronze/flat,
 /area/ruin/powered/reebe)
+"Mh" = (
+/obj/item/ectoplasm,
+/turf/open/floor/bronze/flat,
+/area/ruin/powered/reebe)
 "Mu" = (
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/bronze/flat,
@@ -298,6 +344,10 @@
 "MF" = (
 /obj/structure/fluff/clockwork/blind_eye,
 /turf/open/floor/bronze,
+/area/ruin/powered/reebe)
+"On" = (
+/obj/effect/rune/teleport,
+/turf/open/floor/bronze/flat,
 /area/ruin/powered/reebe)
 "Os" = (
 /obj/item/stack/sheet/mineral/wood,
@@ -326,11 +376,11 @@
 /turf/open/floor/bronze/filled,
 /area/ruin/powered/reebe)
 "Pv" = (
-/obj/machinery/door/airlock/bronze/clock/glass,
+/obj/machinery/door/airlock/bronze,
 /turf/open/floor/bronze,
 /area/ruin/powered/reebe)
 "PD" = (
-/obj/structure/girder/bronze,
+/obj/structure/destructible/clockwork/gear_base/technologists_lectern,
 /turf/open/floor/bronze/flat,
 /area/ruin/powered/reebe)
 "QX" = (
@@ -387,11 +437,15 @@
 /turf/open/floor/bronze/filled,
 /area/ruin/powered/reebe)
 "UJ" = (
-/obj/effect/rune/teleport,
+/obj/structure/door_assembly/door_assembly_bronze/clock,
 /turf/open/floor/bronze,
 /area/ruin/powered/reebe)
 "Vv" = (
 /obj/structure/fluff/clockwork/clockgolem_remains,
+/turf/open/floor/bronze/flat,
+/area/ruin/powered/reebe)
+"Xu" = (
+/obj/structure/door_assembly/door_assembly_bronze/clock,
 /turf/open/floor/bronze/flat,
 /area/ruin/powered/reebe)
 "XZ" = (
@@ -1106,7 +1160,7 @@ ve
 My
 yd
 qS
-iJ
+UJ
 xd
 Pi
 xd
@@ -1219,7 +1273,7 @@ qS
 iJ
 xd
 pM
-xd
+Mh
 Pi
 ve
 ve
@@ -1265,7 +1319,7 @@ qS
 qS
 iJ
 xd
-UJ
+iJ
 qS
 qS
 ve
@@ -1410,7 +1464,7 @@ QX
 QX
 ve
 yL
-xd
+Xu
 xd
 iJ
 ve
@@ -1462,7 +1516,7 @@ QX
 QX
 ve
 Pi
-xd
+Mh
 iJ
 ve
 ve
@@ -1523,9 +1577,9 @@ QX
 QX
 qS
 qS
-ve
+qS
 Pv
-ve
+qS
 qS
 qS
 QX
@@ -1574,7 +1628,7 @@ ve
 ve
 qS
 qS
-PD
+ny
 Bm
 Pi
 Pi
@@ -1587,7 +1641,7 @@ ve
 qS
 aj
 xd
-iJ
+UJ
 aj
 qS
 qS
@@ -1625,13 +1679,13 @@ Bm
 Pi
 Pi
 iJ
-Iw
+qS
 Pi
-xd
+uT
 iJ
 xd
 Pi
-ve
+qS
 iJ
 Pi
 Pi
@@ -1729,13 +1783,13 @@ kZ
 yd
 Pi
 iJ
-ve
+qS
 Pi
 xd
 iJ
-xd
+uT
 Pi
-Iw
+sw
 oh
 Pi
 Pi
@@ -1782,11 +1836,11 @@ ve
 ve
 qS
 qS
-PD
+nh
 Pi
 Pi
 Pi
-PD
+ny
 qS
 qS
 ve
@@ -1835,9 +1889,9 @@ QX
 QX
 qS
 qS
-ve
+qS
 Pv
-ve
+qS
 qS
 qS
 QX
@@ -1930,7 +1984,7 @@ QX
 QX
 ve
 iJ
-xd
+On
 FM
 iJ
 ve
@@ -2091,7 +2145,7 @@ et
 xd
 xd
 iJ
-UJ
+iJ
 ve
 qS
 qS
@@ -2197,13 +2251,13 @@ iJ
 Pi
 FM
 xd
-xd
+cN
 xd
 xd
 Pd
 xd
 xd
-xd
+cN
 xd
 xd
 Pi
@@ -2407,9 +2461,9 @@ QX
 QX
 QX
 qS
-yL
+nx
 Pi
-iJ
+BP
 qS
 QX
 QX


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This change updates Reebe, making it easier for a clockwork cultist to initially defend as well as adding tools to help them get started with re-fortifying it.

## Why It's Good For The Game

In order for a clockwork cultist to be able to get to reebe they must sacrifice a blood cultist. However, in a round with a blood cult the blood cultists are easily able to teleport to Reebe thanks to the teleport runes that are there by default. That, along with the lack of any form of cover for what is typically a solo clockwork cultist vs the entire blood cult is crippling as it means the entire blood cult can actually get to reebe before you as the solo clockwork cultist. This is so bad because the clockwork cult revolves around being on the defensive, almost all of your sigils and structures revolve around having a defender's advantage.

This PR makes it so that there is cover for the clockwork cultist from lasers and sight as well as a single of each structure, thus making it easier for them to use their natural defenders advantage to offset the potential attack from the blood cult.
There is also added some bronze and a replica fabricator to the armory section of Reebe, making it easier for a clockwork cultist to begin reinforcing and rebuilding Reebe.

## Changelog

:cl:
add: Adds a Replica Fabricator and some sheets of bronze to fill it to the Reebe armory
add: Adds a set of doors to the Armory of Reebe
balance: Changes Reebe's central room doors to be opaque
balance: Changes Reebe's central room window's to be walls
balance: Removes one of the 2 teleport runes at Reebe
/:cl:
