### PR TITLE
[TEST MERGE ONLY] [EARLY MIRROR] [SEMIMODULAR] Fixes multi-bodytype characters (digitigrade, species custom) only having digi apply when custom could be applied

### DIFF
--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -375,15 +375,15 @@ There are several things that need to be remembered:
 
 		if((bodytype & BODYTYPE_DIGITIGRADE) && (worn_item.supports_variations_flags & CLOTHING_DIGITIGRADE_VARIATION))
 			var/obj/item/bodypart/leg = src.get_bodypart(BODY_ZONE_L_LEG)
-			if(leg.limb_id == "digitigrade")//Snowflakey and bad. But it makes it look consistent.
+			if(leg.limb_id == "digitigrade" || leg.bodytype & BODYTYPE_DIGITIGRADE)//Snowflakey and bad. But it makes it look consistent.
 				icon_file = worn_item.worn_icon_digi || DIGITIGRADE_SHOES_FILE // SKYRAT EDIT CHANGE
 				mutant_override = TRUE // SKYRAT EDIT ADDITION
-		else if(bodytype & BODYTYPE_CUSTOM)
+		if(!mutant_override && bodytype & BODYTYPE_CUSTOM)
 			var/species_icon_file = dna.species.generate_custom_worn_icon(LOADOUT_ITEM_SHOES, shoes, src)
 			if(species_icon_file)
 				icon_file = species_icon_file
 				mutant_override = TRUE
-		else if(bodytype & BODYTYPE_HIDE_SHOES)
+		if(bodytype & BODYTYPE_HIDE_SHOES)
 			return // We just don't want shoes that float if we're not displaying legs (useful for taurs, for now)
 		// SKYRAT EDIT END
 
@@ -528,7 +528,7 @@ There are several things that need to be remembered:
 				icon_file = worn_item.worn_icon_digi || DIGITIGRADE_SUIT_FILE // SKYRAT EDIT CHANGE
 				mutant_override = TRUE
 
-		else if(bodytype & BODYTYPE_CUSTOM)
+		if(!mutant_override && bodytype & BODYTYPE_CUSTOM)
 			var/species_icon_file = dna.species.generate_custom_worn_icon(LOADOUT_ITEM_SUIT, wear_suit, src)
 			if(species_icon_file)
 				icon_file = species_icon_file


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# DO NOT MERGE UNTIL UPSTREAM MERGES THIS. ONLY TESTMERGE

## About The Pull Request

Early mirror of https://github.com/Skyrat-SS13/Skyrat-tg/pull/26507, because I have a character that depends on this (and ozzo said i could)

A bit of a technical PR..

Basically, limbs have bodytypes. Ex. tesh limbs have BODYTYPE_CUSTOM. Digi legs have BODYTYPE_DIGITIGRADE. If a mob had BODYTYPE_DIGITIGRADE, we wouldnt even consider CUSTOM, despite the fact that the clothing might not even support digi, meaning we can safely use custom. This allows tesh to have digi legs and wear things like winter coats without the game breaking.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

bugs bad

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/59709059/52639f96-66d1-4aed-a91e-d602e9fe611f)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/59709059/8b534b33-2847-415c-987e-7a3091f5e96e)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/59709059/7d5ffb32-1061-46d4-84d8-d8c2b6d6505d)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/59709059/90842cc9-0af2-4a7a-92e0-c8c6651eae5a)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/59709059/6dc9c687-e804-4d68-97ef-40c518366a8f)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
