### PR TITLE
Vetted Player Locks

### DIFF
--- a/code/modules/admin/verbs/admingame.dm
+++ b/code/modules/admin/verbs/admingame.dm
@@ -43,7 +43,10 @@
 
 		if(SSplayer_ranks.is_veteran(M.client, admin_bypass = FALSE))
 			player_ranks += "Veteran"
-
+		//BUBBER ADDITION START
+		if(SSplayer_ranks.is_vetted(M.client, admin_bypass = FALSE))
+			player_ranks |= "Vetted"
+		// BUBBER ADDITION END
 		body += "<br><br><b>Player Ranks: </b>[length(player_ranks) ? player_ranks.Join(", ") : "None"]"
 		// SKYRAT EDIT END
 		body += "<br><br><b>CentCom Galactic Ban DB: </b> "

--- a/code/modules/client/preferences/middleware/jobs.dm
+++ b/code/modules/client/preferences/middleware/jobs.dm
@@ -102,6 +102,10 @@
 	if(SSplayer_ranks.is_veteran(user.client))
 		data["is_veteran"] = TRUE
 	// SKYRAT EDIT END
+	// BUBBER EDIT BEGIN
+	if(SSplayer_ranks.is_vetted(user.client))
+		data["is_vetted"] = TRUE
+	// BUBBER EDIT END
 	var/list/required_job_playtime = get_required_job_playtime(user)
 	if (!isnull(required_job_playtime))
 		data += required_job_playtime

--- a/modular_skyrat/master_files/code/modules/client/preferences/erp_preferences.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/erp_preferences.dm
@@ -20,7 +20,8 @@
 /datum/preference/toggle/master_erp_preferences/is_accessible(datum/preferences/preferences)
 	if (!..(preferences))
 		return FALSE
-
+	if(!SSplayer_ranks.is_vetted(preferences.parent, admin_bypass = FALSE)) // BUBBER EDIT
+		return FALSE // BUBBER EDIT
 	if(CONFIG_GET(flag/disable_erp_preferences))
 		return FALSE
 
@@ -40,7 +41,8 @@
 /datum/preference/toggle/erp/is_accessible(datum/preferences/preferences)
 	if (!..(preferences))
 		return FALSE
-
+	if(!SSplayer_ranks.is_vetted(preferences.parent, admin_bypass = FALSE)) // BUBBER EDIT
+		return FALSE // BUBBER EDIT
 	if(CONFIG_GET(flag/disable_erp_preferences))
 		return FALSE
 

--- a/modular_skyrat/modules/player_ranks/code/subsystem/player_ranks.dm
+++ b/modular_skyrat/modules/player_ranks/code/subsystem/player_ranks.dm
@@ -20,7 +20,7 @@ SUBSYSTEM_DEF(player_ranks)
 	var/datum/player_rank_controller/mentor/mentor_controller
 	/// The veteran player rank controller.
 	var/datum/player_rank_controller/veteran/veteran_controller
-
+	var/datum/player_rank_controller/vetted/vetted_controller // BUBBER EDIT ADDITION
 
 /datum/controller/subsystem/player_ranks/Initialize()
 	if(IsAdminAdvancedProcCall())
@@ -29,7 +29,7 @@ SUBSYSTEM_DEF(player_ranks)
 	load_donators()
 	load_mentors()
 	load_veterans()
-
+	load_vetted_ckeys() // BUBBER EDIT ADDITION
 	return SS_INIT_SUCCESS
 
 
@@ -39,7 +39,7 @@ SUBSYSTEM_DEF(player_ranks)
 	QDEL_NULL(donator_controller)
 	QDEL_NULL(mentor_controller)
 	QDEL_NULL(veteran_controller)
