### PR TITLE
Blueshield Part II: The MOD suit awakening (+ buffs security modsuit armor)

### DIFF
--- a/modular_skyrat/modules/blueshield/code/closet.dm
+++ b/modular_skyrat/modules/blueshield/code/closet.dm
@@ -31,4 +31,4 @@
 	new /obj/item/storage/medkit/tactical/blueshield(src)
 	new /obj/item/storage/toolbox/guncase/skyrat/carwo_large_case/wt550(src) // Bubberstation Edit
 	new /obj/item/storage/bag/garment/blueshield(src)
-	// new /obj/item/mod/control/pre_equipped/blueshield(src) Bubberstation Removal
+	new /obj/item/mod/control/pre_equipped/blueshield(src)

--- a/modular_skyrat/modules/blueshield/code/modsuit/mod_theme.dm
+++ b/modular_skyrat/modules/blueshield/code/modsuit/mod_theme.dm
@@ -15,7 +15,7 @@
 	atom_flags = PREVENT_CONTENTS_EXPLOSION_1
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
-	complexity_max = DEFAULT_MAX_COMPLEXITY // Bubberstation edit: original 18
+	complexity_max = DEFAULT_MAX_COMPLEXITY // Bubberstation edit, original: DEFAULT_MAX_COMPLEXITY + 3
 	slowdown_inactive = 0.75
 	slowdown_active = 0.25
 	allowed_suit_storage = list(

--- a/modular_skyrat/modules/blueshield/code/modsuit/mod_theme.dm
+++ b/modular_skyrat/modules/blueshield/code/modsuit/mod_theme.dm
@@ -15,7 +15,7 @@
 	atom_flags = PREVENT_CONTENTS_EXPLOSION_1
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
-	complexity_max = DEFAULT_MAX_COMPLEXITY + 3
+	complexity_max = DEFAULT_MAX_COMPLEXITY // Bubberstation edit: original 18
 	slowdown_inactive = 0.75
 	slowdown_active = 0.25
 	allowed_suit_storage = list(

--- a/modular_skyrat/modules/blueshield/code/modsuit/mod_type.dm
+++ b/modular_skyrat/modules/blueshield/code/modsuit/mod_type.dm
@@ -8,10 +8,10 @@
 		/obj/item/mod/module/storage, // Bubberstation Edit - Original: Extended storage
 		/obj/item/mod/module/magnetic_harness,
 		/obj/item/mod/module/flashlight,
-		// /obj/item/mod/module/jetpack, // Bubberstation Removal
+		/obj/item/mod/module/jetpack,
 		// /obj/item/mod/module/projectile_dampener, Bubberstation Removal
 		/obj/item/mod/module/quick_carry,
 	)
-	/* default_pins = list( 			// Bubberstation Removal
+	default_pins = list(
 		/obj/item/mod/module/jetpack,
-	)*/
+	)

--- a/modular_skyrat/modules/blueshield/code/modsuit/mod_type.dm
+++ b/modular_skyrat/modules/blueshield/code/modsuit/mod_type.dm
@@ -3,15 +3,15 @@
 	icon = 'modular_skyrat/modules/blueshield/icons/praetorian.dmi'
 	icon_state = "praetorian-control"
 	theme = /datum/mod_theme/blueshield
-	applied_cell = /obj/item/stock_parts/cell/super
+	applied_cell = /obj/item/stock_parts/cell // Bubberstation Edit - Original: Super Cell
 	applied_modules = list(
-		/obj/item/mod/module/storage/large_capacity,
+		/obj/item/mod/module/storage, // Bubberstation Edit - Original: Extended storage
 		/obj/item/mod/module/magnetic_harness,
 		/obj/item/mod/module/flashlight,
-		/obj/item/mod/module/jetpack,
-		/obj/item/mod/module/projectile_dampener,
+		// /obj/item/mod/module/jetpack, // Bubberstation Removal
+		// /obj/item/mod/module/projectile_dampener, Bubberstation Removal
 		/obj/item/mod/module/quick_carry,
 	)
-	default_pins = list(
+	/* default_pins = list( 			// Bubberstation Removal
 		/obj/item/mod/module/jetpack,
-	)
+	)*/

--- a/modular_skyrat/modules/blueshield/code/modsuit/mod_type.dm
+++ b/modular_skyrat/modules/blueshield/code/modsuit/mod_type.dm
@@ -3,7 +3,7 @@
 	icon = 'modular_skyrat/modules/blueshield/icons/praetorian.dmi'
 	icon_state = "praetorian-control"
 	theme = /datum/mod_theme/blueshield
-	applied_cell = /obj/item/stock_parts/cell // Bubberstation Edit - Original: Super Cell
+	applied_cell = /obj/item/stock_parts/cell/high // Bubberstation Edit - Original: Super Cell
 	applied_modules = list(
 		/obj/item/mod/module/storage, // Bubberstation Edit - Original: Extended storage
 		/obj/item/mod/module/magnetic_harness,

--- a/modular_zubbers/code/datums/armor_overrides.dm
+++ b/modular_zubbers/code/datums/armor_overrides.dm
@@ -26,4 +26,4 @@
 	bio = 100
 	fire = 100
 	acid = 100
-	wound = 10
+	wound = 20

--- a/modular_zubbers/code/datums/armor_overrides.dm
+++ b/modular_zubbers/code/datums/armor_overrides.dm
@@ -1,0 +1,14 @@
+// Buffs security modsuit armor
+/datum/mod_theme/security
+	armor_type = /datum/armor/mod_theme_security
+
+/datum/armor/mod_theme_security
+	melee = 40
+	bullet = 30
+	laser = 30
+	energy = 40
+	bomb = 50
+	bio = 100
+	fire = 100
+	acid = 100
+	wound = 20

--- a/modular_zubbers/code/datums/armor_overrides.dm
+++ b/modular_zubbers/code/datums/armor_overrides.dm
@@ -18,7 +18,7 @@
 	armor_type = /datum/armor/mod_theme_blueshield
 
 /datum/armor/mod_theme_blueshield // Not really great for fighting.
-	melee = 30
+	melee = 40
 	bullet = 20
 	laser = 20
 	energy = 30

--- a/modular_zubbers/code/datums/armor_overrides.dm
+++ b/modular_zubbers/code/datums/armor_overrides.dm
@@ -11,4 +11,19 @@
 	bio = 100
 	fire = 100
 	acid = 100
-	wound = 20
+	wound = 10
+
+// Blueshield Armor
+/datum/mod_theme/blueshield
+	armor_type = /datum/armor/mod_theme_blueshield
+
+/datum/armor/mod_theme_blueshield // Not really great for fighting.
+	melee = 30
+	bullet = 20
+	laser = 20
+	energy = 30
+	bomb = 50
+	bio = 100
+	fire = 100
+	acid = 100
+	wound = 10

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7940,6 +7940,7 @@
 #include "modular_zubbers\code\_globalvars\lists\maintenance_loot_uncommon.dm"
 #include "modular_zubbers\code\_globalvars\lists\~maintenance_loot.dm"
 #include "modular_zubbers\code\controllers\subsystem\air.dm"
+#include "modular_zubbers\code\datums\armor_overrides.dm"
 #include "modular_zubbers\code\datums\department_security.dm"
 #include "modular_zubbers\code\datums\ert.dm"
 #include "modular_zubbers\code\datums\ai_laws\laws_antagonistic.dm"


### PR DESCRIPTION
## About The Pull Request

Security modsuit armor got buffed to be identical to the blueshield armor.

![image](https://github.com/Bubberstation/Bubberstation/assets/95130227/8d2557db-66e0-4a5e-ae20-7ddab19fb599)

Removes the jetpack, upgraded cell, and projectile dampener from the blueshield modsuit and gives it back. Also sets its complexity to default capacity (15 complexity)

## Why It's Good For The Game

Upon review of the security modsuit, it's extremely weak and barely touched when all the other armor overrides buff everything else significantly. There should be a little more of a fighting chance inside space for security.

Also the blueshield modsuit is a great feature, it just needed some balancing to focus it more around saving people from space. It's stripped down roundstart, but it has 15 complexity.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: The Sharkening
balance: Nerfs the blueshield modsuit and gives it back
balance: Security modsuit buffed (	melee = 40, bullet = 30, laser = 30, energy = 40, bomb = 50, bio = 100, fire = 100, acid = 100, wound = 10
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
