### PR TITLE
The Bioscrambler can no longer replace internal organs.

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -922,7 +922,7 @@
 		body_parts -= part
 	GLOB.bioscrambler_valid_parts = body_parts
 
-	var/list/organs = subtypesof(/obj/item/organ/external)
+	var/list/organs = subtypesof(/obj/item/organ/external) - typesof(/obj/item/organ/external/genital) //BUBBERSTATION CHANGE, REMOVES INTERANL ORGAN SWAPPING AND REMOVES GENITALS.
 	for(var/obj/item/organ/organ_type as anything in organs)
 		if(!is_type_in_typecache(organ_type, GLOB.bioscrambler_organs_blacklist) && !(initial(organ_type.organ_flags) & ORGAN_ROBOTIC))
 			continue

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -922,7 +922,7 @@
 		body_parts -= part
 	GLOB.bioscrambler_valid_parts = body_parts
 
-	var/list/organs = subtypesof(/obj/item/organ/internal) + subtypesof(/obj/item/organ/external)
+	var/list/organs = subtypesof(/obj/item/organ/external)
 	for(var/obj/item/organ/organ_type as anything in organs)
 		if(!is_type_in_typecache(organ_type, GLOB.bioscrambler_organs_blacklist) && !(initial(organ_type.organ_flags) & ORGAN_ROBOTIC))
 			continue


### PR DESCRIPTION
## About The Pull Request

The Bioscrambler can no longer replace internal organs or genitals.

## Why It's Good For The Game

Internal organ replacing is kind of insane and can be VERY bad depending on what was chosen for what internal organ to replace. Not only is it mechanically very dangerous, but it can seriously bug out your character and have strange reactions within the game. The SAD cannot fix internal organs so a competent doctor (rare) is usually needed.

Also fun fact, sex organs are also in the pool of possible organs to replace, so this fixes that too.

And yes, I am doing this after I got my internal organs replaced with something very round crippling and something the SAD could not fix.

## Changelog


:cl: BurgerBB
del: The Bioscrambler can no longer replace internal organs or gentials.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
