### PR TITLE
Removes armour boosters from antagonist MODsuits (buff)

### DIFF
--- a/modular_zubbers/code/datums/armor_overrides.dm
+++ b/modular_zubbers/code/datums/armor_overrides.dm
@@ -67,7 +67,7 @@
 	. = ..()
 
 /datum/mod_theme/contractor
-inbuilt_modules = list(/obj/item/mod/module/chameleon/contractor)
+	inbuilt_modules = list(/obj/item/mod/module/chameleon/contractor)
 
 /datum/armor/mod_theme_contractor
 	melee = 30

--- a/modular_zubbers/code/datums/armor_overrides.dm
+++ b/modular_zubbers/code/datums/armor_overrides.dm
@@ -27,3 +27,56 @@
 	fire = 100
 	acid = 100
 	wound = 20
+
+/datum/mod_theme/syndicate // Bloodred Syndicate
+	inbuilt_modules = null //removing the armour booster. Its just base armour now.
+	slowdown_active = 0 //no armour booster to control slowdown
+
+/datum/armor/mod_theme_syndicate
+	melee = 40
+	bullet = 50
+	laser = 30
+	energy = 40
+	bomb = 40
+	bio = 100
+	fire = 50
+	acid = 90
+	wound = 25
+
+/obj/item/mod/control/pre_equipped/syndicate/Initialize()
+	default_pins -= /obj/item/mod/module/armor_booster
+
+/datum/mod_theme/elite // Elite Syndiate
+	inbuilt_modules = null //ditto
+	slowdown_active = 0
+
+/datum/armor/mod_theme_elite
+	melee = 60
+	bullet = 60
+	laser = 50
+	energy = 60
+	bomb = 60
+	bio = 100
+	fire = 100
+	acid = 100
+	wound = 25
+
+/obj/item/mod/control/pre_equipped/elite/Initialize()
+	default_pins -= /obj/item/mod/module/armor_booster
+
+/datum/mod_theme/contractor
+inbuilt_modules = list(/obj/item/mod/module/chameleon/contractor)
+
+/datum/armor/mod_theme_contractor
+	melee = 30
+	bullet = 10
+	laser = 30
+	energy = 30
+	bomb = 35
+	bio = 100
+	fire = 80
+	acid = 90
+	wound = 25
+
+/obj/item/mod/control/pre_equipped/contractor/Initialize()
+	default_pins -= /obj/item/mod/module/armor_booster

--- a/modular_zubbers/code/datums/armor_overrides.dm
+++ b/modular_zubbers/code/datums/armor_overrides.dm
@@ -45,6 +45,7 @@
 
 /obj/item/mod/control/pre_equipped/syndicate/Initialize()
 	default_pins -= /obj/item/mod/module/armor_booster
+	. = ..()
 
 /datum/mod_theme/elite // Elite Syndiate
 	inbuilt_modules = null //ditto
@@ -63,6 +64,7 @@
 
 /obj/item/mod/control/pre_equipped/elite/Initialize()
 	default_pins -= /obj/item/mod/module/armor_booster
+	. = ..()
 
 /datum/mod_theme/contractor
 inbuilt_modules = list(/obj/item/mod/module/chameleon/contractor)
@@ -80,3 +82,4 @@ inbuilt_modules = list(/obj/item/mod/module/chameleon/contractor)
 
 /obj/item/mod/control/pre_equipped/contractor/Initialize()
 	default_pins -= /obj/item/mod/module/armor_booster
+	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Alternative to #910 since it was closed
Antagonist MODsuits (syndicate, contractor) have had their armour boosters removed. The benefits from the boosters have been moved to the MODsuit's base stats.

## Why It's Good For The Game

Antagonist MODsuits deserve some parity with the over-armoured station-side MODsuits. It isn't fair if only one side has to choose between Armour or EVA

I obviously prefer #910 but if maintainers are going to close the PR then I have no choice here to set things right, and Nevimer wants "less MODsuit complexity" which this provides.

## Changelog

:cl:
balance: Syndicate MODsuits no longer have armour boosters. The armour and speed they provided are now built into the modsuit's baseline.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
