### PR TITLE
Changes where Goblin Gas is outputted in the RBMK2

### DIFF
--- a/modular_zubbers/code/game/machinery/burger_reactor/reactor_processing.dm
+++ b/modular_zubbers/code/game/machinery/burger_reactor/reactor_processing.dm
@@ -58,7 +58,7 @@
 			var/temperature_mod = last_power_generation >= max_power_generation ? 4 : 1
 			consumed_mix.assert_gas(/datum/gas/goblin)
 			consumed_mix.gases[/datum/gas/goblin][MOLES] += last_tritium_consumption*4
-			consumed_mix.temperature += (temperature_mod-rand())*8 + (16000/our_heat_capacity)*(overclocked ? 2 : 1)*power_efficiency*temperature_mod*0.25
+			consumed_mix.temperature += (temperature_mod-rand())*8 + (16000/our_heat_capacity)*(overclocked ? 2 : 1)*power_efficiency*temperature_mod*0.5
 			consumed_mix.temperature = clamp(consumed_mix.temperature,5,0xFFFFFF)
 
 		if(rod_mix_pressure >= stored_rod.pressure_limit*(1 + rand()*0.25)) //Pressure friction penalty.

--- a/modular_zubbers/code/game/machinery/burger_reactor/reactor_processing.dm
+++ b/modular_zubbers/code/game/machinery/burger_reactor/reactor_processing.dm
@@ -56,11 +56,11 @@
 		var/our_heat_capacity = consumed_mix.heat_capacity()
 		if(our_heat_capacity > 0)
 			var/temperature_mod = last_power_generation >= max_power_generation ? 4 : 1
-			consumed_mix.temperature += (temperature_mod-rand())*8 + (16000/our_heat_capacity)*(overclocked ? 2 : 1)*power_efficiency*temperature_mod
+			consumed_mix.temperature += (temperature_mod-rand())*8 + (16000/our_heat_capacity)*(overclocked ? 2 : 1)*power_efficiency*temperature_mod*0.25
 			consumed_mix.temperature = clamp(consumed_mix.temperature,5,0xFFFFFF)
 
 		if(rod_mix_pressure >= stored_rod.pressure_limit*(1 + rand()*0.25)) //Pressure friction penalty.
-			rod_mix.temperature += (min(rod_mix_pressure/stored_rod.pressure_limit,4) - 1) * (3/rod_mix_heat_capacity) * 0.25
+			rod_mix.temperature += (min(rod_mix_pressure/stored_rod.pressure_limit,4) - 1) * (3/rod_mix_heat_capacity)
 			rod_mix.temperature = clamp(rod_mix.temperature,5,0xFFFFFF)
 		if(last_tritium_consumption > 0)
 			consumed_mix.assert_gas(/datum/gas/goblin)

--- a/modular_zubbers/code/game/machinery/burger_reactor/reactor_processing.dm
+++ b/modular_zubbers/code/game/machinery/burger_reactor/reactor_processing.dm
@@ -56,15 +56,14 @@
 		var/our_heat_capacity = consumed_mix.heat_capacity()
 		if(our_heat_capacity > 0)
 			var/temperature_mod = last_power_generation >= max_power_generation ? 4 : 1
+			consumed_mix.assert_gas(/datum/gas/goblin)
+			consumed_mix.gases[/datum/gas/goblin][MOLES] += last_tritium_consumption*4
 			consumed_mix.temperature += (temperature_mod-rand())*8 + (16000/our_heat_capacity)*(overclocked ? 2 : 1)*power_efficiency*temperature_mod*0.25
 			consumed_mix.temperature = clamp(consumed_mix.temperature,5,0xFFFFFF)
 
 		if(rod_mix_pressure >= stored_rod.pressure_limit*(1 + rand()*0.25)) //Pressure friction penalty.
 			rod_mix.temperature += (min(rod_mix_pressure/stored_rod.pressure_limit,4) - 1) * (3/rod_mix_heat_capacity)
 			rod_mix.temperature = clamp(rod_mix.temperature,5,0xFFFFFF)
-		if(last_tritium_consumption > 0)
-			consumed_mix.assert_gas(/datum/gas/goblin)
-			consumed_mix.gases[/datum/gas/goblin][MOLES] += last_tritium_consumption*4
 
 	else
 		toggle_active(null,FALSE)

--- a/modular_zubbers/code/game/machinery/burger_reactor/reactor_processing.dm
+++ b/modular_zubbers/code/game/machinery/burger_reactor/reactor_processing.dm
@@ -60,11 +60,11 @@
 			consumed_mix.temperature = clamp(consumed_mix.temperature,5,0xFFFFFF)
 
 		if(rod_mix_pressure >= stored_rod.pressure_limit*(1 + rand()*0.25)) //Pressure friction penalty.
-			rod_mix.temperature += (min(rod_mix_pressure/stored_rod.pressure_limit,4) - 1) * (3/rod_mix_heat_capacity)
+			rod_mix.temperature += (min(rod_mix_pressure/stored_rod.pressure_limit,4) - 1) * (3/rod_mix_heat_capacity) * 0.25
 			rod_mix.temperature = clamp(rod_mix.temperature,5,0xFFFFFF)
 		if(last_tritium_consumption > 0)
-			rod_mix.assert_gas(/datum/gas/goblin)
-			rod_mix.gases[/datum/gas/goblin][MOLES] += last_tritium_consumption*4
+			consumed_mix.assert_gas(/datum/gas/goblin)
+			consumed_mix.gases[/datum/gas/goblin][MOLES] += last_tritium_consumption*4
 
 	else
 		toggle_active(null,FALSE)


### PR DESCRIPTION
## About The Pull Request

Goblin Gas is outputted in the RBMK's buffer gasses instead of the rod itself.
Reduces buffer gas temperature gain by ~50%.

## Why It's Good For The Game

People weren't really harvesting the Goblin Gas because it involves shutting off the reactor and removing the rod itself. To make it less tedious to extract, it is outputted directly in the air.

Buffer gas temperature gain was reduced by 50% to compensate for the extra extremely hot air exhaust.

## Changelog

:cl: BurgerBB
balance: Goblin Gas is outputted in the RBMK's buffer gasses instead of the rod itself. Reduces buffer gas temperature gain by ~50%.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
