### PR TITLE
Prosperity Prism no longer kills slime clockies. Coggers!

### DIFF
--- a/modular_skyrat/modules/clock_cult/code/structures/prosperity_prism.dm
+++ b/modular_skyrat/modules/clock_cult/code/structures/prosperity_prism.dm
@@ -26,7 +26,7 @@
 			continue
 
 		if(use_power(POWER_PER_USE))
-			possible_cultist.adjustToxLoss(-2.5 * seconds_per_tick)
+			possible_cultist.adjustToxLoss(-2.5 * seconds_per_tick, forced = TRUE) // BUBBER EDIT - Stops the prosperity prism from killing slime cultists.
 			possible_cultist.adjustStaminaLoss(-7.5 * seconds_per_tick)
 			possible_cultist.adjustBruteLoss(-2.5 * seconds_per_tick)
 			possible_cultist.adjustFireLoss(-2.5 * seconds_per_tick)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Makes it so that the healing from the prosperity prism is forced, thus making it so that slimepeople can also heal from it.
<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

Clockwork cultist's have their healing self sustain in the form of the prosperity prism. If they just so happen to be a slime though then they're shit out of luck because it will kill them just as quickly as it heals them. This PR, similar to my previous Nanites no longer kill [slimepeople PR](https://github.com/tgstation/tgstation/pull/81458), makes them now heal toxin damage for everyone including slimes.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Proof Of Testing

Tested locally and it didn't kill me. Huzzah!
<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Slimeperson Clockwork Cultists now heal toxins from the prosperity prism properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
