### PR TITLE
DNR and suit sensor adjustments

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -283,7 +283,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		// BUBBERSTATION EDIT BEGIN: Add DNR status
 		// If sensors are above living tracking, set DNR state
 		if (sensor_mode >= SENSOR_LIVING)
-			entry["is_dnr"] = HAS_TRAIT(tracked_living_mob, TRAIT_DNR) || !((tracked_human?.mind?.get_ghost(FALSE, TRUE)) ? 1 : 0)
+			entry["is_dnr"] = tracked_human.get_dnr()
 		// BUBBERSTATION EDIT END
 
 		// Binary living/dead status

--- a/modular_zubbers/code/game/machinery/crew_monitor.dm
+++ b/modular_zubbers/code/game/machinery/crew_monitor.dm
@@ -16,13 +16,20 @@
 
 	for(var/tracked_mob in GLOB.suit_sensors_list)
 		var/mob/living/carbon/human/mob = tracked_mob
+		if(tracked_mob["is_dnr"]) // No more beeps on DNRs
+			continue
 		if(mob.z != src.z  && !HAS_TRAIT(mob, TRAIT_MULTIZ_SUIT_SENSORS))
 			continue
 		var/obj/item/clothing/under/uniform = mob.w_uniform
 		if(uniform.sensor_mode >= SENSOR_VITALS && HAS_TRAIT(mob, TRAIT_CRITICAL_CONDITION) || mob.stat == DEAD && mob.mind)
 			canalarm = TRUE
+			break // Why wasn't this here?
+
+		/* 	Low sensors don't deserve our attention. Half the time these are in pisshole nowhere.
+			Keep those sensors up if you wanna get revived in a timely manner
 		else if(uniform.sensor_mode == SENSOR_LIVING && mob.stat == DEAD)
 			canalarm = TRUE
+		*/
 
 
 	if(canalarm)

--- a/modular_zubbers/code/game/machinery/crew_monitor.dm
+++ b/modular_zubbers/code/game/machinery/crew_monitor.dm
@@ -21,17 +21,11 @@
 		if(mob.z != src.z  && !HAS_TRAIT(mob, TRAIT_MULTIZ_SUIT_SENSORS))
 			continue
 		var/obj/item/clothing/under/uniform = mob.w_uniform
-		if(uniform.sensor_mode >= SENSOR_VITALS && HAS_TRAIT(mob, TRAIT_CRITICAL_CONDITION) || mob.stat == DEAD && mob.mind)
+		if(uniform.sensor_mode >= SENSOR_VITALS && (HAS_TRAIT(mob, TRAIT_CRITICAL_CONDITION) || mob.stat == DEAD))
 			if(mob.get_dnr()) // DNR won't beep anymore
 				continue
 			canalarm = TRUE
 			break // Why wasn't this here?
-
-		/* 	Low sensors don't deserve our attention. The constant beeping of John Gray dying in their hidden maints base no paramed can find irritates everyone
-			Keep those sensors up if you wanna get revived in a timely manner
-		else if(uniform.sensor_mode == SENSOR_LIVING && mob.stat == DEAD)
-			canalarm = TRUE
-		*/
 
 	if(canalarm)
 		playsound(src, 'sound/machines/twobeep.ogg', 50, TRUE)

--- a/modular_zubbers/code/game/machinery/crew_monitor.dm
+++ b/modular_zubbers/code/game/machinery/crew_monitor.dm
@@ -16,21 +16,22 @@
 
 	for(var/tracked_mob in GLOB.suit_sensors_list)
 		var/mob/living/carbon/human/mob = tracked_mob
-		if(tracked_mob["is_dnr"]) // No more beeps on DNRs
+		if(!istype(mob))
 			continue
 		if(mob.z != src.z  && !HAS_TRAIT(mob, TRAIT_MULTIZ_SUIT_SENSORS))
 			continue
 		var/obj/item/clothing/under/uniform = mob.w_uniform
 		if(uniform.sensor_mode >= SENSOR_VITALS && HAS_TRAIT(mob, TRAIT_CRITICAL_CONDITION) || mob.stat == DEAD && mob.mind)
+			if(mob.get_dnr()) // DNR won't beep anymore
+				continue
 			canalarm = TRUE
 			break // Why wasn't this here?
 
-		/* 	Low sensors don't deserve our attention. Half the time these are in pisshole nowhere.
+		/* 	Low sensors don't deserve our attention. The constant beeping of John Gray dying in their hidden maints base no paramed can find irritates everyone
 			Keep those sensors up if you wanna get revived in a timely manner
 		else if(uniform.sensor_mode == SENSOR_LIVING && mob.stat == DEAD)
 			canalarm = TRUE
 		*/
-
 
 	if(canalarm)
 		playsound(src, 'sound/machines/twobeep.ogg', 50, TRUE)

--- a/modular_zubbers/code/game/machinery/crew_monitor.dm
+++ b/modular_zubbers/code/game/machinery/crew_monitor.dm
@@ -14,8 +14,8 @@
 /obj/machinery/computer/crew/proc/alarm()
 	canalarm = FALSE
 
-	for(var/tracked_mob in GLOB.suit_sensors_list)
-		var/mob/living/carbon/human/mob = tracked_mob
+	for(var/mob/living/carbon/human/mob in GLOB.suit_sensors_list)
+
 		if(!istype(mob))
 			continue
 		if(mob.z != src.z  && !HAS_TRAIT(mob, TRAIT_MULTIZ_SUIT_SENSORS))

--- a/modular_zubbers/code/modules/mob/living/carbon/human/human.dm
+++ b/modular_zubbers/code/modules/mob/living/carbon/human/human.dm
@@ -1,2 +1,5 @@
 /mob/living/carbon/human/species/shadekin
 	race = /datum/species/shadekin
+
+/mob/living/carbon/human/proc/get_dnr()
+	return (src.stat == DEAD && (HAS_TRAIT(src, TRAIT_DNR) || !((src.mind?.get_ghost(FALSE, TRUE)) ? 1 : 0)))

--- a/modular_zubbers/code/modules/mob/living/carbon/human/human.dm
+++ b/modular_zubbers/code/modules/mob/living/carbon/human/human.dm
@@ -1,5 +1,7 @@
 /mob/living/carbon/human/species/shadekin
 	race = /datum/species/shadekin
 
+
+// This is expected to be called or used in situations where you already know the mob is dead
 /mob/living/carbon/human/proc/get_dnr()
-	return (src.stat == DEAD && (HAS_TRAIT(src, TRAIT_DNR) || !((src.mind?.get_ghost(FALSE, TRUE)) ? 1 : 0)))
+	return ((HAS_TRAIT(src, TRAIT_DNR) || !((src.mind?.get_ghost(FALSE, TRUE)) ? 1 : 0)))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a lot of the silly sensor console beeping code. (Why was there no break statement)

Makes people on low sensor settings and DNR no longer beep!

Introduces `/mob/living/carbon/human/proc/get_dnr()`

## Why It's Good For The Game

Let's be completely honest, the beeping of the console rarely does anything but annoy the living shit out of people. And having it beep on a random sensorless assistant dying somewhere in a secret maint base that nobody can find is getting on everyone's mind. Same goes for DNR people.

![RDT_20240102_0034016772755654577949803](https://github.com/Bubberstation/Bubberstation/assets/49160555/b5895db9-19ea-4c9d-a65b-c082525c0737)


## Proof Of Testing

Sources: Trust me

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Crew monitor consoles receive a new firmware update to address recent complaints, removing the low health alarm on DNR and low sensor settings
code: Introduced get_dnr() proc
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
