### PR TITLE
Fixes trash pile linter

### DIFF
--- a/modular_zubbers/code/game/objects/structures/trash_pile.dm
+++ b/modular_zubbers/code/game/objects/structures/trash_pile.dm
@@ -155,7 +155,7 @@
 		return ..()
 
 	var/mob/living/carbon/dropped_mob = dropped_atom
-	if(!dropped_mob.mobility_flags & MOBILITY_MOVE)
+	if(!(dropped_mob.mobility_flags & MOBILITY_MOVE))
 		return
 
 	user.visible_message(


### PR DESCRIPTION
Missing closed brackets cause the function to perform differently.