### PR TITLE
Contractor TC reversion

### DIFF
--- a/modular_skyrat/modules/contractor/code/datums/midround/outfit.dm
+++ b/modular_skyrat/modules/contractor/code/datums/midround/outfit.dm
@@ -22,7 +22,7 @@
 	)
 
 	implants = list(
-		/obj/item/implant/uplink,
+		/obj/item/implant/uplink/precharged/bonus,
 	)
 
 	id_trim = /datum/id_trim/chameleon/contractor

--- a/modular_skyrat/modules/skyrat-uplinks/code/uplink_implant.dm
+++ b/modular_skyrat/modules/skyrat-uplinks/code/uplink_implant.dm
@@ -1,0 +1,2 @@
+/obj/item/implant/uplink/precharged/bonus
+	starting_tc = TELECRYSTALS_PRELOADED_IMPLANT + 3

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7807,6 +7807,7 @@
 #include "modular_skyrat\modules\shotgunrebalance\code\shotgun.dm"
 #include "modular_skyrat\modules\SiliconQoL\code\_onclick.dm"
 #include "modular_skyrat\modules\SiliconQoL\code\robotic_factory.dm"
+#include "modular_skyrat\modules\skyrat-uplinks\code\uplink_implant.dm"
 #include "modular_skyrat\modules\skyrat-uplinks\code\categories\bundles.dm"
 #include "modular_skyrat\modules\skyrat-uplinks\code\categories\dangerous.dm"
 #include "modular_skyrat\modules\skyrat-uplinks\code\categories\device_tools.dm"


### PR DESCRIPTION
resolves #823 
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR directly reverts: https://github.com/Skyrat-SS13/Skyrat-tg/pull/23582
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

Skyrat removed the Contractor's TC for no good reason quite a while ago, i had assumed someone else was working on a reversion so never bothered till now. But honestly the reasons Skyrat gave for removing them were rather stupid. Contractors as a whole have never been the greatest of threats, with even the most robust contractors usually dying to a concentrated and coordinated attack from security. In recent weeks with contractors almost always instantly losing to security it has become clear that the complete removal of TC is not a good idea for an antagonist that almost always loses a proper, on station, fight with security anyway.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Syndicate command has realised that giving their extremely obvious Contractors no TC is a bad idea, thus deciding to give them their 13TC back.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
