### PR TITLE
[NON-MODULAR] Prybars no longer force doors open.

### DIFF
--- a/modular_skyrat/modules/colony_fabricator/code/tools/tools.dm
+++ b/modular_skyrat/modules/colony_fabricator/code/tools/tools.dm
@@ -97,12 +97,11 @@
 
 /obj/item/crowbar/large/doorforcer
 	name = "prybar"
-	desc = "A large, sturdy crowbar, painted orange. This one just happens to be tough enough to \
-		survive <b>forcing doors open</b>."
+	desc = "A large, sturdy crowbar, painted orange." // BUBBER EDIT
 	icon = 'modular_skyrat/modules/colony_fabricator/icons/tools.dmi'
 	icon_state = "prybar"
 	toolspeed = 1.3
-	force_opens = TRUE
+	force_opens = FALSE // BUBBER EDIT
 	custom_materials = list(
 		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 1.75,
 		/datum/material/titanium = HALF_SHEET_MATERIAL_AMOUNT,


### PR DESCRIPTION
## About The Pull Request

Prybars no longer force open doors.

## Why It's Good For The Game

Prybars were a poor decision made by Skyrat. They have made entrance to restricted areas too easy in comparison to hacking, and made what was previously a techweb locked item available roundstart. This item is too powerful, and thus needs nerfed. Every crewmember being able to negate ID cards and the access system for 300 credits from Cargo or free once they buy the printer for them is incredibly stupid and shouldn't of been merged.

## "But how will I get into-"

Get access, law 2 the door with the AI, hack in, or go in via an alternative entrance.

## "But I don't want to talk to people/engage with the systems in the game!"

![image - 2024-06-03T130725 450](https://github.com/Bubberstation/Bubberstation/assets/4081722/b6cee155-46ce-4f25-bcc9-c02eac4a2800)

## Changelog
:cl:
balance: Prybars no longer force doors open.
/:cl:
