### PR TITLE
Forces Map Votes to be at sane settings so we're not at the mercy of upstreams having dogshit voting configs

### DIFF
--- a/modular_zubbers/code/__DEFINES/votes.dm
+++ b/modular_zubbers/code/__DEFINES/votes.dm
@@ -1,5 +1,7 @@
 /datum/vote/map_vote
+	count_method = VOTE_COUNT_METHOD_MULTI
 	winner_method = VOTE_WINNER_METHOD_SIMPLE
 
 /datum/vote/transfer_vote
+	count_method = VOTE_COUNT_METHOD_SINGLE
 	winner_method = VOTE_WINNER_METHOD_SIMPLE


### PR DESCRIPTION

## About The Pull Request

Map vote is always multiple choice, with winner being the map that was voted the most.
Transfer vote is always single choice, with winner being the choice that was voted the most.

## Why It's Good For The Game

![image](https://github.com/Bubberstation/Bubberstation/assets/8602857/0f729dfa-d5db-487a-aa1a-235d282416fe)



## Proof Of Testing

If it compiles, it werks.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: BurgerBB
add: Map vote is always multiple choice, with winner being the map that was voted the most. Transfer vote is always single choice, with winner being the choice that was voted the most.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
