### PR TITLE
[Non-Modular] Readied up players are now visible to everyone

### DIFF
--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -42,8 +42,9 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 		. += "Time To Start: SOON"
 
 	. += "Players: [LAZYLEN(GLOB.clients)]"
+	. += "Players Ready: [SSticker.totalPlayersReady]" //Bubberstation edit
 	if(client.holder)
-		. += "Players Ready: [SSticker.totalPlayersReady]"
+		// . += "Players Ready: [SSticker.totalPlayersReady]" Bubberstation edit
 		. += "Admins Ready: [SSticker.total_admins_ready] / [length(GLOB.admins)]"
 
 #define SERVER_HOPPER_TRAIT "server_hopper"


### PR DESCRIPTION
## About The Pull Request

Makes readied up players visible to everyone

## Why It's Good For The Game

Mob mentality. 

![image](https://github.com/Bubberstation/Bubberstation/assets/95130227/856fbd6d-4272-477e-853d-7c635f158286)

## Changelog

:cl:
qol: Readied up players aren't just visible to admins anymore
/:cl:

