### PR TITLE
Hugboxes heresy without adding weird metagame

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -377,7 +377,10 @@
 		var/datum/antagonist/heretic/victim_heretic = sac_target.mind?.has_antag_datum(/datum/antagonist/heretic)
 		victim_heretic.knowledge_points -= 3
 	else
-		sac_target.gain_trauma(/datum/brain_trauma/mild/phobia/heresy, TRAUMA_RESILIENCE_MAGIC)
+	//BUBBER EDIT START - makes the phobia curable
+		sac_target.gain_trauma(/datum/brain_trauma/mild/phobia/heresy, TRAUMA_RESILIENCE_SURGERY /*TRAUMA_RESILIENCE_MAGIC*/)
+	//BUBBER EDIT END
+
 	// Wherever we end up, we sure as hell won't be able to explain
 	sac_target.adjust_timed_status_effect(40 SECONDS, /datum/status_effect/speech/slurring/heretic)
 	sac_target.adjust_stutter(40 SECONDS)


### PR DESCRIPTION
## About The Pull Request

Alternative to #514

Removes the brain trauma resilience from Brazil, making it only surgery level.


## Why It's Good For The Game

It's not fun to have your char gimped by an antag that is built around the feature that gimps you.

This is different from brainwashing, where people have to do this intentionally.

## Changelog

:cl:
qol: Heretics no longer give permanent traumas
/:cl:
