### PR TITLE
Map Voting Occurs when the shuttle is called and cannot be recalled.

### DIFF
--- a/modular_zubbers/code/modules/shuttle/emergency.dm
+++ b/modular_zubbers/code/modules/shuttle/emergency.dm
@@ -1,0 +1,7 @@
+/obj/docking_port/mobile/emergency/check()
+	. = ..()
+	if(!timer)
+		return
+	if(mode == SHUTTLE_CALL)
+		if(!SSshuttle.canRecall())
+			SSmapping.mapvote() //Do a map vote if we're at the point of no return.


### PR DESCRIPTION

## About The Pull Request

Map Voting Occurs when the shuttle is called and cannot be recalled.

This means that if you call the shuttle, and then the point of no return happens where you can't recall (either due to time or adminbus), then map voting will occur.

This should be merged with https://github.com/Bubberstation/config/pull/59

## Why It's Good For The Game

People rarely vote when the shuttle launches considering there is a lot of chaos happening on the shuttle (especially for security) or people are busy wrapping up RP. This is the alternative solution to that where hopefully there is enough time for people to vote here.

## Proof Of Testing

Untested. Doing that now.

## Changelog

:cl: BurgerBB
qol: Map Voting Occurs when the shuttle is called and cannot be recalled.
/:cl:
