### PR TITLE
Removes the blast cannon because I saw someone saw the entire station in half once.

### DIFF
--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -325,7 +325,7 @@
 
 */
 // SKYRAT EDIT END
-/datum/uplink_item/role_restricted/blastcannon
+/* /datum/uplink_item/role_restricted/blastcannon - BUBBER REMOVE START
 	name = "Blast Cannon"
 	desc = "A highly specialized weapon, the Blast Cannon is actually relatively simple. It contains an attachment for a tank transfer valve mounted to an angled pipe specially constructed \
 			withstand extreme pressure and temperatures, and has a mechanical trigger for triggering the transfer valve. Essentially, it turns the explosive force of a bomb into a narrow-angle \
@@ -336,7 +336,7 @@
 	cost = 14 //High cost because of the potential for extreme damage in the hands of a skilled scientist.
 	restricted_roles = list(JOB_RESEARCH_DIRECTOR, JOB_SCIENTIST)
 	surplus = 5
-
+BUBBER REMOVE END*/
 /datum/uplink_item/role_restricted/evil_seedling
 	name = "Evil Seedling"
 	desc = "A rare seed we have recovered that grows into a dangerous species that will aid you with your tasks!"


### PR DESCRIPTION
## About The Pull Request

Removes a fun little item that cuts the station in half.

## Why It's Good For The Game

![image](https://github.com/Bubberstation/Bubberstation/assets/95130227/2415e4f9-e1b9-4634-aafd-36447cab6a3d)


## Proof Of Testing

![image](https://github.com/Bubberstation/Bubberstation/assets/95130227/b38c5bd0-dd97-4ecd-8e91-07e1c7752cfd)

## Changelog

:cl:
del: Removes the blast cannon from the traitor scientist uplink
/:cl:
