### PR TITLE
[Early Pull] Minor Cafe Mod (Changes the ID to Cham, adds a stamp) #2

### DIFF
--- a/modular_skyrat/modules/ghostcafe/code/ghost_role_spawners.dm
+++ b/modular_skyrat/modules/ghostcafe/code/ghost_role_spawners.dm
@@ -69,7 +69,7 @@
 	name = "ID, jumpsuit and shoes"
 	uniform = /obj/item/clothing/under/color/random
 	shoes = /obj/item/clothing/shoes/sneakers/black
-	id = /obj/item/card/id/advanced/ghost_cafe
+	id = /obj/item/card/id/advanced/chameleon/ghost_cafe
 	back = /obj/item/storage/backpack/chameleon
 	backpack_contents = list(/obj/item/storage/box/syndie_kit/chameleon/ghostcafe = 1)
 
@@ -112,9 +112,10 @@
 	new /obj/item/clothing/neck/chameleon(src)
 	new /obj/item/storage/belt/chameleon(src)
 	new /obj/item/card/id/advanced/chameleon(src)
+	new /obj/item/stamp/chameleon(src)
 	new /obj/item/hhmirror/syndie(src)
 
-/obj/item/card/id/advanced/ghost_cafe
+/obj/item/card/id/advanced/chameleon/ghost_cafe
 	name = "\improper Cafe ID"
 	desc = "An ID straight from God."
 	icon_state = "card_centcom"


### PR DESCRIPTION
#26158 

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

## How This Contributes To The Skyrat Roleplay Experience

It doesn't because this isn't Skyrat.

There is already a set of stamps in the Manager's office. If you want to do some sort of 'sold yourself to the Syndicate/Clown/Cargo' you can now have a fancy stamp. The Cafe can't fax the station anyway, so this is just flavour.

The kit already has a cham ID, this just makes the one they spawn with moddable. I tested most of the doors and they don't have access on the anyway.
Unsure if I should delete the kit one. I guess it means you have a spare/another 'character' to swap to.

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Paper ERPers rejoice. You can now stamp stuff in the Cafe.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