-
+	QDEL_NULL(vetted_controller) // BUBBER EDIT ADDITION
 
 /**
  * Returns whether or not the user is qualified as a donator.

--- a/modular_zubbers/modules/vetted/examine.dm
+++ b/modular_zubbers/modules/vetted/examine.dm
@@ -1,0 +1,9 @@
+/mob/living/silicon/get_silicon_flavortext()
+	. = ..()
+	if(SSplayer_ranks.is_vetted(client, admin_bypass = FALSE))
+		. += span_info("This player has been vetted by staff.")
+
+/mob/living/carbon/human/examine(mob/user)
+	. = ..()
+	if(SSplayer_ranks.is_vetted(client, admin_bypass = FALSE))
+		. += span_info("This player has been vetted by staff.")

--- a/modular_zubbers/modules/vetted/examine.dm
+++ b/modular_zubbers/modules/vetted/examine.dm
@@ -1,9 +1,9 @@
 /mob/living/silicon/get_silicon_flavortext()
 	. = ..()
 	if(client && SSplayer_ranks.is_vetted(client, admin_bypass = FALSE))
-		. += span_info("This player has been vetted by staff.")
+		. += span_greenannounce("This player has been vetted by staff.")
 
 /mob/living/carbon/human/examine(mob/user)
 	. = ..()
 	if(client && SSplayer_ranks.is_vetted(client, admin_bypass = FALSE))
-		. += span_info("This player has been vetted by staff.")
+		. += span_greenannounce("This player has been vetted by staff.")

--- a/modular_zubbers/modules/vetted/examine.dm
+++ b/modular_zubbers/modules/vetted/examine.dm
@@ -1,9 +1,9 @@
 /mob/living/silicon/get_silicon_flavortext()
 	. = ..()
-	if(SSplayer_ranks.is_vetted(client, admin_bypass = FALSE))
+	if(client && SSplayer_ranks.is_vetted(client, admin_bypass = FALSE))
 		. += span_info("This player has been vetted by staff.")
 
 /mob/living/carbon/human/examine(mob/user)
 	. = ..()
-	if(SSplayer_ranks.is_vetted(client, admin_bypass = FALSE))
+	if(client && SSplayer_ranks.is_vetted(client, admin_bypass = FALSE))
 		. += span_info("This player has been vetted by staff.")

--- a/modular_zubbers/modules/vetted/vetted.dm
+++ b/modular_zubbers/modules/vetted/vetted.dm
@@ -1,0 +1,53 @@
+GLOBAL_LIST_EMPTY(vetted_list)
+GLOBAL_PROTECT(vetted_list)
+
+/datum/controller/subsystem/player_ranks
+
+/datum/player_rank_controller/vetted
+	rank_title = "vetted user"
+	var/file_path_vetted
+/datum/controller/subsystem/player_ranks/proc/is_vetted(client/user, admin_bypass = TRUE)
+	if(!istype(user))
+		CRASH("Invalid user type provided to is_vetted(), expected 'client' and obtained '[user ? user.type : "null"]'.")
+
+	if(GLOB.vetted_list[user.ckey])
+		return TRUE
+
+	if(admin_bypass && is_admin(user))
+		return TRUE
+
+	return FALSE
+
+
+/datum/controller/subsystem/player_ranks/proc/load_vetted_ckeys()
+	PROTECTED_PROC(TRUE)
+
+	if(IsAdminAdvancedProcCall())
+		return
+
+	vetted_controller = new
+	vetted_controller.file_path_vetted = "[global.config.directory]/bubbers/vetted_players.txt"
+	for(var/line in world.file2list(vetted_controller.file_path_vetted))
+		if(!line)
+			continue
+
+		if(findtextEx(line, "#", 1, 2))
+			continue
+
+		vetted_controller.add_player(line)
+
+	return TRUE
+
+/datum/player_rank_controller/vetted/add_player(ckey)
+	if(IsAdminAdvancedProcCall())
+		return
+
+	ckey = ckey(ckey)
+
+	GLOB.vetted_list[ckey] = TRUE
+
+/datum/player_rank_controller/vetted/remove_player(ckey)
+	if(IsAdminAdvancedProcCall())
+		return
+
+	GLOB.vetted_list -= ckey

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7875,4 +7875,6 @@
 #include "modular_zubbers\modules\customization\modules\mob\dead\new_player\sprite_accessories\skrell_hair.dm"
 #include "modular_zubbers\modules\customization\modules\mob\living\carbon\human\species\akula.dm"
 #include "modular_zubbers\modules\emotes\code\emotes.dm"
+#include "modular_zubbers\modules\vetted\examine.dm"
+#include "modular_zubbers\modules\vetted\vetted.dm"
 // END_INCLUDE

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
@@ -176,7 +176,7 @@ export type PreferencesMenuData = {
   preview_selection: string; // SKYRAT EDIT ADDITION
 
   is_veteran: BooleanLike; // SKYRAT EDIT - Veteran status
-
+  is_vetted: BooleanLike; // BUBBER EDIT - Vetted Users
   character_preferences: {
     clothing: Record<string, string>;
     features: Record<string, string>;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR makes it so that players who are vetted receive a message on inspect in game, as to indicate their status within the player vetting system. Staff in game will also be able to know who is and isn't. 
![MGJNhWOmc3](https://github.com/Bubberstation/Bubberstation/assets/77420409/a12d2128-1806-46ae-93c8-232ff763ebf3)
![dreamseeker_bG2t0qSBZ6](https://github.com/Bubberstation/Bubberstation/assets/77420409/26afa081-88d6-4e87-9986-cdd9c97bc9f3)
![3VbJKWQA4j](https://github.com/Bubberstation/Bubberstation/assets/77420409/94e9265e-cb72-4e3a-9048-fd32dff1d832)


Mechanical Organic Interface Activity is also locked behind being vetted now.

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

Ambiguity is bad in this case, so this adds incentive on both sides to get vetted. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added new player ranks for being vetted.
code: Organic Interface is now locked behind being vetted. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
