### PR TITLE
Removes prybars from the RCF

### DIFF
--- a/modular_skyrat/modules/colony_fabricator/code/design_datums/tools.dm
+++ b/modular_skyrat/modules/colony_fabricator/code/design_datums/tools.dm
@@ -35,7 +35,7 @@
 /datum/design/colony_door_crowbar
 	name = "Prybar"
 	id = "colony_prybar"
-	build_type = COLONY_FABRICATOR
+	// build_type = COLONY_FABRICATOR // Zubber Edit: Takes it out of the all-too-easy to acquire RCF
 	build_path = /obj/item/crowbar/large/doorforcer
 	materials = list(
 		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 1.75,

--- a/modular_zubbers/modules/colony_fabricator/code/design_datums/fabricator_flag_additions/tools.dm
+++ b/modular_zubbers/modules/colony_fabricator/code/design_datums/fabricator_flag_additions/tools.dm
@@ -1,0 +1,3 @@
+/datum/design/crowbar/New()
+	. = ..()
+	build_type |= COLONY_FABRICATOR

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8628,6 +8628,7 @@
 #include "modular_zubbers\modules\clothing\code\donator_clothing.dm"
 #include "modular_zubbers\modules\clothing\code\head\helmet.dm"
 #include "modular_zubbers\modules\clothing\code\sprite_accessories\sprite_accessories.dm"
+#include "modular_zubbers\modules\colony_fabricator\code\design_datums\fabricator_flag_additions\tools.dm"
 #include "modular_zubbers\modules\customization\modules\language\_language_holder.dm"
 #include "modular_zubbers\modules\customization\modules\language\common.dm"
 #include "modular_zubbers\modules\customization\modules\language\nekomimetic.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Band-aid fix since https://github.com/Bubberstation/Bubberstation/pull/1298 is in dev hell. Prybars are no longer available in the RCF, and have been replaced with pocket crowbars.

I want to keep the scope fairly narrow so currently you can still order them standalone for 100 creds each.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game
I've seen a resurgence of departments just ordering a RCF at roundstart with the dept budget. Every department being able to mass-produce what's essentially jaws of life with zero research involved and only a tiny bit of titanium is quite bad.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Proof Of Testing
![image](https://github.com/Bubberstation/Bubberstation/assets/21011148/4d7e8b62-2811-4c0a-88f6-333881293ac8)
But if you close your eyes...
<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:VrazzleDazzle
del: Prybars are no longer available in the Rapid Construction Fabricator.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
