### PR TITLE
Removes security comms and access from blueshield

### DIFF
--- a/modular_zubbers/code/modules/jobs/job_types/blueshield.dm
+++ b/modular_zubbers/code/modules/jobs/job_types/blueshield.dm
@@ -18,8 +18,6 @@
 		ACCESS_COMMAND, ACCESS_CONSTRUCTION, ACCESS_ENGINEERING, ACCESS_CARGO,
 		ACCESS_MAINT_TUNNELS, ACCESS_MEDICAL, ACCESS_RESEARCH, ACCESS_WEAPONS,
 	)
-	minimal_wildcard_access = list(ACCESS_CAPTAIN)
-	template_access = null
 
 /obj/item/encryptionkey/heads/blueshield // Removes security channel because you don't need it
 	channels = list(RADIO_CHANNEL_COMMAND = 1)

--- a/modular_zubbers/code/modules/jobs/job_types/blueshield.dm
+++ b/modular_zubbers/code/modules/jobs/job_types/blueshield.dm
@@ -9,4 +9,17 @@
 
 /datum/outfit/job/blueshield
 	id = /obj/item/card/id/advanced/silver
+
 //Making the Blueshield have a silver ID, which cannot receive All Access by default.
+
+/datum/id_trim/job/blueshield // Removes security access. Gives basic cargo access (either all or none basic department access), and removes template access
+	extra_access = list(ACCESS_COURT, ACCESS_GATEWAY)
+	minimal_access = list(
+		ACCESS_COMMAND, ACCESS_CONSTRUCTION, ACCESS_ENGINEERING, ACCESS_CARGO,
+		ACCESS_MAINT_TUNNELS, ACCESS_MEDICAL, ACCESS_RESEARCH, ACCESS_WEAPONS,
+	)
+	minimal_wildcard_access = list(ACCESS_CAPTAIN)
+	template_access = null
+
+/obj/item/encryptionkey/heads/blueshield // Removes security channel because you don't need it
+	channels = list(RADIO_CHANNEL_COMMAND = 1)

--- a/modular_zubbers/code/modules/jobs/job_types/blueshield.dm
+++ b/modular_zubbers/code/modules/jobs/job_types/blueshield.dm
@@ -13,7 +13,7 @@
 //Making the Blueshield have a silver ID, which cannot receive All Access by default.
 
 /datum/id_trim/job/blueshield // Removes security access. Gives basic cargo access (either all or none basic department access), and removes template access
-	extra_access = list(ACCESS_COURT, ACCESS_GATEWAY)
+	extra_access = list(ACCESS_COURT, ACCESS_GATEWAY, ACCESS_BRIG_ENTRANCE)
 	minimal_access = list(
 		ACCESS_COMMAND, ACCESS_CONSTRUCTION, ACCESS_ENGINEERING, ACCESS_CARGO,
 		ACCESS_MAINT_TUNNELS, ACCESS_MEDICAL, ACCESS_RESEARCH, ACCESS_WEAPONS,


### PR DESCRIPTION
## About The Pull Request

* Removes blueshield security comms
* Removes blueshield security accesss
* Places cargo into minimal access. (which means they have access) because either all basic department access is ok, or none of it is ok. I have no clue why skyrat did not give basic cargo access, but we'll try it

## Why It's Good For The Game

I spoke to a lot of admins and the other maintainers about this.

Every time I see the term redshield, I get a hernia. Especially when a blueshield is just doing security work. To be honest, if you don't want someone to do security work, you don't give them access to their comms and their doors. It's bwoink bait. While valid hunting is not alright for blueshield, the fundimental action of removing them off security comms and access will make this task a far more concious decision for the player. You're no longer going to have second by second snapshots of every threat and their movement.

You don't need security access, or comms, to do your job. You have a pinpointer and you're standing next to the person who can tell you everything you need to know. If there's a communication issue between command and security, and heads die, that's the consiquences when communication breaks down. It's not necisiarrily a bad thing. Command, 

Also, I threw in a bone with the cargo access. We'll try it, and it can always be adjusted.

## Proof Of Testing

![image](https://github.com/Bubberstation/Bubberstation/assets/95130227/038f1a04-bf5a-41bb-858c-a4130648311f)

![image](https://github.com/Bubberstation/Bubberstation/assets/95130227/972b3ba4-f0b1-4a34-8b85-e8d4d61c9d77)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Blueshield no longer starts with security comms or access. But they now have basic cargo access
/:cl:
