### PR TITLE
[Early Port] [TM Only] Fixes morgue trays husking corpses, organ/limb cryopreservation (#80811)

### DIFF
--- a/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
+++ b/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
@@ -73,6 +73,8 @@
 /// This also affects how fast the body normalises it's temperature when cold.
 /// 270k is about -3c, that is below freezing and would hurt over time.
 #define BODYTEMP_COLD_DAMAGE_LIMIT (BODYTEMP_NORMAL - 40)
+/// The temperature which a bodypart/organ is considered cryogenically frozen
+#define BODYTEMP_CRYO_THRESHOLD 96.15
 /// A temperature limit which is above the minimum icebox temperature
 #define BODYTEMP_COLD_ICEBOX_SAFE (ICEBOX_MIN_TEMPERATURE - 5)
 /// The body temperature limit the human body can take before it will take wound damage.

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -190,7 +190,7 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 	/// The rate at which the internal air mixture cools
 	var/cooling_rate_per_second = 4
 	/// Minimum temperature of the internal air mixture
-	var/minimum_temperature = T0C - 60
+	var/minimum_temperature = BODYTEMP_CRYO_THRESHOLD - 7
 
 
 /obj/structure/bodycontainer/morgue/Initialize(mapload)
@@ -204,6 +204,7 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 		internal_air = external_air.copy()
 	else
 		internal_air = new()
+	internal_air.temperature = BODYTEMP_CRYO_THRESHOLD
 	START_PROCESSING(SSobj, src)
 
 /obj/structure/bodycontainer/morgue/return_air()

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1502,6 +1502,10 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		// Apply the damage to all body parts
 		humi.apply_damage(burn_damage, BURN, spread_damage = TRUE)
 
+	// No cold damage if the body is cryogenically frozen
+	if(humi.coretemperature <= BODYTEMP_CRYO_THRESHOLD)
+		return
+
 	// Apply some burn / brute damage to the body (Dependent if the person is hulk or not)
 	var/is_hulk = HAS_TRAIT(humi, TRAIT_HULK)
 

--- a/code/modules/surgery/organs/internal/_internal_organ.dm
+++ b/code/modules/surgery/organs/internal/_internal_organ.dm
@@ -45,13 +45,13 @@
 		return
 
 	if(owner)
-		if(owner.bodytemperature > T0C)
-			var/air_temperature_factor = min((owner.bodytemperature - T0C) / T20C, 1)
+		if(owner.bodytemperature > BODYTEMP_CRYO_THRESHOLD)
+			var/air_temperature_factor = min((owner.bodytemperature - BODYTEMP_CRYO_THRESHOLD) / (T20C - BODYTEMP_CRYO_THRESHOLD), 1)
 			apply_organ_damage(decay_factor * maxHealth * seconds_per_tick * air_temperature_factor)
 	else
 		var/datum/gas_mixture/exposed_air = return_air()
-		if(exposed_air && exposed_air.temperature > T0C)
-			var/air_temperature_factor = min((exposed_air.temperature - T0C) / T20C, 1)
+		if(exposed_air && exposed_air.temperature > BODYTEMP_CRYO_THRESHOLD)
+			var/air_temperature_factor = min((exposed_air.temperature - BODYTEMP_CRYO_THRESHOLD) / (T20C - BODYTEMP_CRYO_THRESHOLD), 1)
 			apply_organ_damage(decay_factor * maxHealth * seconds_per_tick * air_temperature_factor)
 
 /// Called once every life tick on every organ in a carbon's body


### PR DESCRIPTION
## About The Pull Request

Implements a cryopreservation threshold for bodies/bodyparts. At or below the cryogenic threshold a bodypart/organ is considered cold enough to prevent further cellular decay.

Morgue trays are adjusted to reduce the bodies below this temperature. Includes fix for organ decay from https://github.com/tgstation/tgstation/pull/80419

Tested, a corpse will take approximately 50 burn damage from being placed in a morgue tray at normal body temperature until they reach the point of cryopreservation.

## Why It's Good For The Game

Morgue trays stop husking bodies. Dead bodies left out in the snow still decay. Fixes https://github.com/tgstation/tgstation/issues/80302

## Changelog

:cl: LT3
fix: Morgue trays will now properly cool bodies into cryogenesis instead of husking
/:cl: