### PR TITLE
[MODULAR](if i did it right) makes plant bags usable in pocket slots

### DIFF
--- a/modular_zubbers/code/game/objects/items/storage/bags.dm
+++ b/modular_zubbers/code/game/objects/items/storage/bags.dm
@@ -1,0 +1,20 @@
+/obj/item/storage/bag/plants
+	name = "plant bag"
+	icon = 'icons/obj/service/hydroponics/equipment.dmi'
+	icon_state = "plantbag"
+	worn_icon_state = "plantbag"
+	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_POCKETS
+	resistance_flags = FLAMMABLE
+
+/obj/item/storage/bag/plants/Initialize(mapload)
+	. = ..()
+	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
+	atom_storage.max_total_storage = 100
+	atom_storage.max_slots = 100
+	atom_storage.set_holdable(list(
+		/obj/item/food/grown,
+		/obj/item/graft,
+		/obj/item/grown,
+		/obj/item/food/honeycomb,
+		/obj/item/seeds,
+		))


### PR DESCRIPTION
## About The Pull Request

you can do it with the mining bags, why not the plant ones? it makes the botany belt effectively useless.
needs testing im like 80% sure it works maybe

## Why It's Good For The Game

QoL fix for my botany peeps

## Changelog

:cl:
Balance: Allows botany bags to be worn in the pocket slot
:cl: