### PR TITLE
Disallows siphoning credits outside of station

### DIFF
--- a/code/game/machinery/bank_machine.dm
+++ b/code/game/machinery/bank_machine.dm
@@ -106,7 +106,7 @@
 	// BUBBER EDIT BEGIN: NO MORE SIPHONING
 	switch(action)
 		if("siphon")
-			if(is_centcom_level(src.z) || is_station_level(src.z))
+			if(is_station_level(src.z) || is_centcom_level(src.z))
 				say("Siphon of station credits has begun!")
 				start_siphon(ui.user)
 			else

--- a/code/game/machinery/bank_machine.dm
+++ b/code/game/machinery/bank_machine.dm
@@ -103,16 +103,20 @@
 	if(.)
 		return
 
+	// BUBBER EDIT BEGIN: NO MORE SIPHONING
 	switch(action)
 		if("siphon")
-			say("Siphon of station credits has begun!")
-			start_siphon(ui.user)
+			if(is_centcom_level(src.z) || is_station_level(src.z))
+				say("Siphon of station credits has begun!")
+				start_siphon(ui.user)
+			else
+				say("Error: Console not in reach of station, withdrawal cannot begin.")
 			. = TRUE
+	// BUBBER EDIT END
 		if("halt")
 			say("Station credit withdrawal halted.")
 			end_siphon()
 			. = TRUE
-
 /obj/machinery/computer/bank_machine/proc/end_siphon()
 	siphoning = FALSE
 	unauthorized = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See name

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

I'll admit, it was pretty funny seeing the dauntless drain the station dry. But this is one of the things that can be used to completely fuck over the station, with no counterplay. Imagine a funny little antagonist going to deep space with one of these. You'll never find them, and even if it were to have a gps signal by the time you were out to the location they could (And most like will) be long gone, or in a different ruin entirely.

This isn't even a salt PR I wasn't in the round, it didn't affect me directly. I am looking at this solely from the objective perspective of "This is really easy to exploit"

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Disallows siphoning credits outside of station
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
