### PR TITLE
Removes Burgerstation from being votable

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -77,7 +77,6 @@ endmap
 ##BUBBERSTATION MAPS##
 
 map burgerstation
-	votable
 endmap
 
 map ss13_construct


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes Burgerstation from being votable. Yes I know that this should just be a config option but this PR is basically written and official permission for me to disable the map.

## Why It's Good For The Game

I hate playing on my own map because it means there is a high chance that people will complain about it when something bad happens. It basically sours my mood for the round and makes it difficult to play. There are rounds where I just want to chill and relax but that isn't possible when people ICly and OOCly badmouth the map.

Burgerstation 2 is in development anyways and that will fix most issues that people have with the map and people can wait until then.

## Changelog

:cl: BurgerBB
del: Removes Burgerstation from being votable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
