### PR TITLE
Removes bulletproof armor from maintenance because I lived once.

### DIFF
--- a/modular_zubbers/code/_globalvars/lists/maintenance_loot_uncommon.dm
+++ b/modular_zubbers/code/_globalvars/lists/maintenance_loot_uncommon.dm
@@ -270,10 +270,8 @@ GLOBAL_LIST_INIT(uncommon_loot, list(//uncommon: useful items
 		/obj/item/clothing/gloves/cut = 25
 	) = 100,
 	list(
-		/obj/item/clothing/suit/armor/bulletproof/old = 5,
-		/obj/item/clothing/head/helmet/old = 10,
-		/obj/item/clothing/head/helmet/toggleable/justice = 3,
-		/obj/item/clothing/head/helmet/toggleable/justice/escape = 3
+		/obj/item/clothing/head/helmet/toggleable/justice = 1,
+		/obj/item/clothing/head/helmet/toggleable/justice/escape = 1
 	) = 20,
 	list(
 		/obj/item/clothing/head/utility/welding = 10,


### PR DESCRIPTION

## About The Pull Request

Bulletproof armor and helmets can no longer be found in maintenance. Exceptions apply to the justice/siren helmet.

## Why It's Good For The Game

There was a misunderstanding of what "old" meant as a subtype. It didn't mean the degrading variant, but rather just an old sprite of the armor.

## Changelog

:cl: BurgerBB
balance: Bulletproof armor and helmets can no longer be found in maintenance. Exceptions apply to the justice/siren helmet.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
