### PR TITLE
Ion Storm announce chance increased from 33% to 100%.

### DIFF
--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -16,7 +16,7 @@
 	var/botEmagChance = 1
 	var/ionMessage = null
 	announce_when = 1
-	announce_chance = 33
+	announce_chance = 100 //BUBBERSTATION CHANGE: 33% to 100%.
 
 /datum/round_event/ion_storm/add_law_only // special subtype that adds a law only
 	replaceLawsetChance = 0


### PR DESCRIPTION

## About The Pull Request

Ion Storm announce chance increased from 33% to 100%.

## Why It's Good For The Game

Ion laws are kind of insane when you think about it. 

25% chance to replace the entire lawset with a completely different template lawset.
10% chance to remove a random law.
10% chance to replace a random law with something else.
10% chance to shuffle the order of the laws randomly.

This isn't "chance to do one of those" it's literally 4 different dice rolls on changing the AI's laws. In most scenarios, the AI will usually have some sort of serious damage to the lawset that will allow them to basically antag without antag status. Instead of removing that fun feature, I decided it would be just best to make it so that the crew is aware of an ion law so it is more balanced.

## Changelog

:cl: BurgerBB
balance: Ion Storm announce chance increased from 33% to 100%.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
