### PR TITLE
Disables Blob from rolling midround for good

### DIFF
--- a/code/modules/events/ghost_role/blob.dm
+++ b/code/modules/events/ghost_role/blob.dm
@@ -40,5 +40,4 @@
 	message_admins("[ADMIN_LOOKUPFLW(BC)] has been made into a blob overmind by an event.")
 	BC.log_message("was spawned as a blob overmind by an event.", LOG_GAME)
 	return SUCCESSFUL_SPAWN
-
 */

--- a/code/modules/events/ghost_role/blob.dm
+++ b/code/modules/events/ghost_role/blob.dm
@@ -1,3 +1,5 @@
+/* BUBBERSTATION CHANGE: Disables blob for good.
+
 /datum/round_event_control/blob
 	name = "Blob"
 	typepath = /datum/round_event/ghost_role/blob
@@ -38,3 +40,5 @@
 	message_admins("[ADMIN_LOOKUPFLW(BC)] has been made into a blob overmind by an event.")
 	BC.log_message("was spawned as a blob overmind by an event.", LOG_GAME)
 	return SUCCESSFUL_SPAWN
+
+*/

--- a/modular_skyrat/modules/ices_events/code/ICES_event_config.dm
+++ b/modular_skyrat/modules/ices_events/code/ICES_event_config.dm
@@ -119,10 +119,11 @@
  *
  * Disabled: Controlled by Dynamic
  */
+ /* BUBBERSTATION CHANGE: Disables blob for good.
 /datum/round_event_control/blob
 	max_occurrences = 0
 	intensity_restriction = TRUE
-
+BUBBERSTATION CHANGE END: Disables blob for good. */
 /**
  * Brain Trauma
  *


### PR DESCRIPTION
## About The Pull Request

Blob midround event is disabled via code.

## Why It's Good For The Game

Blob was added quite a long time ago. Before Skyrat event existed and before citadel even existed. It's exceptionally an old mechanic. Ironically, since the creation of blob, it has not evolved with the features from /tg/, citadel, skyrat, and bubberstation. Here is what I mean by this.

- Since then, firesuits are no longer effective against fighting blob. They no longer protect fully against cold temperatures and thus are now near useless against blob since the atmosphere is always drained.
- The atmos system has improved significantly. Breaches now drain the station of air extremely fast, making it extremely difficult to traverse to the blob and around the blob as a hardsuit is almost always required.
- Cargo has received several significant nerfs to money generation, limiting how many hardsuits and guns that can be purchased. On /tg/, it used to be common for cargo to generate an upwards of 500,000 credits due to funny money making techniques, but this has been patched. Cargo on Bubberstation has a budget of 25,000-50,000 during midround as a lot of people like spending money on other features and projects that cargo has to offer.
- The amount of guns the crew and security have, as well as the damage, has received significant nerfs by skyrat, bubberstation, and /tg/ in order to make playing traitor more balanced.
- The /tg/ coderbase has received several nerfs to the medical system, and most notably, the chemistry system. Medication is no longer as good as it once was before.
- The /tg/ coderbase has received several nerfs to virology, so healing viruses are no longer as effective as they once were.
- The /tg/ coderbase has received several nerfs to genetics, so space adaptation and cold/heat adaptation can no longer really be used as good as it once was.
- Multi-z was added to /tg/, and maps were made significantly bigger, allowing more space for blobs to spawn and expand freely. This effect is compounded by the fact that Bubberstation is mostly a roleplay server and not everyone patrols maint 24/7.
- There are several maps that have broken the "Box shaped." structure that the standard /tg/ maps had, adding lots of curves and corners to areas that make it difficult to setup emitters.
- The viewport size has been decreased by Bubberstation, making it significantly more difficult to see if emitters are lined up.
- Wounds were added to the /tg/ medical system, something that doesn't really affect blobs but has a substantial effect on the people fighting the blob.

Despite all that, blob hasn't really been worked on at all. A lot of code hasn't been touched for an upwards of 2 years, and if it has, it's usually a slight change or a code cleaning thing that removes a few spaces from the code. On bubberstation, there have been 0 blob related PRs that have been merged, despite all the changes that we've done to combat, ballistics, lasers, medical, etc. It's abundantly clear that no one wants to maintain it, so there is no point in keeping it.


## So why can /tg/ handle blob, but Bubbers can't?

On /tg/station, rounds last ~45 minutes, and not 2.5 hours where most people are just zoned out midround just chilling in the bar. On /tg/station, they are no subject to Skyrat balancing or Bubberstation rules. People don't usually sit around in one spot, so blobs are detected instantly, and if a blob spawns, most people have an entire arsenals of explosives and guns in their backpack anyways to kill the blob. Powergaming is not allowed on Bubberstation, and rules are extremely strict on when the crew or security are allowed to have guns.

## Yeah but the blob can be defeated easily if crew could just xyz.

I hate this argument so much because it's hard to argue against it without calling out the nonsense of it is. Every time there is a blob round, an observer, the person who played blob, or the person playing juggernaut will always start talking about how a certain department wasn't organized enough or how they could've beat the blob if they setup emitters in this one spot, something that does not work. 

Hindsight is 20/20.

Relevant video: https://www.youtube.com/watch?v=N1fVL4AQEW8

With so many players, and so many departments required to do xyz, the human factor tends to fuck things up. Sometimes engineering can't setup emitters in time. Sometimes security is dead. Sometimes medical has new players. Sometimes, people just flee for interlink.

## Why not just improve, and not remove?

We don't have enough maintainers for this. We don't have enough coders for this. We don't have a guideline for balance nor do we have any sort of direction that everyone is comfortable with when it comes to an antag type that spawns maybe once every 4 days. With how many strains there are, combined with the amount of people who have their own ideas on how to nerf blob (if at all), it is extremely unrealistic to expect a volunteer to put in the effort to making a several PRs or one large PR to nerf blob. If someone would like to prove me wrong, please do because blob is extremely outdated in terms of balance.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: BurgerBB
del: Blob midround event is disabled via code.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
