### PR TITLE
Nerfs Changeling Absorb because I died to it once

### DIFF
--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -1,6 +1,6 @@
 /datum/action/changeling/absorb_dna
 	name = "Absorb DNA"
-	desc = "Absorb the DNA of our victim. Requires us to strangle them."
+	desc = "Absorb the DNA of our victim. Requires a firm grip." //BUBBERSTATION CHANGE: NO NECKGRAB REQUIRED.
 	button_icon_state = "absorb_dna"
 	chemical_cost = 0
 	dna_cost = CHANGELING_POWER_INNATE
@@ -19,7 +19,7 @@
 	if(!owner.pulling || !iscarbon(owner.pulling))
 		owner.balloon_alert(owner, "needs grab!")
 		return
-	if(owner.grab_state <= GRAB_NECK)
+	if(owner.grab_state <= GRAB_AGGRESSIVE) //BUBBERSTATION CHANGE: NO NECKGRAB REQUIRED.
 		owner.balloon_alert(owner, "needs tighter grip!")
 		return
 
@@ -145,7 +145,7 @@
 				target.take_overall_damage(40)
 
 		SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("Absorb DNA", "[absorbing_iteration]"))
-		if(!do_after(owner, 15 SECONDS, target, hidden = TRUE))
+		if(!do_after(owner, 5 SECONDS, target, hidden = TRUE)) //BUBBERSATION CHANGE: 15 SECONDS TO 3 SECONDS.
 			owner.balloon_alert(owner, "interrupted!")
 			is_absorbing = FALSE
 			return FALSE

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -145,7 +145,7 @@
 				target.take_overall_damage(40)
 
 		SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("Absorb DNA", "[absorbing_iteration]"))
-		if(!do_after(owner, 5 SECONDS, target, hidden = TRUE)) //BUBBERSATION CHANGE: 15 SECONDS TO 3 SECONDS.
+		if(!do_after(owner, 5 SECONDS, target, hidden = TRUE)) //BUBBERSATION CHANGE: 15 SECONDS TO 5 SECONDS.
 			owner.balloon_alert(owner, "interrupted!")
 			is_absorbing = FALSE
 			return FALSE

--- a/modular_zubbers/code/modules/changeling_overhaul/drain.dm
+++ b/modular_zubbers/code/modules/changeling_overhaul/drain.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon/Drain()
 
-	var/obj/item/bodypart/head = carbon_victim.get_bodypart(BODY_ZONE_HEAD)
+	var/obj/item/bodypart/head = src.get_bodypart(BODY_ZONE_HEAD)
 	if(head)
 		src.cause_wound_of_type_and_severity(WOUND_PIERCE, head, WOUND_SEVERITY_SEVERE, wound_source = "inhuman puncture")
 

--- a/modular_zubbers/code/modules/changeling_overhaul/drain.dm
+++ b/modular_zubbers/code/modules/changeling_overhaul/drain.dm
@@ -8,6 +8,6 @@
 
 	src.blood_volume = round(src.blood_volume*0.5,1) //Halves the CURRENT blood volume. Easier to suck more blood when there is more of it.
 
-	ADD_TRAIT(affected_mob, TRAIT_DISFIGURED, TRAIT_GENERIC) //Fixed via cryoxadone!
+	ADD_TRAIT(src, TRAIT_DISFIGURED, TRAIT_GENERIC) //Fixed via cryoxadone!
 
 	return TRUE

--- a/modular_zubbers/code/modules/changeling_overhaul/drain.dm
+++ b/modular_zubbers/code/modules/changeling_overhaul/drain.dm
@@ -1,0 +1,11 @@
+/mob/living/carbon/Drain()
+
+	var/obj/item/bodypart/head = carbon_victim.get_bodypart(BODY_ZONE_HEAD)
+	if(head)
+		src.cause_wound_of_type_and_severity(WOUND_PIERCE, head, WOUND_SEVERITY_SEVERE, wound_source = "inhuman puncture")
+
+	src.adjustOrganLoss(ORGAN_SLOT_BRAIN, BRAIN_DAMAGE_DEATH, BRAIN_DAMAGE_DEATH)
+
+	src.blood_volume = round(src.blood_volume*0.5,1) //Halves the CURRENT blood volume. Easier to suck more blood when there is more of it.
+
+	return TRUE

