### PR TITLE
Fixes Blooduckers missing null check which caused runetimes. 

### DIFF
--- a/modular_zubbers/code/modules/antagonists/bloodsucker/bloodsuckers/integration.dm
+++ b/modular_zubbers/code/modules/antagonists/bloodsucker/bloodsuckers/integration.dm
@@ -113,5 +113,5 @@
 // prevents players being trapped in their brain, alive, yet limbless and voiceless
 /obj/item/bodypart/head/drop_organs(mob/user, violent_removal)
 	var/obj/item/organ/internal/brain/brain = locate(/obj/item/organ/internal/brain) in src
-	brain.brainmob.death()
+	brain?.brainmob.death()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

The same as the tittle suggests

## Why It's Good For The Game

## Proof Of Testing

Its a simple change, waterpig approved. 🦎 

## Changelog

:cl:
fix: Bloodsucker braincheck was missing a null check causing runetimes, its been fixed. 
/:cl:
