### PR TITLE
Interdyne: Adjust access for brig lockers and suit storage

### DIFF
--- a/_maps/RandomRuins/IceRuins/bubberstation/icemoon_interdyne.dmm
+++ b/_maps/RandomRuins/IceRuins/bubberstation/icemoon_interdyne.dmm
@@ -234,7 +234,9 @@
 /obj/machinery/airalarm/directional/east{
 	req_access = list("syndicate")
 	},
-/obj/structure/closet/secure_closet/interdynefob/armory_gear_locker,
+/obj/structure/closet/secure_closet/interdynefob/armory_gear_locker{
+	req_access = list("syndicate")
+	},
 /obj/machinery/light/small/red/directional/east{
 	pixel_y = 16
 	},
@@ -1058,7 +1060,9 @@
 /turf/open/floor/plating,
 /area/ruin/syndicate_ice_base/engineering)
 "io" = (
-/obj/structure/closet/secure_closet/interdynefob/mod_locker,
+/obj/structure/closet/secure_closet/interdynefob/mod_locker{
+	req_access = list("syndicate")
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/syndicate_ice_base/armory)
 "is" = (
@@ -3542,7 +3546,7 @@
 	},
 /obj/machinery/suit_storage_unit/syndicate/chameleon{
 	name = "suit storage unit";
-	req_access = list("syndicate_leader")
+	req_access = list("syndicate")
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/syndicate_ice_base/armory)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

This adjusts the access requirements for the brig armory closet and the suit storage. It changes `syndicate_leader` to `syndicate`

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

It means non-deck officer crew can use these without having to take an axe to the closets.

## Proof Of Testing

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->

I have ran this on my local server and confirm it works.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Interdyne brig closets can be accessed by regular crew
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->