### PR TITLE
Fixes a reversion that causes the bureaucratic error event to have a chance to close all job slots

### DIFF
--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -14,7 +14,7 @@
 
 /datum/round_event/bureaucratic_error/start()
 	var/list/jobs = SSjob.get_valid_overflow_jobs()
-	// BUBBER EDIT BEGIN /* SKYRAT EDIT REMOVAL START
+	/* SKYRAT EDIT REMOVAL START
 	if(prob(33)) // Only allows latejoining as a single role.
 		var/datum/job/overflow = pick_n_take(jobs)
 		overflow.spawn_positions = -1
@@ -23,7 +23,7 @@
 			var/datum/job/current = job
 			current.total_positions = 0
 		return
-	// BUBBER EDIT END */ // SKYRAT EDIT REMOVAL - no more locking off jobs
+	*/ // SKYRAT EDIT REMOVAL - no more locking off jobs
 	// Adds/removes a random amount of job slots from all jobs.
 	for(var/datum/job/current as anything in jobs)
 		current.total_positions = max(current.total_positions + rand(-2,4), 1) // SKYRAT EDIT CHANGE - No more locking off jobs - ORIGINAL: current.total_positions = max(current.total_positions + rand(-2,4), 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reverts a reversion in #456 which re-enabled the bureaucratic error event having a 33% chance to choose a random overflow job and close all job slots for all other jobs.

## Why It's Good For The Game

A HoP can only open non-command job slots at a rate of one slot every thirty seconds.
This can leave people only able to latejoin as assistants.
The job slot randomization that skyrat added is annoying, but doesn't prevent new people from joining actual jobs.

## Proof Of Testing

N/A, just re-commented out something that was un-commented out.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Fixes a reversion which re-enabled a chance to close all job slots except one when the bureaucratic error event triggers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
