### PR TITLE
Makes the SAD need synthflesh for monkeys

### DIFF
--- a/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
+++ b/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
@@ -63,13 +63,17 @@
 /obj/machinery/self_actualization_device/Initialize(mapload)
 	. = ..()
 	update_appearance()
+	create_reagents(300, OPENCONTAINER) // BUBBER EDIT
+	AddComponent(/datum/component/plumbing/simple_demand) // BUBBER EDIT
 
 /obj/machinery/self_actualization_device/close_machine(atom/movable/target, density_to_set = TRUE)
 	..()
 	playsound(src, 'sound/machines/click.ogg', 50)
 	if(!occupant)
 		return FALSE
-	if(!ishuman(occupant))
+	if(!ishuman(occupant) || istype(occupant, /mob/living/carbon/human/species/monkey))// BUBBER EDIT BEGIN
+		say("Warning: Occupant lacks actualizing genes. Please insert synthflesh or select new user. ")
+		playsound(loc, 'sound/machines/chime.ogg', 30, FALSE) // BUBBER EDIT END
 		occupant.forceMove(drop_location())
 		set_occupant(null)
 		return FALSE
@@ -84,6 +88,10 @@
 	. = ..()
 	if(!powered() || !occupant || state_open)
 		return FALSE
+	if(!reagents.has_reagent(/datum/reagent/medicine/c2/synthflesh, 300)) // BUBBER EDIT BEGIN
+		audible_message(span_notice("The [src] buzzes."))
+		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, FALSE)
+		break // BUBBER EDIT END
 
 	to_chat(user, "You power on [src].")
 	addtimer(CALLBACK(src, PROC_REF(eject_new_you)), processing_time, TIMER_OVERRIDE|TIMER_UNIQUE)
@@ -152,7 +160,9 @@
 	else if (tgui_alert(occupant, "The SAD you are within is about to rejuvenate you, resetting your body to its default state (in character preferences). Do you consent?", "Rejuvenate", list("Yes", "No"), timeout = 10 SECONDS) != "Yes")
 		failure = TRUE // defaults to rejecting it unless specified otherwise
 		failure_text = "ERROR: Occupant genes have willfully rejected the procedure. You may try again if you think this was an error."
-
+	if(!reagents.remove_reagent(/datum/reagent/medicine/c2/synthflesh, 300)) // BUBBER EDIT BEGIN
+		failure = TRUE
+		failure_text = "ERROR: Occupant has not received enough Synthflesh to complete the NEW YOU PROCEDURE." // BUBBER EDIT END
 	if (failure)
 		say(failure_text)
 		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, FALSE)

--- a/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
+++ b/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
@@ -90,8 +90,8 @@
 		return FALSE
 	if(!reagents.has_reagent(/datum/reagent/medicine/c2/synthflesh, 300)) // BUBBER EDIT BEGIN
 		audible_message(span_notice("The [src] buzzes."))
-		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, FALSE)
-		break // BUBBER EDIT END
+		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, FALSE)// BUBBER EDIT END
+		return FALSE
 
 	to_chat(user, "You power on [src].")
 	addtimer(CALLBACK(src, PROC_REF(eject_new_you)), processing_time, TIMER_OVERRIDE|TIMER_UNIQUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If you're put in the manual transmission, you will learn the manual transmission. Makes it so you have to use synthflesh to SAD monkeys (typically brain transplants). 
You can't circumvent husks anymore, you need that synthflesh or you will be in a monkey body. 

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game
Makes circumventing medical by doing improvised cloning have a cost other than free. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: synthflesh is required for monkey conversion
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
