### PR TITLE
[MODULAR] removes the antag-spawning trumpet from the maintenance pool because this is not supposed to be spawned

### DIFF
--- a/modular_zubbers/code/_globalvars/lists/maintenance_loot_common.dm
+++ b/modular_zubbers/code/_globalvars/lists/maintenance_loot_common.dm
@@ -1070,11 +1070,8 @@ GLOBAL_LIST_INIT(common_loot, list( //common: basic items
 		/obj/item/instrument/piano_synth/headphones/spacepods = 1,
 		/obj/item/instrument/recorder = 5,
 		/obj/item/instrument/saxophone = 10,
-		/obj/item/instrument/saxophone/spectral = 1,
 		/obj/item/instrument/trombone = 10,
-		/obj/item/instrument/trombone/spectral = 1,
 		/obj/item/instrument/trumpet = 10,
-		/obj/item/instrument/trumpet/spectral = 1,
 		/obj/item/instrument/violin = 10,
 		/obj/item/instrument/violin/golden = 1
 	) = 25,


### PR DESCRIPTION
## About The Pull Request

removes the antag-spawning trumpet from the maintenance pool because this is not supposed to be spawned

## Why It's Good For The Game

we really need to add a lint for this

## Proof Of Testing

this shit ain't nothing to me, man

## Changelog
:cl:
balance:  removes the antag-spawning trumpet from the maintenance pool because this is not supposed to be spawned
/:cl:
