### PR TITLE
Removes Explosive Lemon Grudgecode because I died to it once.

### DIFF
--- a/code/modules/hydroponics/unique_plant_genes.dm
+++ b/code/modules/hydroponics/unique_plant_genes.dm
@@ -609,7 +609,7 @@
 		our_plant.color = COLOR_RED
 
 	playsound(our_plant.drop_location(), 'sound/weapons/armbomb.ogg', 75, TRUE, -3)
-	addtimer(CALLBACK(src, PROC_REF(detonate), our_plant), rand(4 SECONDS, 12 SECONDS)) //BUBBERSTATION CHANGE: 1 TO 6 INTO 4 TO 12.
+	addtimer(CALLBACK(src, PROC_REF(detonate), our_plant), rand(4 SECONDS, 10 SECONDS)) //BUBBERSTATION CHANGE: 1 TO 6 INTO 4 TO 10.
 
 /datum/plant_gene/trait/bomb_plant/potency_based/detonate(obj/item/our_plant)
 	var/obj/item/seeds/our_seed = our_plant.get_plant_seed()

--- a/code/modules/hydroponics/unique_plant_genes.dm
+++ b/code/modules/hydroponics/unique_plant_genes.dm
@@ -609,7 +609,7 @@
 		our_plant.color = COLOR_RED
 
 	playsound(our_plant.drop_location(), 'sound/weapons/armbomb.ogg', 75, TRUE, -3)
-	addtimer(CALLBACK(src, PROC_REF(detonate), our_plant), rand(1 SECONDS, 6 SECONDS))
+	addtimer(CALLBACK(src, PROC_REF(detonate), our_plant), rand(4 SECONDS, 12 SECONDS)) //BUBBERSTATION CHANGE: 1 TO 6 INTO 4 TO 12.
 
 /datum/plant_gene/trait/bomb_plant/potency_based/detonate(obj/item/our_plant)
 	var/obj/item/seeds/our_seed = our_plant.get_plant_seed()


### PR DESCRIPTION

## About The Pull Request

Explosive lemon detonation time changed from 1 to 6 seconds to 4 to 12 seconds.

## Why It's Good For The Game

Absolutely insane decision by the person who decided to make the minimum time 1 second considering that activating a lemon grenade does not enable throw mode (despite literally every other grenade doing this) and expecting people to take less than 1 second to realize this and fight with the controls with an average ping of 100ms.

PR makes the change much more reasonable by adding a minimum time of 4 to 12 seconds so they're not too powerful in combat but can still be used viably without c*ders fucking over players.

## Changelog

:cl: BurgerBB
balance: Explosive lemon detonation time changed from 1 to 6 seconds to 4 to 12 seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
