### PR TITLE
Remove bow and arrow crafting recipe*

### DIFF
--- a/code/modules/projectiles/guns/ballistic/bows/bow_arrows.dm
+++ b/code/modules/projectiles/guns/ballistic/bows/bow_arrows.dm
@@ -29,11 +29,11 @@
 	desc = "Ow! Get it out of me!"
 	icon = 'icons/obj/weapons/bows/arrows.dmi'
 	icon_state = "arrow_projectile"
-	damage = 50
+	damage = 30 //BUBBER EDIT ORIGINAL 50
 	speed = 1
 	range = 25
 	embedding = list(
-		embed_chance = 90,
+		embed_chance = 50, //BUBBER EDIT ORIGINAL 90
 		fall_chance = 2,
 		jostle_chance = 2,
 		ignore_throwspeed_threshold = TRUE,

--- a/code/modules/projectiles/guns/ballistic/bows/bow_arrows.dm
+++ b/code/modules/projectiles/guns/ballistic/bows/bow_arrows.dm
@@ -33,7 +33,7 @@
 	speed = 1
 	range = 25
 	embedding = list(
-		embed_chance = 50, //BUBBER EDIT ORIGINAL 90
+		embed_chance = 90
 		fall_chance = 2,
 		jostle_chance = 2,
 		ignore_throwspeed_threshold = TRUE,

--- a/code/modules/projectiles/guns/ballistic/bows/bow_arrows.dm
+++ b/code/modules/projectiles/guns/ballistic/bows/bow_arrows.dm
@@ -29,7 +29,7 @@
 	desc = "Ow! Get it out of me!"
 	icon = 'icons/obj/weapons/bows/arrows.dmi'
 	icon_state = "arrow_projectile"
-	damage = 30 //BUBBER EDIT ORIGINAL 50
+	damage = 50
 	speed = 1
 	range = 25
 	embedding = list(

--- a/modular_skyrat/modules/tribal_extended/code/recipes.dm
+++ b/modular_skyrat/modules/tribal_extended/code/recipes.dm
@@ -5,8 +5,8 @@
 	time = 5 SECONDS
 	category = CAT_MISC
 
-/datum/crafting_recipe/wood_bow
-	name = "Wooden Bow"
+/*/datum/crafting_recipe/wood_bow BUBBER EDIT: TG BUFFED THE ARROW UPSTREAM ON https://github.com/tgstation/tgstation/pull/74811 AND THIS IS A SKYRAT THING
+	name = "Wooden Bow" // THIS CAUSE WAY TOO MUCH DAMAGE AT THE MOMENT SO WE ARE NOT MAKING IT EASILY OBTAINABLE, HOWEVER, ALL OTHER ASHWALKER RECIPE INHERE WILL STILL BE AVAILABLE
 	result = /obj/item/gun/ballistic/bow/longbow
 	reqs = list(
 		/obj/item/stack/sheet/mineral/wood = 25,
@@ -15,7 +15,7 @@
 	time = 30 SECONDS
 	category = CAT_WEAPON_RANGED
 
-/datum/crafting_recipe/pipebow
+/datum/crafting_recipe/pipebow //REFER TO BLACKSMITHING FOR NOW
 	name = "Pipe Bow"
 	result = /obj/item/gun/ballistic/bow/tribalbow/pipe
 	reqs = list(
@@ -36,7 +36,7 @@
 	)
 	time = 1.5 SECONDS
 	category = CAT_WEAPON_AMMO
-
+*/
 /datum/crafting_recipe/bone_arrow
 	name = "Bone Arrow"
 	result = /obj/item/ammo_casing/arrow/bone


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As it turns out, 7 months ago, TG had 50 damages.
What does this mean?
Skyrat was never made in mind that arrows deal straight up 50 damages, and neither was TG( to a degree, given you can't really just craft arrow there as far as my VSC searching skill goes) 

Let's [Review](https://github.com/tgstation/tgstation/pull/74811) this is where the gitblame was linked to so that's as good as it get
What in god name is this shit
![image](https://github.com/Bubberstation/Bubberstation/assets/99981766/8902b58d-9b6a-4422-b62b-5d21dae444ad)

![image](https://github.com/Bubberstation/Bubberstation/assets/99981766/3b9f258b-82c8-4a53-afbf-d466a201cf34)

I never thought I'd have to nerf down a feature I didn't even know exist until someone did something funny with it


and who do we blame for this?
Well skyrat of coruse
![image](https://github.com/Bubberstation/Bubberstation/assets/99981766/b5b5672a-a84a-48f0-a3d4-071f8f7df217)

This PR removes* the recipe to craft bow and arrows for most  easily obtainable on station materials, making it more or less a blacksmithing only item or restricted to ashwalkers/icecat entirely
The goal here is not to remove the bow and arrows, but make it harder to obtain and utilise as station-side. 

Wooden Bow recipe is now disabled
Pipe Bow recipe is now disabled
Arrow* recipe is now disabled and can only be obtained via blacksmithing
You are still able to make the bone bow and arrows/ashen arrows, as it was always intended as a lavaland item, and I don't see an issue with if the crew went down and put the efforts to obtain those item that they should be punished for it.

Standard arrow damage reduced to 30
Standard arrow embed reduced to 50% instead of 90%
This is a really half-hazard solution and I know someone will come up with a better one later, but leaving it like this does not help anyone except the people who uses it

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game
Skyrat and TG literally could not had anticipated a combination of both of their PR coming to fuck each other up,  and it's now our problem, In a perfect world, bubberstation does not have issues with ballistic weapon because most of them don't deal enough damage to send you back to the lobby screen. 
Unfortunately, this is not a perfect world, we're going to be repeating that mistake a few more time and I'm sure of it. 
However, everytime, someone has to come up and deal with it. This is one of those time

