### PR TITLE
Darkened character directory rows

### DIFF
--- a/tgui/packages/tgui/interfaces/ZubbersCharacterDirectory.js
+++ b/tgui/packages/tgui/interfaces/ZubbersCharacterDirectory.js
@@ -5,13 +5,13 @@ import { Window } from '../layouts';
 
 const erpTagColor = {
   'Unset': 'label',
-  'Yes - Dom': 'red',
-  'Yes - Sub': 'blue',
-  'Yes - Switch': 'yellow',
-  'Yes': 'yellow',
-  'Check OOC': 'black',
-  'Ask': 'black',
-  'No': 'black',
+  'Yes - Dom': '#570000',
+  'Yes - Sub': '#002B57',
+  'Yes - Switch': '#022E00',
+  'Yes': '#022E00',
+  'Check OOC': '#222222',
+  'Ask': '#222222',
+  'No': '#000000',
 };
 
 export const ZubbersCharacterDirectory = (props, context) => {


### PR DESCRIPTION
## About The Pull Request

Darkens the row colors on the character directory for better contrast with the white text, less searing of the eyes.

![image](https://github.com/Bubberstation/Bubberstation/assets/83487515/5fa389e2-428b-4309-a4b8-74c066e92c6a)

![image](https://github.com/Bubberstation/Bubberstation/assets/83487515/99e432f9-fedd-4feb-b010-d571bbb6f01a)

![image](https://github.com/Bubberstation/Bubberstation/assets/83487515/23738745-551f-4e09-8af7-4cdf9a0b9386)

## Changelog

None required, really.