### PR TITLE
I BROUGHT YOU INTO THIS WORLD, I CAN TAKE YOU OUT (Removes Slaughter Demons from wizards, limits laughter demons to one purchase)

### DIFF
--- a/modular_zubbers/code/modules/spells/spell_types/disabled_spells.dm
+++ b/modular_zubbers/code/modules/spells/spell_types/disabled_spells.dm
@@ -12,3 +12,8 @@
 // Very easy way to get round removed, and a very easy way to grief the crew as you are now a funny xenomorph that can lay eggs.
 /datum/spellbook_entry/item/staffchange
 	category = null
+
+// Blood in a Bottle: Spawns a Slaughter Demon. Players consumed are effectively round removed until the slaughter demon dies.
+// 99% of slaughter demons just target medbay and it's not really fun for anyone except the slaughter demon (and ghost chat).
+/datum/spellbook_entry/item/bloodbottle
+	category = null

--- a/modular_zubbers/code/modules/spells/spell_types/nerfed_spells.dm
+++ b/modular_zubbers/code/modules/spells/spell_types/nerfed_spells.dm
@@ -63,3 +63,9 @@
 	victim.death(FALSE)
 
 	return TRUE
+
+// Laughter Demon. They're basically hugboxed slaughter demons (hence the name), but are still really powerful.
+// While you're basically put in gay baby jail until it's killed, it's not TOO bad, but it should still be limited to 1.
+/datum/spellbook_entry/item/hugbottle
+	cost = 2
+	limit = 1


### PR DESCRIPTION
## About The Pull Request

Removes Slaughter Demons from the wizard spellbook.
Laughter Demons cost 2 points (instead of 1), and are limited to 1 purchase per wizard.

## Why It's Good For The Game

Slaughter Demons are a little too crazy for bubberstation. They're extremely tanky, robust, etc etc and their only drawback is "They could kill the wizard" which never really happens. I'm 100% against ghost roles that have this much power to take out half the crew, but I still think they have some sort of place in Bubberstation, so laughter demons are being kept.

## Proof Of Testing

Untested. Uncompiled. Unhinged.

## Changelog

:cl: BurgerBB
del: Removes Slaughter Demons from the wizard spellbook.
balance: Laughter Demons cost 2 points (instead of 1), and are limited to 1 purchase per wizard.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