--- a/modular_zubbers/code/modules/changeling_overhaul/drain.dm
+++ b/modular_zubbers/code/modules/changeling_overhaul/drain.dm
@@ -8,4 +8,6 @@
 
 	src.blood_volume = round(src.blood_volume*0.5,1) //Halves the CURRENT blood volume. Easier to suck more blood when there is more of it.
 
+	ADD_TRAIT(affected_mob, TRAIT_DISFIGURED, TRAIT_GENERIC) //Fixed via cryoxadone!
+
 	return TRUE

--- a/modular_zubbers/code/modules/changeling_overhaul/drain.dm
+++ b/modular_zubbers/code/modules/changeling_overhaul/drain.dm
@@ -4,7 +4,7 @@
 	if(head)
 		src.cause_wound_of_type_and_severity(WOUND_PIERCE, head, WOUND_SEVERITY_SEVERE, wound_source = "inhuman puncture")
 
-	src.adjustOrganLoss(ORGAN_SLOT_BRAIN, BRAIN_DAMAGE_DEATH, BRAIN_DAMAGE_DEATH)
+	src.adjustOrganLoss(ORGAN_SLOT_BRAIN, BRAIN_DAMAGE_MILD, BRAIN_DAMAGE_SEVERE)
 
 	src.blood_volume = round(src.blood_volume*0.5,1) //Halves the CURRENT blood volume. Easier to suck more blood when there is more of it.
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8534,6 +8534,7 @@
 #include "modular_zubbers\code\modules\cargo\packs\metalsheets.dm"
 #include "modular_zubbers\code\modules\cargo\packs\security.dm"
 #include "modular_zubbers\code\modules\cargo\packs\service.dm"
+#include "modular_zubbers\code\modules\changeling_overhaul\drain.dm"
 #include "modular_zubbers\code\modules\client\autopunctuation\preferences.dm"
 #include "modular_zubbers\code\modules\client\preferences\middleware\species.dm"
 #include "modular_zubbers\code\modules\client\verbs\character_directory.dm"


### PR DESCRIPTION
## About The Pull Request

### For Changelings
Changeling absorptions:
- Take 15 seconds (previously 45 seconds).
- Now only require an aggressive grab (previously a full neck grab).

### For Changeling Victims
Changeling absorptions:
- No longer husk, but instead cause disfigurement which can be cured by cryoxadone.
- Now causes 20 brain damage, up to 100.
- Now only drains half your current blood volume, instead of 100% of it.
- Causes a severe piercing headwound.

## Why It's Good For The Game

Being absorbed by a changeling is generally not a fun experience. Not because you've died, but rather because your fate lies in medical's hands, and sometimes those hands are... not very skilled. Depending on the amount of medical players and their experience, it could take an absurd amount of time for them to make synthflesh, treat all your wounds, fill you back up with blood, fix/replace your organs. I've had rounds where this process has taken 5 minutes, and I've had rounds where this has taken 40 minutes.

Previously to cure changeling victims, doctors had to:
- Know how to make blood.
- Know how to fix bloodloss.
- Know how to make synthflesh.
- Know how much synthflesh to apply.
- Know how stasis beds work and how they can stop dehusking.

Now, to cure changeling victims, doctors have to:
- Know how to fix bloodloss.
- Know how to put people in cryotubes.
- Know how to make mannitol.
- Know how to fix a piercing wound.

Now with changes to husking and changes to how fast/easy it is to absorb, changelings should now feel encouraged to use it more.

## Proof Of Testing

Untested.

## Changelog

:cl: BurgerBB
balance: Changeling Absorption no longer husks, but instead causes disfigurement. This can be cured via the cryo tubes.
balance: Changeling Absorptions are now significantly faster, and now only require an aggressive grab to perform.
/:cl:

