### PR TITLE
Fixes a linter issue with the rbmk2

### DIFF
--- a/modular_zubbers/code/game/machinery/burger_reactor_sniffer/reactor_sniffer_processing.dm
+++ b/modular_zubbers/code/game/machinery/burger_reactor_sniffer/reactor_sniffer_processing.dm
@@ -10,7 +10,7 @@
 	for(var/obj/machinery/power/rbmk2/reactor as anything in linked_reactors)
 		if(!reactor.active)
 			continue
-		var/integrity_percent = reactor.atom_integrity/reactor.max_integrity
+		var/integrity_percent = reactor.get_integrity()/reactor.max_integrity
 		if(integrity_percent <= lowest_integrity_percent)
 			lowest_integrity_percent = integrity_percent
 			if(lowest_integrity_percent <= 0.8)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the linter issue for the rbmk2, there really should not be any functional changes due to this.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game
You really shouldn't have linter errors on master.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: /obj/machinery/rbmk2_sniffer/process() no longer checks private variable atom_jntegrity, instead it uses the function get_integrity. No functional changes except removing the error this caused.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
