### PR TITLE
Reverts brainwashing disk obfuscation

### DIFF
--- a/code/modules/surgery/advanced/brainwashing.dm
+++ b/code/modules/surgery/advanced/brainwashing.dm
@@ -1,10 +1,7 @@
 /obj/item/disk/surgery/brainwashing
-	name = "Surgery Disk" //SKYRAT EDIT: Formerly "Brainwashing Surgery Disk" //Finally I can upload the funny surgery disk without letting everyone in the room know about it!
-	desc = "The disk provides instructions on some kind of surgery, but the label has been scratched off..." //Skyrat edit: Moved to Special Desc. 
+	name = "Brainwashing Surgery Disk"
+	desc =  "The disk provides instructions on how to impress an order on a brain, making it the primary objective of the patient."
 	surgeries = list(/datum/surgery/advanced/brainwashing)
-	special_desc_requirement = EXAMINE_CHECK_JOB // Skyrat edit
-	special_desc_jobs = list("Medical Doctor, Chief Medical Officer, Roboticist") //SKYRAT CHANGE //You mean to tell me the roles that get this role-exclusive item know what it does?
-	special_desc = "The disk provides instructions on how to impress an order on a brain, making it the primary objective of the patient."
 
 /datum/surgery/advanced/brainwashing
 	name = "Brainwashing"

--- a/code/modules/surgery/advanced/brainwashing.dm
+++ b/code/modules/surgery/advanced/brainwashing.dm
@@ -1,6 +1,6 @@
 /obj/item/disk/surgery/brainwashing
 	name = "Brainwashing Surgery Disk"
-	desc =  "The disk provides instructions on how to impress an order on a brain, making it the primary objective of the patient."
+	desc = "The disk provides instructions on how to impress an order on a brain, making it the primary objective of the patient."
 	surgeries = list(/datum/surgery/advanced/brainwashing)
 
 /datum/surgery/advanced/brainwashing


### PR DESCRIPTION
## About The Pull Request

This reverts the skyrat edits to the brainwashing disk. While it would be smart to make brainwashing show up on health scanners, it's not an actual trauma and would require some refactoring which I'd rather just do upstream.

## Why It's Good For The Game

This thing is insanely powerful once things start rolling and it should be 100 percent obvious to anyone who catches a glimpse at the disk to be more mindful around operating tables. You should not be capable of uploading it into a table in the middle of medical without nearby people noticing.

![image](https://github.com/Bubberstation/Bubberstation/assets/95130227/0a445000-75e3-4522-ba19-0b99cd531345)


## Changelog

:cl: The Sharkening
balance: The brainwashing surgery disk is no longer obfuscated
/:cl:
