### PR TITLE
[FIX] Removes the ability to adjust the command stripper outfit

### DIFF
--- a/modular_zubbers/code/modules/clothing/under/jobs/command.dm
+++ b/modular_zubbers/code/modules/clothing/under/jobs/command.dm
@@ -12,6 +12,8 @@
 	worn_icon_digi = 'modular_zubbers/icons/mob/clothing/under/captain.dmi'
 	greyscale_colors = "#081027#41579a#c06822"
 
+	can_adjust = FALSE
+
 /obj/item/clothing/under/rank/civilian/head_of_personnel/stripper/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/gags_recolorable)
@@ -30,6 +32,8 @@
 	sensor_mode = SENSOR_COORDS
 	random_sensor = FALSE
 	greyscale_colors = "#081027#46b946#e6b917"
+
+	can_adjust = FALSE
 
 /obj/item/clothing/under/rank/nanotrasen_consultant/stripper/Initialize(mapload)
 	. = ..()

--- a/modular_zubbers/code/modules/command_vendor/vending.dm
+++ b/modular_zubbers/code/modules/command_vendor/vending.dm
@@ -1,5 +1,5 @@
 /obj/machinery/vending/access/command/build_access_list(list/access_lists)
-	.=..()
+	. = ..()
 	access_lists["[ACCESS_CENT_GENERAL]"] += list(
 		/obj/item/clothing/under/rank/nanotrasen_consultant/stripper
 	)


### PR DESCRIPTION
## About The Pull Request

No more needing to install CS:S mid ERP

## Changelog

:cl:
fix: Command members no longer have to install CS:S mid erp because they altclicked their stripper outfit
/:cl:
