### PR TITLE
Adds a paramedic slot

### DIFF
--- a/config/jobconfig.toml
+++ b/config/jobconfig.toml
@@ -253,8 +253,8 @@
 "Playtime Requirements" = 0
 "Required Account Age" = 0
 "# Required Character Age" = 0
-"Spawn Positions" = 2
-"Total Positions" = 3
+"Spawn Positions" = 4
+"Total Positions" = 4
 
 [PRISONER]
 "Playtime Requirements" = 0


### PR DESCRIPTION
## About The Pull Request

Adds a paramedic slot and makes all slots available roundstart.

## Why It's Good For The Game

A single paramedic being traitor can lead to only a single paramed, which is insufficient particularly on high pop/chaotic rounds.

## Changelog

:cl: LT3
balance: +1 paramedic slots
/:cl: