### PR TITLE
[NON-MODULAR] Takes the ashwalker translation necklace out of the loadout; ashwalker translation is supposed to be rare/craftable with resource/Curator, not a roundstart thing any crewmember can have.

### DIFF
--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_neck.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_neck.dm
@@ -274,10 +274,11 @@ GLOBAL_LIST_INIT(loadout_necks, generate_loadout_items(/datum/loadout_item/neck)
 /*
 *	MISC
 */
+/* BUBBER EDIT START
 /datum/loadout_item/neck/cursed_ashen_necklace
 	name = "Cursed Ashen Necklace"
 	item_path = /obj/item/clothing/neck/necklace/ashwalker/cursed
-
+BUBBER EDIT END */
 /datum/loadout_item/neck/stethoscope
 	name = "Stethoscope"
 	item_path = /obj/item/clothing/neck/stethoscope


### PR DESCRIPTION
## About The Pull Request

Takes the ashwalker translation necklace out of the loadout; ashwalker translation is supposed to be rare/craftable with resource/Curator, not a roundstart thing any crewmember can have.

## Why It's Good For The Game

Ashwalkers were intentionally given a different language datum to enforce the language barrier and ensure ashwalker<->crew communication is a rare thing, requiring expensive to gather parts for ashwalkers or the Curator to leverage their translation skills for the crew. Skyrat, in their infinite wisdom, put one of these necklaces that translate ashwalker language in the loadout, completely nuking this entire system.

The language barrier is an intentional part of Ashwalker design at the core; they are not your friendly neighbor lizards, they're the locals of the planet NT is colonizing, strip mining, and conducting experiments on without consulting with them. The NT relationship with ashwalkers is not friendly in the slightest. Effort should have to be put in by the ashwalkers or the crew to cross the language barrier.

## Proof Of Testing

I removed an item from the loadout. Loadout code can handle this.

## Changelog
:cl:
balance: Takes the ashwalker translation necklace out of the loadout; ashwalker translation is supposed to be rare/craftable with resource/Curator, not a roundstart thing any crewmember can have.
/:cl: