### PR TITLE
[MIRROR/PORT] Expanded Interaction Preferences

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences/erp_preferences.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/erp_preferences.dm
@@ -134,10 +134,30 @@
 	savefile_key = "erp_status_pref"
 
 /datum/preference/choiced/erp_status/init_possible_values()
-	return list("Yes - Switch", "Yes - Sub", "Yes - Dom", "Check OOC", "Ask", "No", "Yes")
+	return list(
+		"Top - Dom",
+		"Top - Switch",
+		"Top - Sub",
+		"Verse-Top - Dom",
+		"Verse-Top - Switch",
+		"Verse-Top - Sub",
+		"Verse - Dom",
+		"Verse - Switch",
+		"Verse - Sub",
+		"Verse-Bottom - Dom",
+		"Verse-Bottom - Switch",
+		"Verse-Bottom - Sub",
+		"Bottom - Dom",
+		"Bottom - Switch",
+		"Bottom - Sub",
+		"Check OOC Notes",
+		"Ask (L)OOC",
+		"No",
+		"Yes",
+	)
 
 /datum/preference/choiced/erp_status/create_default_value()
-	return "Ask"
+	return "Ask (L)OOC"
 
 /datum/preference/choiced/erp_status/is_accessible(datum/preferences/preferences)
 	if (!..(preferences))
@@ -164,10 +184,10 @@
 	savefile_key = "erp_status_pref_nc"
 
 /datum/preference/choiced/erp_status_nc/init_possible_values()
-	return list("Yes - Switch", "Yes - Sub", "Yes - Dom", "Check OOC", "Ask", "No", "Yes")
+	return list("Yes - Switch", "Yes - Dom", "Yes - Sub", "Yes", "Ask (L)OOC", "Check OOC Notes", "No")
 
 /datum/preference/choiced/erp_status_nc/create_default_value()
-	return "Ask"
+	return "No"
 
 /datum/preference/choiced/erp_status_nc/is_accessible(datum/preferences/preferences)
 	if (!..(preferences))
@@ -194,10 +214,10 @@
 	savefile_key = "erp_status_pref_v"
 
 /datum/preference/choiced/erp_status_v/init_possible_values()
-	return list("Yes - Switch", "Yes - Prey", "Yes - Pred", "Check OOC", "Ask", "No", "Yes")
+	return list("Yes - Switch", "Yes - Prey", "Yes - Pred", "Check OOC Notes", "Ask (L)OOC", "No", "Yes")
 
 /datum/preference/choiced/erp_status_v/create_default_value()
-	return "Ask"
+	return "No"
 
 /datum/preference/choiced/erp_status_v/is_accessible(datum/preferences/preferences)
 	if (!..(preferences))

--- a/modular_skyrat/master_files/code/modules/mob/living/examine_tgui.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/examine_tgui.dm
@@ -61,13 +61,13 @@
 	//  Handle OOC notes first
 	if(preferences && preferences.read_preference(/datum/preference/toggle/master_erp_preferences))
 		var/e_prefs = preferences.read_preference(/datum/preference/choiced/erp_status)
-		var/e_prefs_nc = preferences.read_preference(/datum/preference/choiced/erp_status_nc)
 		var/e_prefs_hypno = preferences.read_preference(/datum/preference/choiced/erp_status_hypno) // bubberstation edit
+		var/e_prefs_nc = preferences.read_preference(/datum/preference/choiced/erp_status_nc)
 		var/e_prefs_v = preferences.read_preference(/datum/preference/choiced/erp_status_v)
 		var/e_prefs_mechanical = preferences.read_preference(/datum/preference/choiced/erp_status_mechanics)
 		ooc_notes += "ERP: [e_prefs]\n"
-		ooc_notes += "Non-Con: [e_prefs_nc]\n"
 		ooc_notes += "Hypnosis: [e_prefs_hypno]\n" // bubberstation Edit
+		ooc_notes += "Non-Con: [e_prefs_nc]\n"
 		ooc_notes += "Vore: [e_prefs_v]\n"
 		ooc_notes += "ERP Mechanics: [e_prefs_mechanical]\n"
 		ooc_notes += "\n"

--- a/tgui/packages/tgui/interfaces/ZubbersCharacterDirectory.jsx
+++ b/tgui/packages/tgui/interfaces/ZubbersCharacterDirectory.jsx
@@ -13,14 +13,26 @@ import {
 import { Window } from '../layouts';
 
 const erpTagColor = {
-  Unset: 'label',
-  'Yes - Dom': '#570000',
-  'Yes - Sub': '#002B57',
-  'Yes - Switch': '#022E00',
-  Yes: '#022E00',
-  'Check OOC': '#222222',
-  Ask: '#222222',
-  No: '#000000',
+  Unset: '#000000',
+  'Top - Dom': '#410308',
+  'Top - Switch': '#410308',
+  'Top - Sub': '#410308',
+  'Verse-Top - Dom': '#3d003b',
+  'Verse-Top - Switch': '#3d003b',
+  'Verse-Top - Sub': '#3d003b',
+  'Verse - Dom': '#310042',
+  'Verse - Switch': '#310042',
+  'Verse - Sub': '#310042',
+  'Verse-Bottom - Dom': '#29084b',
+  'Verse-Bottom - Switch': '#29084b',
+  'Verse-Bottom - Sub': '#29084b',
+  'Bottom - Dom': '#002f51',
+  'Bottom - Switch': '#002f51',
+  'Bottom - Sub': '#002f51',
+  'Check OOC Notes': '#333333',
+  'Ask (L)OOC': '#333333',
+  No: '#131313',
+  Yes: '#002901',
 };
 
 export const ZubbersCharacterDirectory = (props) => {


### PR DESCRIPTION
## About The Pull Request

Mirror of https://github.com/Skyrat-SS13/Skyrat-tg/pull/27043 / https://github.com/NovaSector/NovaSector/pull/1527 with Bubber edits included (character directory.)

## Original PR

Port:
Original PR: https://github.com/NovaSector/NovaSector/pull/1527/
Additional port: https://github.com/effigy-se/effigy-se/pull/790

Hi.
This PR adds some preferences for illicit meetups.
Let's go over them.
For clarification, verse refers to 'okay with either bottoming or topping' and switch corresponds with domming and subbing. Jsyk.

For midnight meetings,
Top - Dom
Top - Switch
Top - Sub

Verse-Top - Dom
Verse-Top - Switch
Verse-Top - Sub

Verse - Dom
Verse - Switch
Verse - Sub

Verse-Bottom - Dom
Verse-Bottom - Switch
Verse-Bottom - Sub

Bottom - Dom
Bottom - Switch
Bottom - Sub

I am willing to put 'Yes -' infront of each of those, but I don't really think it's needed? It's sort of implied.
I also changed some of the other ones.
'Ask' is now 'Ask (L)OOC.' Of course you ask ICly, it came free with your 'playing a social interaction game,' and I don't know why we'd have a preference just for Ask ICly? So instead, ask in LOOC if it's a go or not.

As for assault and consumption, I have made the default be 'no,' and slimmed down the options for assault. This sort of assault is implicitly tied with conception, you should go off the preference readout for that.

I have added another preference for hypnosis.
Always/Whenever - Corresponding to just 'yeah whenever's fine even if it's just for trivial RP stuff.'
Gameplay Only - For stuff like hypnobangs or traitor stuff, not for "woohoo."
Ask (L)OOC - We've been over this.
Check OOC - Check the notes.
No - Means no.

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/83487515/c6477e7c-7a59-4990-beb4-dc4afa8af297)

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/83487515/b40d46fa-4650-47e7-bd51-9c698f74bd5b)

This allows you to get a more granular experience and allows for a wider array of display of identity, and there have been situations where, say, a sub person being engaged with and being expected to bottom when they don't want to.
Additionally, it really, really shouldn't default to 'ask' for extreme content like the other two.

As to the hypnosis preference, I am self-serving; but more importantly, this stuff is surprisingly accessible nowadays (thru the NIFsoft and Hypno Goggles) and there's been more people around with it as kind of a central theme.

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/83487515/8d6f48b6-4ff0-4996-8175-da70f191f070)
  
</details>

## Changelog

🆑 Nerev4r
qol: Interaction preferences have been expanded to make a wider array of characters more comfortable.
/:cl: