### PR TITLE
Revert "Hugboxes heresy without adding weird metagame (#519)"

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -377,10 +377,7 @@
 		var/datum/antagonist/heretic/victim_heretic = sac_target.mind?.has_antag_datum(/datum/antagonist/heretic)
 		victim_heretic.knowledge_points -= 3
 	else
-	//BUBBER EDIT START - makes the phobia curable
-		sac_target.gain_trauma(/datum/brain_trauma/mild/phobia/heresy, TRAUMA_RESILIENCE_SURGERY /*TRAUMA_RESILIENCE_MAGIC*/)
-	//BUBBER EDIT END
-
+		sac_target.gain_trauma(/datum/brain_trauma/mild/phobia/heresy, TRAUMA_RESILIENCE_MAGIC)
 	// Wherever we end up, we sure as hell won't be able to explain
 	sac_target.adjust_timed_status_effect(40 SECONDS, /datum/status_effect/speech/slurring/heretic)
 	sac_target.adjust_stutter(40 SECONDS)


### PR DESCRIPTION
This reverts commit 3fd5db0532fc390b9d8be8e83f162444b23bbd5d.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

Revert PR for #519. 

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

The original PR to change heretic sacrificing was generally given negative feedback and yet was merged anyway for some reason? Regardless of that it's a bad change nonetheless. The heretic brain trauma WAS revertible via usage of a regen extract from xenobio, making the heretic brain trauma now super easy to remove is kind of stupid. 

"Ah yes, i've been sent to a realm of gods beyond mortal comprehension and my brain was scarred forever as a result... Or as it turns out just till i get a bit of minor brain surgery, not even a lobotomy."

How about instead of complaining about the heretic brain trauma, instead you head over to xenobio and get a regen extract. 

This change was not necessary and is massive overkill as well as being massively over dramatized in how bad it is. Your standard spessman can be sacrificed and go back to do their job with no issues, the only time this was ever and issue is if you was security and honestly, if you die/lose to an antag you shouldn't be rushing back to go kill them again anyway, we specifically added a rule that lets antags RR security if they do this.

TL:DR Original PR was a bad change that shouldn't have been merged, it cited the fact the trauma was irreversible as it's main reason to be merged and that was just plainly untrue as xenobio can in fact heal the trauma.

## Changelog

🆑 
qol: Reverts Heretics no longer giving surgery resistant traumas
🆑 
