### PR TITLE
[DNM] Moves the claw implant to 6 points

### DIFF
--- a/modular_zubbers/modules/customization/modules/client/augment/implants.dm
+++ b/modular_zubbers/modules/customization/modules/client/augment/implants.dm
@@ -1,0 +1,5 @@
+/datum/augment_item/implant/l_arm/razor_claws
+	cost = 6
+
+/datum/augment_item/implant/r_arm/razor_claws
+	cost = 6

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7872,6 +7872,7 @@
 #include "modular_zubbers\master_files\code\modules\research\designs\biogenerator_designs.dm"
 #include "modular_zubbers\modules\ashwalkers\code\effects\ash_rituals.dm"
 #include "modular_zubbers\modules\cargoborg\code\robot_items.dm"
+#include "modular_zubbers\modules\customization\modules\client\augment\implants.dm"
 #include "modular_zubbers\modules\customization\modules\mob\dead\new_player\sprite_accessories\skrell_hair.dm"
 #include "modular_zubbers\modules\customization\modules\mob\living\carbon\human\species\akula.dm"
 #include "modular_zubbers\modules\emotes\code\emotes.dm"


### PR DESCRIPTION
## About The Pull Request

This is one of the possible resolutions to the whole claw discussion.

The alternative is nerfing the weapon, as removal is downright just stupid.

## Why It's Good For The Game

We have decided that a roundstart weapon with less power than a kitchen knife is apparently too good to be only a 4 quirk point cost.

See here:
https://discord.com/channels/1059199070016655462/1162423073673322537

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Razor claw implant point cost 4 -> 6
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
