### PR TITLE
Includes the modular file for biogenerator additions

### DIFF
--- a/modular_zubbers/code/modules/research/designs/biogenerator_designs.dm
+++ b/modular_zubbers/code/modules/research/designs/biogenerator_designs.dm
@@ -1,0 +1,72 @@
+
+/datum/design/diethylamine
+	name = "Diethylamine"
+	id = "diethylamine"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 0.5)
+	make_reagent = /datum/reagent/diethylamine
+	category = list(RND_CATEGORY_INITIAL, RND_CATEGORY_BIO_CHEMICALS)
+
+/datum/design/saltpetre
+	name = "Saltpetre"
+	id = "saltpetre"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 0.5)
+	make_reagent = /datum/reagent/saltpetre
+	category = list(RND_CATEGORY_INITIAL, RND_CATEGORY_BIO_CHEMICALS)
+
+/datum/design/orangejuice
+	name = "Orange Juice"
+	id = "orangejuice"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 0.1)
+	make_reagent = /datum/reagent/consumable/orangejuice
+	category = list(RND_CATEGORY_INITIAL, RND_CATEGORY_BIO_FOOD)
+
+/datum/design/lemonjuice
+	name = "Lemon Juice"
+	id = "lemonjuice"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 0.1)
+	make_reagent = /datum/reagent/consumable/lemonjuice
+	category = list(RND_CATEGORY_INITIAL, RND_CATEGORY_BIO_FOOD)
+
+/datum/design/limejuice
+	name = "Lime Juice"
+	id = "limejuice"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 0.1)
+	make_reagent = /datum/reagent/consumable/orangejuice
+	category = list(RND_CATEGORY_INITIAL, RND_CATEGORY_BIO_FOOD)
+
+/datum/design/berryjuice
+	name = "Berry Juice"
+	id = "berryjuice"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 0.1)
+	make_reagent = /datum/reagent/consumable/berryjuice
+	category = list(RND_CATEGORY_INITIAL, RND_CATEGORY_BIO_FOOD)
+
+/datum/design/berryjuice
+	name = "Tomato Juice"
+	id = "tomatojuice"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 0.1)
+	make_reagent = /datum/reagent/consumable/tomatojuice
+	category = list(RND_CATEGORY_INITIAL, RND_CATEGORY_BIO_FOOD)
+
+/datum/design/grenadine
+	name = "Grenadine"
+	id = "grenadine"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 0.1)
+	make_reagent = /datum/reagent/consumable/grenadine
+	category = list(RND_CATEGORY_INITIAL, RND_CATEGORY_BIO_FOOD)
+
+/datum/design/soysauce //Alternative to having to make it using sulphuric acid
+	name = "Soy Sauce"
+	id = "soysauce"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 0.5)
+	make_reagent = /datum/reagent/consumable/soysauce
+	category = list(RND_CATEGORY_INITIAL, RND_CATEGORY_BIO_FOOD)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7448,6 +7448,7 @@
 #include "modular_zubbers\code\modules\paperwork\fax.dm"
 #include "modular_zubbers\code\modules\projectiles\guns\energy\pulse.dm"
 #include "modular_zubbers\code\modules\protected_roles\code\antag_restricted_jobs.dm"
+#include "modular_zubbers\code\modules\research\designs\biogenerator_designs.dm"
 #include "modular_zubbers\code\modules\research\designs\comp_board_designs.dm"
 #include "modular_zubbers\code\modules\research\designs\machine_board_designs.dm"
 #include "modular_zubbers\code\modules\research\designs\medical_designs.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Someone did an oopsie and the file got un-included in the dme. This fixes the problem.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game
It was an approved and merged addition
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Biogenerator additions are once again included in the dme
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
