### PR TITLE
Fixes the Crew Monitoring Console

### DIFF
--- a/tgui/packages/tgui/interfaces/CrewConsoleBubbers.js
+++ b/tgui/packages/tgui/interfaces/CrewConsoleBubbers.js
@@ -4,6 +4,9 @@ import { Box, Button, Section, Table, Icon } from '../components';
 import { COLORS } from '../constants';
 import { Window } from '../layouts';
 
+const STAT_LIVING = 0;
+const STAT_DEAD = 4;
+
 const HEALTH_COLOR_BY_LEVEL = [
   '#17d568',
   '#c4cf2d',
@@ -18,7 +21,7 @@ const HEALTH_ICON_BY_LEVEL = [
   'heart',
   'heart-circle-exclamation',
   'heartbeat',
-  'skull',
+  'heart-crack',
 ];
 const jobIsHead = (jobId) => jobId % 10 === 0;
 
@@ -141,13 +144,15 @@ const CrewTableEntry = (props, context) => {
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">
         {is_robot ? (
-          <Icon name="steam" color="#EFEFEF" size={1} />
+          <Icon name="user-cog" color="#CCCCCC" size={1} />
         ) : (
           <Icon name="user" color="#EFEFEF" size={1} />
         )}
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">
-        {oxydam !== undefined && life_status ? (
+        {life_status === STAT_DEAD ? (
+          <Icon name="skull" color="#801308" size={1} />
+        ) : oxydam !== undefined ? (
           <Icon
             name={healthToAttribute(
               oxydam,
@@ -165,12 +170,10 @@ const CrewTableEntry = (props, context) => {
             )}
             size={1}
           />
-        ) : life_status ? (
-          <Icon name="heart" color="#17d568" size={1} />
         ) : (
-          <Icon name="skull" color="#801308" size={1} />
+          <Icon name="heart" color="#FFFFFF" size={1} />
         )}
-        {!life_status && is_dnr ? ' (DNR)' : ''}
+        {life_status === STAT_DEAD && is_dnr ? ' (DNR)' : ''}
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">
         {oxydam !== undefined ? (
@@ -183,7 +186,7 @@ const CrewTableEntry = (props, context) => {
             {'/'}
             <HealthStat type="brute" value={brutedam} />
           </Box>
-        ) : life_status ? (
+        ) : life_status !== STAT_DEAD ? (
           'Alive'
         ) : (
           'DEAD'


### PR DESCRIPTION

## About The Pull Request

![image](https://github.com/Bubberstation/Bubberstation/assets/8602857/5cfc84f9-e568-4caf-b337-550437204c46)


Fixes synths not getting their own icon.
Fixes everyone being dead.
Those without suit sensors set to vitals get a white heart.

## Why It's Good For The Game

Fixes are good.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: BurgerBB
fix: Fixes suit sensors making everyone dead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
