### PR TITLE
Disables the Galactic Materials Market completely

### DIFF
--- a/code/modules/cargo/packs/imports.dm
+++ b/code/modules/cargo/packs/imports.dm
@@ -296,7 +296,7 @@
 	contains = list(/obj/item/reagent_containers/cup/glass/bottle/juice/dreadnog = 3)
 	crate_name = "dreadnog crate"
 
-/* BUBBER EDIT - No craftable slappy
+/* BUBBER EDIT - Removal Start
 /datum/supply_pack/imports/giant_wrench_parts
 	name = "Big Slappy parts"
 	desc = "Illegal Big Slappy parts. The fastest and statistically most dangerous wrench."
@@ -304,8 +304,8 @@
 	contraband = TRUE
 	contains = list(/obj/item/weaponcrafting/giant_wrench)
 	crate_name = "unknown parts crate"
-*/
-/datum/supply_pack/imports/materials_market
+
+/datum/supply_pack/imports/materials_market - RENABLE IF FIXED UPSTREAM
 	name = "Galactic Materials Market Crate"
 	desc = "A circuit board to build your own materials market for use by certified market traders. Warning: Losses are not covered by insurance."
 	cost = CARGO_CRATE_VALUE * 3
@@ -318,3 +318,4 @@
 	)
 	crate_name = "materials market crate"
 	crate_type = /obj/structure/closet/crate/cargo
+Removal End */

--- a/modular_zubbers/code/modules/cargo/packs/metalsheets.dm
+++ b/modular_zubbers/code/modules/cargo/packs/metalsheets.dm
@@ -1,0 +1,27 @@
+/datum/supply_pack/materials/glass50 // Introduced with the GMM disable. Delete this file when the GMM gets fixed.
+	name = "50 Glass Sheets"
+	desc = "Let some nice light in with fifty glass sheets!"
+	cost = CARGO_CRATE_VALUE * 2
+	contains = list(/obj/item/stack/sheet/glass/fifty)
+	crate_name = "glass sheets crate"
+
+/datum/supply_pack/materials/iron50
+	name = "50 Iron Sheets"
+	desc = "Any construction project begins with a good stack of fifty iron sheets!"
+	cost = CARGO_CRATE_VALUE * 2
+	contains = list(/obj/item/stack/sheet/iron/fifty)
+	crate_name = "iron sheets crate"
+
+/datum/supply_pack/materials/plasteel20
+	name = "20 Plasteel Sheets"
+	desc = "Reinforce the station's integrity with twenty plasteel sheets!"
+	cost = CARGO_CRATE_VALUE * 15
+	contains = list(/obj/item/stack/sheet/plasteel/twenty)
+	crate_name = "plasteel sheets crate"
+
+/datum/supply_pack/materials/plasteel50
+	name = "50 Plasteel Sheets"
+	desc = "For when you REALLY have to reinforce something."
+	cost = CARGO_CRATE_VALUE * 33
+	contains = list(/obj/item/stack/sheet/plasteel/fifty)
+	crate_name = "plasteel sheets crate"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8041,6 +8041,7 @@
 #include "modular_zubbers\code\modules\cargo\bounties\blacksmith.dm"
 #include "modular_zubbers\code\modules\cargo\exports\weapons.dm"
 #include "modular_zubbers\code\modules\cargo\packs\contraband.dm"
+#include "modular_zubbers\code\modules\cargo\packs\metalsheets.dm"
 #include "modular_zubbers\code\modules\cargo\packs\security.dm"
 #include "modular_zubbers\code\modules\cargo\packs\service.dm"
 #include "modular_zubbers\code\modules\clothing\gloves\syndicate.dm"


### PR DESCRIPTION
closes #789 

## About The Pull Request

Disables the GMM completely until TG gets around to fixing it. You can revert this when they maintain their code.

## Why It's Good For The Game

Because I don't want cargo to make 180 million credits

## Changelog

:cl: The Sharkening
add: Readds the ability to buy metal and glass
del: Removes the GMM from cargo due to infinite money.
/:cl: