### PR TITLE
adds cameras to dauntless

### DIFF
--- a/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_dauntless.dmm
+++ b/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_dauntless.dmm
@@ -1447,9 +1447,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/camera/autoname/directional/east{
-	network = list("dauntless")
-	},
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bubbers/dauntless/med/treatment)
 "iF" = (
@@ -1917,9 +1914,6 @@
 "lk" = (
 /obj/structure/closet/secure_closet/interdynefob/brig_officer_locker,
 /obj/structure/sign/flag/syndicate/directional/north,
-/obj/machinery/camera/autoname/directional/east{
-	network = list("dauntless")
-	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bubbers/dauntless/sec/officer)
 "ln" = (
@@ -4894,9 +4888,6 @@
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
-/obj/machinery/camera/autoname/directional/south{
-	network = list("dauntless")
-	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bubbers/dauntless/sec/holding)
 "zM" = (
@@ -6078,9 +6069,6 @@
 /area/ruin/space/has_grav/bubbers/dauntless/med/treatment)
 "Fb" = (
 /obj/machinery/atmospherics/miner/oxygen,
-/obj/machinery/camera/autoname/directional/east{
-	network = list("dauntless")
-	},
 /turf/open/floor/engine/o2,
 /area/ruin/space/has_grav/bubbers/dauntless/engineering/turbine)
 "Fc" = (
@@ -8095,9 +8083,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/obj/machinery/camera/autoname/directional/west{
-	network = list("dauntless")
-	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/bubbers/dauntless/sci/xenobio)
 "Pf" = (
@@ -8592,9 +8577,6 @@
 /obj/structure/closet/crate/trashcart/laundry,
 /obj/effect/spawner/random/trash/janitor_supplies,
 /obj/item/mop,
-/obj/machinery/camera/autoname/directional/west{
-	network = list("dauntless")
-	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/bubbers/dauntless/sec/prison)
 "Rr" = (

--- a/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_dauntless.dmm
+++ b/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_dauntless.dmm
@@ -184,6 +184,9 @@
 /area/ruin/space/has_grav/bubbers/dauntless/sec/prison)
 "bd" = (
 /obj/effect/turf_decal/tile/dark_green/half,
+/obj/machinery/camera/autoname/directional/west{
+	network = list("dauntless")
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bubbers/dauntless/med/viro)
 "be" = (
@@ -401,7 +404,7 @@
 /area/ruin/space/has_grav/bubbers/dauntless/engineering/mining)
 "ck" = (
 /obj/machinery/computer/atmos_control/nocontrol/incinerator{
-	atmos_chambers = list("syndiship_turbine"="Dauntless Turbine")
+	atmos_chambers = list("syndiship_turbine" = "Dauntless Turbine")
 	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -459,6 +462,9 @@
 /obj/machinery/computer/crew/syndie{
 	dir = 8
 	},
+/obj/machinery/camera/autoname/directional/east{
+	network = list("dauntless")
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bubbers/dauntless/command/maa)
 "cD" = (
@@ -469,6 +475,9 @@
 	dir = 8
 	},
 /obj/structure/bed/dogbed,
+/obj/machinery/camera/autoname/directional/north{
+	network = list("dauntless")
+	},
 /mob/living/basic/pet/fox{
 	name = "Rhials";
 	faction = list("neutral","Syndicate")
@@ -843,6 +852,9 @@
 /area/ruin/space/has_grav/bubbers/dauntless/cargo)
 "eZ" = (
 /obj/machinery/iv_drip,
+/obj/machinery/camera/autoname/directional/east{
+	network = list("dauntless")
+	},
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/bubbers/dauntless/med/treatment)
 "fa" = (
@@ -874,6 +886,12 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bubbers/dauntless/command/bridge)
+"fi" = (
+/obj/machinery/camera/autoname/directional/south{
+	network = list("dauntless")
+	},
+/turf/open/floor/iron/dark/small,
+/area/ruin/space/has_grav/bubbers/dauntless/sec/prison)
 "fj" = (
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 4
@@ -1432,6 +1450,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/camera/autoname/directional/east{
+	network = list("dauntless")
+	},
 /turf/open/floor/iron/white/diagonal,
 /area/ruin/space/has_grav/bubbers/dauntless/med/treatment)
 "iF" = (
@@ -1630,6 +1651,9 @@
 /obj/item/pen{
 	pixel_x = -2;
 	pixel_y = 5
+	},
+/obj/machinery/camera/autoname/directional/east{
+	network = list("dauntless")
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bubbers/dauntless/command/bridge)
@@ -1896,6 +1920,9 @@
 "lk" = (
 /obj/structure/closet/secure_closet/interdynefob/brig_officer_locker,
 /obj/structure/sign/flag/syndicate/directional/north,
+/obj/machinery/camera/autoname/directional/east{
+	network = list("dauntless")
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bubbers/dauntless/sec/officer)
 "ln" = (
@@ -1959,6 +1986,9 @@
 /obj/machinery/computer/monitor,
 /obj/effect/turf_decal/siding/dark{
 	dir = 5
+	},
+/obj/machinery/camera/autoname/directional/east{
+	network = list("dauntless")
 	},
 /turf/open/floor/iron/dark/diagonal,
 /area/ruin/space/has_grav/bubbers/dauntless/engineering)
@@ -2172,9 +2202,6 @@
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/bubbers/dauntless/med/viro)
 "mW" = (
-/obj/machinery/computer/security{
-	dir = 8
-	},
 /obj/machinery/button/door/directional/south{
 	name = "Window Shutters";
 	id = "maa_w1";
@@ -2192,10 +2219,16 @@
 	default_raw_text = "<h1>DS2 Long-Term Brig Report</h1><p>The SSV Dauntless has successfully relocated itself near active Nanotrasen installations. Engine shutdown in progress...</p><p>The Syndicate has been capable of kidnapping a few key NT workers of various hierarchy levels. It is your task to interrogate, question and break their wills in order to find more intel on our enemy, Nanotrasen.</p><p>Stay winning.";
 	name = "paper- 'SSV Dauntless Long-Term Brig Report'"
 	},
+/obj/machinery/computer/security/dauntless{
+	dir = 8
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bubbers/dauntless/command/maa)
 "mZ" = (
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/camera/autoname/directional/west{
+	network = list("dauntless")
+	},
 /turf/open/floor/carpet/royalblack,
 /area/ruin/space/has_grav/bubbers/dauntless/service/dorms)
 "na" = (
@@ -2317,6 +2350,9 @@
 	},
 /obj/item/crowbar/power/syndicate,
 /obj/structure/cable,
+/obj/machinery/camera/autoname/directional/east{
+	network = list("dauntless")
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bubbers/dauntless/sec/armory)
 "nP" = (
@@ -2404,6 +2440,9 @@
 /area/ruin/space/has_grav/bubbers/dauntless/sec/armory)
 "nZ" = (
 /obj/effect/turf_decal/trimline/dark_green/corner,
+/obj/machinery/camera/autoname/directional/west{
+	network = list("dauntless")
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bubbers/dauntless/service)
 "oa" = (
@@ -2942,6 +2981,9 @@
 	pixel_y = 10;
 	pixel_x = 4
 	},
+/obj/machinery/camera/autoname/directional/south{
+	network = list("dauntless")
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/bubbers/dauntless/sci/rnd)
 "qE" = (
@@ -3135,11 +3177,11 @@
 "rA" = (
 /obj/structure/window/reinforced/survival_pod/spawner/directional/south,
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/effect/turf_decal/tile/dark_red/full,
 /mob/living/carbon/human/species/monkey{
 	ai_controller = null;
 	faction = list("neutral","Syndicate")
 	},
-/obj/effect/turf_decal/tile/dark_red/full,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/bubbers/dauntless/med/viro)
 "rC" = (
@@ -3336,6 +3378,9 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
+/obj/machinery/camera/autoname/directional/west{
+	network = list("dauntless")
+	},
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/bubbers/dauntless/med/chem)
 "sC" = (
@@ -3430,6 +3475,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/camera/autoname/directional/east{
+	network = list("dauntless")
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bubbers/dauntless/cargo)
 "sX" = (
@@ -3624,6 +3672,9 @@
 /obj/machinery/microwave{
 	pixel_y = 8
 	},
+/obj/machinery/camera/autoname/directional/west{
+	network = list("dauntless")
+	},
 /turf/open/floor/iron/kitchen{
 	dir = 4
 	},
@@ -3691,6 +3742,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
+	},
+/obj/machinery/camera/autoname/directional/east{
+	network = list("dauntless")
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bubbers/dauntless/sec/prison/holding)
@@ -4255,6 +4309,9 @@
 	pixel_y = 5
 	},
 /obj/effect/turf_decal/bot_white,
+/obj/machinery/camera/autoname/directional/west{
+	network = list("dauntless")
+	},
 /turf/open/floor/iron/white/textured_large,
 /area/ruin/space/has_grav/bubbers/dauntless/sec/prison)
 "xf" = (
@@ -4326,6 +4383,9 @@
 /area/ruin/space/has_grav/bubbers/dauntless/med/chem)
 "xt" = (
 /obj/structure/cable,
+/obj/machinery/camera/autoname/directional/south{
+	network = list("dauntless")
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bubbers/dauntless/engineering/mining)
 "xu" = (
@@ -4497,6 +4557,9 @@
 "yp" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/radio/headset/interdyne,
+/obj/machinery/camera/autoname/directional/west{
+	network = list("dauntless")
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bubbers/dauntless/command/bridge)
 "yt" = (
@@ -4840,6 +4903,9 @@
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
 /obj/item/restraints/handcuffs,
+/obj/machinery/camera/autoname/directional/south{
+	network = list("dauntless")
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bubbers/dauntless/sec/holding)
 "zM" = (
@@ -5139,6 +5205,9 @@
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/camera/autoname/directional/west{
+	network = list("dauntless")
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bubbers/dauntless/sec/interrogation)
 "Bk" = (
@@ -5546,6 +5615,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/camera/autoname/directional/west{
+	network = list("dauntless")
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bubbers/dauntless/sec/holding)
 "De" = (
@@ -5700,12 +5772,12 @@
 /area/ruin/space/has_grav/bubbers/dauntless/sec/holding)
 "DR" = (
 /obj/structure/bed/dogbed,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/light_switch/directional/north,
 /mob/living/simple_animal/pet/cat/kitten{
 	desc = "What appears to be a single-celled organism with a pronounced low-level intelligence.";
 	name = "Murder-Mittens"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/light_switch/directional/north,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bubbers/dauntless/command/maa)
 "DT" = (
@@ -5942,12 +6014,12 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/bubbers/dauntless/sci/xenobio)
 "EK" = (
-/obj/machinery/computer/security{
-	dir = 4
-	},
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
 /obj/structure/window/reinforced/survival_pod/spawner/directional/east{
 	dir = 9
+	},
+/obj/machinery/computer/security/dauntless{
+	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bubbers/dauntless/sec/holding)
@@ -5987,6 +6059,9 @@
 /area/ruin/space/has_grav/bubbers/dauntless/service/dorms)
 "ER" = (
 /obj/machinery/atmospherics/miner/nitrogen,
+/obj/machinery/camera/autoname/directional/east{
+	network = list("dauntless")
+	},
 /turf/open/floor/engine/n2,
 /area/ruin/space/has_grav/bubbers/dauntless/engineering/turbine)
 "ES" = (
@@ -6012,6 +6087,9 @@
 /area/ruin/space/has_grav/bubbers/dauntless/med/treatment)
 "Fb" = (
 /obj/machinery/atmospherics/miner/oxygen,
+/obj/machinery/camera/autoname/directional/east{
+	network = list("dauntless")
+	},
 /turf/open/floor/engine/o2,
 /area/ruin/space/has_grav/bubbers/dauntless/engineering/turbine)
 "Fc" = (
@@ -6125,6 +6203,9 @@
 	dir = 10
 	},
 /obj/structure/cable,
+/obj/machinery/camera/autoname/directional/west{
+	network = list("dauntless")
+	},
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/bubbers/dauntless/service/diner)
 "Fv" = (
@@ -6277,6 +6358,9 @@
 	},
 /obj/effect/turf_decal/tile/dark_blue{
 	dir = 4
+	},
+/obj/machinery/camera/autoname/directional/east{
+	network = list("dauntless")
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bubbers/dauntless/command/vault)
@@ -6592,6 +6676,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/camera/autoname/directional/south{
+	network = list("dauntless")
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bubbers/dauntless/command/bridge)
@@ -7154,10 +7241,10 @@
 /turf/open/floor/wood/large,
 /area/ruin/space/has_grav/bubbers/dauntless/command/liason)
 "Kp" = (
+/obj/structure/bed/dogbed,
 /mob/living/basic/lizard/tegu{
 	name = "Entertains-The-Hostages"
 	},
-/obj/structure/bed/dogbed,
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bubbers/dauntless/sec/prison)
 "Kq" = (
@@ -7380,6 +7467,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
+	},
+/obj/machinery/camera/autoname/directional/west{
+	network = list("dauntless")
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bubbers/dauntless/sci/robotics)
@@ -7638,6 +7728,19 @@
 "MB" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/bubbers/dauntless/command/maa)
+"MF" = (
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/camera/autoname/directional/east{
+	network = list("dauntless")
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/bubbers/dauntless/service)
 "MI" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/structure/cable,
@@ -7677,6 +7780,9 @@
 /obj/structure/punching_bag,
 /obj/item/reagent_containers/cup/glass/waterbottle{
 	pixel_x = 11
+	},
+/obj/machinery/camera/autoname/directional/south{
+	network = list("dauntless")
 	},
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bubbers/dauntless/sec/prison)
@@ -7826,10 +7932,10 @@
 "NV" = (
 /obj/structure/window/reinforced/survival_pod/spawner/directional/south,
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/effect/turf_decal/tile/dark_red/full,
 /mob/living/carbon/human/species/lizard/ashwalker{
 	faction = list("neutral","Syndicate")
 	},
-/obj/effect/turf_decal/tile/dark_red/full,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/bubbers/dauntless/med/viro)
 "NY" = (
@@ -7904,6 +8010,9 @@
 "Ou" = (
 /obj/structure/chair/sofa/corp/corner,
 /obj/machinery/light_switch/directional/north,
+/obj/machinery/camera/autoname/directional/east{
+	network = list("dauntless")
+	},
 /turf/open/floor/carpet/royalblack,
 /area/ruin/space/has_grav/bubbers/dauntless/sec/prison/rec)
 "Ov" = (
@@ -8111,6 +8220,21 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bubbers/dauntless/sec/brig)
+"PM" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/autoname/directional/south{
+	network = list("dauntless")
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/bubbers/dauntless/cargo)
 "PN" = (
 /obj/effect/turf_decal/tile/dark_green/half{
 	dir = 1
@@ -8407,6 +8531,9 @@
 /area/ruin/space/has_grav/bubbers/dauntless/service/sauna)
 "Rb" = (
 /obj/effect/mob_spawn/ghost_role/human/dauntless/syndicate/service,
+/obj/machinery/camera/autoname/directional/west{
+	network = list("dauntless")
+	},
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/bubbers/dauntless/service/freezer)
 "Rc" = (
@@ -8477,6 +8604,9 @@
 /obj/structure/closet/crate/trashcart/laundry,
 /obj/effect/spawner/random/trash/janitor_supplies,
 /obj/item/mop,
+/obj/machinery/camera/autoname/directional/west{
+	network = list("dauntless")
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/bubbers/dauntless/sec/prison)
 "Rr" = (
@@ -8773,6 +8903,9 @@
 	name = "dat fukken disk"
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/camera/autoname/directional/north{
+	network = list("dauntless")
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bubbers/dauntless/cargo)
 "SL" = (
@@ -9234,6 +9367,9 @@
 /area/ruin/space/has_grav/bubbers/dauntless/service)
 "UV" = (
 /obj/machinery/atmospherics/miner/plasma,
+/obj/machinery/camera/autoname/directional/east{
+	network = list("dauntless")
+	},
 /turf/open/floor/engine/plasma,
 /area/ruin/space/has_grav/bubbers/dauntless/engineering/turbine)
 "UW" = (
@@ -9633,6 +9769,9 @@
 	name = "admiral's fountain pen";
 	pixel_y = 5
 	},
+/obj/machinery/camera/autoname/directional/south{
+	network = list("dauntless")
+	},
 /turf/open/floor/carpet/red,
 /area/ruin/space/has_grav/bubbers/dauntless/command/admiral)
 "XL" = (
@@ -9648,8 +9787,20 @@
 	initialize_directions = 4;
 	dir = 4
 	},
+/obj/machinery/camera/autoname/directional/north{
+	network = list("dauntless")
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bubbers/dauntless/engineering/turbine)
+"XP" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/camera/autoname/directional/west{
+	network = list("dauntless")
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/bubbers/dauntless/service)
 "XS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9771,6 +9922,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/machinery/camera/autoname/directional/south{
+	network = list("dauntless")
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bubbers/dauntless/engineering/turbine)
@@ -9947,6 +10101,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/autoname/directional/east{
+	network = list("dauntless")
+	},
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/bubbers/dauntless/med/storage)
 "ZM" = (
@@ -9975,6 +10132,9 @@
 /area/ruin/space/has_grav/bubbers/dauntless/engineering/turbine)
 "ZR" = (
 /obj/machinery/seed_extractor,
+/obj/machinery/camera/autoname/directional/north{
+	network = list("dauntless")
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/bubbers/dauntless/service/hydro)
 "ZS" = (
@@ -9985,6 +10145,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/camera/autoname/directional/east{
+	network = list("dauntless")
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bubbers/dauntless/service)
 "ZW" = (
@@ -10977,7 +11140,7 @@ tB
 tB
 tB
 tB
-xc
+PM
 JV
 JV
 JV
@@ -11464,7 +11627,7 @@ aP
 Lf
 mQ
 az
-kZ
+XP
 mQ
 LG
 mQ
@@ -12183,7 +12346,7 @@ EN
 EN
 EN
 EN
-EN
+MF
 jr
 EN
 lH
@@ -12408,7 +12571,7 @@ Zp
 ei
 Qg
 cT
-Qg
+fi
 Pi
 FN
 gi

--- a/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_dauntless.dmm
+++ b/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_dauntless.dmm
@@ -852,9 +852,6 @@
 /area/ruin/space/has_grav/bubbers/dauntless/cargo)
 "eZ" = (
 /obj/machinery/iv_drip,
-/obj/machinery/camera/autoname/directional/east{
-	network = list("dauntless")
-	},
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/bubbers/dauntless/med/treatment)
 "fa" = (
@@ -3378,9 +3375,6 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
-/obj/machinery/camera/autoname/directional/west{
-	network = list("dauntless")
-	},
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/bubbers/dauntless/med/chem)
 "sC" = (
@@ -3475,9 +3469,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/camera/autoname/directional/east{
-	network = list("dauntless")
-	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bubbers/dauntless/cargo)
 "sX" = (
@@ -5793,6 +5784,9 @@
 /obj/item/book/manual/wiki/chemistry{
 	pixel_x = -4
 	},
+/obj/machinery/camera/autoname/directional/south{
+	network = list("dauntless")
+	},
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/bubbers/dauntless/med/chem)
 "DW" = (
@@ -6059,9 +6053,6 @@
 /area/ruin/space/has_grav/bubbers/dauntless/service/dorms)
 "ER" = (
 /obj/machinery/atmospherics/miner/nitrogen,
-/obj/machinery/camera/autoname/directional/east{
-	network = list("dauntless")
-	},
 /turf/open/floor/engine/n2,
 /area/ruin/space/has_grav/bubbers/dauntless/engineering/turbine)
 "ES" = (
@@ -8531,9 +8522,6 @@
 /area/ruin/space/has_grav/bubbers/dauntless/service/sauna)
 "Rb" = (
 /obj/effect/mob_spawn/ghost_role/human/dauntless/syndicate/service,
-/obj/machinery/camera/autoname/directional/west{
-	network = list("dauntless")
-	},
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/bubbers/dauntless/service/freezer)
 "Rc" = (
@@ -9367,9 +9355,6 @@
 /area/ruin/space/has_grav/bubbers/dauntless/service)
 "UV" = (
 /obj/machinery/atmospherics/miner/plasma,
-/obj/machinery/camera/autoname/directional/east{
-	network = list("dauntless")
-	},
 /turf/open/floor/engine/plasma,
 /area/ruin/space/has_grav/bubbers/dauntless/engineering/turbine)
 "UW" = (
@@ -10101,9 +10086,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera/autoname/directional/east{
-	network = list("dauntless")
-	},
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/bubbers/dauntless/med/storage)
 "ZM" = (

--- a/modular_zubbers/maps/offstation/dauntless/camera.dm
+++ b/modular_zubbers/maps/offstation/dauntless/camera.dm
@@ -1,0 +1,5 @@
+/obj/machinery/computer/security/dauntless
+	name = "dauntless camera console"
+	desc = "Used to access the various cameras on the Dauntless."
+	network = list("dauntless")
+	circuit = null

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8078,6 +8078,7 @@
 #include "modular_zubbers\maps\biodome\vendcation.dm"
 #include "modular_zubbers\maps\biodome\weapons.dm"
 #include "modular_zubbers\maps\offstation\dauntless\areas.dm"
+#include "modular_zubbers\maps\offstation\dauntless\camera.dm"
 #include "modular_zubbers\maps\offstation\dauntless\code.dm"
 #include "modular_zubbers\maps\offstation\dauntless\gasminers.dm"
 #include "modular_zubbers\maps\offstation\dauntless\ID_trims.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://github.com/Bubberstation/Bubberstation/assets/10399117/d1e69f13-0fd6-4d4a-8fc8-7ad218593cc6)
Adds cameras to Dauntless, as well as replacing the camera consoles in security with ones that actually use the dauntless camera network.
## Why It's Good For The Game

Having three different consoles for watching the station was a little strange, especially since the prison has no cameras to watch the prisoners with. For the sake of realism, I put cameras all over the station for the bored Master of Arms to scroll tthrough

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Dauntless now has a proper cameranet, and consoles to monitor it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
