### PR TITLE
Fixes NTR Locker Access

### DIFF
--- a/modular_zubbers/code/modules/jobs/job_types/nanotrasen_consultant.dm
+++ b/modular_zubbers/code/modules/jobs/job_types/nanotrasen_consultant.dm
@@ -15,3 +15,7 @@
 	req_access = list()
 	req_one_access = list(ACCESS_CENT_GENERAL) //Make it so the Consultant can access their own locker with these changes
 //Making the Nanotrasen Consultant have a silver ID, so they cannot have all access by default.
+
+/obj/structure/closet/secure_closet/nanotrasen_consultant // Ditto of the previous for skyrat automapper placed lockers.
+	req_access = list()
+	req_one_access = list(ACCESS_CENT_GENERAL)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Skyrat/TG maps / automapper don't use our subtype, and don't get our access changes. This fixes it. 
<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: ntr gets locker access again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
