### PR TITLE
Update security_medic Locker Privs

### DIFF
--- a/modular_zubbers/code/modules/sec_haul/code/security_medic/security_medic.dm
+++ b/modular_zubbers/code/modules/sec_haul/code/security_medic/security_medic.dm
@@ -90,8 +90,8 @@
 	keyslot = new /obj/item/encryptionkey/headset_medsec
 
 /obj/structure/closet/secure_closet/security_medic
-	name = "security medics's locker"
-	req_access = list(ACCESS_SECURITY)
+	name = "security medic's locker"
+	req_access = list(ACCESS_BRIG)
 	icon = 'modular_skyrat/modules/sec_haul/icons/lockers/closet.dmi'
 	icon_state = "secmed"
 


### PR DESCRIPTION
## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Moved the security medic's locker required access from ACCESS_SECURITY (Anyone who can walk in security) to ACCESS_BRIG (Anyone who can access security equipment room.) Also fixed the name from medics's(???) to medic's.

## Why It's Good For The Game

The role isn't used on Skyrat anymore so they probably didn't care, but on here the locker should have the same access as any other security officer's locker. Otherwise it is available to a much larger amount of roles then intended.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: secmed's locker access and name
/:cl:
