### PR TITLE
Abductor Baton Sleep Nerf

### DIFF
--- a/modular_zubbers/code/game/objects/items/abductor.dm
+++ b/modular_zubbers/code/game/objects/items/abductor.dm
@@ -1,0 +1,4 @@
+// Various adjustments to abductor
+
+/obj/item/melee/baton/abductor
+	sleep_time = 30 SECONDS

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8381,6 +8381,7 @@
 #include "modular_zubbers\code\game\objects\effects\spawners\random\armory.dm"
 #include "modular_zubbers\code\game\objects\effects\spawners\random\moonstation_random.dm"
 #include "modular_zubbers\code\game\objects\effects\spawners\random\vending.dm"
+#include "modular_zubbers\code\game\objects\items\abductor.dm"
 #include "modular_zubbers\code\game\objects\items\cards_ids.dm"
 #include "modular_zubbers\code\game\objects\items\cigs_lighters.dm"
 #include "modular_zubbers\code\game\objects\items\holy_weapons.dm"


### PR DESCRIPTION
## About The Pull Request

30 second sleep instead of two minutes

## Why It's Good For The Game

Abductor needs a nerf, and I'll start with something simple to help shift the balance away from being capable of taking down an entire department with a 2 minute sleep.

## Proof Of Testing

It works

## Changelog

:cl:
balance: Abductor sleep is 30 seconds instead of 2 minutes
/:cl: