### PR TITLE
Fixes the second layer of moonstation creating space turfs

### DIFF
--- a/_maps/moonstation.json
+++ b/_maps/moonstation.json
@@ -28,7 +28,7 @@
 			"Mining": true,
 			"Linkage": null,
 			"Gravity": true,
-			"Baseturf": "/turf/open/misc/moonstation_rock/cave",
+			"Baseturf": "/turf/open/misc/moonstation_rock",
 			"No Parallax": true
 		},
 		{


### PR DESCRIPTION
## About The Pull Request

Fixes the second layer of moonstation creating space turfs.
This bug was caused by a missing pathtype in the map config.

## Proof Of Testing

If it compiles, it werks.

## Changelog

:cl: BurgerBB
fix: Fixes the second layer of moonstation creating space turfs.
/:cl:
