### PR TITLE
Removes the spasm animation from sensors

### DIFF
--- a/modular_zubbers/code/game/machinery/crew_monitor.dm
+++ b/modular_zubbers/code/game/machinery/crew_monitor.dm
@@ -28,7 +28,6 @@
 	if(canalarm)
 		playsound(src, 'sound/machines/twobeep.ogg', 50, TRUE)
 		set_light((initial(light_range) + 3), 3, CIRCUIT_COLOR_SECURITY, TRUE)
-		spasm_animation(10)
 	else
 		set_light((initial(light_range)), initial(light_power), initial(light_color), TRUE)
 	addtimer(CALLBACK(src, .proc/alarm), SENSORS_UPDATE_PERIOD) // Fix this for 515


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The animation is broken, and this is the fastest way to fix it. 

I won't be reasoning this on bad shifts they just run away so nobody will watch sensors anyhow

## Changelog

:cl:
del: Removes broken stealthmerge change
/:cl:

