### PR TITLE
[Non-Modular] Removes speed increase from cocaine and makes it more addictive

### DIFF
--- a/modular_skyrat/modules/morenarcotics/code/cocaine.dm
+++ b/modular_skyrat/modules/morenarcotics/code/cocaine.dm
@@ -27,18 +27,16 @@
 	description = "A powerful stimulant extracted from coca leaves. Reduces stun times, but causes drowsiness and severe brain damage if overdosed."
 	reagent_state = LIQUID
 	color = "#ffffff"
-	overdose_threshold = 20
+	overdose_threshold = 10
 	ph = 9
 	taste_description = "bitterness" //supposedly does taste bitter in real life
 	addiction_types = list(/datum/addiction/stimulants = 14) //5.6 per 2 seconds
 
 /datum/reagent/drug/cocaine/on_mob_metabolize(mob/living/containing_mob)
 	..()
-	containing_mob.add_movespeed_modifier(/datum/movespeed_modifier/reagent/stimulants)
 	ADD_TRAIT(containing_mob, TRAIT_BATON_RESISTANCE, type)
 
 /datum/reagent/drug/cocaine/on_mob_end_metabolize(mob/living/containing_mob)
-	containing_mob.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/stimulants)
 	REMOVE_TRAIT(containing_mob, TRAIT_BATON_RESISTANCE, type)
 	..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

What it says on the tin.

## Why It's Good For The Game

I'm not gonna deny this is the result of a couple players using poor sportsmanship across a few rounds, but considering coke wasn't even meant to survive this long to begin with in its current form I think this is just a long time coming. Plenty of other options for making yourself move faster already in-game, and one that does that on top of making you resistant to stuns and batons is insane when it's so easy to stack with stuff like strained muscles, stimpacks, stimulant pills, meth, ephedrine, coffee, or nuka cola.

## Proof Of Testing

Ran tests with it. Speed boost is gone, you just get a small mood boost and the stun resistance. Did you know it takes three baton hits to actually make someone horizontal on cocaine? Wild.

## Changelog


:cl:
balance: removed speed buff from cocaine, made it slightly more addictive
code: see balance tag
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
