### PR TITLE
[HEAT} Balance Heating Below This Point

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -392,7 +392,9 @@ GLOBAL_LIST_INIT(arm_zones, list(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM))
 #define DEATHMATCH_PRE_PLAYING 1
 #define DEATHMATCH_PLAYING 2
 
+/* BUBBERSTATION CHANGE START: MOVED AND REFACTORED TO MODULAR FILE
 /// The amount of energy needed to increase the burn force by 1 damage during electrocution.
 #define JOULES_PER_DAMAGE (25 KILO JOULES)
 /// Calculates the amount of burn force when applying this much energy to a mob via electrocution from an energy source.
 #define ELECTROCUTE_DAMAGE(energy) (energy >= 1 KILO JOULES ? clamp(20 + round(energy / JOULES_PER_DAMAGE), 20, 195) + rand(-5,5) : 0)
+BUBBERSTATION CHANGE END */

--- a/code/__DEFINES/~~bubber_defines/combat.dm
+++ b/code/__DEFINES/~~bubber_defines/combat.dm
@@ -1,4 +1,4 @@
 /// The amount of energy needed to increase the burn force by 1 damage during electrocution. The below means that 100 damage will be dealt if you touch a max safe loaded powergrid. As (4 MEGA JOULES) / 100 == 40 KILO JOULES
 #define JOULES_PER_DAMAGE (40 KILO JOULES)
 /// Calculates the amount of burn force when applying this much energy to a mob via electrocution from an energy source.
-#define ELECTROCUTE_DAMAGE(energy) (energy >= 1 KILO JOULES ? clamp(round(energy / JOULES_PER_DAMAGE) + rand(0,15), 10, (HUMAN_MAXHEALTH-10)) : 0)
+#define ELECTROCUTE_DAMAGE(energy) (energy >= 1 KILO JOULES ? clamp(round(energy / JOULES_PER_DAMAGE) + rand(-5,5), 10, (HUMAN_MAXHEALTH-10)) : 0)

--- a/code/__DEFINES/~~bubber_defines/combat.dm
+++ b/code/__DEFINES/~~bubber_defines/combat.dm
@@ -1,0 +1,4 @@
+/// The amount of energy needed to increase the burn force by 1 damage during electrocution. The below means that 100 damage will be dealt if you touch a max safe loaded powergrid. As (4 MEGA JOULES) / 100 == 40 KILO JOULES
+#define JOULES_PER_DAMAGE (40 KILO JOULES)
+/// Calculates the amount of burn force when applying this much energy to a mob via electrocution from an energy source.
+#define ELECTROCUTE_DAMAGE(energy) (energy >= 1 KILO JOULES ? clamp(round(energy / JOULES_PER_DAMAGE) + rand(0,15), 10, (HUMAN_MAXHEALTH-10)) : 0)

--- a/code/__DEFINES/~~bubber_defines/combat.dm
+++ b/code/__DEFINES/~~bubber_defines/combat.dm
@@ -1,4 +1,4 @@
-/// The amount of energy needed to increase the burn force by 1 damage during electrocution. The below means that 100 damage will be dealt if you touch a max safe loaded powergrid. As (4 MEGA JOULES) / 100 == 40 KILO JOULES
-#define JOULES_PER_DAMAGE (40 KILO JOULES)
+/// The amount of energy needed to increase the burn force by 1 damage during electrocution. The below means that 100 damage will be dealt if you touch a max safe loaded powergrid. As ((4 MEGA JOULES) / HUMAN_MAXHEALTH) == ~30 KILO JOULES
+#define JOULES_PER_DAMAGE (30 KILO JOULES)
 /// Calculates the amount of burn force when applying this much energy to a mob via electrocution from an energy source.
 #define ELECTROCUTE_DAMAGE(energy) (energy >= 1 KILO JOULES ? clamp(round(energy / JOULES_PER_DAMAGE) + rand(-5,5), 10, (HUMAN_MAXHEALTH-10)) : 0)

--- a/modular_skyrat/master_files/code/modules/power/powernet.dm
+++ b/modular_skyrat/master_files/code/modules/power/powernet.dm
@@ -1,6 +1,8 @@
+/* BUBBERSTATION CHANGE: THIS IS NO LONGER NEEDED.
 /datum/powernet/get_electrocute_damage()
 	if(avail >= 1000)
 		var/damage = clamp(20 + round(avail/25000), 20, 195) + rand(-5,5)
 		return damage * HUMAN_HEALTH_MODIFIER
 	else
 		return 0
+BUBBERSTATION CHANGE END*/

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -485,6 +485,7 @@
 #include "code\__DEFINES\~skyrat_defines\traits\declarations.dm"
 #include "code\__DEFINES\~~bubber_defines\access.dm"
 #include "code\__DEFINES\~~bubber_defines\colors.dm"
+#include "code\__DEFINES\~~bubber_defines\combat.dm"
 #include "code\__DEFINES\~~bubber_defines\economy.dm"
 #include "code\__DEFINES\~~bubber_defines\footsteps.dm"
 #include "code\__DEFINES\~~bubber_defines\jobs.dm"


### PR DESCRIPTION
## About The Pull Request

I ran into a door and died because there was 2+ MW in the grid. 

## About The Pull Request (For Real)

Currently, electrocution damage is balanced around having 1MW in the grid, but since we're now allowing an upwards of 4MW in the grid now, I balanced electrocution damage to that 4MW value and applied other changes.

You now take 1 damage per 30J (previously 20J). This wasn't just an arbitrary x1.5 multiplier but the math worked out.
The maximum damage you can take from electrocution is now 125 (previously 195). Maximum health is 135 for reference.
The minimum damage you can take from shocks is 10 (previously 20).

## Why It's Good For The Game

As mentioned above, electrocution damage is currently in a bad state right now since it hasn't been balanced around the new power requirement changes.

This change is also good if we actually unironically want to add malf AI back into rotation because I don't want a round where the AI insta-kills everyone because they touched a door once.

## Proof Of Testing

Untested.

## Changelog

:cl: BurgerBB
balance: Nerfs electrocution damage because I died to it once
/:cl:
