### PR TITLE
Malfunctioning AIs can no longer purchase the "Nuke Station" module.

### DIFF
--- a/code/modules/antagonists/malf_ai/malf_ai_modules.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai_modules.dm
@@ -49,7 +49,7 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 		/obj/machinery/portable_atmospherics/canister,
 	)))
 
-GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
+GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module) - /datum/ai_module/destructive/nuke_station) //BUBBERSTATION CHANGE: REMOVES NUKE STATION ROUNDSTART MODULE
 
 /// The malf AI action subtype. All malf actions are subtypes of this.
 /datum/action/innate/ai


### PR DESCRIPTION

## About The Pull Request

Malfunctioning AIs can no longer purchase the "Nuke Station" module.

## Why It's Good For The Game

I'm tired of rounds where literally nothing happens for 2 hours and then the AI goes code delta because the Captain called them a mean word in command radio or because the shuttle transfer was called and the AI wants their dogshit gimmick that only involves 2% of the crew to go out with a bang.

It's incredibly bad gameplay design to have a crutch for dogshit malf players to go code delta for no reason and for the crew to enter nukies-tier fight or flight mode where half the crew fucks off to interlink because they're tired of malf rounds, and the other half of crew are required by rules to stay and fight or they want an excuse to use the 50 powerful items they've been hoarding in their dufflebag because they've been prepping for the AI to go malf.

## Proof Of Testing

It's literally a 1 line change. The reason it's not a hard removal so that admins can give them the ability if they want to and doesn't fuck up future code changes.

## Changelog

:cl: BurgerBB
del: Malfunctioning AIs can no longer purchase the "Nuke Station" module.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
