### PR TITLE
Moves the emergancy shuttle off the interlink

### DIFF
--- a/_maps/skyrat/automapper/automapper_config.toml
+++ b/_maps/skyrat/automapper/automapper_config.toml
@@ -22,8 +22,8 @@ trait_name = "CentCom"
 [templates.centcom_shuttle_dock]
 map_files = ["centcom_shuttle_dock.dmm"]
 directory = "_maps/skyrat/automapper/templates/centcom/"
-required_map = "builtin"
-coordinates = [206, 85, 1]
+required_map = "CentCom_skyrat_z2.dmm" ## BUBBERSTATION EDIT - MOVES THE SHUTTLE TO THE CENTCOM DOCK
+coordinates = [51, 167, 2]			   ## BUBBERSTATION EDIT
 trait_name = "CentCom"
 
 # METASTATION MAP TEMPLATES


### PR DESCRIPTION
## About The Pull Request

Moves the emergancy shuttle from the interlink to the normal centcomm dock.

## Why It's Good For The Game

This will allow the EORG to be easier to understand rule wise and you would not have to worry about Interlink dorms

## Proof Of Testing

![image](https://github.com/Bubberstation/Bubberstation/assets/95130227/bc922847-f19b-4102-b681-bd3eff84d0bb)


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Switches the emergancy shuttle to Centcom instead of the Interlink
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
