### PR TITLE
Makes the Prybar Bulky (and adds it back to the RCF)

### DIFF
--- a/modular_skyrat/modules/colony_fabricator/code/design_datums/tools.dm
+++ b/modular_skyrat/modules/colony_fabricator/code/design_datums/tools.dm
@@ -35,7 +35,7 @@
 /datum/design/colony_door_crowbar
 	name = "Prybar"
 	id = "colony_prybar"
-	// build_type = COLONY_FABRICATOR // Zubber Edit: Takes it out of the all-too-easy to acquire RCF
+	build_type = COLONY_FABRICATOR
 	build_path = /obj/item/crowbar/large/doorforcer
 	materials = list(
 		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 1.75,

--- a/modular_skyrat/modules/colony_fabricator/code/tools/tools.dm
+++ b/modular_skyrat/modules/colony_fabricator/code/tools/tools.dm
@@ -101,7 +101,7 @@
 		survive <b>forcing doors open</b>."
 	icon = 'modular_skyrat/modules/colony_fabricator/icons/tools.dmi'
 	icon_state = "prybar"
-	toolspeed = 1.3
+	//toolspeed = 1.3 BUBBER REMOVAL - Why? Jaws are 0.7 themselves.
 	force_opens = TRUE
 	custom_materials = list(
 		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 1.75,

--- a/modular_zubbers/modules/colony_fabricator/code/design_datums/fabricator_flag_additions/tools.dm
+++ b/modular_zubbers/modules/colony_fabricator/code/design_datums/fabricator_flag_additions/tools.dm
@@ -1,3 +1,0 @@
-/datum/design/crowbar/New()
-	. = ..()
-	build_type |= COLONY_FABRICATOR

--- a/modular_zubbers/modules/colony_fabricator/prybar.dm
+++ b/modular_zubbers/modules/colony_fabricator/prybar.dm
@@ -1,0 +1,6 @@
+/datum/design/crowbar/New()
+	. = ..()
+	build_type |= COLONY_FABRICATOR
+
+/obj/item/crowbar/large/doorforcer
+	w_class = WEIGHT_CLASS_BULKY

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8732,7 +8732,6 @@
 #include "modular_zubbers\modules\clothing\code\donator_clothing.dm"
 #include "modular_zubbers\modules\clothing\code\head\helmet.dm"
 #include "modular_zubbers\modules\clothing\code\sprite_accessories\sprite_accessories.dm"
-#include "modular_zubbers\modules\colony_fabricator\code\design_datums\fabricator_flag_additions\tools.dm"
 #include "modular_zubbers\modules\customization\modules\language\_language_holder.dm"
 #include "modular_zubbers\modules\customization\modules\language\common.dm"
 #include "modular_zubbers\modules\customization\modules\language\nekomimetic.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8732,6 +8732,7 @@
 #include "modular_zubbers\modules\clothing\code\donator_clothing.dm"
 #include "modular_zubbers\modules\clothing\code\head\helmet.dm"
 #include "modular_zubbers\modules\clothing\code\sprite_accessories\sprite_accessories.dm"
+#include "modular_zubbers\modules\colony_fabricator\prybar.dm"
 #include "modular_zubbers\modules\customization\modules\language\_language_holder.dm"
 #include "modular_zubbers\modules\customization\modules\language\common.dm"
 #include "modular_zubbers\modules\customization\modules\language\nekomimetic.dm"


### PR DESCRIPTION
Reverts Bubberstation/Bubberstation#1378

## About this PR

Prybar changes. Simply adds bulk to them.

## Why it's good for the game

I think an overall thing that people don't consider in regards to item balance is that bulk massively changes the utility of something. I'm not against it being able to pry open doors, but it can be the size of the robotics mech crowbar in game.

## Proof of Testing

It has girth and compiled and it was too big for my bag.

## Changelog

🆑
balance: Prybars are added back to the colony fabricator, but they are bulky items now.
/:cl: