### PR TITLE
Removes the 100% energy reflect chance from Marked One armor and the 25% block chance from the Marked One sword because my attacks got blocked once.

### DIFF
--- a/modular_zubbers/modules/gladiator/code/game/objects/items/gladiator_items.dm
+++ b/modular_zubbers/modules/gladiator/code/game/objects/items/gladiator_items.dm
@@ -1,0 +1,16 @@
+/obj/structure/closet/crate/necropolis/gladiator/PopulateContents()
+	new /obj/item/claymore/dragonslayer(src)
+	new /obj/item/clothing/suit/hooded/berserker/gatsu(src)
+	new /obj/item/clothing/neck/warrior_cape(src)
+
+/obj/structure/closet/crate/necropolis/gladiator/crusher/PopulateContents()
+	new /obj/item/claymore/dragonslayer(src)
+	new /obj/item/clothing/suit/hooded/berserker/gatsu(src)
+	new /obj/item/clothing/neck/warrior_cape(src)
+	new /obj/item/crusher_trophy/gladiator(src)
+
+/obj/item/claymore/dragonslayer
+	block_chance = 0
+
+/obj/item/clothing/head/hooded/berserker/gatsu/IsReflect()
+	return FALSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8210,6 +8210,7 @@
 #include "modular_zubbers\modules\customization\modules\mob\dead\new_player\sprite_accessories\skrell_hair.dm"
 #include "modular_zubbers\modules\customization\modules\mob\living\carbon\human\species\akula.dm"
 #include "modular_zubbers\modules\emotes\code\emotes.dm"
+#include "modular_zubbers\modules\gladiator\code\game\objects\items\gladiator_items.dm"
 #include "modular_zubbers\modules\modular_items\code\cake_light.dm"
 #include "modular_zubbers\modules\modular_items\code\HoS_beacon.dm"
 #include "modular_zubbers\modules\modular_items\code\idmaco_donator.dm"


### PR DESCRIPTION
## About The Pull Request

- Removes annoying alternative and very loud sound from Gladiator loot.
- Dragonslayer/Marked One/Gladiator/Beserker sword now has a 0% block chance.
- Dragonslayer/Marked One/Gladiator/Beserker no longer has a 100% chance to reflect energy while beserking.

## Why It's Good For The Game

I always thought that the armor just had Anti-Magic, but the reality is that it's just the Immortality Talisman that had it and the Berserker armor actually had a 100% chance to reflect energy during Berserk on top of the sword that had a 25% chance to block. These are just extremely insane stats for a non-shield to have.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: BurgerBB
balance: Removes the 100% reflect energy chance from Marked One armor and the 25% block chance from the Marked One sword.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
