### PR TITLE
Fixes some Moonstation things

### DIFF
--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -3411,6 +3411,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"bbs" = (
+/obj/machinery/rnd/server/master,
+/turf/closed/wall/r_wall,
+/area/station/science/server)
 "bbu" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/conveyor{
@@ -22557,10 +22561,10 @@
 /turf/open/floor/carpet/purple,
 /area/station/security/courtroom)
 "hqD" = (
-/obj/machinery/rnd/server/master,
 /obj/effect/turf_decal/siding/blue{
 	dir = 8
 	},
+/obj/machinery/rnd/server,
 /turf/open/floor/circuit/telecomms/server,
 /area/station/science/server)
 "hqI" = (
@@ -29150,6 +29154,17 @@
 /obj/structure/railing/corner/end/flip,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
+"jxo" = (
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/hallway/primary/aft)
 "jxp" = (
 /obj/structure/fluff/beach_umbrella/science{
 	pixel_x = -5;
@@ -57199,6 +57214,7 @@
 	name = "Server Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/rd,
+/obj/machinery/rnd/server/master,
 /turf/open/floor/catwalk_floor,
 /area/station/science/server)
 "swQ" = (
@@ -61107,9 +61123,6 @@
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
 	},
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark/corner{
@@ -98640,7 +98653,7 @@ nWc
 nWc
 nWc
 nWc
-nWc
+jxo
 tNM
 ofn
 uzr
@@ -116389,7 +116402,7 @@ xfl
 tRH
 hqD
 eog
-tRH
+bbs
 gSX
 suS
 tRH

--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -249,6 +249,9 @@
 	dir = 8
 	},
 /obj/machinery/vending/dinnerware,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "aeN" = (
@@ -1189,8 +1192,18 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "atp" = (
-/obj/structure/chair/stool/bar/directional/east,
-/obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/structure/sign/plaques/kiddie{
+	pixel_y = 32;
+	name = "Nanotrasen Food Safety Inspection Certificate";
+	desc = "Allegedly, a food and safety inspection certificate certifying that the food served here is okay."
+	},
+/obj/effect/turf_decal/tile/dark_red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/cafeteria,
 /area/station/hallway/primary/central/fore)
 "atG" = (
@@ -4390,6 +4403,9 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "buP" = (
@@ -10450,6 +10466,9 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "dtY" = (
@@ -12413,6 +12432,10 @@
 	},
 /obj/structure/sink/kitchen/directional/south,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "ecN" = (
@@ -20026,6 +20049,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "gyt" = (
@@ -20258,6 +20282,16 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
+"gBC" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Library Access"
+	},
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/station/service/library)
 "gBR" = (
 /obj/structure/table/wood,
 /obj/item/table_clock{
@@ -20506,7 +20540,6 @@
 	id = "cafe_counter";
 	name = "Kitchen Counter Shutters"
 	},
-/obj/machinery/dish_drive,
 /obj/effect/turf_decal/tile/dark_red/opposingcorners{
 	dir = 8
 	},
@@ -20514,6 +20547,9 @@
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/displaycase/forsale/kitchen{
+	pixel_y = 8
 	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
@@ -20979,6 +21015,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/blue/opposingcorners,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "gPQ" = (
@@ -21307,10 +21344,6 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/cargo/drone_bay)
-"gUG" = (
-/obj/effect/spawner/random/vending/snackvend,
-/turf/open/floor/glass/reinforced,
-/area/station/hallway/primary/central/fore)
 "gUK" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
@@ -23080,6 +23113,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "hzx" = (
@@ -24797,6 +24831,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "idj" = (
@@ -25160,6 +25195,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/cafeteria,
 /area/station/hallway/primary/central/fore)
 "ikN" = (
@@ -25971,6 +26007,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/range)
+"iAP" = (
+/obj/effect/turf_decal/tile/dark_red/opposingcorners{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/food/flour,
+/obj/effect/landmark/start/cook,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "iAQ" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -28431,6 +28478,7 @@
 /obj/effect/turf_decal/tile/dark_red/opposingcorners{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "jml" = (
@@ -29986,14 +30034,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/common/night_club/back_stage)
-"jMA" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/hallway/primary/central/aft)
 "jMC" = (
 /obj/structure/chair/stool/bamboo,
 /obj/effect/spawner/random/clothing/lizardboots,
@@ -30777,6 +30817,7 @@
 	},
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/tile/blue/opposingcorners,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "jYX" = (
@@ -32587,6 +32628,9 @@
 	},
 /obj/effect/landmark/start/cook,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "kCV" = (
@@ -32817,7 +32861,7 @@
 	pixel_x = 32;
 	pixel_y = -40
 	},
-/obj/structure/disposalpipe/junction{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/corner,
@@ -34658,10 +34702,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/yellow/warning,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
+/obj/effect/landmark/navigate_destination/autoname,
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "lkL" = (
@@ -37733,6 +37774,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/dark_red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/cafeteria,
 /area/station/hallway/primary/central/fore)
 "miI" = (
@@ -38942,12 +38990,7 @@
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos)
 "mDt" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/camera/autoname/directional/east,
-/turf/open/floor/iron/cafeteria,
+/turf/closed/wall/mineral/wood,
 /area/station/hallway/primary/central/fore)
 "mDv" = (
 /obj/effect/turf_decal/siding/wood{
@@ -40696,6 +40739,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "nfK" = (
@@ -41088,6 +41132,7 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "noc" = (
@@ -42130,6 +42175,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/checker,
 /area/station/hallway/primary/central/aft)
 "nFV" = (
@@ -42257,12 +42303,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
-"nIG" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/hallway/primary/central/aft)
 "nIN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/general/visible,
 /turf/open/floor/engine,
@@ -42551,6 +42591,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/cook,
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "nNB" = (
@@ -43868,6 +43909,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "ohj" = (
@@ -43950,6 +43994,7 @@
 	dir = 8
 	},
 /obj/machinery/light_switch/directional/east,
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "ojc" = (
@@ -47622,6 +47667,9 @@
 /obj/effect/turf_decal/tile/dark_red/opposingcorners{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "ptZ" = (
@@ -49300,6 +49348,9 @@
 /obj/machinery/chem_dispenser/drinks,
 /obj/effect/turf_decal/tile/dark_red/opposingcorners{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
@@ -52191,7 +52242,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/arrivals)
 "qSE" = (
-/obj/effect/spawner/random/vending/colavend,
+/obj/machinery/restaurant_portal/restaurant,
 /turf/open/floor/glass/reinforced,
 /area/station/hallway/primary/central/fore)
 "qSI" = (
@@ -55535,6 +55586,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/rbmk2)
+"rVp" = (
+/obj/effect/turf_decal/tile/dark_red/opposingcorners{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/cook,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "rVu" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -58155,6 +58217,12 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/atmos/project)
+"sNT" = (
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/turf/open/floor/iron/grimy,
+/area/station/service/library)
 "sOf" = (
 /obj/structure/railing{
 	dir = 8
@@ -59090,6 +59158,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "teB" = (
@@ -61871,6 +61940,7 @@
 /obj/machinery/duct,
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/camera/autoname/directional/east,
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "tZX" = (
@@ -62376,6 +62446,18 @@
 "uiV" = (
 /turf/closed/wall/mineral/wood,
 /area/station/commons/lounge)
+"uiY" = (
+/obj/structure/chair/stool/bar/directional/east,
+/obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/dark_red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/cafeteria,
+/area/station/hallway/primary/central/fore)
 "ujc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -62631,9 +62713,6 @@
 /area/station/medical/morgue)
 "unG" = (
 /obj/structure/table/reinforced,
-/obj/structure/displaycase/forsale/kitchen{
-	pixel_y = 8
-	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 8;
 	id = "cafe_counter";
@@ -63897,21 +63976,6 @@
 /obj/item/stock_parts/cell/high,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/electrical)
-"uIh" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Library Access"
-	},
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/yellow/warning,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/landmark/navigate_destination/autoname,
-/turf/open/floor/iron/dark,
-/area/station/service/library)
 "uIi" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/atmospherics/components/tank/nitrogen{
@@ -64650,6 +64714,9 @@
 /obj/effect/turf_decal/tile/dark_red/opposingcorners{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "uVV" = (
@@ -64935,6 +65002,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/food/egg_smudge,
 /obj/effect/landmark/start/cook,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "vca" = (
@@ -65258,7 +65328,6 @@
 /area/station/commons/dorms)
 "vhZ" = (
 /obj/item/radio/intercom/directional/south,
-/obj/machinery/restaurant_portal/restaurant,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66335,6 +66404,7 @@
 	},
 /obj/effect/decal/cleanable/food/flour,
 /obj/effect/landmark/start/cook,
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "vzt" = (
@@ -94245,7 +94315,7 @@ pDK
 tYP
 bAP
 qSE
-gUG
+nEY
 bSL
 nEY
 nEY
@@ -94540,8 +94610,8 @@ dnZ
 lhR
 klf
 dro
-oyW
-oyW
+sNT
+sNT
 qbN
 bEN
 giR
@@ -95288,9 +95358,9 @@ kqd
 tMS
 uiV
 ref
-jMA
-nIG
-nIG
+orl
+mfS
+mfS
 bld
 xSn
 oJK
@@ -95303,8 +95373,8 @@ nDb
 ddG
 kAg
 lEn
-ayH
-vCU
+wPD
+emU
 iNB
 oyW
 ssU
@@ -95529,11 +95599,11 @@ qDs
 kIq
 mDt
 atp
-atp
-atp
-atp
-atp
-kOS
+uiY
+uiY
+uiY
+uiY
+uiY
 miG
 pjQ
 dON
@@ -96045,8 +96115,8 @@ rHZ
 aeB
 vbS
 kCP
-nNy
-vzs
+rVp
+iAP
 ohc
 jYU
 rHZ
@@ -96589,7 +96659,7 @@ uAE
 qYj
 rkT
 wPD
-uIh
+emU
 oyW
 vbR
 oyW
@@ -96846,7 +96916,7 @@ tEm
 boH
 rkT
 wPD
-lkD
+gBC
 oyW
 oyW
 oyW
@@ -98393,7 +98463,7 @@ vCU
 emU
 emU
 emU
-emU
+vCU
 emU
 emU
 emU

--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -37,6 +37,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/corrections_officer)
+"aaZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "aba" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light/directional/west,
@@ -2395,8 +2399,16 @@
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "aLI" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance/four,
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/door/airlock/atmos{
+	name = "Emergency Atmospherics"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "aLJ" = (
@@ -5156,7 +5168,11 @@
 	},
 /area/station/commons/dorms)
 "bKy" = (
-/obj/effect/spawner/random/decoration/glowstick,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/item/wrench,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "bKC" = (
@@ -11674,6 +11690,11 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/glass/reinforced,
 /area/station/security/lockers)
+"dQL" = (
+/obj/machinery/atmospherics/components/tank/air,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/aft)
 "dQN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -14137,6 +14158,12 @@
 "eDX" = (
 /turf/open/floor/iron/white,
 /area/station/science/lab)
+"eEi" = (
+/obj/machinery/atmospherics/components/binary/pump/on/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "eEn" = (
 /obj/machinery/duct/supply,
 /obj/machinery/duct/waste,
@@ -16526,13 +16553,13 @@
 /turf/open/floor/iron,
 /area/station/command/cc_dock)
 "fsy" = (
-/obj/structure/sign/poster/contraband/free_drone/directional/south,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "fsA" = (
@@ -23416,6 +23443,12 @@
 "hET" = (
 /turf/closed/wall,
 /area/station/science/ordnance/testlab)
+"hEZ" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "hFi" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 1
@@ -29814,14 +29847,14 @@
 /turf/open/floor/wood,
 /area/station/security/courtroom)
 "jLf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos{
 	dir = 1;
 	piping_layer = 2;
 	icon_state = "dpvent_map-2"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
@@ -30452,7 +30485,7 @@
 /area/station/maintenance/aft)
 "jUg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
@@ -43454,6 +43487,8 @@
 /obj/item/toy/figure/mime,
 /obj/item/inspector/clown/bananium,
 /obj/item/radio/intercom/directional/south,
+/obj/item/bot_assembly/honkbot,
+/obj/item/bikehorn,
 /turf/open/floor/carpet,
 /area/station/service/theater)
 "ocm" = (
@@ -47946,7 +47981,9 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "pzI" = (
-/obj/effect/spawner/random/burgerstation/odd,
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "pzQ" = (
@@ -48490,6 +48527,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "pJo" = (
@@ -49752,11 +49790,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/emitter)
-"qdy" = (
-/obj/effect/spawner/random/burgerstation/loot,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
 "qdF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -53303,6 +53336,14 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/catwalk_floor,
 /area/station/engineering/supermatter/room)
+"rjF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/light/small/red/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "rjP" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Two";
@@ -60608,6 +60649,17 @@
 /obj/item/radio/intercom/prison/directional/west,
 /turf/open/floor/iron/white,
 /area/station/security/prison/shower)
+"tFV" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/utility/fire/firefighter,
+/obj/item/tank/internals/oxygen,
+/obj/item/clothing/mask/gas,
+/obj/item/extinguisher,
+/obj/item/clothing/head/utility/hardhat/red,
+/obj/item/clothing/glasses/meson,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/aft)
 "tFX" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -62741,6 +62793,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/security/eva)
+"uqA" = (
+/obj/machinery/atmospherics/components/binary/pump/on/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "uqI" = (
 /obj/structure/window/reinforced/plasma/spawner/directional/south,
 /obj/machinery/power/energy_accumulator/grounding_rod/anchored,
@@ -63839,7 +63898,10 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/aft)
 "uIm" = (
-/obj/effect/spawner/random/trash/mess,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "uIn" = (
@@ -64965,16 +65027,6 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/glass/reinforced,
 /area/station/hallway/primary/starboard)
-"vdV" = (
-/obj/structure/sign/poster/random/directional/south,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
 "vdY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -67184,6 +67236,17 @@
 	},
 /turf/open/floor/carpet/red,
 /area/station/medical/break_room)
+"vRp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/obj/machinery/meter,
+/obj/effect/turf_decal/box/white/corners{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "vRA" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/landmark/start/cyborg,
@@ -69685,6 +69748,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
+"wIB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/turf_decal/box/blue/corners{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "wIC" = (
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 4
@@ -71388,6 +71462,10 @@
 /obj/structure/rack,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
+"xob" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "xoe" = (
 /obj/structure/sign/poster/random/directional/north,
 /obj/structure/cable,
@@ -72380,7 +72458,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "xDc" = (
-/obj/effect/spawner/random/burgerstation/vending,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/sign/poster/random/directional/south,
+/obj/machinery/atmospherics/components/binary/pump/off/general/visible{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "xDi" = (
@@ -108107,7 +108189,7 @@ fJl
 cKG
 hPO
 qFK
-noW
+aaZ
 pzI
 cKG
 sUD
@@ -108364,7 +108446,7 @@ xVd
 jvi
 jvi
 qFK
-iGh
+eEi
 jvi
 jvi
 sHa
@@ -108621,7 +108703,7 @@ tqP
 hLS
 gKw
 qFK
-iGh
+hEZ
 jvi
 hvb
 jOF
@@ -108878,7 +108960,7 @@ wzL
 vwV
 jvi
 tNY
-nOs
+uqA
 jvi
 xFS
 xdR
@@ -111421,9 +111503,9 @@ cKG
 nOs
 qFK
 cKG
-cKG
-cKG
-cKG
+iGh
+iGh
+xob
 cKG
 iGh
 iGh
@@ -111678,8 +111760,8 @@ ubL
 wzh
 fsy
 cKG
-iGh
-bln
+cKG
+cKG
 aLI
 cKG
 cKG
@@ -111934,10 +112016,10 @@ cKG
 pzz
 hDh
 qFK
-fNS
-cct
+cKG
+tFV
 bKy
-iGh
+wIB
 cKG
 pHJ
 lcC
@@ -112192,7 +112274,7 @@ lNv
 rhR
 qFK
 cKG
-iGh
+dQL
 uIm
 xDc
 cKG
@@ -112447,11 +112529,11 @@ ghC
 lKm
 lKm
 qhA
-vdV
+cyS
 cKG
-qdy
-sFk
-cKG
+dQL
+rjF
+vRp
 cKG
 jIL
 jvi

--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -519,6 +519,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "aiK" = (
@@ -1879,6 +1880,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "aEP" = (
@@ -3761,6 +3763,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
+"bip" = (
+/obj/machinery/light/floor,
+/turf/open/floor/iron/grimy,
+/area/station/service/bar)
 "biq" = (
 /obj/machinery/door/airlock/mining/glass{
 	id_tag = "innercargo";
@@ -10946,6 +10952,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "dDO" = (
@@ -31010,11 +31017,12 @@
 	name = "Bar-Kitchen Counter Shutters"
 	},
 /obj/structure/table,
-/obj/item/clothing/head/utility/hardhat/cakehat,
 /obj/effect/turf_decal/tile/dark_red/opposingcorners{
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
+/obj/item/book/granter/crafting_recipe/cooking_sweets_101,
+/obj/item/clothing/head/utility/hardhat/cakehat,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "kdX" = (
@@ -38339,15 +38347,10 @@
 /turf/open/floor/noslip,
 /area/station/engineering/main)
 "mtC" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bar_kitchen_counter";
-	name = "Bar-Kitchen Counter Shutters"
-	},
-/obj/structure/table,
-/obj/item/book/granter/crafting_recipe/cooking_sweets_101,
 /obj/effect/turf_decal/tile/dark_red/opposingcorners{
 	dir = 8
 	},
+/obj/machinery/vending/boozeomat,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
@@ -43450,7 +43453,6 @@
 /obj/item/toy/figure/clown,
 /obj/item/toy/figure/mime,
 /obj/item/inspector/clown/bananium,
-/mob/living/simple_animal/bot/secbot/honkbot,
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/carpet,
 /area/station/service/theater)
@@ -44285,11 +44287,10 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/radshelter)
 "opr" = (
-/obj/machinery/vending/boozeomat,
 /obj/effect/turf_decal/tile/dark_red/opposingcorners{
 	dir = 8
 	},
-/turf/open/floor/iron/kitchen,
+/turf/closed/wall/mineral/wood,
 /area/station/service/kitchen)
 "opv" = (
 /obj/structure/disposalpipe/trunk,
@@ -50287,6 +50288,13 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/library,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"qlh" = (
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "qlm" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
@@ -58252,7 +58260,6 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/drone_bay)
 "sRM" = (
-/obj/machinery/light/directional/north,
 /obj/machinery/newscaster/directional/north,
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks{
@@ -58535,6 +58542,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/mining,
 /obj/effect/turf_decal/tile/brown/fourcorners,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "sWR" = (
@@ -65601,6 +65609,7 @@
 "vnU" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "vnV" = (
@@ -65676,6 +65685,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "voT" = (
@@ -65925,6 +65935,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "vss" = (
@@ -66152,6 +66163,7 @@
 "vxW" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "vyk" = (
@@ -89026,7 +89038,7 @@ xql
 koz
 aiQ
 aEy
-dWl
+qlh
 dWl
 jHQ
 sNi
@@ -96707,7 +96719,7 @@ jmk
 opr
 pjJ
 kwr
-jwQ
+bip
 mPH
 kNz
 ksN
@@ -98249,7 +98261,7 @@ wvc
 rLP
 sRM
 kwr
-jwQ
+bip
 bWb
 kNz
 xbH

--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -2380,6 +2380,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate/coffin,
 /obj/machinery/airalarm/directional/east,
+/obj/item/clothing/under/misc/burial,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/storage)
 "aLn" = (
@@ -3255,6 +3256,10 @@
 /area/station/command/heads_quarters/hop)
 "aYw" = (
 /obj/structure/closet/crate/coffin,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/item/clothing/under/misc/burial,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/storage)
 "aYx" = (
@@ -19318,6 +19323,9 @@
 	id = "crematoriumChapel";
 	pixel_x = -26
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/storage)
 "glr" = (
@@ -31486,9 +31494,6 @@
 /turf/open/floor/iron,
 /area/station/common/pool)
 "klz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/machinery/firealarm/directional/north,
 /obj/effect/decal/cleanable/cobweb,
@@ -70597,11 +70602,13 @@
 /area/station/science/xenobiology)
 "wYv" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/item/radio/intercom/directional/east,
+/obj/structure/table,
+/obj/item/storage/box/bodybags,
+/obj/item/clothing/under/misc/burial,
+/obj/item/clothing/under/misc/burial,
+/obj/item/clothing/under/misc/burial,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/storage)
 "wYw" = (

--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -29288,7 +29288,6 @@
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/secondary/entry)
 "jAf" = (
-/obj/machinery/light/directional/south,
 /obj/item/mod/construction/broken_core{
 	pixel_y = 10
 	},

--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -13583,6 +13583,10 @@
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
+"etU" = (
+/obj/machinery/vending/wardrobe/robo_wardrobe,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "eur" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -47879,10 +47883,10 @@
 /area/station/security/brig/entrance)
 "pyh" = (
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/item/kirbyplants/random/fullysynthetic,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/radio/intercom/directional/east,
+/obj/item/kirbyplants/random/fullysynthetic,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "pyi" = (
@@ -63110,6 +63114,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/blacksmith)
 "uwm" = (
+/obj/effect/landmark/start/roboticist,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "uwr" = (
@@ -69654,7 +69659,6 @@
 /turf/open/floor/wood,
 /area/station/hallway/primary/central/fore)
 "wGW" = (
-/obj/effect/landmark/start/roboticist,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
@@ -114831,7 +114835,7 @@ kaE
 jFI
 tZz
 lpn
-uwm
+etU
 uwm
 txv
 tWq


### PR DESCRIPTION
## About The Pull Request

Fixes some Moonstation things.

- Fixes mining shuttle not having power.
- Honkbot in clown's room starts unconstructed.
- Fixes missing Bar lighting.
- Fixes missing emergency atmos in maint.
- Fixes missing robodrobe.

## Changelog

:cl: BurgerBB
fix: Fixes some Moonstation things (Fixes mining shuttle not having power, Honkbot in clown's room starts unconstructed, Fixes missing Bar lighting, Fixes missing emergency atmos in maint, Fixes missing robodrobe)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
