### PR TITLE
Adds a clock-out timecard clock thing to Limastation

### DIFF
--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -660,6 +660,7 @@
 /obj/machinery/cryopod{
 	dir = 8
 	},
+/obj/machinery/time_clock/directional/east,
 /turf/open/floor/iron/freezer,
 /area/station/common/cryopods)
 "arc" = (


### PR DESCRIPTION
## About The Pull Request
I got a ticket today asking to spawn a timeclock machine on Limastation.

## Why It's Good For The Game
Now you can peace out of your duties like a real slacker and do some a hardcore rough sigma-grindset-worthy Enterprise Resource Planning session.

## Changelog
:cl:
fix: Adds missing timeclock machine to Limastation, in the cryo area.
/:cl:
