### PR TITLE
Oops! Broke Job Estimation!

### DIFF
--- a/modular_zubbers/code/modules/job_estimation/code/dead.dm
+++ b/modular_zubbers/code/modules/job_estimation/code/dead.dm
@@ -37,7 +37,7 @@
 		var/datum/job/J = prefs?.get_highest_priority_job()
 		var/title = J?.title
 		//If a player does not have preferences (for some reason) or they don't want to be shown on the panel, continue
-		if(!J || (prefs.read_preference(/datum/preference/toggle/ready_job)))
+		if(!J || !(prefs.read_preference(/datum/preference/toggle/ready_job)))
 			continue
 		//If the readied player has selected a miscellaneous job (Assistant, or Prisoner), they shouldn't be displayed
 		if(title == JOB_ASSISTANT || title == JOB_PRISONER)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I accidentally removed an ! in the job estimation menu, meaning only people who switched it on actually showed on the menu.
Of course, people didn't know this, and didn't turn off their preference. This fixes that.

![image](https://github.com/Bubberstation/Bubberstation/assets/110273561/874af1cb-1af6-424a-8de3-6205a0d542ac)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game
Job estimation my beloved
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: ReturnToZender
fix: job estimation actually works again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
