### PR TITLE
Disables Station Blackout and Random Machine Languages Station Traits

### DIFF
--- a/modular_zubbers/code/datums/station_traits/disabled_traits.dm
+++ b/modular_zubbers/code/datums/station_traits/disabled_traits.dm
@@ -1,0 +1,9 @@
+//Causes all lights on the station to be busted.
+//Extremely annoying, especially with a lack of a janitor. Also laggy when it happens.
+/datum/station_trait/blackout
+	weight = 0
+
+//Randomizes the language for all bots AND machines.
+//Very annoying considering this affects the arrivals announcement system as well as the cryo announcement system.
+/datum/station_trait/bot_languages
+	weight = 0

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8244,6 +8244,7 @@
 #include "modular_zubbers\code\datums\mood_events\miasma_events.dm"
 #include "modular_zubbers\code\datums\shuttle\arena.dm"
 #include "modular_zubbers\code\datums\shuttles\emergency.dm"
+#include "modular_zubbers\code\datums\station_traits\disabled_traits.dm"
 #include "modular_zubbers\code\datums\weather\weather_types\radiation_storm.dm"
 #include "modular_zubbers\code\datums\weather\weather_types\sand_storm.dm"
 #include "modular_zubbers\code\game\area\areas\centcom.dm"


### PR DESCRIPTION
## About The Pull Request

Disables the Station Blackout and Random Machine Language station traits.

## Why It's Good For The Game

Station Blackout would kill all the lights on station. This was awful, especially if there was no janitor.

Random Machine Language would give a random language to every machine that speaks and every bot. This was annoying since it affected cryo announcements and arrivals announcements.

## Proof Of Testing

If it compiles, it werks.

## Changelog


:cl: BurgerBB
del: Disables Station Blackout and Random Machine Languages Station Traits
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
