### PR TITLE
[FULLY MODULAR] New quirk: Hungry

### DIFF
--- a/modular_zubbers/code/datums/quirks/neutral_quirks/hungry.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/hungry.dm
@@ -1,0 +1,13 @@
+/datum/quirk/item_quirk/hungry
+	name = "Hungry"
+	desc = "For some reason, you get hungrier faster than others"
+	value = 0
+	gain_text = span_notice("You feel like your stomach is bottomless")
+	lose_text = span_notice("You no longer feel like your stomach is bottomless")
+	medical_record_text = "Patient exhibits a significantly faster metabolism"
+	quirk_flags = QUIRK_HUMAN_ONLY
+	mail_goodies = list(/obj/item/food/chips)
+
+/datum/quirk/item_quirk/hungry/process(seconds_per_tick)
+	quirk_holder.adjust_nutrition(-(HUNGER_FACTOR * 3 * seconds_per_tick)) //This is about double of what is defined in _stomach.dm
+

--- a/modular_zubbers/code/datums/quirks/neutral_quirks/hungry.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/hungry.dm
@@ -1,3 +1,5 @@
+#define QUIRK_HUNGRY_MOD 2
+
 /datum/quirk/item_quirk/hungry
 	name = "Hungry"
 	desc = "For some reason, you get hungrier faster than others"
@@ -8,6 +10,14 @@
 	quirk_flags = QUIRK_HUMAN_ONLY
 	mail_goodies = list(/obj/item/food/chips)
 
-/datum/quirk/item_quirk/hungry/process(seconds_per_tick)
-	quirk_holder.adjust_nutrition(-(HUNGER_FACTOR * 3 * seconds_per_tick)) //This is about double of what is defined in _stomach.dm
+/datum/quirk/item_quirk/hungry/add(client/client_source)
+	var/mob/living/carbon/human/H = quirk_holder
+	if(istype(H))
+		H.physiology.hunger_mod *= QUIRK_HUNGRY_MOD
 
+/datum/quirk/item_quirk/hungry/remove()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(istype(H))
+		H.physiology.hunger_mod /= QUIRK_HUNGRY_MOD
+
+#undef QUIRK_HUNGRY_MOD

--- a/modular_zubbers/code/datums/quirks/neutral_quirks/hungry.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/hungry.dm
@@ -4,6 +4,7 @@
 	name = "Hungry"
 	desc = "For some reason, you get hungrier faster than others"
 	value = 0
+	icon = FA_ICON_HAMBURGER
 	gain_text = span_notice("You feel like your stomach is bottomless")
 	lose_text = span_notice("You no longer feel like your stomach is bottomless")
 	medical_record_text = "Patient exhibits a significantly faster metabolism"

--- a/modular_zubbers/code/datums/quirks/neutral_quirks/hungry.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/hungry.dm
@@ -4,7 +4,7 @@
 	name = "Hungry"
 	desc = "For some reason, you get hungrier faster than others"
 	value = 0
-	icon = FA_ICON_HAMBURGER
+	icon = FA_ICON_BOWL_FOOD
 	gain_text = span_notice("You feel like your stomach is bottomless")
 	lose_text = span_notice("You no longer feel like your stomach is bottomless")
 	medical_record_text = "Patient exhibits a significantly faster metabolism"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7729,6 +7729,7 @@
 #include "modular_zubbers\code\datums\computer_datums\protolathe_modifications.dm"
 #include "modular_zubbers\code\datums\diseases\advance\presets.dm"
 #include "modular_zubbers\code\datums\id_trim\jobs.dm"
+#include "modular_zubbers\code\datums\quirks\neutral_quirks\hungry.dm"
 #include "modular_zubbers\code\datums\shuttle\arena.dm"
 #include "modular_zubbers\code\datums\shuttles\emergency.dm"
 #include "modular_zubbers\code\game\area\areas\burgerstation.dm"


### PR DESCRIPTION
## About The Pull Request

Adds a new neutral quirk, hungry, with the current effect of doubling the decay of one's nutrition.
Neutral because Moffy told me to make it so, might make it a -1 or add something positive to it if others have a different opinion.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

Even more reason to interact with the kitchen for those who take this quirk. Please take it I need someone to talk to

![image](https://github.com/Bubberstation/Bubberstation/assets/49160555/01e1ef13-f425-49ed-9fbb-81e3b387d824)

This is not a quirk for those fat fetishists to abuse like some of you claimed, they already have their one

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: New quirk: Hungry
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
