### PR TITLE
Allows engineering cyborgs (and some saboteur cyborgs) to carry handheld tanks.

### DIFF
--- a/modular_zubbers/code/game/objects/items/robot/items/storage.dm
+++ b/modular_zubbers/code/game/objects/items/robot/items/storage.dm
@@ -3,3 +3,29 @@
 	desc = "An apparatus for carrying, deploying, and manipulating sheets of paper."
 	icon_state = "borg_stack_apparatus"
 	storable = list(/obj/item/paper)
+
+/obj/item/borg/apparatus/tank_manipulator
+	name = "tank manipulation apparatus"
+	desc = "An apparatus for carrying and manipulating handheld tanks."
+	icon_state = "borg_beaker_apparatus"
+	storable = list(/obj/item/tank)
+
+/obj/item/robot_model/roleplay/New(...)
+	. = ..()
+	basic_modules += /obj/item/borg/apparatus/tank_manipulator
+
+/obj/item/robot_model/syndicatejack/New(...)
+	. = ..()
+	basic_modules += /obj/item/borg/apparatus/tank_manipulator
+
+/obj/item/robot_model/ninja_saboteur/New(...)
+	. = ..()
+	basic_modules += /obj/item/borg/apparatus/tank_manipulator
+
+/obj/item/robot_model/engineering/New(...)
+	. = ..()
+	basic_modules += /obj/item/borg/apparatus/tank_manipulator
+
+/obj/item/robot_model/saboteur/New(...)
+	. = ..()
+	basic_modules += /obj/item/borg/apparatus/tank_manipulator


### PR DESCRIPTION

## About The Pull Request

Adds a module that allows engineering cyborgs (and some saboteur cyborgs) to carry handheld tanks.

Note that this does not apply to tank transfer valve bombs or single tank bombs

## Why It's Good For The Game

Allows cyborgs to dick around with the RBMK and possibly other unforeseen interactions. Anything bad a cyborg can do with a handheld tank can already be done with a tank canister.

## Proof Of Testing

Untested.

## Changelog

:cl: BurgerBB
qol: Adds a module that allows engineering cyborgs (and some saboteur cyborgs) to carry handheld tanks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
