### PR TITLE
Removes Sentient Disease because I died to it once.

### DIFF
--- a/modular_zubbers/code/modules/events/ghost_role/sentient_disease.dm
+++ b/modular_zubbers/code/modules/events/ghost_role/sentient_disease.dm
@@ -1,0 +1,3 @@
+/datum/round_event_control/sentient_disease
+	weight = 0
+	max_occurrences = 0

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8422,6 +8422,7 @@
 #include "modular_zubbers\code\modules\emotes\scream_datums.dm"
 #include "modular_zubbers\code\modules\emotes\species_screams.dm"
 #include "modular_zubbers\code\modules\events\ghost_role\blob.dm"
+#include "modular_zubbers\code\modules\events\ghost_role\sentient_disease.dm"
 #include "modular_zubbers\code\modules\experisci\experiment\types\scanning_fish.dm"
 #include "modular_zubbers\code\modules\fishing\fishing_minigame.dm"
 #include "modular_zubbers\code\modules\fluff\sex_barrier.dm"


### PR DESCRIPTION
## About The Pull Request

Removes the sentient disease event from occurring normally.

## Why It's Good For The Game

Sentient Diseases is a midround ghost role antagonist that doesn't roleplay, doesn't need to follow escalation rules, doesn't even communicate except to act like an entertainer for deadchat, and honestly doesn't fit on bubberstation. Even if we pretend we're not a roleplay server, it is mechanically stale and incredibly outdated as an antagonist type as /tg/station's virus system (and by extension, sentient disease) hasn't really been updated for ages in terms of gameplay. All Sentient Disease follows one of five paths:

Path 1: Fuck I can't INFECT ANYONE because everyone is wearing masks and/or are synths and/or I was randomly assigned to someone who spends the entire shift doing atmos projects. I'm going to ghost because this is boring.

Path 2: Fuck I infected one person and they coughed once and they rushed straight to medical and instantly claimed it was a sentient disease because there are no other reasons to mechanically cough as they don't have the smoker trait.

Path 3: Fuck I infected maybe like 10 people but I'm bored. Everyone is now coughing up blood. Fuck all of you lmao.

Path 4: Fuck I don't know what to do. Oh I'll just be completely and totally stealthy for the entire round, infect like 20 people, and then go for funny symptoms when the shuttle arrives. Yeah I don't care if I fuck up antagonists and/or roleplay and/or anything else; It's funny to me and deadchat.

Path 5: Fuck I don't want to kill anyone. I'll just be a helpful sentient disease and hope that the CMO doesn't produce cures. Oh my god why are you PRODUCING CURES. FUCK YOU, EVERYONE IS ON FIRE NOW.

## Proof Of Testing

If it compiles, it werks.

## Changelog

:cl: BurgerBB
del: Removes the sentient disease event from occurring normally.
/:cl:

