### PR TITLE
Mouseover Highlights for Handheld Objects

### DIFF
--- a/modular_zubbers/code/modules/mouseover/highlights.dm
+++ b/modular_zubbers/code/modules/mouseover/highlights.dm
@@ -152,3 +152,11 @@
 		refresh_mouseover_highlight_timer(current_atom, object)
 
 	. = ..()
+
+
+/datum/preference/toggle/item_outlines/apply_to_client(client/client, value)
+	. = ..()
+	if(value == FALSE)
+		client.mouseover = FALSE
+	else
+		client.mouseover = TRUE

--- a/modular_zubbers/code/modules/mouseover/highlights.dm
+++ b/modular_zubbers/code/modules/mouseover/highlights.dm
@@ -25,7 +25,7 @@
 	. = ..()
 /mob/Login()
 	. = ..()
-	client?.new_mouseover_callback()
+	client?.delete_mouseover_images()
 
 /client/proc/refresh_mouseover_highlight_timer(atom/movable/current_atom, object)
 
@@ -41,11 +41,11 @@
 	)
 
 /client/proc/delete_mouseover_images()
-	QDEL_NULL(current_highlight_atom)
+//	QDEL_NULL(current_highlight_atom)
 	images -= current_highlight
 	qdel(current_highlight)
 	current_highlight = null
-//			current_highlight_atom = null
+	current_highlight_atom = null
 //	deltimer(mouseover_refresh_timer)
 //	mouseover_refresh_timer = null
 // Main body of work happens in this proc.

--- a/modular_zubbers/code/modules/mouseover/highlights.dm
+++ b/modular_zubbers/code/modules/mouseover/highlights.dm
@@ -99,7 +99,7 @@
 		list(
 			type = "drop_shadow",
 			color = mouseover_rainbow ? rgb(rand(0,255),rand(0,255),rand(0,255)) : "#0082c6",
-			size = 4,
+			size = 1,
 			offset = 2, x = 0, y = 0
 		)
 	)

--- a/modular_zubbers/code/modules/mouseover/highlights.dm
+++ b/modular_zubbers/code/modules/mouseover/highlights.dm
@@ -1,0 +1,154 @@
+/client/
+	//MOUSEOVER THINGS
+	var/datum/callback/mouseover_callback   // Cached callback, see /client/New()
+	var/obj/mouseover_highlight_dummy       // Dummy atom to hold the appearance of our highlighted atom, see comments in /client/proc/refresh_mouseover_highlight.
+	var/datum/weakref/current_highlight_atom      // Current weakref to highlighted atom, used for checking if we're mousing over the same atom repeatedly.
+	var/image/current_highlight             // Current dummy image holding our highlight.
+
+	var/mouseover_refresh_timer             // Holds an ID to the timer used to update the mouseover highlight.
+	var/last_mouseover_params               // Stores mouse/keyboard params as of last mouseover, to check for shift being held.
+	var/last_mouseover_highlight_time       // Stores last world.time we mouseover'd, to prevent it happening more than once per world.tick_lag.
+	var/mouseover
+	var/mouseover_rainbow
+// Making these procs systematic in view of a future where we have a
+// proper system for queuing/caching/updating vis contents cleanly.
+#define add_vis_contents(A, B)    A.vis_contents |= (B)
+#define remove_vis_contents(A, B) A.vis_contents -= (B)
+#define clear_vis_contents(A)     A.vis_contents.Cut()
+#define set_vis_contents(A, B)    A.vis_contents = (B)
+/client/proc/new_mouseover_callback()
+	mouseover = TRUE
+	mouseover_rainbow = TRUE
+	return mouseover_callback = CALLBACK(src, PROC_REF(refresh_mouseover_highlight_timer))
+/client/New()
+	new_mouseover_callback()
+	. = ..()
+/mob/Login()
+	. = ..()
+	client?.new_mouseover_callback()
+
+/client/proc/refresh_mouseover_highlight_timer(atom/movable/current_atom, object)
+
+	animate(
+		mouseover_highlight_dummy,
+		pixel_y = 0,
+		pixel_x = 0,
+		pixel_w = 0,
+		pixel_z = 0,
+		time = 0.5 SECONDS,
+		easing = BACK_EASING,
+		alpha = 0,
+	)
+
+/client/proc/delete_mouseover_images()
+	QDEL_NULL(current_highlight_atom)
+	images -= current_highlight
+	qdel(current_highlight)
+	current_highlight = null
+//			current_highlight_atom = null
+//	deltimer(mouseover_refresh_timer)
+//	mouseover_refresh_timer = null
+// Main body of work happens in this proc.
+/client/proc/refresh_mouseover_highlight(object, params, check_adjacency = FALSE)
+
+	if(!mouseover)
+		return FALSE
+	// Verify if we should be showing a highlight at all.
+	if(!istype(object, /atom/movable) || istype(object, /mob) || istype(object, /obj/structure) || (check_adjacency && !mob.Adjacent(object)))
+		return FALSE
+//	var/list/modifiers = params2list(params)
+	var/atom/movable/AM = object
+	if(get_dist(mob, object) > 1 || AM.anchored)
+		return FALSE
+
+	// Generate our dummy objects if they got nulled/discarded.
+	if(!current_highlight)
+		current_highlight = new /image
+		current_highlight.appearance_flags |= (KEEP_TOGETHER|RESET_COLOR)
+		images += current_highlight
+	if(!mouseover_highlight_dummy)
+		mouseover_highlight_dummy = new
+
+	// Copy over the atom's appearance to our holder object.
+	// client.images does not respect pixel offsets for images, but vis contents does,
+	// and images have vis contents - so we throw a null image into client.images, then
+	// throw a holder object with the appearance of the mouse-overed atom into its vis contents.
+	mouseover_highlight_dummy.appearance = AM
+	mouseover_highlight_dummy.name = ""
+	mouseover_highlight_dummy.verbs.Cut()
+	mouseover_highlight_dummy.vis_flags |= VIS_INHERIT_ID
+	mouseover_highlight_dummy.dir = AM.dir
+	mouseover_highlight_dummy.transform = AM.transform
+
+	// For some reason you need to explicitly zero the pixel offsets of the holder object
+	// or anything with a pixel offset will not line up with the highlight. Thanks DM.
+	mouseover_highlight_dummy.pixel_x = 0
+	mouseover_highlight_dummy.pixel_y = 0
+	mouseover_highlight_dummy.pixel_w = 0
+	mouseover_highlight_dummy.pixel_z = 0
+
+	// Replane to be over the UI, make sure it can't block clicks, and set its outline.
+	mouseover_highlight_dummy.mouse_opacity = 0
+	mouseover_highlight_dummy.layer = ABOVE_HUD_PLANE
+	mouseover_highlight_dummy.plane = BALLOON_CHAT_PLANE
+	mouseover_highlight_dummy.alpha = 255
+	mouseover_highlight_dummy.appearance_flags |= (KEEP_TOGETHER|RESET_COLOR)
+	mouseover_highlight_dummy.add_filter(
+		"drop",
+		1,
+		list(
+			type = "drop_shadow",
+			color = mouseover_rainbow ? rgb(rand(0,255),rand(0,255),rand(0,255)) : "#0082c6",
+			size = 4,
+			offset = 2, x = 0, y = 0
+		)
+	)
+	animate(mouseover_highlight_dummy, pixel_y = 24, time = 0.5 SECONDS, easing = ELASTIC_EASING, alpha = 180, maptext_y = 24)
+
+
+	// Replanes the overlays to avoid explicit plane/layer setting (such as
+	// computer overlays) interfering with the ordering of the highlight.
+/* 	if(length(mouseover_highlight_dummy.overlays))
+		var/list/replaned_overlays
+		for(var/thing in mouseover_highlight_dummy.overlays)
+			var/mutable_appearance/MA = new(thing)
+			MA.plane = ABOVE_HUD_PLANE
+			MA.layer = ABOVE_ALL_MOB_LAYER
+			LAZYADD(replaned_overlays, MA)
+		mouseover_highlight_dummy.overlays = replaned_overlays
+	if(length(mouseover_highlight_dummy.underlays))
+		var/list/replaned_underlays
+		for(var/thing in mouseover_highlight_dummy.underlays)
+			var/mutable_appearance/MA = new(thing)
+			MA.plane = ABOVE_HUD_PLANE
+			MA.layer = ABOVE_ALL_MOB_LAYER
+			LAZYADD(replaned_underlays, MA)
+		mouseover_highlight_dummy.underlays = replaned_underlays */
+	mouseover_highlight_dummy.maptext_width = 128
+	mouseover_highlight_dummy.maptext_x = -48
+	mouseover_highlight_dummy.maptext = MAPTEXT_PIXELLARI(AM)
+	// Finally update our highlight's vis contents and location .
+	clear_vis_contents(current_highlight)
+	add_vis_contents(current_highlight, mouseover_highlight_dummy)
+	current_highlight.loc = object
+	current_highlight_atom = WEAKREF(AM)
+
+	// Keep track our params so the update ticker knows if we were holding shift or not.
+	last_mouseover_params = params
+
+	return TRUE
+
+// Simple hooks to catch the client mouseover/mouseleave events and start our highlight timer as needed.
+/client/MouseEntered(object, location, control, params)
+	if(world.time > last_mouseover_highlight_time && refresh_mouseover_highlight(object, params, check_adjacency = TRUE) && !mouseover_refresh_timer)
+		last_mouseover_highlight_time = world.time
+		mouseover_refresh_timer = addtimer(mouseover_callback, 1 SECONDS, (TIMER_OVERRIDE | TIMER_UNIQUE | TIMER_STOPPABLE))
+	. = ..()
+/client/MouseExited(object, location, control, params)
+	var/initalpha = initial(mouseover_highlight_dummy.alpha)
+	var/atom/movable/current_atom = current_highlight_atom?.resolve()
+	if(current_atom != object && mouseover_highlight_dummy)
+		animate(mouseover_highlight_dummy, pixel_y = 0, time = 0.2 SECONDS, easing = BOUNCE_EASING, alpha = initalpha)
+		refresh_mouseover_highlight_timer(current_atom, object)
+
+	. = ..()

--- a/modular_zubbers/code/modules/mouseover/highlights.dm
+++ b/modular_zubbers/code/modules/mouseover/highlights.dm
@@ -105,28 +105,9 @@
 	)
 	animate(mouseover_highlight_dummy, pixel_y = 24, time = 0.5 SECONDS, easing = ELASTIC_EASING, alpha = 180, maptext_y = 24)
 
-
-	// Replanes the overlays to avoid explicit plane/layer setting (such as
-	// computer overlays) interfering with the ordering of the highlight.
-/* 	if(length(mouseover_highlight_dummy.overlays))
-		var/list/replaned_overlays
-		for(var/thing in mouseover_highlight_dummy.overlays)
-			var/mutable_appearance/MA = new(thing)
-			MA.plane = ABOVE_HUD_PLANE
-			MA.layer = ABOVE_ALL_MOB_LAYER
-			LAZYADD(replaned_overlays, MA)
-		mouseover_highlight_dummy.overlays = replaned_overlays
-	if(length(mouseover_highlight_dummy.underlays))
-		var/list/replaned_underlays
-		for(var/thing in mouseover_highlight_dummy.underlays)
-			var/mutable_appearance/MA = new(thing)
-			MA.plane = ABOVE_HUD_PLANE
-			MA.layer = ABOVE_ALL_MOB_LAYER
-			LAZYADD(replaned_underlays, MA)
-		mouseover_highlight_dummy.underlays = replaned_underlays */
 	mouseover_highlight_dummy.maptext_width = 128
 	mouseover_highlight_dummy.maptext_x = -48
-	mouseover_highlight_dummy.maptext = MAPTEXT_PIXELLARI(AM)
+	mouseover_highlight_dummy.maptext = MAPTEXT_SPESSFONT(AM)
 	// Finally update our highlight's vis contents and location .
 	clear_vis_contents(current_highlight)
 	add_vis_contents(current_highlight, mouseover_highlight_dummy)
@@ -148,7 +129,7 @@
 	var/initalpha = initial(mouseover_highlight_dummy.alpha)
 	var/atom/movable/current_atom = current_highlight_atom?.resolve()
 	if(current_atom != object && mouseover_highlight_dummy)
-		animate(mouseover_highlight_dummy, pixel_y = 0, time = 0.2 SECONDS, easing = BOUNCE_EASING, alpha = initalpha)
+		animate(mouseover_highlight_dummy, pixel_y = 0, time = 0.2 SECONDS, easing = ELASTIC_EASING, alpha = initalpha)
 		refresh_mouseover_highlight_timer(current_atom, object)
 
 	. = ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8000,6 +8000,7 @@
 #include "modular_zubbers\code\modules\mod\mod_theme.dm"
 #include "modular_zubbers\code\modules\mod\mod_types.dm"
 #include "modular_zubbers\code\modules\modular_computers\file_system\programs\minesweeper.dm"
+#include "modular_zubbers\code\modules\mouseover\highlights.dm"
 #include "modular_zubbers\code\modules\opposing_force\code\items.dm"
 #include "modular_zubbers\code\modules\opposing_force\code\equipment\antagonist_powers.dm"
 #include "modular_zubbers\code\modules\pai\ghost_pai.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This adds a feature to mouseover events, it creates a clientside image to represent what you currently mouseover. This is to supplement the screentips and the tooltips at the bottom left, it is intended to make things feel more fluid in game. 

https://github.com/Bubberstation/Bubberstation/assets/77420409/51d6cceb-4398-4d30-8789-73a539c77837
VVVV- looks like this right now -VVVV
https://github.com/Bubberstation/Bubberstation/assets/77420409/debacb47-d46e-4c39-bfe3-d38569383003



<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

Accessibility, primarily. Should let you know what exactly you are clicking on without actually clicking on said thing. Lets you see things in rubbish piles easier, for precision clicking. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Mouse-over highlights to world objects. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
