### PR TITLE
[DAUNTLESS] Adds syndicate access module for cyborgs, Removes duplicate air alarm

### DIFF
--- a/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_dauntless.dmm
+++ b/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_dauntless.dmm
@@ -3205,7 +3205,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/dark,
-/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/textured,
 /area/ruin/space/has_grav/bubbers/dauntless/sci/robotics)
 "rO" = (

--- a/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_dauntless.dmm
+++ b/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_dauntless.dmm
@@ -5785,6 +5785,9 @@
 /obj/structure/table,
 /obj/effect/turf_decal/tile/dark_red/fourcorners,
 /obj/item/mmi/posibrain,
+/obj/item/borg/upgrade/dauntless,
+/obj/item/borg/upgrade/dauntless,
+/obj/item/borg/upgrade/dauntless,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bubbers/dauntless/sci/robotics)
 "Ej" = (

--- a/modular_zubbers/maps/offstation/dauntless/robot.dm
+++ b/modular_zubbers/maps/offstation/dauntless/robot.dm
@@ -1,0 +1,19 @@
+/obj/item/borg/upgrade/dauntless
+	name = "Syndicate cyborg access override"
+	desc = "Makes any model of cyborg appear as a syndicate cyborg to syndicate targetting systems, additionally giving them access to syndicate airlocks. \
+	\n\nFOR OPERATIVES: Handle with extreme care to prevent rogue cyborgs on your designated ship/station"
+
+	// It is not module specific
+	one_use = TRUE
+
+/obj/item/borg/upgrade/dauntless/action(mob/living/silicon/robot/R, user)
+	. = ..()
+	// Turns out this is all you need for access to the doors. See code\game\machinery\_machinery.dm
+	R.faction += ROLE_SYNDICATE
+	to_chat(T, span_alert("Additional access detected!"))
+	to_chat(user, span_warning("The cyborg whirrs a bit as additional access levels are added."))
+
+
+/obj/item/borg/upgrade/dauntless/deactivate(mob/living/silicon/robot/R, user)
+	. = ..()
+	R.faction = initial(R.faction)

--- a/modular_zubbers/maps/offstation/dauntless/robot.dm
+++ b/modular_zubbers/maps/offstation/dauntless/robot.dm
@@ -10,7 +10,7 @@
 	. = ..()
 	// Turns out this is all you need for access to the doors. See code\game\machinery\_machinery.dm
 	R.faction += ROLE_SYNDICATE
-	to_chat(T, span_alert("Additional access detected!"))
+	to_chat(R, span_alert("Additional access detected!"))
 	to_chat(user, span_warning("The cyborg whirrs a bit as additional access levels are added."))
 
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8073,6 +8073,7 @@
 #include "modular_zubbers\maps\offstation\dauntless\ID_trims.dm"
 #include "modular_zubbers\maps\offstation\dauntless\laws.dm"
 #include "modular_zubbers\maps\offstation\dauntless\mob_spawns.dm"
+#include "modular_zubbers\maps\offstation\dauntless\robot.dm"
 #include "modular_zubbers\master_files\code\modules\client\preferences\obscurity_examine.dm"
 #include "modular_zubbers\master_files\code\modules\research\designs\biogenerator_designs.dm"
 #include "modular_zubbers\master_files\code\modules\research\designs\weapon_designs.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a (So far - To be made much cooler soonish) limited supply of 3 syndicate access modules to the dauntless. When inserted, these make any cyborg able to use syndicate machinery (Including airlocks). Also makes turrets not shoot said cyborgs.

Additionally removes the duplicate air alarm in robotics

## Why It's Good For The Game

Cyborgs on the dauntless are tedious with half assed access. This fixes it

## Changelog
:cl:
add: Syndicate access modules for cyborgs
add: 3 Syndicate access modules aboard the Dauntless
fix: Removed duplicate air alarm in Dauntless robotics
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
