### PR TITLE
Gives medical borgs back their crew monitor

### DIFF
--- a/modular_skyrat/master_files/code/modules/research/techweb/all_nodes.dm
+++ b/modular_skyrat/master_files/code/modules/research/techweb/all_nodes.dm
@@ -245,11 +245,11 @@
 	design_ids += list(
 		"borg_upgrade_surgicaltools",
 	)
-
+	return ..() // Bubber Edit - Moves this up because it doesn't compile otherwise
 /*	design_ids -= list(
 		"borg_upgrade_pinpointer",
-	)*/ //BUBBERSTATION REMOVAL
-	return ..()
+	)
+	return ..() */ //BUBBERSTATION REMOVAL
 
 /datum/techweb_node/basic_mining/New()
 	design_ids += list(

--- a/modular_skyrat/master_files/code/modules/research/techweb/all_nodes.dm
+++ b/modular_skyrat/master_files/code/modules/research/techweb/all_nodes.dm
@@ -248,8 +248,8 @@
 
 /*	design_ids -= list(
 		"borg_upgrade_pinpointer",
-	)
-	return ..()*/ //BUBBERSTATION REMOVAL
+	)*/ //BUBBERSTATION REMOVAL
+	return ..()
 
 /datum/techweb_node/basic_mining/New()
 	design_ids += list(

--- a/modular_skyrat/master_files/code/modules/research/techweb/all_nodes.dm
+++ b/modular_skyrat/master_files/code/modules/research/techweb/all_nodes.dm
@@ -246,10 +246,10 @@
 		"borg_upgrade_surgicaltools",
 	)
 
-	design_ids -= list(
+/*	design_ids -= list(
 		"borg_upgrade_pinpointer",
 	)
-	return ..()
+	return ..()*/ //BUBBERSTATION REMOVAL
 
 /datum/techweb_node/basic_mining/New()
 	design_ids += list(


### PR DESCRIPTION
## About The Pull Request

Simply allows medical borgs to get the crew monitor upgrade again

## Why It's Good For The Game

We have a ton of medical chaos and they need a little help. This was removed on Skyrat because of worries that borgs encroach on their job. Are some of these worries valid? Yes. But medical here always has plenty of work to go around.

## Proof Of Testing

![image](https://github.com/Bubberstation/Bubberstation/assets/95130227/ca65a5ce-8ee1-4756-8c7c-e37d53dad356)


## Changelog

:cl:
balance: gives medical borgs back their crew monitors
/:cl:


