### PR TITLE
Less Messy Scrubber Event

### DIFF
--- a/code/modules/events/scrubber_overflow.dm
+++ b/code/modules/events/scrubber_overflow.dm
@@ -22,20 +22,23 @@
 	/// A list of scrubbers that will have reagents ejected from them
 	var/list/scrubbers = list()
 	/// The list of chems that scrubbers can produce
+
+	// BUBBERSTATION EDIT - DISABLES MESSY REAGENTS
+
 	var/list/safer_chems = list(/datum/reagent/water,
 		/datum/reagent/carbon,
-		/datum/reagent/consumable/flour,
+	//	/datum/reagent/consumable/flour,
 		/datum/reagent/space_cleaner,
-		/datum/reagent/carpet/royal/blue,
-		/datum/reagent/carpet/orange,
+	//	/datum/reagent/carpet/royal/blue,
+	//	/datum/reagent/carpet/orange,
 		/datum/reagent/consumable/nutriment,
 		/datum/reagent/consumable/condensedcapsaicin,
 		/datum/reagent/drug/mushroomhallucinogen,
 		/datum/reagent/lube,
-		/datum/reagent/glitter/blue,
-		/datum/reagent/glitter/pink,
+	//	/datum/reagent/glitter/blue,
+	//	/datum/reagent/glitter/pink,
 		/datum/reagent/cryptobiolin,
-		/datum/reagent/blood,
+	//	/datum/reagent/blood,
 		/datum/reagent/medicine/c2/multiver,
 		/datum/reagent/water/holywater,
 		/datum/reagent/consumable/ethanol,
@@ -48,16 +51,19 @@
 		/datum/reagent/consumable/laughter,
 		/datum/reagent/concentrated_barbers_aid,
 		/datum/reagent/baldium,
-		/datum/reagent/colorful_reagent,
-		/datum/reagent/consumable/salt,
+	//	/datum/reagent/colorful_reagent,
+	//	/datum/reagent/consumable/salt,
 		/datum/reagent/consumable/ethanol/beer,
 		/datum/reagent/hair_dye,
 		/datum/reagent/consumable/sugar,
-		/datum/reagent/glitter/white,
+	//	/datum/reagent/glitter/white,
 		/datum/reagent/gravitum,
 		/datum/reagent/growthserum,
 		/datum/reagent/yuck,
 	)
+
+	// END BUBBERSTATION EDIT
+
 	//needs to be chemid unit checked at some point
 
 /datum/round_event/scrubber_overflow/announce_deadchat(random, cause)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Since storyteller loves running scrubber overflow so much, it's become an issue that the station looks like total shit all the time. There isn't much point to cleaning it because it'll happen again in 30 seconds!

## Why It's Good For The Game

People seem to overwhelmingly hate the event with how much it fires - this is an alternative to just disabling it.

## Proof Of Testing

Kinda hard to screenshot the whole station not having stuff after a scrubber event but it compiles and works fine in testing.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: scrubbers do not overflow with carpet and rainbow stuff anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
