### PR TITLE
[MODULAR PROBABLY] Adds NIF Huds to loadout

### DIFF
--- a/modular_zubbers/modules/loadouts/loadout_items/loadout_datum_pocket.dm
+++ b/modular_zubbers/modules/loadouts/loadout_items/loadout_datum_pocket.dm
@@ -26,3 +26,37 @@
 /datum/loadout_item/pocket_items/transpride
 	name = "Trans Flag"
 	item_path = /obj/item/sign/flag/pride/trans
+
+/datum/loadout_item/pocket_items/nif_disk_med
+	name = "Medical Scrying Lens Disk"
+	item_path = /obj/item/disk/nifsoft_uploader/med_hud
+	restricted_roles = list(JOB_MEDICAL_DOCTOR, JOB_CHIEF_MEDICAL_OFFICER, JOB_GENETICIST, JOB_CHEMIST, JOB_VIROLOGIST, JOB_PARAMEDIC, JOB_ORDERLY, JOB_CORONER)
+
+/datum/loadout_item/pocket_items/nif_disk_diag
+	name = "Diagnostic Scrying Lens Disk"
+	item_path = /obj/item/disk/nifsoft_uploader/diag_hud
+	restricted_roles = list(JOB_RESEARCH_DIRECTOR, JOB_SCIENTIST, JOB_ROBOTICIST)
+
+/datum/loadout_item/pocket_items/nif_disk_sec
+	name = "Security Scrying Lens Disk"
+	item_path = /obj/item/disk/nifsoft_uploader/sec_hud
+	restricted_roles = list(JOB_SECURITY_OFFICER, JOB_WARDEN, JOB_HEAD_OF_SECURITY, JOB_CORRECTIONS_OFFICER, JOB_BOUNCER, JOB_ORDERLY, JOB_SCIENCE_GUARD, JOB_CUSTOMS_AGENT, JOB_ENGINEERING_GUARD, JOB_BLUESHIELD)
+
+/datum/loadout_item/pocket_items/nif_disk_permit
+	name = "Permit Scrying Lens Disk"
+	item_path = /obj/item/disk/nifsoft_uploader/permit_hud
+	restricted_roles = list(JOB_QUARTERMASTER, JOB_CARGO_TECHNICIAN, JOB_CUSTOMS_AGENT, JOB_SHAFT_MINER)
+
+/datum/loadout_item/pocket_items/nif_disk_sci
+	name = "Science Scrying Lens Disk"
+	item_path = /obj/item/disk/nifsoft_uploader/sci_hud
+	restricted_roles = list(JOB_SCIENTIST, JOB_ROBOTICIST, JOB_GENETICIST, JOB_RESEARCH_DIRECTOR, JOB_CHEMIST, JOB_SCIENCE_GUARD, JOB_VIROLOGIST)
+
+/datum/loadout_item/pocket_items/nif_disk_meson
+	name = "Meson Scrying Lens Disk"
+	item_path = /obj/item/disk/nifsoft_uploader/meson_hud
+	restricted_roles = list(JOB_QUARTERMASTER, JOB_CARGO_TECHNICIAN, JOB_SHAFT_MINER, JOB_CUSTOMS_AGENT, JOB_CHIEF_ENGINEER, JOB_STATION_ENGINEER, JOB_ATMOSPHERIC_TECHNICIAN, JOB_ENGINEERING_GUARD)
+
+/datum/loadout_item/pocket_items/nif_hud_adapter
+	name = "Scrying Lens Adapter"
+	item_path = /obj/item/nif_hud_adapter


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Alternative to #1242 
Instead of persistence, allows players to spawn in with a scrying lens disk through the loadout, with the same job restrictions as the HUD glasses, with the exception of the Permit HUD which has no precedent, and has been restricted to cargo jobs only, since it's available in the cargodrobe.

This also adds scrying lens adapters as a loadout option.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game
See #1242, people can already spawn in with HUDs, this is just an alternative.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Proof Of Testing
![image](https://github.com/Bubberstation/Bubberstation/assets/21011148/9bc0b67c-ce57-4f30-b201-6372e4888808)
![image](https://github.com/Bubberstation/Bubberstation/assets/21011148/02a8c814-c10e-4db6-85ef-6270e8e18454)

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->

## Changelog
:cl:
add: Scrying Lens Disks are now available in the loadout.
/:cl:
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added new mechanics or gameplay changes
add: Added more things
del: Removed old things
qol: made something easier to use
balance: rebalanced something
fix: fixed a few things
sound: added/modified/removed audio or sound effects
image: added/modified/removed some icons or images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
