### PR TITLE
Security now always get deathrattle implants

### DIFF
--- a/modular_zubbers/code/modules/security_deathrattle/security_deathrattle.dm
+++ b/modular_zubbers/code/modules/security_deathrattle/security_deathrattle.dm
@@ -1,0 +1,18 @@
+//This file makes it so that security will always get a deathrattle.
+
+/datum/station_trait/deathrattle_department/security
+	weight = 0
+
+/datum/controller/subsystem/processing/station/SetupTraits()
+
+	. = ..()
+
+	var/datum/station_trait/deathrattle_department/security/existing_security_trait = locate() in station_traits
+	if(existing_security_trait)
+		return .
+
+	var/datum/station_trait/deathrattle_all/existing_all_trait = locate() in station_traits
+	if(existing_all_trait)
+		return .
+
+	setup_trait(/datum/station_trait/deathrattle_department/security)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8548,6 +8548,7 @@
 #include "modular_zubbers\code\modules\research\designs\medical_designs.dm"
 #include "modular_zubbers\code\modules\research\designs\misc_designs.dm"
 #include "modular_zubbers\code\modules\research\techweb\all_nodes.dm"
+#include "modular_zubbers\code\modules\security_deathrattle\security_deathrattle.dm"
 #include "modular_zubbers\code\modules\security_levels\security_level_datums.dm"
 #include "modular_zubbers\code\modules\skub\skub.dm"
 #include "modular_zubbers\code\modules\spells\banhammer_item.dm"


### PR DESCRIPTION

## About The Pull Request

Security now always get deathrattle implants. Note that only security can hear their own deathrattles. Also note that this doesn't roll if the entire station has deathrattle implants.

Mechanically, this just forces the deathrattle security event.

## Why It's Good For The Game

Adds an extra layer of protection for security officers killed in the line of duty. Penalizes random green-shift assassinations of security players just because they're security. This should not affect traitors normally/"fairly" killing security considering:
- Security constantly broadcasts their location anyways.
- Suit sensors exist, and a paramedic/warden/AI usually snitches.
- An AI usually watches most conflicts.

## Proof Of Testing

![image](https://github.com/Bubberstation/Bubberstation/assets/8602857/9c7f195e-2522-42b6-a459-f0d8126bd6b6)

## Changelog

:cl: BurgerBB
balance: Security now always get deathrattle implants. Note that only security can hear their own deathrattles.
/:cl:


