### PR TITLE
Lifts Most Restrictions on Maintenance Drones

### DIFF
--- a/modular_zubbers/code/modules/drone_overhaul.dm
+++ b/modular_zubbers/code/modules/drone_overhaul.dm
@@ -1,0 +1,50 @@
+/mob/living/basic/drone
+	laws = "\
+		1. You may not hinder, harm, or interfere with any being, regardless of intent or cicumstance.\n\
+		2. You may not involve yourself in the matters of another being, even if such matters conflict with Law 1.\n\
+		3. You may actively build, maintain, repair, improve, and provide power to the facility that housed your activation, to the best of your abilities."
+	flavortext = "\
+		\n<big><span class='warning'>DO NOT INTERFERE WITH THE CREW OR ANTAGONISTS AS A DRONE OR YOU WILL BE DRONE BANNED</span></big>\n\
+		<span class='notice'>Drones are a ghost role that are allowed to fix the station and build things. Interfering with the round as a drone is against the rules.</span>\n\
+		<span class='notice'>Actions that constitute interference include, but are not limited to:</span>\n\
+		<span class='notice'>     - Interacting with antagonist or crew critical objects (IDs, weapons, contraband, powersinks, bombs, etc.)</span>\n\
+		<span class='notice'>     - Interacting with the health of living beings (attacking, healing, etc.)</span>\n\
+		<span class='notice'>     - Interacting with non-living beings (dragging bodies, looting bodies, etc.)</span>\n\
+		<span class='notice'>     - Informing crew about threats/dangers (showing crew where bodies are, telling security who killed someone, etc.)</span>\n\
+		<span class='warning'>These rules are at admin discretion and will be heavily enforced.</span>\n\
+		<span class='warning'><u>If you do not have the regular drone laws, follow your laws to the best of your ability.</u></span>\n\
+		<span class='notice'>Prefix your message with :b to speak in Drone Chat.</span>\n"
+
+	/*
+	drone_area_blacklist_flat = null
+	drone_area_blacklist_recursive = null
+
+	drone_machinery_blacklist_flat = null
+	drone_machinery_blacklist_recursive = null
+
+	drone_machinery_whitelist_flat = null
+	drone_machinery_whitelist_recursive = null
+
+	drone_item_whitelist_flat = null
+	drone_item_whitelist_recursive = null
+
+	shy_machine_whitelist = null
+	*/
+
+	shy = FALSE
+
+/mob/living/basic/drone/Initialize(mapload)
+	. = ..()
+	add_traits(list(TRAIT_PACIFISM,TRAIT_NOGUNS))
+
+/datum/language_holder/drone
+	understood_languages = list(
+		/datum/language/drone = list(LANGUAGE_ATOM),
+		/datum/language/common = list(LANGUAGE_ATOM)
+	)
+	spoken_languages = list(
+		/datum/language/drone = list(LANGUAGE_ATOM)
+	)
+	blocked_languages = null
+	selected_language = /datum/language/drone
+

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8457,6 +8457,7 @@
 #include "modular_zubbers\code\game\turfs\closed\lunar_surface.dm"
 #include "modular_zubbers\code\game\turfs\open\sand.dm"
 #include "modular_zubbers\code\modules\_defines.dm"
+#include "modular_zubbers\code\modules\drone_overhaul.dm"
 #include "modular_zubbers\code\modules\admin\verbs\debug.dm"
 #include "modular_zubbers\code\modules\alternative_job_titles\code\alt_job_titles.dm"
 #include "modular_zubbers\code\modules\antagonists\modglue.dm"


### PR DESCRIPTION

## About The Pull Request

Maintenance Drones can no longer be "shy", which means they will never be prevented from doing anything in proximity to another living being.
Maintenance Drones can now understand common, but still can't speak it.
Maintenance Drones are now always pacifist and can never use guns, if they're not hacked.
Maintenance Drones now have updated laws and an additional welcome message.

## Why It's Good For The Game

We don't have the issue of people playing drone to get revenge / grief the station considering we already have respawn enabled, as well as a near steady supply of Cyborg shells ready to go. We're also on a whitelist.

## Proof Of Testing

Untested. Still need to make code it so that drones aren't pacifist when hacked.

## Changelog

:cl: BurgerBB
qol: Lifts Most Restrictions on Maintenance Drones. Don't make me regret this.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
