### PR TITLE
Favorite Thralls now Deconvertable!

### DIFF
--- a/modular_zubbers/code/modules/antagonists/bloodsucker/vassal/vassal_types/favorite_vassal.dm
+++ b/modular_zubbers/code/modules/antagonists/bloodsucker/vassal/vassal_types/favorite_vassal.dm
@@ -24,5 +24,6 @@
 	remove_powers(bloodsucker_powers)
 	. = ..()
 
-/datum/antagonist/vassal/favorite/pre_mindshield(mob/implanter, mob/living/mob_override)
-	return COMPONENT_MINDSHIELD_RESISTED
+// /datum/antagonist/vassal/favorite/pre_mindshield(mob/implanter, mob/living/mob_override)
+//	return COMPONENT_MINDSHIELD_RESISTED
+// Favorite vassals can be deconverted NOW!


### PR DESCRIPTION
## About The Pull Request

Simply comments out a few lines in the /datum/antagonist/vassal/favorite incase it needs to be reverted in the future

## Why It's Good For The Game

Imagine you are the Head of Security. Out of nowhere, Buster McGee the vampire nabs you, and forces you to be their vassal. Cool. But you want out. Too bad you got made their favorite and now are little more than an AFK trophy. Currently, the only way is through ahelping. But not anymore! Now there's actual counterplay aside from needing to RR the antagonist responsible. Just re-mindshield and the goober is fixed!

Conversion antags are not a good trope, and lead into a cascading circle of "well we can't deal with them now what" situations.

## Proof Of Testing

Compilled locally and works. https://gyazo.com/55b5bf016e6c5c9963950a93ef44725f https://gyazo.com/6171246b1c49abd13ce130b0125cd1fa

## Changelog

Just removes mindshield resistance from them.