### PR TITLE
Fixes bloodsuckers sired by ventrue having duplicate powers 

### DIFF
--- a/modular_zubbers/code/modules/antagonists/bloodsucker/bloodsuckers/bloodsucker.dm
+++ b/modular_zubbers/code/modules/antagonists/bloodsucker/bloodsuckers/bloodsucker.dm
@@ -131,6 +131,8 @@
 	if(ishuman(current_mob))
 		current_mob?.dna?.species.on_bloodsucker_gain(current_mob)
 		add_signals_to_heart(current_mob)
+		// check if we already somehow don't have a heart, if this is possible, something is fucked up.
+		on_organ_removal(null, current_mob)
 #ifdef BLOODSUCKER_TESTING
 	var/turf/user_loc = get_turf(current_mob)
 	new /obj/structure/closet/crate/coffin(user_loc)

--- a/modular_zubbers/code/modules/antagonists/bloodsucker/bloodsuckers/procs.dm
+++ b/modular_zubbers/code/modules/antagonists/bloodsucker/bloodsuckers/procs.dm
@@ -183,7 +183,7 @@
 
 /datum/antagonist/bloodsucker/proc/on_organ_removal(obj/item/organ/organ, mob/living/carbon/old_owner)
 	SIGNAL_HANDLER
-	if(old_owner.get_organ_slot(ORGAN_SLOT_HEART) || organ.slot != ORGAN_SLOT_HEART || !old_owner.dna.species.mutantheart)
+	if(old_owner.get_organ_slot(ORGAN_SLOT_HEART) || organ?.slot != ORGAN_SLOT_HEART || !old_owner.dna.species.mutantheart)
 		return
 	remove_signals_from_heart(old_owner)
 	// You don't run bloodsucker life without a heart or brain
@@ -192,7 +192,7 @@
 	DisableAllPowers(TRUE)
 	if(HAS_TRAIT_FROM_ONLY(old_owner, TRAIT_NODEATH, BLOODSUCKER_TRAIT))
 		torpor_end(TRUE)
-	to_chat(old_owner, span_userdanger("You have lost your [organ.slot]!"))
+	to_chat(old_owner, span_userdanger("You have lost your [organ?.slot ? organ.slot : "heart"]!"))
 	to_chat(old_owner, span_warning("This means you will no longer enter torpor nor revive from death, and you will no longer heal any damage, nor can you use your abilities."))
 
 /datum/antagonist/bloodsucker/proc/on_organ_gain(mob/living/carbon/human/current_mob, obj/item/organ/replacement)

--- a/modular_zubbers/code/modules/antagonists/bloodsucker/vassal/vassal_types/favorite_vassal.dm
+++ b/modular_zubbers/code/modules/antagonists/bloodsucker/vassal/vassal_types/favorite_vassal.dm
@@ -21,6 +21,7 @@
 
 /datum/antagonist/vassal/favorite/on_removal()
 	SEND_SIGNAL(master, BLOODSUCKER_LOOSE_FAVORITE, src)
+	remove_powers(bloodsucker_powers)
 	. = ..()
 
 /datum/antagonist/vassal/favorite/pre_mindshield(mob/implanter, mob/living/mob_override)

--- a/modular_zubbers/code/modules/antagonists/bloodsucker/vassal/vassal_types/favorite_vassal.dm
+++ b/modular_zubbers/code/modules/antagonists/bloodsucker/vassal/vassal_types/favorite_vassal.dm
@@ -10,7 +10,7 @@
 	vassal_description = "The Favorite Vassal gets unique abilities over other Vassals depending on your Clan \
 		and becomes completely immune to Mindshields. If part of Ventrue, this is the Vassal you will rank up."
 
-	///Bloodsucker levels, but for Vassals, used by Ventrue.
+	///Bloodsucker levels, but for Vassals, used by Ventrue. Used for ventrue creating a new bloodsucker.
 	var/vassal_level
 	/// Power's we're going to inherit once we turn into a Bloodsucker
 	var/list/bloodsucker_powers = list()
@@ -26,7 +26,3 @@
 
 /datum/antagonist/vassal/favorite/pre_mindshield(mob/implanter, mob/living/mob_override)
 	return COMPONENT_MINDSHIELD_RESISTED
-
-///Set the Vassal's rank to their Bloodsucker level
-/datum/antagonist/vassal/favorite/proc/set_vassal_level(mob/living/carbon/human/target)
-	master.bloodsucker_level = vassal_level


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes sired 
 bloodsuckers having duplicate powers, and also makes applying the bloodsucker datum check if you have a heart or not, so it can properly stop the bloodsucker life, so you don't get stuck in torpor loops as a result, later I need to add some way to get out of torpor loops better.
Checking if you have a heart at the start will also allow them to use the coffin in heart mechanic to gain one if need be.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game
Trying to make bloodsuckers bugless is a hard job and this is one step closer
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Proof Of Testing

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Ventrue sired bloodsuckers will no longer have a copy of their abilities
add: Bloodsuckers that start out with no heart will be able to regain one, but it now properly checks if they have one or not, and disables their abiltiies accordingly, go into a coffin with a heart if you want to gain one.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
