### PR TITLE
Re-privates my dono item

### DIFF
--- a/modular_skyrat/modules/loadouts/loadout_items/donator/personal/donator_personal.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/donator/personal/donator_personal.dm
@@ -702,7 +702,7 @@
 /datum/loadout_item/inhand/officialcat
 	name = "Official Cat Stamp"
 	item_path = /obj/item/stamp/cat
-//	ckeywhitelist = list("kathrinbailey")
+	ckeywhitelist = list("kathrinbailey")
 
 /datum/loadout_item/inhand/hardlight_wheelchair
 	name = "Hardlight Wheelchair Projector"


### PR DESCRIPTION
<## About The Pull Request
I did my dono item I was going to do for Bubbers upstream instead, to save making two separate PRs for the same item. Plus, no need to modularise it. It was said that private items were allowed, and this one is pretty exclusively meaningless to anyone else. It got understandably un-privatised during an upstream merge.

## Why It's Good For The Game
I guess it makes one person more likely to play, and +1 person is good for the game?

## Changelog
It's kinda only player-facing for one player.