### PR TITLE
Reverts a Skyrat power change that allowed engineers to pump 4MW into the grid without any consequence, causing shocked doors to instantly kill you.

### DIFF
--- a/code/__DEFINES/~~bubber_defines/apc_defines.dm
+++ b/code/__DEFINES/~~bubber_defines/apc_defines.dm
@@ -1,6 +1,6 @@
 /// Lower excess value for APC arcing, 5% chance to arc
-#define APC_ARC_LOWERLIMIT 1.5 MEGA WATTS
+#define APC_ARC_LOWERLIMIT 1.2 MEGA WATTS
 /// Moderate excess value for APC arcing, 10% chance to arc
-#define APC_ARC_MEDIUMLIMIT 2 MEGA WATTS
+#define APC_ARC_MEDIUMLIMIT 1.5 MEGA WATTS
 /// Upper excess value for for APC arcing, 15% chance to arc
-#define APC_ARC_UPPERLIMIT 2.5 MEGA WATTS
+#define APC_ARC_UPPERLIMIT 2 MEGA WATTS

--- a/code/__DEFINES/~~bubber_defines/apc_defines.dm
+++ b/code/__DEFINES/~~bubber_defines/apc_defines.dm
@@ -1,0 +1,6 @@
+/// Lower excess value for APC arcing, 5% chance to arc
+#define APC_ARC_LOWERLIMIT 1.5 MEGA WATTS
+/// Moderate excess value for APC arcing, 10% chance to arc
+#define APC_ARC_MEDIUMLIMIT 2 MEGA WATTS
+/// Upper excess value for for APC arcing, 15% chance to arc
+#define APC_ARC_UPPERLIMIT 2.5 MEGA WATTS

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -484,6 +484,7 @@
 #include "code\__DEFINES\~skyrat_defines\signals\signals_human.dm"
 #include "code\__DEFINES\~skyrat_defines\traits\declarations.dm"
 #include "code\__DEFINES\~~bubber_defines\access.dm"
+#include "code\__DEFINES\~~bubber_defines\apc_defines.dm"
 #include "code\__DEFINES\~~bubber_defines\colors.dm"
 #include "code\__DEFINES\~~bubber_defines\economy.dm"
 #include "code\__DEFINES\~~bubber_defines\footsteps.dm"


### PR DESCRIPTION

## About The Pull Request

APCs now arc at 1.2MW instead of 4MW.

## Why It's Good For The Game

Skyrat, in their infinite wisdom, made it so that engineers could dump 4MW into the main grid without the APCs going apeshit. This resulted in engineers dumping that amount of power into the grid, inadvertently causing anyone to touches a shocked door to go into hardcrit at 1.5MW and probably full on husk at 4MW. I can't be bothered to simulate the latter, but I'm probably right.

And why yes, I made this PR because I died instantly because I just so happened to walk into a shocked door while engineering had 2MW into the grid.

## Proof Of Testing

Untested.

## Changelog

:cl: BurgerB
balance: Reverts a Skyrat power change that allowed engineers to pump 4MW into the grid without any consequence, causing shocked doors to instantly kill you.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
