### PR TITLE
Nerfs the Bow Because I died To It Once

### DIFF
--- a/code/modules/projectiles/guns/ballistic/bows/bow_arrows.dm
+++ b/code/modules/projectiles/guns/ballistic/bows/bow_arrows.dm
@@ -29,18 +29,17 @@
 	desc = "Ow! Get it out of me!"
 	icon = 'icons/obj/weapons/bows/arrows.dmi'
 	icon_state = "arrow_projectile"
-	damage = 50
+	damage = 25
 	speed = 1
 	range = 25
 	shrapnel_type = null
 	embedding = list(
-		embed_chance = 90,
+		embed_chance = 10,
 		fall_chance = 2,
-		jostle_chance = 2,
+		jostle_chance = 0,
 		ignore_throwspeed_threshold = TRUE,
 		pain_stam_pct = 0.5,
 		pain_mult = 3,
-		jostle_pain_mult = 3,
 		rip_time = 1 SECONDS
 	)
 
@@ -60,7 +59,7 @@
 	icon_state = "holy_arrow_projectile"
 	damage = 20 //still a lot but this is roundstart gear so far less
 	embedding = list(
-		embed_chance = 50,
+		embed_chance = 25,
 		fall_chance = 2,
 		jostle_chance = 0,
 		ignore_throwspeed_threshold = TRUE,

--- a/modular_skyrat/modules/tribal_extended/code/ammo/reusable/arrow.dm
+++ b/modular_skyrat/modules/tribal_extended/code/ammo/reusable/arrow.dm
@@ -40,14 +40,13 @@
 	)
 	shrapnel_type = /obj/item/ammo_casing/arrow/bone
 	embedding = list(
-		embed_chance = 33,
-		fall_chance = 3,
-		jostle_chance = 4,
+		embed_chance = 25,
+		fall_chance = 2,
+		jostle_chance = 0,
 		ignore_throwspeed_threshold = TRUE,
-		pain_stam_pct = 0.4,
-		pain_mult = 5,
-		jostle_pain_mult = 6,
-		rip_time = 0.5 SECONDS
+		pain_stam_pct = 0.5,
+		pain_mult = 3,
+		rip_time = 1 SECONDS
 	)
 
 /obj/projectile/bullet/arrow/bronze


### PR DESCRIPTION
## About The Pull Request
This PR completely slashes the damage of arrows and essentially reverts the extremely overpowered tribal buffs from SR as they were not attuned for a player vs player environment. The arrows are essentially brought in line with the stats of the Chaplain arrows. Please, never-ever change this again.

If this severely effects ice cats, i'll buff the mob arrows but ensure they can't really be used against the crew.

## Why It's Good For The Game

Completely overtuned weapons that you can essentially get at round start when the Chaplain gets weaker arrows again, at round start. Also asked to do this so here we are.

## Proof Of Testing

it compiles.

## Changelog

:cl:
balance: Brings arrows into line with the Chaplain arrows.
/:cl:
