### PR TITLE
Character directory proper size on opening

### DIFF
--- a/tgui/packages/tgui/interfaces/ZubbersCharacterDirectory.jsx
+++ b/tgui/packages/tgui/interfaces/ZubbersCharacterDirectory.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+
 import { useBackend } from '../backend';
 import { Box, Button, Icon, LabeledList, Section, Table } from '../components';
 import { Window } from '../layouts';
@@ -33,7 +34,7 @@ export const ZubbersCharacterDirectory = (props, context) => {
   const [overwritePrefs, setOverwritePrefs] = useState(prefsOnly);
 
   return (
-    <Window width={640} height={480} resizeable>
+    <Window width={900} height={640} resizeable>
       <Window.Content scrollable>
         {(overlay && <ViewCharacter />) || (
           <>


### PR DESCRIPTION
## About The Pull Request

Fixes the character directory to open at a proper size where all the columns are visible by default.

## Proof Of Testing

![image](https://github.com/Bubberstation/Bubberstation/assets/83487515/46c5c7ef-bb76-4e7c-8a9b-9e4d10498844)

## Changelog

:cl: LT3
fix: Character directory will show all fields without resizing
/:cl: