### PR TITLE
(Non-Modular) Removes Frieghter / Cargodise Lost

### DIFF
--- a/modular_skyrat/modules/mapping/code/space.dm
+++ b/modular_skyrat/modules/mapping/code/space.dm
@@ -127,12 +127,15 @@
 	name = "Medieval 1"
 	description = "A forgotten peice of history left overrun with a reminder of what brought its destruction"
 
+/* Bubberstation Removal Start
+
 /datum/map_template/ruin/space/skyrat/cargodiselost
 	id = "CargodiseLost"
 	suffix = "cargodiselost.dmm"
 	name = "Cargodise Lost"
 	description = "A small crew of freight-haulers are marooned in space after pirates knock out their engines. They must survive off of the cargo on board their ship and fend off the pirate boarders on their ship."
 
+Bubberstation Removal End*/
 /datum/map_template/ruin/space/skyrat/infestedntship
 	suffix = "scrapheap.dmm"
 	name = "NT Research Vessel"


### PR DESCRIPTION
## About The Pull Request

Virgin Coder: Removes Cargodise Lost
Chad Coder (not me): Remaps Cargodise, which I really don't care to do right now, to be more sane and in line with Bubberstation's goals. 

This removes Cargodise Lost. 

## Why It's Good For The Game

Way too many guns for people who are unaligned and who also have zero ghost role text saying they can't just board the station and trade. (give one of their 4 Krinkov's to the crew)

Cargodise Lost will need some major revisions, which I might do later, but it really encompasses why DS-2 was disabled in the first place. (no you don't need a 38 brute, fire rate 2, AP 40 fully automatic assault rifle to raid ruins)

## Changelog

:cl: Danger Kitten
remove: Cargodise Lost is no longer
/:cl:

