### PR TITLE
Disables Northstar

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -36,8 +36,6 @@ map metastation
 endmap
 
 map northstar
-	minplayers 50
-	votable
 endmap
 
 map tramstation


### PR DESCRIPTION
## About The Pull Request

Does what the title says 

## Why It's Good For The Game

Northstar is a bad map. It may look nice but under all that icing is a whole stations worth of maints and 4 floors of massive empty areas, and somehow the departments still feel small. other than sci and service. It's really self-explanatory and it shouldn't even exist to begin with. TG adding it was a mistake, and it is complained about frequently. No, I'm not going to take the elevator, screw you buddy.

The only way I would deem this map functional is if the elevators were replaced with stairs. Even then, I'd still want it gone. All in all it's just a hard to navigate ERP map. At least the maints are okay.

## Changelog

:cl:
del: stops northstar from being votable
/:cl: