### PR TITLE
Changes the cost of the borg expander to be 1 sheet of iron, not 100

### DIFF
--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1208,7 +1208,7 @@
 	id = "borg_upgrade_expand"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/expand
-	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT*100, /datum/material/titanium =SHEET_MATERIAL_AMOUNT * 2.5)
+	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT*1, /datum/material/titanium =SHEET_MATERIAL_AMOUNT * 2.5) //bubberstation edit - 100 sheets of iron for one upgrade??
 	construction_time = 120
 	category = list(
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_ALL


### PR DESCRIPTION
## About The Pull Request

Originally this PR was going to include the fix to the borg expansion exploit but I am very tired and dont wanna stare at the transform function so this will have to do for now

## Why It's Good For The Game

Miners dont have to bust their backs to mine more iron because a single borg decided to become bigger, that plus its a cosmetic upgrade

## Changelog

:cl:
fix: Changed the cost of the Expansion Module to be 1 sheet instead of 100
/:cl: