### PR TITLE
Nerfs Blob

### DIFF
--- a/code/__DEFINES/blob_defines.dm
+++ b/code/__DEFINES/blob_defines.dm
@@ -5,23 +5,23 @@
 #define OVERMIND_STARTING_REROLLS 1 // Free strain rerolls at the start
 #define OVERMIND_STARTING_MIN_PLACE_TIME (1 MINUTES) // Minimum time before the core can be placed
 #define OVERMIND_STARTING_AUTO_PLACE_TIME (6 MINUTES) // After this time, randomly place the core somewhere viable
-#define OVERMIND_WIN_CONDITION_AMOUNT 500 // Blob structures required to win BUBBERSTATION CHANGE: 400 TO 500.
-#define OVERMIND_ANNOUNCEMENT_MIN_SIZE 50 // Once the blob has this many structures, announce their presence BUBBERSTATION CHANGE 75 TO 50.
+#define OVERMIND_WIN_CONDITION_AMOUNT 400 // Blob structures required to win
+#define OVERMIND_ANNOUNCEMENT_MIN_SIZE 75 // Once the blob has this many structures, announce their presence
 #define OVERMIND_ANNOUNCEMENT_MAX_TIME (10 MINUTES) // If the blob hasn't reached the minimum size before this time, announce their presence
-#define OVERMIND_MAX_CAMERA_STRAY "5x5" // How far the overmind camera is allowed to stray from blob tiles. 3x3 is 1 tile away, 5x5 2 tiles etc BUBBERSTATION CHANGE: 3x3 TO 5x5
+#define OVERMIND_MAX_CAMERA_STRAY "3x3" // How far the overmind camera is allowed to stray from blob tiles. 3x3 is 1 tile away, 5x5 2 tiles etc
 
 
 // Generic blob defines
 
 //#define BLOB_BASE_POINT_RATE 2 // Base amount of points per process()
 #define BLOB_BASE_POINT_RATE 2.5 // SKYRAT EDIT CHANGE
-#define BLOB_EXPAND_COST 4 // Price to expand onto a new tile
-#define BLOB_ATTACK_REFUND 0 // Points 'refunded' when the expand attempt actually attacks something instead BUBBERSTATION CHANGE: 4 TO 0.
+#define BLOB_EXPAND_COST 3 // Price to expand onto a new tile. BUBBERSTATION CHANGE: 4 TO 3.
+#define BLOB_ATTACK_REFUND 0 // Points 'refunded' when the expand attempt actually attacks something instead BUBBERSTATION CHANGE: 2 TO 0.
 #define BLOB_BRUTE_RESIST 1 // Brute damage taken gets multiplied by this value BUBBERSTATION CHANGE: 0.5 TO 1.
 #define BLOB_FIRE_RESIST 1 // Burn damage taken gets multiplied by this value
 #define BLOB_EXPAND_CHANCE_MULTIPLIER 1 // Increase this value to make blobs naturally expand faster
-#define BLOB_REINFORCE_CHANCE 100 // The seconds_per_tick chance for cores/nodes to reinforce their surroundings BUBBERSTATION CHANGE: 2.5 TO 100.
-#define BLOB_REAGENTATK_VOL 5 // Amount of strain-reagents that get injected when the blob attacks: main source of blob damage BUBBERSTATION CHANGE: 25 TO 5.
+#define BLOB_REINFORCE_CHANCE 0 // The seconds_per_tick chance for cores/nodes to reinforce their surroundings BUBBERSTATION CHANGE: 2.5 TO 0.
+#define BLOB_REAGENTATK_VOL 10 // Amount of strain-reagents that get injected when the blob attacks: main source of blob damage BUBBERSTATION CHANGE: 25 TO 10.
 
 
 // Structure properties
@@ -30,7 +30,7 @@
 #define BLOB_CORE_HP_REGEN 2 // Bases health regeneration rate every process(), can be added on by strains
 #define BLOB_CORE_CLAIM_RANGE 12 // Range in which blob tiles are 'claimed' (converted from dead to alive, rarely useful)
 #define BLOB_CORE_PULSE_RANGE 4 // The radius up to which the core activates structures, and up to which structures can be built
-#define BLOB_CORE_EXPAND_RANGE 3 // Radius of automatic expansion
+#define BLOB_CORE_EXPAND_RANGE 4 // Radius of automatic expansion BUBBERSTATION CHANGE: 3 TO 4.
 #define BLOB_CORE_STRONG_REINFORCE_RANGE 1 // The radius of tiles surrounding the core that get upgraded
 #define BLOB_CORE_REFLECTOR_REINFORCE_RANGE 0
 
@@ -39,7 +39,7 @@
 #define BLOB_NODE_MIN_DISTANCE 5 // Minimum distance between nodes
 #define BLOB_NODE_CLAIM_RANGE 10
 #define BLOB_NODE_PULSE_RANGE 3 // The radius up to which the core activates structures, and up to which structures can be built
-#define BLOB_NODE_EXPAND_RANGE 2 // Radius of automatic expansion
+#define BLOB_NODE_EXPAND_RANGE 3 // Radius of automatic expansion BUBBERSTATION CHANGE 2 TO 3.
 #define BLOB_NODE_STRONG_REINFORCE_RANGE 0 // The radius of tiles surrounding the node that get upgraded
 #define BLOB_NODE_REFLECTOR_REINFORCE_RANGE 0
 
@@ -62,28 +62,28 @@
 #define BLOB_STRONG_MAX_HP 150
 #define BLOB_STRONG_HP_REGEN 2
 
-#define BLOB_REFLECTOR_MAX_HP 150
+#define BLOB_REFLECTOR_MAX_HP 100 //BUBBERSTATION CHANGE: 150 TO 100
 #define BLOB_REFLECTOR_HP_REGEN 2
 
 
 // Structure purchasing
 
 #define BLOB_UPGRADE_STRONG_COST 10 // Upgrade and build costs here BUBBERSTATION CHANGE: 15 TO 10.
-#define BLOB_UPGRADE_REFLECTOR_COST 20 //BUBBERSTATION CHANGE: 15 TO 20.
+#define BLOB_UPGRADE_REFLECTOR_COST 10 //BUBBERSTATION CHANGE: 15 TO 10.
 #define BLOB_STRUCTURE_RESOURCE_COST 40
 #define BLOB_STRUCTURE_FACTORY_COST 60
 #define BLOB_STRUCTURE_NODE_COST 50
 
 #define BLOB_REFUND_STRONG_COST 0 // Points refunded when destroying the structure BUBBERSTATION CHANGE: 4 TO 0.
-#define BLOB_REFUND_REFLECTOR_COST 10 //BUBBERSTATION CHANGE: 8 TO 10.
+#define BLOB_REFUND_REFLECTOR_COST 0 //BUBBERSTATION CHANGE: 8 TO 0.
 #define BLOB_REFUND_RESOURCE_COST 40 //BUBBERSTATION CHANGE: 15 TO 40.
 #define BLOB_REFUND_FACTORY_COST 30 //BUBBERSTATION CHANGE: 25 TO 30.
 #define BLOB_REFUND_NODE_COST 25
 
 // Blob power properties
 
-#define BLOB_POWER_RELOCATE_COST 50 // Resource cost to move your core to a different node BUBBERSTATION CHANGE: 80 TO 50.
-#define BLOB_POWER_REROLL_COST 60 // Strain reroll. BUBBERSTATION CHANGE: 40 TO 60.
+#define BLOB_POWER_RELOCATE_COST 100 // Resource cost to move your core to a different node BUBBERSTATION CHANGE: 80 TO 100.
+#define BLOB_POWER_REROLL_COST 50 // Strain reroll. BUBBERSTATION CHANGE: 40 TO 50.
 #define BLOB_POWER_REROLL_FREE_TIME (600 MINUTES) // Gain a free strain reroll every x minutes BUBBERSTATION CHANGE:4 TO 600 MINUTES (PRETTY MUCH DISABLED).
 #define BLOB_POWER_REROLL_CHOICES 6 // Possibilities to choose from; keep in mind increasing this might fuck with the radial menu
 

--- a/code/__DEFINES/blob_defines.dm
+++ b/code/__DEFINES/blob_defines.dm
@@ -56,7 +56,7 @@
 #define BLOB_RESOURCE_GATHER_AMOUNT 1 // The amount of points added to the overmind
 
 #define BLOB_REGULAR_MAX_HP 25
-#define BLOB_REGULAR_HP_INIT 5 // The starting HP of a normal blob tile BUBBERSTATION CHANMGE: 24 TO 5.
+#define BLOB_REGULAR_HP_INIT 10 // The starting HP of a normal blob tile BUBBERSTATION CHANMGE: 24 TO 10.
 #define BLOB_REGULAR_HP_REGEN 1 // Health regenerated when pulsed by a node/core
 
 #define BLOB_STRONG_MAX_HP 150
@@ -84,7 +84,7 @@
 
 #define BLOB_POWER_RELOCATE_COST 100 // Resource cost to move your core to a different node BUBBERSTATION CHANGE: 80 TO 100.
 #define BLOB_POWER_REROLL_COST 50 // Strain reroll. BUBBERSTATION CHANGE: 40 TO 50.
-#define BLOB_POWER_REROLL_FREE_TIME (600 MINUTES) // Gain a free strain reroll every x minutes BUBBERSTATION CHANGE:4 TO 600 MINUTES (PRETTY MUCH DISABLED).
+#define BLOB_POWER_REROLL_FREE_TIME (6 MINUTES) // Gain a free strain reroll every x minutes
 #define BLOB_POWER_REROLL_CHOICES 6 // Possibilities to choose from; keep in mind increasing this might fuck with the radial menu
 
 

--- a/code/__DEFINES/blob_defines.dm
+++ b/code/__DEFINES/blob_defines.dm
@@ -1,14 +1,14 @@
 // Overmind defines
 
 #define OVERMIND_MAX_POINTS_DEFAULT 100 // Max point storage
-#define OVERMIND_STARTING_POINTS 60 // Points granted upon start
+#define OVERMIND_STARTING_POINTS 0 // Points granted upon start BUBBERSTATION CHANGE: 60 TO 0.
 #define OVERMIND_STARTING_REROLLS 1 // Free strain rerolls at the start
 #define OVERMIND_STARTING_MIN_PLACE_TIME (1 MINUTES) // Minimum time before the core can be placed
 #define OVERMIND_STARTING_AUTO_PLACE_TIME (6 MINUTES) // After this time, randomly place the core somewhere viable
-#define OVERMIND_WIN_CONDITION_AMOUNT 400 // Blob structures required to win
-#define OVERMIND_ANNOUNCEMENT_MIN_SIZE 75 // Once the blob has this many structures, announce their presence
+#define OVERMIND_WIN_CONDITION_AMOUNT 500 // Blob structures required to win BUBBERSTATION CHANGE: 400 TO 500.
+#define OVERMIND_ANNOUNCEMENT_MIN_SIZE 50 // Once the blob has this many structures, announce their presence BUBBERSTATION CHANGE 75 TO 50.
 #define OVERMIND_ANNOUNCEMENT_MAX_TIME (10 MINUTES) // If the blob hasn't reached the minimum size before this time, announce their presence
-#define OVERMIND_MAX_CAMERA_STRAY "3x3" // How far the overmind camera is allowed to stray from blob tiles. 3x3 is 1 tile away, 5x5 2 tiles etc
+#define OVERMIND_MAX_CAMERA_STRAY "5x5" // How far the overmind camera is allowed to stray from blob tiles. 3x3 is 1 tile away, 5x5 2 tiles etc BUBBERSTATION CHANGE: 3x3 TO 5x5
 
 
 // Generic blob defines
@@ -16,12 +16,12 @@
 //#define BLOB_BASE_POINT_RATE 2 // Base amount of points per process()
 #define BLOB_BASE_POINT_RATE 2.5 // SKYRAT EDIT CHANGE
 #define BLOB_EXPAND_COST 4 // Price to expand onto a new tile
-#define BLOB_ATTACK_REFUND 2 // Points 'refunded' when the expand attempt actually attacks something instead
-#define BLOB_BRUTE_RESIST 0.5 // Brute damage taken gets multiplied by this value
+#define BLOB_ATTACK_REFUND 0 // Points 'refunded' when the expand attempt actually attacks something instead BUBBERSTATION CHANGE: 4 TO 0.
+#define BLOB_BRUTE_RESIST 1 // Brute damage taken gets multiplied by this value BUBBERSTATION CHANGE: 0.5 TO 1.
 #define BLOB_FIRE_RESIST 1 // Burn damage taken gets multiplied by this value
 #define BLOB_EXPAND_CHANCE_MULTIPLIER 1 // Increase this value to make blobs naturally expand faster
-#define BLOB_REINFORCE_CHANCE 2.5 // The seconds_per_tick chance for cores/nodes to reinforce their surroundings
-#define BLOB_REAGENTATK_VOL 25 // Amount of strain-reagents that get injected when the blob attacks: main source of blob damage
+#define BLOB_REINFORCE_CHANCE 100 // The seconds_per_tick chance for cores/nodes to reinforce their surroundings BUBBERSTATION CHANGE: 2.5 TO 100.
+#define BLOB_REAGENTATK_VOL 5 // Amount of strain-reagents that get injected when the blob attacks: main source of blob damage BUBBERSTATION CHANGE: 25 TO 5.
 
 
 // Structure properties
@@ -46,17 +46,17 @@
 #define BLOB_FACTORY_MAX_HP 200
 #define BLOB_FACTORY_HP_REGEN 1
 #define BLOB_FACTORY_MIN_DISTANCE 7 // Minimum distance between factories
-#define BLOB_FACTORY_MAX_SPORES 3
+#define BLOB_FACTORY_MAX_SPORES 5 //BUBBERSTATION CHANGE: 3 TO 5.
 
-#define BLOB_RESOURCE_MAX_HP 60
-#define BLOB_RESOURCE_HP_REGEN 15
+#define BLOB_RESOURCE_MAX_HP 100 //BUBBERSTATION CHANGE: 60 TO 100.
+#define BLOB_RESOURCE_HP_REGEN 3 //BUBBERSTATION CHANGE: 15 TO 3.
 #define BLOB_RESOURCE_MIN_DISTANCE 4 // Minimum distance between resource blobs
 #define BLOB_RESOURCE_GATHER_DELAY (4 SECONDS) // Gather points when pulsed outside this interval
 #define BLOB_RESOURCE_GATHER_ADDED_DELAY (0.25 SECONDS) // Every additional resource blob adds this amount to the gather delay
 #define BLOB_RESOURCE_GATHER_AMOUNT 1 // The amount of points added to the overmind
 
 #define BLOB_REGULAR_MAX_HP 25
-#define BLOB_REGULAR_HP_INIT 21 // The starting HP of a normal blob tile
+#define BLOB_REGULAR_HP_INIT 5 // The starting HP of a normal blob tile BUBBERSTATION CHANMGE: 24 TO 5.
 #define BLOB_REGULAR_HP_REGEN 1 // Health regenerated when pulsed by a node/core
 
 #define BLOB_STRONG_MAX_HP 150
@@ -68,40 +68,40 @@
 
 // Structure purchasing
 
-#define BLOB_UPGRADE_STRONG_COST 15 // Upgrade and build costs here
-#define BLOB_UPGRADE_REFLECTOR_COST 15
+#define BLOB_UPGRADE_STRONG_COST 10 // Upgrade and build costs here BUBBERSTATION CHANGE: 15 TO 10.
+#define BLOB_UPGRADE_REFLECTOR_COST 20 //BUBBERSTATION CHANGE: 15 TO 20.
 #define BLOB_STRUCTURE_RESOURCE_COST 40
 #define BLOB_STRUCTURE_FACTORY_COST 60
 #define BLOB_STRUCTURE_NODE_COST 50
 
-#define BLOB_REFUND_STRONG_COST 4 // Points refunded when destroying the structure
-#define BLOB_REFUND_REFLECTOR_COST 8
-#define BLOB_REFUND_RESOURCE_COST 15
-#define BLOB_REFUND_FACTORY_COST 25
+#define BLOB_REFUND_STRONG_COST 0 // Points refunded when destroying the structure BUBBERSTATION CHANGE: 4 TO 0.
+#define BLOB_REFUND_REFLECTOR_COST 10 //BUBBERSTATION CHANGE: 8 TO 10.
+#define BLOB_REFUND_RESOURCE_COST 40 //BUBBERSTATION CHANGE: 15 TO 40.
+#define BLOB_REFUND_FACTORY_COST 30 //BUBBERSTATION CHANGE: 25 TO 30.
 #define BLOB_REFUND_NODE_COST 25
 
 // Blob power properties
 
-#define BLOB_POWER_RELOCATE_COST 80 // Resource cost to move your core to a different node
-#define BLOB_POWER_REROLL_COST 40 // Strain reroll
-#define BLOB_POWER_REROLL_FREE_TIME (4 MINUTES) // Gain a free strain reroll every x minutes
+#define BLOB_POWER_RELOCATE_COST 50 // Resource cost to move your core to a different node BUBBERSTATION CHANGE: 80 TO 50.
+#define BLOB_POWER_REROLL_COST 60 // Strain reroll. BUBBERSTATION CHANGE: 40 TO 60.
+#define BLOB_POWER_REROLL_FREE_TIME (600 MINUTES) // Gain a free strain reroll every x minutes BUBBERSTATION CHANGE:4 TO 600 MINUTES (PRETTY MUCH DISABLED).
 #define BLOB_POWER_REROLL_CHOICES 6 // Possibilities to choose from; keep in mind increasing this might fuck with the radial menu
 
 
 // Mob defines
 
 #define BLOBMOB_HEALING_MULTIPLIER 0.0125 // Multiplies by -maxHealth and heals the blob by this amount every blob_act
-#define BLOBMOB_SPORE_HEALTH 30 // Base spore health
-#define BLOBMOB_SPORE_SPAWN_COOLDOWN (8 SECONDS)
+#define BLOBMOB_SPORE_HEALTH 20 // Base spore health. BUBBERSTATION CHANGE: 40 TO 20.
+#define BLOBMOB_SPORE_SPAWN_COOLDOWN (4 SECONDS) //BUBBERSTATION CHANGE: 8 TO 4 SECONDS.
 #define BLOBMOB_SPORE_DMG_LOWER 2
 #define BLOBMOB_SPORE_DMG_UPPER 4
-#define BLOBMOB_BLOBBERNAUT_RESOURCE_COST 40 // Purchase price for making a blobbernaut
-#define BLOBMOB_BLOBBERNAUT_HEALTH 200 // Base blobbernaut health
+#define BLOBMOB_BLOBBERNAUT_RESOURCE_COST 70 // Purchase price for making a blobbernaut. BUBBERSTATION CHANGE: 40 TO 70.
+#define BLOBMOB_BLOBBERNAUT_HEALTH 250 // Base blobbernaut health. BUBBERSTATION CHANGE: 200 TO 250.
 #define BLOBMOB_BLOBBERNAUT_DMG_SOLO_LOWER 20 // Damage without active overmind (core dead or xenobio mob)
 #define BLOBMOB_BLOBBERNAUT_DMG_SOLO_UPPER 20
 #define BLOBMOB_BLOBBERNAUT_DMG_LOWER 4 // Damage dealt with active overmind (most damage comes from strain chems)
 #define BLOBMOB_BLOBBERNAUT_DMG_UPPER 4
-#define BLOBMOB_BLOBBERNAUT_REAGENTATK_VOL 20 // Amounts of strain reagents applied on attack -- basically the main damage stat
+#define BLOBMOB_BLOBBERNAUT_REAGENTATK_VOL 5 // Amounts of strain reagents applied on attack -- basically the main damage stat BUBBERSTATION CHANGE: 20 TO 5.
 #define BLOBMOB_BLOBBERNAUT_DMG_OBJ 60 // Damage dealth to objects/machines
 #define BLOBMOB_BLOBBERNAUT_HEALING_CORE 0.05 // Percentage multiplier HP restored on Life() when within 2 tiles of the blob core
 #define BLOBMOB_BLOBBERNAUT_HEALING_NODE 0.025 // Same, but for a nearby node

--- a/code/modules/mob/living/basic/blob_minions/blob_spore.dm
+++ b/code/modules/mob/living/basic/blob_minions/blob_spore.dm
@@ -65,7 +65,7 @@
 /// Variant of the blob spore which is actually spawned by blob factories
 /mob/living/basic/blob_minion/spore/minion
 	gold_core_spawnable = NO_SPAWN
-	zombie_type = /mob/living/basic/blob_minion/zombie/controlled
+	// zombie_type = /mob/living/basic/blob_minion/zombie/controlled BUBBERSTATION CHANGE: NO GHOST CONTROL.
 	/// We die if we leave the same turf as this z level
 	var/turf/z_turf
 


### PR DESCRIPTION
## Notice to Maintainers

These are some pretty sweeping changes that should be tested before a merge (of course). I recommend asking players in the middle of a round if they want a chaotic antag to spawn, and if the poll passes you just spawn a blob event :^).

## Notice to Players

Everything is subject to change. Maybe something that worked well in paper doesn't really work well at all in this PR. If that happens, leave feedback here and describe the situation. Posts that just say "This stat edit is shit." without explanation is useless to me.

## About The Pull Request

Nerfs a lot of blob defines to how they were previously back in the day, or what I feel is best given the current state of what the crew has to deal with the blob.

Here are all the changes.

| What was Changed | Old Value | New Value | Reason |
| - | - | - | - |
| Blob starting points | 60 | 0 | Puts a bigger emphasis on not getting caught out early, as well as balances it for the fact that people on Bubberstation don't move around too much compared to upstreams due to the nature of roleplay. |
| Blob Expand Cost | 4 | 3 |  Since spawned blobs start out weaker, they are now also cheaper. |
| Blob Attack Refund | 2 | 0 |  Making attacks a little more expensive (basically from 2 to 3 ) will prevent easy breaching of areas and make open areas a little more rewarding compared to cramped areas. |
| Blob Node/Core Reinforce Chance | 2.5 | 0 | The chance is so low, good or bad rng shouldn't determine whether or not a blob wins. Tile reinforcement is cheaper too, so it isn't as bad of a change. |
| Blob Reagent Inject | 25 | 10 | Injecting 25u of a blob reagent per attack is legitimately insane. |
| Blob core automatic expansion range | 3 | 4 | Makes it easier for blobs that start out. |
| Blob node automatic expansion range | 2 | 3 | Makes it more rewarding to invest into nodes first. |
| Blob node automatic reflector range | 0 | 1 | Nodes given automatic reflector creation makes it so that smart node placements are well rewarded. |
| Blob Factory Max Spores | 3 | 5 | Spore HP was nerfed, so to compensate, the numbers were increased. |
| Blob Resource Max HP | 60 | 100 | A buff to make the nerf to resource nodes not so bad. |
| Blob Resource HP Regen | 15 | 3 | 15 HP regeneration is INSANE. Reduced to something more reasonable. |
| Regular Blob Turf Starting HP | 24 | 10 | Blob tiles should start out very weak as to not make it seem like you're fighting something endlessly when the blob can just shit out a 24 HP structure every time it falls. |
| Blob Reflector HP | 150 | 100 |  150 for a reflector blob seems a little strong given that security doesn't really have ballistics anymore. |
| Strong Blob Upgrade Cost | 15 | 10 | Since blobs turfs spawn weaker, you're going to need a lot of these. |
| Reflector Blob Upgrade Cost | 15 | 10 | Matches the upgrade cost of strong blobs. 
| Strong Blob Refund Amount | 4 | 0 | Prevents an exploit where you refund a strong blob before it is destroyed. |
| Reflective Blob Refund Amount | 8 | 0 | Prevents an exploit where you refund a reflective blob before it is destroyed. |
| Resource Node Refund Cost | 15 | 40 | Resource nodes contain resources, yes? |
| Factory Node Refund Cost | 25 | 30 | 30 was chosen because it is half of the factory cost of 60 |
| Blob Relocate Core Cost | 80 | 100 | Relocating your core is extremely strong and basically negates the tactic of having your core rushed. It should be very expensive to do. |
| Strain Reroll Cost | 40 | 50 | Rerolling strain should be costly because it fundamentally changes your weakness, voiding anything the crew prepared for you. |
| Blob Spore Health | 40 | 20 | Blob spores should be pretty weak since they're filled with gas, and they are quite strong. |
| Blob spore cooldown | 8 seconds | 4 seconds | Compensates for the above. |
| Blob zombie player control | Yes | Only possible if done by a player-controlled blob spore | Player-controlled zombies are a little crazy on top of the blobbernauts. Do the distributed neurons strain if you want that. | 
| Blobbernaut Cost | 40 | 70 | Blobbernauts are player controlled tanks. 40 way too cheap for the craziness they can do. |
| Blobbernaut health | 200 | 250 | To compensate for the added cost. |
| Blobbernaut reagent inject amount | 20 | 5 | Injecting 20 reagents per hit is insane.  |

## Why It's Good For The Game

Security (and generally most crew weapons) have received several nerfs over the years compared to /tg/, meanwhile blob has received straight buffs. Given that blob is extremely rare, I don't think people submitting PRs to remove/nerf weapons/equipment are thinking of blob when they make the PRs.

## Changelog

:cl: BurgerBB
balance: Nerfs Blob
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
