### PR TITLE
Click First Combat (Part 1 | The Batonq Knockdown Removal)

### DIFF
--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,4 +1,4 @@
-#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+//#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
 
 #include "map_files\generic\CentCom.dmm"
 

--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,4 +1,4 @@
-//#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
 
 #include "map_files\generic\CentCom.dmm"
 

--- a/modular_zubbers/code/game/objects/items/batonq.dm
+++ b/modular_zubbers/code/game/objects/items/batonq.dm
@@ -1,5 +1,6 @@
 /obj/item/melee/baton/security
 	knockdown_time = null
+	cooldown = 2 SECONDS
 
 /obj/item/melee/baton/security/boomerang
 	knockdown_time = 5 SECONDS
@@ -7,3 +8,4 @@
 
 /obj/item/melee/baton/telescopic/contractor_baton
 	knockdown_time = null
+	cooldown = 1.5 SECONDS

--- a/modular_zubbers/code/game/objects/items/batonq.dm
+++ b/modular_zubbers/code/game/objects/items/batonq.dm
@@ -1,0 +1,9 @@
+/obj/item/melee/baton/security
+	knockdown_time = null
+
+/obj/item/melee/baton/security/boomerang
+	knockdown_time = 5 SECONDS
+	throw_stun_chance = 100 // Org: 99 - Why?
+
+/obj/item/melee/baton/telescopic/contractor_baton
+	knockdown_time = null

--- a/modular_zubbers/code/game/uplink_items.dm
+++ b/modular_zubbers/code/game/uplink_items.dm
@@ -1,0 +1,2 @@
+/datum/uplink_item/stealthy_weapons/contrabaton
+	cost = 4

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8384,6 +8384,7 @@
 #include "modular_zubbers\code\game\objects\effects\spawners\random\moonstation_random.dm"
 #include "modular_zubbers\code\game\objects\effects\spawners\random\vending.dm"
 #include "modular_zubbers\code\game\objects\items\abductor.dm"
+#include "modular_zubbers\code\game\objects\items\batonq.dm"
 #include "modular_zubbers\code\game\objects\items\cards_ids.dm"
 #include "modular_zubbers\code\game\objects\items\cigs_lighters.dm"
 #include "modular_zubbers\code\game\objects\items\holy_weapons.dm"


### PR DESCRIPTION
## About The Pull Request

- Security batons knockdown time removed. This also effects cattleprod, teleprod, and telecrystal prod (security baton is the parent)
- Contractor baton knockdown removed
- Baton boomorange unchanged. (This is subject to change, but this requires a research)
- Reduces the price of the contractor baton to 4 TC from 7 TC
<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

We had a large staff meeting last night and we had a conversation with how to handle antag versus security interactions and how sometimes people do not respect the roleplay of the other side. We've discussed how both antagonists and security sometimes have massive advantages to whoever could click first. I think there needs to be a distinction between batons that either have knockdown (telescopic) as a primary purpose, **or** have stamina damage to wear you down.

**Stamina damage remains unchanged.** The security baton will still floor you after 3 hits and the contractor baton after 2.

This is a balance change that will gradually look into **any and all** combat items. I will be looking at both security gear and antag gear. There's a lot on the latter end, so *please point me to anything you feel like should also be looked at*

I will tackle the abductor baton in a seperate PR since that's a whole 'nother beast

## Proof Of Testing

I tested it.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Knockdown removed from the following batons: Contractor, Security, Teleprod, Telecrystalprod, and Cattleprod
balance: Contractor baton reduced to 4 TC from 7 TC
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
