### PR TITLE
Click First Combat (Part 2 | The Baton Knockdown Wallshove Combo)

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -707,15 +707,19 @@
 
 	if(shove_flags & SHOVE_CAN_HIT_SOMETHING)
 		//Don't hit people through windows, ok?
-		if(!(shove_flags & SHOVE_DIRECTIONAL_BLOCKED) && (SEND_SIGNAL(target_shove_turf, COMSIG_LIVING_DISARM_COLLIDE, src, target, shove_flags, weapon) & COMSIG_LIVING_SHOVE_HANDLED))
-			return
-		if((shove_flags & SHOVE_BLOCKED) && !(shove_flags & (SHOVE_KNOCKDOWN_BLOCKED|SHOVE_CAN_KICK_SIDE)))
-			target.Knockdown(SHOVE_KNOCKDOWN_SOLID)
-			target.visible_message(span_danger("[name] shoves [target.name], knocking [target.p_them()] down!"),
-				span_userdanger("You're knocked down from a shove by [name]!"), span_hear("You hear aggressive shuffling followed by a loud thud!"), COMBAT_MESSAGE_RANGE, src)
-			to_chat(src, span_danger("You shove [target.name], knocking [target.p_them()] down!"))
-			log_combat(src, target, "shoved", "knocking them down[weapon ? " with [weapon]" : ""]")
-			return
+		if((shove_flags & SHOVE_BLOCKED))
+			if(!(shove_flags & (SHOVE_KNOCKDOWN_BLOCKED|SHOVE_CAN_KICK_SIDE)))
+				target.Knockdown(SHOVE_KNOCKDOWN_SOLID)
+				target.visible_message(span_danger("[name] shoves [target.name], knocking [target.p_them()] down!"),
+					span_userdanger("You're knocked down from a shove by [name]!"),
+					span_hear("You hear aggressive shuffling followed by a loud thud!"), COMBAT_MESSAGE_RANGE, src)
+				to_chat(src, span_danger("You shove [target.name], knocking [target.p_them()] down!"))
+				log_combat(src, target, "shoved", "knocking them down[weapon ? " with [weapon]" : ""]")
+				return
+			else if(shove_flags & SHOVE_KNOCKDOWN_BLOCKED) //check specifically for being blocked for an extra feedback message.
+				target.visible_message(span_danger("[name] tries to shove [target.name], but [target.p_they()] manages to stay up!"),
+					span_danger("[name] tries to shove you, but you manage to stay up!"),
+					span_hear("You hear aggressive shuffling!"), COMBAT_MESSAGE_RANGE)
 
 	if(shove_flags & SHOVE_CAN_KICK_SIDE) //KICK HIM IN THE NUTS
 		target.Paralyze(SHOVE_CHAIN_PARALYZE)
@@ -757,7 +761,7 @@
 		. |= SHOVE_CAN_MOVE
 		if(!buckled)
 			. |= SHOVE_CAN_HIT_SOMETHING
-	if(HAS_TRAIT(src, TRAIT_BRAWLING_KNOCKDOWN_BLOCKED))
+	if(HAS_TRAIT(src, TRAIT_BRAWLING_KNOCKDOWN_BLOCKED) || HAS_TRAIT_FROM(src, TRAIT_IWASBATONED, REF(shover)))
 		. |= SHOVE_KNOCKDOWN_BLOCKED
 
 ///Send the chat feedback message for shoving


### PR DESCRIPTION
Early Pull from upstream. It isn't merged at all on TG. I'll modularize it if they abandon the idea.

## About The Pull Request
This removes the ability for people that were recently batoned to be shoved into a wall. This doesn't affect shove stun, only the initial wall shove, although https://github.com/tgstation/tgstation/pull/81886 is doing things with that if you're interested.

This will basically only be affecting stunbaton/stunprod, because telebaton/contractor baton knock you down on the first hit anyways, meaning that shoving them while they are already on the ground will still stun them.

Video demonstration:
https://github.com/tgstation/tgstation/assets/53777086/aa00a00b-7d94-4d82-ba3a-5dd3d6d1f883

## Why It's Good For The Game
Currently the "I was batoned" trait is meant to prevent double batoning by the same person, and give some reaction time to the person being batoned (at least until they fall to the ground), but it has a massive loophole in that you can shove them into a wall to prevent them from being able to do anything in said reaction time. It's a lame strategy that goes against the baton's 2 hit to stun mechanic, so I think we should patch this up.
