### PR TITLE
[TG MIRROR] Fixes DRAGnet net mode not dealing stamina damage

### DIFF
--- a/code/modules/projectiles/projectile/energy/net_snare.dm
+++ b/code/modules/projectiles/projectile/energy/net_snare.dm
@@ -15,11 +15,11 @@
 		var/turf/Tloc = get_turf(target)
 		if(!locate(/obj/effect/nettingportal) in Tloc)
 			new /obj/effect/nettingportal(Tloc)
-	..()
+	. = ..()
 
 /obj/projectile/energy/net/on_range()
 	do_sparks(1, TRUE, src)
-	..()
+	. = ..()
 
 /obj/effect/nettingportal
 	name = "DRAGnet teleportation field"


### PR DESCRIPTION
## [OriginalPR](https://github.com/tgstation/tgstation/pull/82320)

fixes #1067 

## About The Pull Request

This was meant to be a thing. Looking at the gitblame it has been broken for **9 fucking years** (Ever since it was added):


![image](https://github.com/tgstation/tgstation/assets/49160555/5c3d98fa-32f5-4fab-9b9d-301905c5c846)

How the hell did NOBODY notice for so fucking long

## Why It's Good For The Game

Actually makes something work as intended. Might make sec consider less lethal options when dealing with threats.