### PR TITLE
More dauntless ministuff - robotics edition

### DIFF
--- a/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_dauntless.dmm
+++ b/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_dauntless.dmm
@@ -957,7 +957,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/light/cold/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/junction/flip{
@@ -1269,6 +1268,17 @@
 	dir = 1
 	},
 /area/ruin/space/has_grav/bubbers/dauntless/command/bridge)
+"hD" = (
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/cold/directional/east,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/bubbers/dauntless/service)
 "hE" = (
 /obj/structure/sign/painting/library{
 	pixel_y = 30
@@ -1898,9 +1908,6 @@
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 8
 	},
-/obj/machinery/door/airlock/science{
-	name = "Robotics"
-	},
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/effect/mapping_helpers/airlock/cutaiwire,
 /obj/structure/cable,
@@ -1908,6 +1915,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/science/glass,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/bubbers/dauntless/sci/robotics)
 "lk" = (
@@ -12307,7 +12315,7 @@ EN
 kr
 EN
 bG
-EN
+hD
 fH
 EN
 EN

--- a/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_dauntless.dmm
+++ b/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_dauntless.dmm
@@ -5840,9 +5840,9 @@
 /obj/structure/table,
 /obj/effect/turf_decal/tile/dark_red/fourcorners,
 /obj/item/mmi/posibrain,
-/obj/item/borg/upgrade/dauntless,
-/obj/item/borg/upgrade/dauntless,
-/obj/item/borg/upgrade/dauntless,
+/obj/item/borg/upgrade/syndicate_access/dauntless,
+/obj/item/borg/upgrade/syndicate_access/dauntless,
+/obj/item/borg/upgrade/syndicate_access/dauntless,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bubbers/dauntless/sci/robotics)
 "Ej" = (

--- a/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_dauntless.dmm
+++ b/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_dauntless.dmm
@@ -3861,6 +3861,10 @@
 	},
 /turf/open/floor/iron/dark/textured_half,
 /area/ruin/space/has_grav/bubbers/dauntless/command/bridge)
+"uG" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/bubbers/dauntless/sci/robotics)
 "uI" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/incinerator_input,
 /turf/open/floor/engine,
@@ -12367,8 +12371,8 @@ So
 Tp
 Qn
 Qn
-Qn
-Qn
+uG
+uG
 Qn
 PX
 PX

--- a/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_dauntless.dmm
+++ b/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_dauntless.dmm
@@ -5851,10 +5851,10 @@
 "Eh" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/dark_red/fourcorners,
+/obj/item/borg/upgrade/syndicate_access/dauntless,
+/obj/item/borg/upgrade/syndicate_access/dauntless,
+/obj/item/borg/upgrade/syndicate_access/dauntless,
 /obj/item/mmi/posibrain,
-/obj/item/borg/upgrade/syndicate_access/dauntless,
-/obj/item/borg/upgrade/syndicate_access/dauntless,
-/obj/item/borg/upgrade/syndicate_access/dauntless,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bubbers/dauntless/sci/robotics)
 "Ej" = (

--- a/modular_zubbers/maps/offstation/dauntless/robot.dm
+++ b/modular_zubbers/maps/offstation/dauntless/robot.dm
@@ -28,3 +28,4 @@
 	// Yes, this forces out and removes any other keys. Which it should, in this case.
 	R.radio.keyslot = new /obj/item/encryptionkey/headset_syndicate/interdyne(src)
 	R.radio.recalculateChannels()
+	

--- a/modular_zubbers/maps/offstation/dauntless/robot.dm
+++ b/modular_zubbers/maps/offstation/dauntless/robot.dm
@@ -1,4 +1,4 @@
-/obj/item/borg/upgrade/dauntless
+/obj/item/borg/upgrade/syndicate_access
 	name = "Syndicate cyborg access override"
 	desc = "Makes any model of cyborg appear as a syndicate cyborg to syndicate targetting systems, additionally giving them access to syndicate airlocks. \
 	\n\nFOR OPERATIVES: Handle with extreme care to prevent rogue cyborgs on your designated ship/station"
@@ -6,7 +6,7 @@
 	// It is not module specific
 	one_use = TRUE
 
-/obj/item/borg/upgrade/dauntless/action(mob/living/silicon/robot/R, user)
+/obj/item/borg/upgrade/syndicate_access/action(mob/living/silicon/robot/R, user)
 	. = ..()
 	// Turns out this is all you need for access to the doors. See code\game\machinery\_machinery.dm
 	R.faction += ROLE_SYNDICATE
@@ -14,6 +14,17 @@
 	to_chat(user, span_warning("The cyborg whirrs a bit as additional access levels are added."))
 
 
-/obj/item/borg/upgrade/dauntless/deactivate(mob/living/silicon/robot/R, user)
+/obj/item/borg/upgrade/syndicate_access/deactivate(mob/living/silicon/robot/R, user)
 	. = ..()
 	R.faction = initial(R.faction)
+
+/obj/item/borg/upgrade/syndicate_access/dauntless/examine_more(mob/user)
+	. = ..()
+	. += span_notice("This one seems to include a Interdyne communication chip. How neat!")
+
+/obj/item/borg/upgrade/syndicate_access/dauntless/action(mob/living/silicon/robot/R, user)
+	. = ..()
+
+	// Yes, this forces out and removes any other keys. Which it should, in this case.
+	R.radio.keyslot = new /obj/item/encryptionkey/headset_syndicate/interdyne(src)
+	R.radio.recalculateChannels()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The syndicate access override on the Dauntless gives borgs the radio key as well.

Robotics is now more open so it's easier to spawn a possessed posibrain

## Why It's Good For The Game

No longer do you have to plead Dauntless crew for radios as a borg, or sit in the baby jail until someone notices you

## Proof Of Testing

![image](https://github.com/Bubberstation/Bubberstation/assets/49160555/57b877be-2674-434f-8d13-8031d8eacba7)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: The syndicate access override on the Dauntless now includes the radio key
add: Windows on Dauntless robotics
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
