### PR TITLE
[Modular] Removes multiple secure tech boards from the research tree (Makes them orderable)

### DIFF
--- a/modular_zubbers/code/modules/cargo/packs/tech.dm
+++ b/modular_zubbers/code/modules/cargo/packs/tech.dm
@@ -1,0 +1,14 @@
+/datum/supply_pack/science/secure_tech
+	name = "Secure Tech Replacement"
+	desc = "Lost your secure tech storage? Here's some replacements!"
+	cost = CARGO_CRATE_VALUE * 15 //4200
+	access = ACCESS_RD
+	contains = list(
+		/obj/item/circuitboard/computer/aiupload,
+		/obj/item/circuitboard/computer/borgupload,
+		/obj/item/circuitboard/computer/communications,
+		/datum/design/board/apc_control,
+		/obj/item/circuitboard/computer/mecha_control,
+		/datum/design/board/robocontrol
+	)
+

--- a/modular_zubbers/code/modules/cargo/packs/tech.dm
+++ b/modular_zubbers/code/modules/cargo/packs/tech.dm
@@ -7,8 +7,8 @@
 		/obj/item/circuitboard/computer/aiupload,
 		/obj/item/circuitboard/computer/borgupload,
 		/obj/item/circuitboard/computer/communications,
-		/datum/design/board/apc_control,
+		/obj/item/circuitboard/computer/apc_control,
 		/obj/item/circuitboard/computer/mecha_control,
-		/datum/design/board/robocontrol
+		/obj/item/circuitboard/computer/robotics
 	)
 

--- a/modular_zubbers/code/modules/cargo/packs/tech.dm
+++ b/modular_zubbers/code/modules/cargo/packs/tech.dm
@@ -1,7 +1,7 @@
 /datum/supply_pack/science/secure_tech
 	name = "Secure Tech Replacement"
 	desc = "Lost your secure tech storage? Here's some replacements!"
-	cost = CARGO_CRATE_VALUE * 15 //4200
+	cost = CARGO_CRATE_VALUE * 15 //3000
 	access = ACCESS_RD
 	contains = list(
 		/obj/item/circuitboard/computer/aiupload,

--- a/modular_zubbers/code/modules/research/techweb/all_nodes.dm
+++ b/modular_zubbers/code/modules/research/techweb/all_nodes.dm
@@ -47,6 +47,29 @@
 		"minesweeper",
 	)
 
+// Secure Tech Removals - Moved to cargo
+
+/datum/techweb_node/ai_basic/New()
+	. = ..()
+	design_ids -= "aiupload"
+
+/datum/techweb_node/cyborg/New()
+	. = ..()
+	design_ids -= "borgupload"
+	design_ids -= "robocontrol"
+
+/datum/techweb_node/mech/New()
+	. = ..()
+	design_ids -= "mechacontrol"
+
+/datum/techweb_node/comptech/New()
+	. = ..()
+	design_ids -= "comconsole"
+
+/datum/techweb_node/engineering/New()
+	. = ..()
+	design_ids -= "apc_control"
+
 /datum/techweb_node/weaponry/New()
 	design_ids += "wt550_ammo_rubber"
 	design_ids += "wt550_ammo_flathead"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7944,6 +7944,7 @@
 #include "modular_zubbers\code\modules\cargo\exports\weapons.dm"
 #include "modular_zubbers\code\modules\cargo\packs\security.dm"
 #include "modular_zubbers\code\modules\cargo\packs\service.dm"
+#include "modular_zubbers\code\modules\cargo\packs\tech.dm"
 #include "modular_zubbers\code\modules\clothing\gloves\syndicate.dm"
 #include "modular_zubbers\code\modules\clothing\head\helmet.dm"
 #include "modular_zubbers\code\modules\clothing\head\jobs.dm"


### PR DESCRIPTION
## About The Pull Request

What the title says. This removes these boards from the techweb:
- AI upload
- Cyborg upload
- APC control
- Communications
- Robotics Control
- Exosuit Control

Makes them into a 3000 cost supply pack

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

These are very heavy game-impacting boards and I feel they should have a level of scarcity and not be free printables from two departmental lathes- especially the uploads and communication console where you can deconstruct the computer to avoid someone tracking them with a GPS. You can order more through cargo, or use secure tech storage.

- Laws can still be modified by swiping on the physical AI or cyborg. Or you can order a crate.
- Communications has a board in tech storage and a board inside the bridge. You can also order a crate if you need another one.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: removes multiple secure tech boards from the tech web and makes them orderable via a supply pack
/:cl:

