### PR TITLE
[MODULAR] contractor kit random item shuffle AWESOME PART TWO BAYBEE

### DIFF
--- a/modular_zubbers/code/modules/contractor/code/items/boxes.dm
+++ b/modular_zubbers/code/modules/contractor/code/items/boxes.dm
@@ -1,0 +1,20 @@
+/obj/item/storage/box/syndicate/contract_kit/midround
+// bubber edits
+// removed items: dartgun, edagger, sleepy pen, mulligan, sentience potion, radio implant, tackle gloves, rad laser
+	item_list = list(
+		/obj/item/storage/backpack/duffelbag/syndie/x4,
+		/obj/item/storage/box/syndie_kit/throwing_weapons,
+		/obj/item/flashlight/emp,
+		/obj/item/storage/medkit/tactical,
+		/obj/item/mod/module/visor/thermal, // replaced with the module
+		/obj/item/mod/module/noslip, // new - 2tc, just a good utility item
+		/obj/item/gun/ballistic/automatic/c20r/toy/unrestricted/riot,
+		/obj/item/reagent_containers/hypospray/medipen/stimulants,
+		/obj/item/storage/box/syndie_kit/imp_freedom,
+		/obj/item/storage/box/syndie_kit/imp_stealth, // new - 8tc, exepensive for here but most 'practical' stealth option available
+		/obj/item/crowbar/power/syndicate,
+		/obj/item/card/emag, // new - 4tc, about same tier as a doorjack or jaws very versatile but situational. maybe promotes cyborg play
+		/obj/item/card/emag/doorjack, // new - 3tc, similar to the jaws of life but more convenient
+		/obj/item/storage/box/syndie_kit/emp,
+		/obj/item/shield/energy
+	)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7522,6 +7522,7 @@
 #include "modular_zubbers\code\modules\clothing\suits\armor.dm"
 #include "modular_zubbers\code\modules\clothing\suits\jacket.dm"
 #include "modular_zubbers\code\modules\clothing\under\syndicate.dm"
+#include "modular_zubbers\code\modules\contractor\code\items\boxes.dm"
 #include "modular_zubbers\code\modules\customization\modules\clothing\under\security.dm"
 #include "modular_zubbers\code\modules\customization\modules\jobs\_job.dm"
 #include "modular_zubbers\code\modules\customization\sprite_accessories\ears.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

https://github.com/Bubberstation/Bubberstation/pull/325

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

read above

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: shuffled contractor's random items to remove some of the more useless options and add better ones
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
