### PR TITLE
Hugboxes Blob

### DIFF
--- a/code/__DEFINES/blob_defines.dm
+++ b/code/__DEFINES/blob_defines.dm
@@ -13,7 +13,7 @@
 
 // Generic blob defines
 
-#define BLOB_BASE_POINT_RATE 2 // Base amount of points per process()
+#define BLOB_BASE_POINT_RATE 2.5 // SKYRAT EDIT CHANGE
 #define BLOB_EXPAND_COST 4 // Price to expand onto a new tile
 #define BLOB_ATTACK_REFUND 2 // Points 'refunded' when the expand attempt actually attacks something instead
 #define BLOB_BRUTE_RESIST 0.5 // Brute damage taken gets multiplied by this value

--- a/code/__DEFINES/blob_defines.dm
+++ b/code/__DEFINES/blob_defines.dm
@@ -5,7 +5,7 @@
 #define OVERMIND_STARTING_REROLLS 1 // Free strain rerolls at the start
 #define OVERMIND_STARTING_MIN_PLACE_TIME (1 MINUTES) // Minimum time before the core can be placed
 #define OVERMIND_STARTING_AUTO_PLACE_TIME (6 MINUTES) // After this time, randomly place the core somewhere viable
-#define OVERMIND_WIN_CONDITION_AMOUNT 400 // Blob structures required to win
+// BUBBERSTATION CHANGE: HUGBOXES BLOB #define OVERMIND_WIN_CONDITION_AMOUNT 400 // Blob structures required to win
 #define OVERMIND_ANNOUNCEMENT_MIN_SIZE 75 // Once the blob has this many structures, announce their presence
 #define OVERMIND_ANNOUNCEMENT_MAX_TIME (10 MINUTES) // If the blob hasn't reached the minimum size before this time, announce their presence
 #define OVERMIND_MAX_CAMERA_STRAY "3x3" // How far the overmind camera is allowed to stray from blob tiles. 3x3 is 1 tile away, 5x5 2 tiles etc
@@ -13,8 +13,7 @@
 
 // Generic blob defines
 
-//#define BLOB_BASE_POINT_RATE 2 // Base amount of points per process()
-#define BLOB_BASE_POINT_RATE 2.5 // SKYRAT EDIT CHANGE
+#define BLOB_BASE_POINT_RATE 2 // Base amount of points per process()
 #define BLOB_EXPAND_COST 4 // Price to expand onto a new tile
 #define BLOB_ATTACK_REFUND 2 // Points 'refunded' when the expand attempt actually attacks something instead
 #define BLOB_BRUTE_RESIST 0.5 // Brute damage taken gets multiplied by this value

--- a/code/modules/antagonists/blob/blob_antag.dm
+++ b/code/modules/antagonists/blob/blob_antag.dm
@@ -18,9 +18,14 @@
 	//Display max blobpoints for blebs that lost
 	if(isovermind(owner.current)) //embarrasing if not
 		var/mob/camera/blob/overmind = owner.current
+		/* BUBBERSTATION CHANGE: HUGBOXES BLOB
 		if(!overmind.victory_in_progress) //if it won this doesn't really matter
 			var/point_report = "<br><b>[owner.name]</b> took over [overmind.max_count] tiles at the height of its growth."
 			return basic_report+point_report
+		*/
+		var/point_report = "<br><b>[owner.name]</b> took over [overmind.max_count] tiles at the height of its growth."
+		return basic_report+point_report
+		//BUBBERSTATION CHANGE END: HUGBOXES BLOB
 	return basic_report
 
 /datum/antagonist/blob/greet()
@@ -85,7 +90,8 @@
 	pop_action.Grant(owner.current)
 
 /datum/objective/blob_takeover
-	explanation_text = "Reach critical mass!"
+	explanation_text = "Grow as large as possible!" //BUBBERSTATION CHANGE: HUGBOXES BLOB
+	completed = TRUE // BUBBERSTATION CHANGE: HUGBOXES BLOB
 
 //Non-overminds get this on blob antag assignment
 /datum/action/innate/blobpop
@@ -151,7 +157,7 @@
 	if(owner?.current)
 		var/mob/camera/blob/blob_cam = owner.current
 		if(istype(blob_cam))
-			. += "(Progress: [length(blob_cam.blobs_legit)]/[blob_cam.blobwincount])"
+			. += "<b>Current Blob Size:</b> [span_notice("[blob_cam.blobs_legit.len]")]." //BUBBERSTATION CHANGE: HUGBOXES BLOB
 
 /// A subtype of blob meant to represent the infective version.
 /datum/antagonist/blob/infection

--- a/code/modules/antagonists/blob/blobstrains/_blobstrain.dm
+++ b/code/modules/antagonists/blob/blobstrains/_blobstrain.dm
@@ -166,4 +166,4 @@ GLOBAL_LIST_INIT(valid_blobstrains, subtypesof(/datum/blobstrain) - list(/datum/
 	return
 
 /datum/blobstrain/proc/examine(mob/user)
-	return list("<b>Progress to Critical Mass:</b> [span_notice("[overmind.blobs_legit.len]/[overmind.blobwincount].")]")
+	return list("<b>Current Blob Size:</b> [span_notice("[overmind.blobs_legit.len]")].") //BUBBERSTATION CHANGE: HUGBOXES BLOB

--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -43,8 +43,10 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	var/autoplace_max_time = OVERMIND_STARTING_AUTO_PLACE_TIME // Automatically place the core in a random spot
 	var/list/blobs_legit = list()
 	var/max_count = 0 //The biggest it got before death
+	/* BUBBERSTATION CHANGE: HUGBOXES BLOB
 	var/blobwincount = OVERMIND_WIN_CONDITION_AMOUNT
 	var/victory_in_progress = FALSE
+	BUBBERSTATION END CHANGE: HUGBOXES BLOB */
 	var/rerolling = FALSE
 	var/announcement_size = OVERMIND_ANNOUNCEMENT_MIN_SIZE // Announce the biohazard when this size is reached
 	var/announcement_time
@@ -144,6 +146,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 			// If we get here, it means yes: the blob is kill
 			SSticker.news_report = BLOB_DESTROYED
 			qdel(src)
+	/* BUBBERSTATION CHANGE: HUGBOXES BLOB
 	else if(!victory_in_progress && (blobs_legit.len >= blobwincount))
 		victory_in_progress = TRUE
 		priority_announce("Biohazard has reached critical mass. Station loss is imminent.", "Biohazard Alert")
@@ -151,17 +154,19 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 		max_blob_points = INFINITY
 		blob_points = INFINITY
 		addtimer(CALLBACK(src, PROC_REF(victory)), 450)
+	BUBBERSTATION CHANGE END: HUGBOXES BLOB */
 	else if(!free_strain_rerolls && (last_reroll_time + BLOB_POWER_REROLL_FREE_TIME<world.time))
 		to_chat(src, span_boldnotice("You have gained another free strain re-roll."))
 		free_strain_rerolls = 1
 
-	if(!victory_in_progress && max_count < blobs_legit.len)
-		max_count = blobs_legit.len
+	//if(!victory_in_progress && max_count < blobs_legit.len) BUBBERSTATION CHANGE: HUGBOXES BLOB
+	max_count = blobs_legit.len //Bubberstation change: Hugboxes blob
 
 	if(announcement_time && (world.time >= announcement_time || blobs_legit.len >= announcement_size) && !has_announced)
 		priority_announce("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", ANNOUNCER_OUTBREAK5)
 		has_announced = TRUE
 
+/* BUBBERSTATION CHANGE: HUGBOXES BLOB
 /mob/camera/blob/proc/victory()
 	sound_to_playing_players('sound/machines/alarm.ogg')
 	sleep(10 SECONDS)
@@ -208,6 +213,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	to_chat(world, span_blob("[real_name] consumed the station in an unstoppable tide!"))
 	SSticker.news_report = BLOB_WIN
 	SSticker.force_ending = FORCE_END_ROUND
+BUBBERSTATION CHANGE END: HUGBOXES BLOB */
 
 /mob/camera/blob/Destroy()
 	QDEL_NULL(blobstrain)
@@ -308,7 +314,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	if(blob_core)
 		. += "Core Health: [blob_core.get_integrity()]"
 		. += "Power Stored: [blob_points]/[max_blob_points]"
-		. += "Blobs to Win: [blobs_legit.len]/[blobwincount]"
+		// BUBBERSTATION CHANGE: HUGBOXES BLOB. += "Blobs to Win: [blobs_legit.len]/[blobwincount]"
 	if(free_strain_rerolls)
 		. += "You have [free_strain_rerolls] Free Strain Reroll\s Remaining"
 	if(!placed)

--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -70,7 +70,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	color = blobstrain.complementary_color
 	if(blob_core)
 		blob_core.update_appearance()
-	SSshuttle.registerHostileEnvironment(src)
+	//SSshuttle.registerHostileEnvironment(src) BUBBERSTATION CHANGE: I WANT TO GET OFF MR. BLOB'S WILD RIDE
 	. = ..()
 	START_PROCESSING(SSobj, src)
 

--- a/code/modules/antagonists/blob/structures/_blob.dm
+++ b/code/modules/antagonists/blob/structures/_blob.dm
@@ -247,7 +247,7 @@
 		to_chat(user, "<b>The analyzer beeps once, then reports:</b><br>")
 		SEND_SOUND(user, sound('sound/machines/ping.ogg'))
 		if(overmind)
-			to_chat(user, "<b>Progress to Critical Mass:</b> [span_notice("[overmind.blobs_legit.len]/[overmind.blobwincount].")]")
+			to_chat(user, "<b>Current Blob Size:</b> [span_notice("[overmind.blobs_legit.len]")]." )//BUBBERSTATION CHANGE: HUGBOXES BLOB
 			to_chat(user, chemeffectreport(user).Join("\n"))
 		else
 			to_chat(user, "<b>Blob core neutralized. Critical mass no longer attainable.</b>")

--- a/code/modules/mob/living/simple_animal/hostile/blob.dm
+++ b/code/modules/mob/living/simple_animal/hostile/blob.dm
@@ -46,7 +46,8 @@
 /mob/living/simple_animal/hostile/blob/get_status_tab_items()
 	. = ..()
 	if(overmind)
-		. += "Blobs to Win: [overmind.blobs_legit.len]/[overmind.blobwincount]"
+		. += "<b>Current Blob Size:</b> [span_notice("[overmind.blobs_legit.len]")]." //BUBBERSTATION CHANGE: HUGBOXES BLOB
+
 
 /mob/living/simple_animal/hostile/blob/blob_act(obj/structure/blob/B)
 	if(stat != DEAD && health < maxHealth)


### PR DESCRIPTION
## About The Pull Request

Blob can no longer go to code delta and end the game.
Blob can expand indefinitely. 
Blob can no longer hold the shuttle.

## Why It's Good For The Game

Blob is a weird mid-round ghost gamemode where it is the only gamemode that can effectively (and literally) end the round. It is also the only mid-round ghost gamemode where it requires the entire crew to cooperative or perish. This PR effectively makes blob a choice to fight, like all roundtypes (except nukies), because forcing everyone to be all hands on death or perish is really bad.

## Changelog

:cl: BurgerBB
add: Blob can no longer go to code delta and end the game. Blob can expand indefinitely. Blob can no longer hold the shuttle.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
