### PR TITLE
Nerfs Blob's ability to space things based on temperature

### DIFF
--- a/modular_zubbers/code/modules/antagonists/blob/structures/_blob.dm
+++ b/modular_zubbers/code/modules/antagonists/blob/structures/_blob.dm
@@ -1,0 +1,7 @@
+/obj/structure/blob/can_atmos_pass(turf/T, vertical = FALSE)
+
+	var/datum/gas_mixture/turf_air = T.return_air()
+	if(turf_air.temperature <= T0C + 15.5556) // https://www.menshealth.com/trending-news/a19548271/why-penis-shrinks-in-cold/
+		return FALSE
+
+	return !atmosblock

--- a/modular_zubbers/code/modules/antagonists/blob/structures/_blob.dm
+++ b/modular_zubbers/code/modules/antagonists/blob/structures/_blob.dm
@@ -1,7 +1,9 @@
 /obj/structure/blob/can_atmos_pass(turf/T, vertical = FALSE)
 
-	var/datum/gas_mixture/turf_air = T.return_air()
-	if(turf_air.temperature <= T0C + 15.5556) // https://www.menshealth.com/trending-news/a19548271/why-penis-shrinks-in-cold/
-		return FALSE
+	. = ..()
 
-	return !atmosblock
+	if(!.)
+		return .
+
+	var/datum/gas_mixture/turf_air = T.return_air()
+	return turf_air.temperature < T0C + 15.5556 // https://www.menshealth.com/trending-news/a19548271/why-penis-shrinks-in-cold/

--- a/modular_zubbers/code/modules/antagonists/blob/structures/_blob.dm
+++ b/modular_zubbers/code/modules/antagonists/blob/structures/_blob.dm
@@ -6,4 +6,5 @@
 		return .
 
 	var/datum/gas_mixture/turf_air = T.return_air()
-	return turf_air.temperature < T0C + 15.5556 // https://www.menshealth.com/trending-news/a19548271/why-penis-shrinks-in-cold/
+	return turf_air.temperature > T0C + 15.5556 // https://www.menshealth.com/trending-news/a19548271/why-penis-shrinks-in-cold/
+

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7770,6 +7770,7 @@
 #include "modular_zubbers\code\modules\altborgs\code\robot_upgrade.dm"
 #include "modular_zubbers\code\modules\alternative_job_titles\code\alt_job_titles.dm"
 #include "modular_zubbers\code\modules\antagonists\ashwalker\ashwalker.dm"
+#include "modular_zubbers\code\modules\antagonists\blob\structures\_blob.dm"
 #include "modular_zubbers\code\modules\asset_cache\assets\arcade.dm"
 #include "modular_zubbers\code\modules\automapper\code\area_spawn_entries.dm"
 #include "modular_zubbers\code\modules\borer_hud\borer.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Blob atmos only passes if the temperature is above 15.56 degrees Celsius.

## Why It's Good For The Game

Atmos processing has evolved over the years while blob balance (with respect to that) has vastly remained untouched. Some servers I've played on have handled this by making blob tiles block atmos, but I think I can add that and make it better.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: BurgerBB
balance: Blob atmos only passes if the temperature is above 15.56 degrees celcius.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
