### PR TITLE
Disables Blob, Xeno Infestation, and Spider Infestation on maps with "unbalanced" maintenance designs (Icebox, Blueshift, Void Raptor).

### DIFF
--- a/modular_zubbers/code/modules/map_event_blacklist/events.dm
+++ b/modular_zubbers/code/modules/map_event_blacklist/events.dm
@@ -1,0 +1,31 @@
+/datum/round_event
+	// A blacklist of maps. Use the full name that appears in map config, under map_name.
+	var/list/map_blacklist
+
+/datum/round_event_control/alien_infestation
+	map_blacklist = list(
+		"Ice Box Station",
+		"Blueshift",
+		"Void Raptor"
+	)
+
+/datum/round_event_control/blob
+	map_blacklist = list(
+		"Ice Box Station",
+		"Blueshift",
+		"Void Raptor"
+	)
+
+/datum/round_event_control/spider_infestation
+	map_blacklist = list(
+		"Ice Box Station",
+		"Blueshift",
+		"Void Raptor"
+	)
+
+/datum/round_event_control/blob/can_spawn_event(players, allow_magic = FALSE)
+
+	if(SSmapping.config && SSmapping.config.map_name && (SSmapping.config.map_name in map_blacklist))
+		return FALSE
+
+	. = ..()

--- a/modular_zubbers/code/modules/map_event_blacklist/events.dm
+++ b/modular_zubbers/code/modules/map_event_blacklist/events.dm
@@ -1,4 +1,4 @@
-/datum/round_event
+/datum/round_event_control
 	// A blacklist of maps. Use the full name that appears in map config, under map_name.
 	var/list/map_blacklist
 
@@ -25,7 +25,7 @@
 
 /datum/round_event_control/blob/can_spawn_event(players, allow_magic = FALSE)
 
-	if(SSmapping.config && SSmapping.config.map_name && (SSmapping.config.map_name in map_blacklist))
+	if(map_blacklist && SSmapping.config && SSmapping.config.map_name && (SSmapping.config.map_name in map_blacklist))
 		return FALSE
 
 	. = ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8618,6 +8618,7 @@
 #include "modular_zubbers\code\modules\loadouts\loadout_items\loadout_datum_suit.dm"
 #include "modular_zubbers\code\modules\loadouts\loadout_items\loadout_datum_toys.dm"
 #include "modular_zubbers\code\modules\loadouts\loadout_items\loadout_datum_under.dm"
+#include "modular_zubbers\code\modules\map_event_blacklist\events.dm"
 #include "modular_zubbers\code\modules\mapping\access_helpers.dm"
 #include "modular_zubbers\code\modules\mapping\limastation\areas.dm"
 #include "modular_zubbers\code\modules\mapping\limastation\shuttles.dm"


### PR DESCRIPTION

## About The Pull Request

Disables Blob, Xeno Infestation, and Spider Infestation on maps with "unbalanced" maintenance designs (Icebox, Blueshift, Void Raptor).

## Why It's Good For The Game

Every time Blueshift, Void Raptor, or Icebox rolls, I dread the eventual mid-round antagonist role of Aliens, Spiders, and Blob simply because of the maintenance design of these three maps.

Blueshift has MASSIVE sprawling maintenance sections, some of which are completely restricted to non-engineers, where most people have NEVER set foot in. These areas are ALWAYS chosen by these antagonist types as a base of operations just because of how expansive and isolated it is. It's the worst offender of these three, and the creator of Blueshift fully admits that maintenance is a pretty big problem of the map.

Void raptor also has massive sections of maintenance that are cramped, sprawling, and filled with tons of dead ends that many people don't visit. Engineering maintenance is a very common area for these antagonist types to spawn in because it gives them access to flammable gas and and it is pretty isolated and hard to navigate in.

Icebox has a ton of isolated areas only accessible by z-level traversal that are almost always destroyed by these three midround types. Virology is a prime example of this, with only one access point. There are also a lot of nearby ruins that spiders and xenos can easily take advantage of.


## Confession

One of the reasons why I made the maintenance loot PR and as the wizard dice PR is because I wanted to give reasons for people to go into maintenance. Since we're on a roleplay server, many people don't set foot inside it and instead rather visit roleplay locations like the Bar, Kitchen, or many recreational areas. Unfortunately, those PRs weren't good enough to convince people to go into maintenance, and I legitimately don't have any ideas to make it so that people enter it. 

## "Why not just fix these maps?"

These are all upstream maps. Touching an upstream map means a huge possibility of conflict.

## "Why not just use automapper?"

Automapper requires a lot of effort on the mapper's part to use, and if something is changed about the design of one of the areas upstream, the changes will have to be redone again. Way too much effort.


## Proof Of Testing

Untested, but should work :^)

## Changelog

:cl: BurgerBB
del: Disables Blob, Xeno Infestation, and Spider Infestation on maps with "unbalanced" maintenance designs (Icebox, Blueshift, Void Raptor).
/:cl:

