### PR TITLE
Blueshield station trait

### DIFF
--- a/_maps/map_files/NSVBlueshift/Blueshift.dmm
+++ b/_maps/map_files/NSVBlueshift/Blueshift.dmm
@@ -126929,15 +126929,9 @@
 /turf/open/floor/iron/smooth,
 /area/station/cargo/power_station/upper)
 "yeG" = (
-/obj/structure/closet/secure_closet/blueshield,
-/obj/item/storage/backpack/blueshield,
-/obj/item/storage/backpack/duffelbag/blueshield,
-/obj/item/storage/backpack/satchel/blueshield,
-/obj/item/clothing/gloves/tackler/combat/insulated/blueshield,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/item/clothing/neck/mantle/bsmantle,
 /obj/machinery/duct,
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/blueshield)

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -82720,7 +82720,6 @@
 /turf/open/misc/beach/sand,
 /area/station/science/research)
 "wSc" = (
-/obj/structure/closet/secure_closet/blueshield,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9

--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -18288,10 +18288,6 @@
 /obj/effect/turf_decal/bot/left,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"fDq" = (
-/obj/structure/closet/secure_closet/blueshield,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/blueshield)
 "fDu" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -234737,7 +234733,7 @@ stM
 stM
 stM
 eeA
-fDq
+lmq
 brw
 xSO
 xCR

--- a/modular_skyrat/modules/automapper/code/area_spawn_entries.dm
+++ b/modular_skyrat/modules/automapper/code/area_spawn_entries.dm
@@ -19,12 +19,12 @@
 /datum/area_spawn/secmed_locker
 	target_areas = list(/area/station/security/medical, /area/station/security/lockers)
 	desired_atom = /obj/structure/closet/secure_closet/security_medic
-
+/*// BUBBER REMOVAL BEGIN
 /datum/area_spawn/blueshield_locker
 	target_areas = list(/area/station/command/heads_quarters/captain, /area/station/command/bridge, /area/station/command/corporate_dock, /area/station/command/meeting_room, /area/station/command/gateway)
 	desired_atom = /obj/structure/closet/secure_closet/blueshield
 	mode = AREA_SPAWN_MODE_HUG_WALL
-
+*/// BUBBER REMOVAL END
 /datum/area_spawn/command_drobe
 	target_areas = list(/area/station/command/meeting_room, /area/station/command/meeting_room/council, /area/station/command/bridge)
 	desired_atom = /obj/machinery/vending/access/command

--- a/modular_skyrat/modules/blueshield/code/blueshield.dm
+++ b/modular_skyrat/modules/blueshield/code/blueshield.dm
@@ -4,8 +4,8 @@
 	auto_deadmin_role_flags = DEADMIN_POSITION_SECURITY
 	department_head = list(JOB_NT_REP)
 	faction = FACTION_STATION
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0 //BUBBER EDIT. Original = 1
+	spawn_positions = 0 //BUBBER EDIT. Original = 1
 	supervisors = "Central Command and the Nanotrasen Consultant"
 	minimal_player_age = 7
 	exp_requirements = 2400

--- a/modular_skyrat/modules/blueshield/code/blueshield.dm
+++ b/modular_skyrat/modules/blueshield/code/blueshield.dm
@@ -4,8 +4,8 @@
 	auto_deadmin_role_flags = DEADMIN_POSITION_SECURITY
 	department_head = list(JOB_NT_REP)
 	faction = FACTION_STATION
-	total_positions = 0 //BUBBER EDIT Original = 1
-	spawn_positions = 0 //BUBBER EDIT Original = 1
+	total_positions = 1
+	spawn_positions = 1
 	supervisors = "Central Command and the Nanotrasen Consultant"
 	minimal_player_age = 7
 	exp_requirements = 2400
@@ -53,11 +53,6 @@
 	ears = /obj/item/radio/headset/headset_bs/alt
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	implants = list(/obj/item/implant/mindshield)
-	//BUBBER ADDITION START
-	backpack_contents = list(
-		/obj/item/choice_beacon/blueshield = 1,
-	)
-	//BUBBER ADDITION END
 	backpack = /obj/item/storage/backpack/blueshield
 	satchel = /obj/item/storage/backpack/satchel/blueshield
 	duffelbag = /obj/item/storage/backpack/duffelbag/blueshield

--- a/modular_skyrat/modules/blueshield/code/blueshield.dm
+++ b/modular_skyrat/modules/blueshield/code/blueshield.dm
@@ -53,6 +53,11 @@
 	ears = /obj/item/radio/headset/headset_bs/alt
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	implants = list(/obj/item/implant/mindshield)
+	//BUBBER ADDITION START
+	backpack_contents = list(
+		/obj/item/choice_beacon/blueshield = 1,
+	)
+	//BUBBER ADDITION END
 	backpack = /obj/item/storage/backpack/blueshield
 	satchel = /obj/item/storage/backpack/satchel/blueshield
 	duffelbag = /obj/item/storage/backpack/duffelbag/blueshield

--- a/modular_skyrat/modules/blueshield/code/blueshield.dm
+++ b/modular_skyrat/modules/blueshield/code/blueshield.dm
@@ -4,8 +4,8 @@
 	auto_deadmin_role_flags = DEADMIN_POSITION_SECURITY
 	department_head = list(JOB_NT_REP)
 	faction = FACTION_STATION
-	total_positions = 0 //BUBBER EDIT. Original = 1
-	spawn_positions = 0 //BUBBER EDIT. Original = 1
+	total_positions = 0 //BUBBER EDIT Original = 1
+	spawn_positions = 0 //BUBBER EDIT Original = 1
 	supervisors = "Central Command and the Nanotrasen Consultant"
 	minimal_player_age = 7
 	exp_requirements = 2400
@@ -40,7 +40,7 @@
 	)
 
 	veteran_only = TRUE
-	job_flags = STATION_JOB_FLAGS | JOB_CANNOT_OPEN_SLOTS
+	job_flags = STATION_JOB_FLAGS | JOB_CANNOT_OPEN_SLOTS | STATION_TRAIT_JOB_FLAGS //BUBBER EDIT: Added "| STATION_TRAIT_JOB_FLAGS"
 
 /datum/outfit/job/blueshield
 	name = "Blueshield"

--- a/modular_zubbers/code/datums/station_traits/job_traits.dm
+++ b/modular_zubbers/code/datums/station_traits/job_traits.dm
@@ -1,7 +1,7 @@
 //Blueshield becomes a station trait job
 /datum/station_trait/job/blueshield
 	name = "Blueshield"
-	button_desc = "Protect heads of staff, get your fancy gun stolen, cry as the captain touches the supermatter."
+	button_desc = "Protect the Heads of Staff and get your hands dirty so they can keep theirs clean."
 	weight = 2
 	report_message = "A Blueshield has been assigned to the station today."
 	show_in_report = TRUE

--- a/modular_zubbers/code/datums/station_traits/job_traits.dm
+++ b/modular_zubbers/code/datums/station_traits/job_traits.dm
@@ -1,0 +1,8 @@
+//Blueshield becomes a station trait job
+/datum/station_trait/job/blueshield
+	name = "Blueshield"
+	button_desc = "Protect heads of staff, get your fancy gun stolen, cry as the captain touches the supermatter."
+	weight = 2
+	report_message = "A Blueshield has been assigned to the station today."
+	show_in_report = TRUE
+	job_to_add = /datum/job/blueshield

--- a/modular_zubbers/master_files/skyrat/modules/blueshield/code/blueshield.dm
+++ b/modular_zubbers/master_files/skyrat/modules/blueshield/code/blueshield.dm
@@ -1,3 +1,10 @@
 /datum/job/blueshield
 	description = "Protect the Heads of Staff and get your hands dirty so they can keep theirs clean."
 	supervisors = "All Command Staff and Central Command when applicable"
+	total_positions = 0
+	spawn_positions = 0
+
+/datum/outfit/job/blueshield
+	backpack_contents = list(
+		/obj/item/choice_beacon/blueshield = 1,
+	)

--- a/modular_zubbers/master_files/skyrat/modules/blueshield/code/objects/items/choice_beacon.dm
+++ b/modular_zubbers/master_files/skyrat/modules/blueshield/code/objects/items/choice_beacon.dm
@@ -1,0 +1,16 @@
+/obj/item/choice_beacon/blueshield
+	name = "Blueshield's locker beacon"
+	desc = "Summons the Blueshield's equipment locker. Recommended for use only in secure areas."
+	company_source = "Nanotrasen kitting division"
+	company_message = span_bold("Request status: Received. Package status: Delivered. Note: This equipment is to be used solely by Blueshield personnel to protect heads of staff.")
+
+/obj/item/choice_beacon/blueshield/generate_display_names()
+	var/static/list/blueshield_locker
+	if(!blueshield_locker)
+		blueshield_locker = list()
+		var/list/locker_choice = list(
+			/obj/structure/closet/secure_closet/blueshield
+		)
+		for(var/obj/structure/closet/secure_closet/blueshield/locker as anything in locker_choice)
+			blueshield_locker[initial(locker.name)] = locker
+	return blueshield_locker

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8184,6 +8184,7 @@
 #include "modular_zubbers\code\datums\mood_events\miasma_events.dm"
 #include "modular_zubbers\code\datums\shuttle\arena.dm"
 #include "modular_zubbers\code\datums\shuttles\emergency.dm"
+#include "modular_zubbers\code\datums\station_traits\job_traits.dm"
 #include "modular_zubbers\code\datums\weather\weather_types\sand_storm.dm"
 #include "modular_zubbers\code\game\area\areas\centcom.dm"
 #include "modular_zubbers\code\game\area\areas\moonstation.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8528,6 +8528,7 @@
 #include "modular_zubbers\master_files\code\modules\research\designs\biogenerator_designs.dm"
 #include "modular_zubbers\master_files\code\modules\research\designs\weapon_designs.dm"
 #include "modular_zubbers\master_files\skyrat\modules\blueshield\code\blueshield.dm"
+#include "modular_zubbers\master_files\skyrat\modules\blueshield\code\objects\items\choice_beacon.dm"
 #include "modular_zubbers\master_files\skyrat\modules\cortical_borer\code\cortical_borer_antag.dm"
 #include "modular_zubbers\master_files\skyrat\modules\opposing_force\code\opposing_force_subsystem.dm"
 #include "modular_zubbers\master_files\skyrat\modules\verbs\code\subtle.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Puts blueshield behind a new station trait, much like bridge assistant or cargorilla. 

List of changes I have made: 

- Blueshield can now only be played if the station trait rolls or is bussed.
- Blueshield lockers will no longer be spawned on the map. (I think, I'm not a mapper lmao)
- Blueshields will spawn with a beacon in their backpack that will supply drop a blueshield locker when used. 
- When the Blueshield trait rolls, it will be available for latejoins to choose. 


Weighting is subject to change. 

_**Also maintainers the config needs to be updated to accommodate the slot # change (I think???)**_


## Why It's Good For The Game

I have had a feeling for a while when playing this server that Blueshield is often poorly utilized. This isn't a dig at any specific players, the role just feels like it doesn't fit, especially when I'm playing command, and ESPECIALLY when there's an NT rep present. 

Originally I wanted to remove it but after playing a bit more I felt that was going too far. 

I think putting it behind a trait will improve the enjoyment both the people who play and the people who interact with because it will be more sought after and I believe people who see it open and pick it will try to make the most out of their shift.

Admins can force a slot open or bus the station trait to take effect next-round if they've got plans and want to make it available, or someone's been very good and redeemed their good bubber points.

## Proof Of Testing

No blueshield without the trait.
![image](https://github.com/Bubberstation/Bubberstation/assets/26744576/c81406c1-f67d-4571-b1e9-70c155cc3778)

I bussed the trait then restarted the server, blueshield available for latejoins.
![image](https://github.com/Bubberstation/Bubberstation/assets/26744576/0ff348ed-bd15-407c-b909-be8424c693ac)

Blueshield cannot be selected in the character preferences occupations tab.
![image](https://github.com/Bubberstation/Bubberstation/assets/26744576/f341d630-ccbf-4a66-a1e4-c9268db545a9)

Spawned with the beacon and used it.
![image](https://github.com/Bubberstation/Bubberstation/assets/26744576/3a5e2a79-3fec-4b3b-8eca-1d051a722696)

Pod came down and dropped the BS locker off
![image](https://github.com/Bubberstation/Bubberstation/assets/26744576/5146e66b-7db4-41ef-a943-dfef63169554)


<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added the Blueshield station trait.
del: Blueshields are no longer available every round.
del: Blueshield lockers have been removed from the maps.
add: Blueshields spawn with a beacon to supply drop their locker in.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
