### PR TITLE
Fixes missing telecomms wire in Moonstation

### DIFF
--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -12252,6 +12252,7 @@
 "dNg" = (
 /obj/machinery/light/warm/directional/west,
 /obj/machinery/power/smes/engineering,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/tcommsat/computer)
 "dNh" = (

--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -62154,10 +62154,6 @@
 /obj/structure/fluff/tram_rail/electric,
 /turf/open/floor/plating/rust/moonstation,
 /area/station/terminal/tramline)
-"sQi" = (
-/obj/structure/stone_tile/slab,
-/turf/open/indestructible/boss,
-/area/ruin/unpowered/ash_walkers)
 "sQw" = (
 /obj/structure/railing{
 	dir = 10
@@ -272676,7 +272672,7 @@ hsI
 dic
 dic
 dic
-nJi
+dic
 mfi
 mfi
 fMg
@@ -272933,7 +272929,7 @@ hsI
 dic
 dic
 dic
-nJi
+dic
 mfi
 mfi
 eqQ
@@ -272946,7 +272942,7 @@ gzb
 qDn
 mKM
 tYz
-sQi
+ayT
 vxY
 vxY
 vxY
@@ -273190,7 +273186,7 @@ hsI
 dic
 dic
 dic
-nJi
+dic
 mfi
 mfi
 ajZ

--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -237148,7 +237148,7 @@ itb
 pQk
 mnR
 mZQ
-hEm
+hPo
 aGH
 hPo
 mza

--- a/modular_zubbers/code/controllers/subsystem/mapping.dm
+++ b/modular_zubbers/code/controllers/subsystem/mapping.dm
@@ -1,0 +1,14 @@
+//This is for Moonstation.
+
+/datum/controller/subsystem/mapping/setup_rivers()
+	. = ,.()
+	// Generate mining ruins
+	var/list/lava_ruins = levels_by_trait(ZTRAIT_LAVA_RUINS)
+	for (var/lava_z in lava_ruins)
+		spawn_rivers(lava_z, 4, /turf/open/lava/smooth/lava_land_surface, /area/lavaland/underground/unexplored)
+
+/datum/controller/subsystem/mapping/setup_ruins()
+	. = ..()
+	var/list/lava_ruins = levels_by_trait(ZTRAIT_LAVA_RUINS)
+	if (lava_ruins.len)
+		seedRuins(lava_ruins, CONFIG_GET(number/lavaland_budget), list(/area/lavaland/underground/unexplored), themed_ruins[ZTRAIT_LAVA_RUINS], clear_below = TRUE)

--- a/modular_zubbers/code/controllers/subsystem/mapping.dm
+++ b/modular_zubbers/code/controllers/subsystem/mapping.dm
@@ -1,7 +1,7 @@
 //This is for Moonstation.
 
 /datum/controller/subsystem/mapping/setup_rivers()
-	. = ,.()
+	. = ..()
 	// Generate mining ruins
 	var/list/lava_ruins = levels_by_trait(ZTRAIT_LAVA_RUINS)
 	for (var/lava_z in lava_ruins)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8161,6 +8161,7 @@
 #include "modular_zubbers\code\_globalvars\lists\maintenance_loot_uncommon.dm"
 #include "modular_zubbers\code\_globalvars\lists\~maintenance_loot.dm"
 #include "modular_zubbers\code\controllers\subsystem\air.dm"
+#include "modular_zubbers\code\controllers\subsystem\mapping.dm"
 #include "modular_zubbers\code\controllers\subsystem\sol_subsystem.dm"
 #include "modular_zubbers\code\datums\armor_overrides.dm"
 #include "modular_zubbers\code\datums\department_security.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes missing telecomms wire in Moonstation

## Why It's Good For The Game

Fixes missing telecomms wire in Moonstation

## Proof Of Testing

Fixes missing telecomms wire in Moonstation

## Changelog

:cl: BurgerBB
fix: Fixes missing telecomms wire in Moonstation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
