### PR TITLE
Fixes planetary atmos getting created when turfs inside the station are destroyed.

### DIFF
--- a/modular_zubbers/code/game/turfs/change_turf.dm
+++ b/modular_zubbers/code/game/turfs/change_turf.dm
@@ -1,0 +1,7 @@
+/turf/open/AfterChange(flags, oldType)
+	. = ..()
+	//This makes it so that turfs will NOT create planetary atmos if it's indoors.
+	if(oldType && src.planetary_atmos && (flags & (CHANGETURF_IGNORE_AIR | CHANGETURF_INHERIT_AIR)))
+		var/area/turf_area = src.loc
+		if(!turf_area.outdoors)
+			src.planetary_atmos = FALSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8250,6 +8250,7 @@
 #include "modular_zubbers\code\game\objects\structures\plaques\static_plaques.dm"
 #include "modular_zubbers\code\game\traits\negative.dm"
 #include "modular_zubbers\code\game\traits\neutral.dm"
+#include "modular_zubbers\code\game\turfs\change_turf.dm"
 #include "modular_zubbers\code\game\turfs\closed\lunar_cave.dm"
 #include "modular_zubbers\code\game\turfs\closed\lunar_surface.dm"
 #include "modular_zubbers\code\game\turfs\open\sand.dm"


### PR DESCRIPTION

## About The Pull Request

Fixes planetary atmos getting created when turfs inside the station are destroyed.

## Why It's Good For The Game

Prevents breaches being created due to floor turfs.

## Proof Of Testing

Listen I forgot to get a screenshot but just trust me it works.

## Changelog

:cl: BurgerBB
fix: Fixes planetary atmos getting created when turfs inside the station are destroyed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
