### PR TITLE
[MODULAR I HOPE] Adds persistence to NIF huds

### DIFF
--- a/modular_zubbers/modules/loadouts/loadout_items/loadout_datum_pocket.dm
+++ b/modular_zubbers/modules/loadouts/loadout_items/loadout_datum_pocket.dm
@@ -26,3 +26,7 @@
 /datum/loadout_item/pocket_items/transpride
 	name = "Trans Flag"
 	item_path = /obj/item/sign/flag/pride/trans
+
+/datum/loadout_item/pocket_items/nif_hud_adapter
+	name = "Scrying Lens Adapter"
+	item_path = /obj/item/nif_hud_adapter

--- a/modular_zubbers/modules/modular_implants/code/nifsofts/huds.dm
+++ b/modular_zubbers/modules/modular_implants/code/nifsofts/huds.dm
@@ -1,0 +1,2 @@
+/datum/nifsoft/hud
+	able_to_keep = TRUE // You can have HUDs in loadout anyway.

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8601,6 +8601,7 @@
 #include "modular_zubbers\modules\modular_weapons\code\company_and_or_faction_based\carwo_defense_systems\ammo\carwo.dm"
 #include "modular_zubbers\modules\modular_weapons\code\company_and_or_faction_based\trappiste_fabriek\ammo.dm"
 #include "modular_zubbers\modules\normalized_syndie_clothing_4_tesh\unsorted_clothes.dm"
+#include "modular_zubbers\modules\modular_implants\code\nifsofts\huds.dm"
 #include "modular_zubbers\modules\pollution\code\perfumes.dm"
 #include "modular_zubbers\modules\pollution\code\pollutants_generic.dm"
 #include "modular_zubbers\modules\quirks\code\_quirk.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Scrying Lens NIFsoft is now able to be kept persistently between rounds. Accordingly, players may now receive a scrying lens adapter through their loadout.
See #1243 for an alternative which preserves the job restrictions.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game
Reasoning: HUD glasses are already able to be picked from the loadout, so the precedent of roundstart HUDs is already there. 
This still requires players to first acquire the HUD once through R&D before it can be saved in their NIF, and it still requires them to wear one of a specific selection of eyewear, with the refit giving it a very obvious "HUD-Adapted [Glasses]", making it evident they're using a scrying lens.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Proof Of Testing
It runs chief. This is like five lines of code.
<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->

## Changelog
:cl:
qol: Thanks to Centcom updating to the premium version of Scrying Lens NIFsoft, it may now be persistently kept between rounds.
/:cl:
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
