### PR TITLE
Revert announcement CSS back to TG

### DIFF
--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -1056,8 +1056,8 @@ em {
   border-bottom: 1px dashed #fff;
 }
 
+// BUBBER EDIT CHANGE BEGIN - Revert SR override to TG color scheme
 // SKYRAT EDIT CHANGE BEGIN - Remove neon colors, replaced with less saturated
-/*
 $alert-stripe-colors: (
   'default': #00283a,
   'green': #003d00,
@@ -1105,8 +1105,8 @@ $alert-subheader-header-colors: (
   'purple': #33d5ff,
   'grey': #33d5ff,
 );
-*/
 
+/*
 $alert-stripe-colors: (
   'default': #0e152c,
   'green': #0f2e0f,
@@ -1154,7 +1154,9 @@ $alert-subheader-header-colors: (
   'purple': #f7cfcf,
   'grey': #e9aa72,
 );
+*/
 // SKYRAT EDIT CHANGE END
+// BUBBER EDIT CHANGE END
 
 $border-width: 4;
 

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -984,8 +984,8 @@ h2.alert {
   border-bottom: 1px dashed #000;
 }
 
+// BUBBER EDIT CHANGE BEGIN - Revert SR override to TG color scheme
 // SKYRAT EDIT CHANGE BEGIN - Remove neon colors, replaced with less saturated
-/*
 $alert-stripe-colors: (
   'default': #b3bfff,
   'green': #adffad,
@@ -1033,8 +1033,8 @@ $alert-subheader-header-colors: (
   'purple': #002c85,
   'grey': #002c85,
 );
-*/
 
+/*
 $alert-stripe-colors: (
   'default': #c6ccec,
   'green': #ceebc2,
@@ -1082,7 +1082,9 @@ $alert-subheader-header-colors: (
   'purple': #991200,
   'grey': #002c85,
 );
+*/
 // SKYRAT EDIT CHANGE END
+// BUBBER EDIT CHANGE END
 
 $border-width: 4;
 


### PR DESCRIPTION
## About The Pull Request

Reverts the CSS styling for announcements back to TG/Effigy original as in https://github.com/tgstation/tgstation/pull/79071, https://github.com/tgstation/tgstation/pull/79236.

## Why It's Good For The Game

There's no technical need to override this, the announcements overhaul should be implemented as designed. Bubber doesn't need SR's override. 

## Changelog

:cl: LT3
code: Announcement CSS is reverted to TG default
/:cl: