### PR TITLE
Fixes Air Alarms resetting scrubbers/vents on map load.

### DIFF
--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -112,7 +112,7 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 
 	my_area = connected_sensor ? get_area(connected_sensor) : get_area(src)
 	alarm_manager = new(src)
-	select_mode(src, /datum/air_alarm_mode/filtering)
+	select_mode(src, /datum/air_alarm_mode/filtering, should_apply = FALSE) //BUBBERSTATION CHANGE: ADDS should_apply
 
 	AddElement(/datum/element/connect_loc, atmos_connections)
 	AddComponent(/datum/component/usb_port, list(
@@ -586,14 +586,14 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 
 	selected_mode.replace(my_area, pressure)
 
-/obj/machinery/airalarm/proc/select_mode(atom/source, datum/air_alarm_mode/mode_path)
+/obj/machinery/airalarm/proc/select_mode(atom/source, datum/air_alarm_mode/mode_path, should_apply = TRUE) //BUBBERSTATION CHANGE: ADDS should_apply
 	var/datum/air_alarm_mode/new_mode = GLOB.air_alarm_modes[mode_path]
 	if(!new_mode)
 		return
 	if(new_mode.emag && !(obj_flags & EMAGGED))
 		return
 	selected_mode = new_mode
-	selected_mode.apply(my_area)
+	if(should_apply) selected_mode.apply(my_area) //BUBBERSTATION CHANGE: ADDS should_apply
 	SEND_SIGNAL(src, COMSIG_AIRALARM_UPDATE_MODE, source)
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airalarm, 27)


### PR DESCRIPTION

## About The Pull Request

What it says on the can. Fixes Air Alarms resetting scrubbers/vents on map load. What was happening is that air alarms were forcing scrubbers/vents to go to their default setting, which is a problem for vents that siphon or scrubbers that scrub out certain things.

This should be testmerged considering things may or may not go wrong with very specific and really niche issues such as for some reason a far off ruin that hasn't been worked on since 2014 somehow relying on this bug to exist to have bad air.

Will fix the bug upstream on /tg/ once there are no issues found.

## Why It's Good For The Game

Fixes are good.

## Changelog

:cl: BurgerBB
fix: Fixes Air Alarms resetting scrubbers/vents on map load.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
