### PR TITLE
Changeling Zombie Toxins are capped when it reaches the curable stage + Cryotube resistance

### DIFF
--- a/modular_zubbers/code/modules/changeling_zombies/infection.dm
+++ b/modular_zubbers/code/modules/changeling_zombies/infection.dm
@@ -135,6 +135,8 @@ GLOBAL_VAR_INIT(changeling_zombies_detected,FALSE)
 				can_cure = FALSE
 			else
 				var/damage_multiplier = max(1, (world.time - infection_timestamp) / (1 MINUTES) )
+				if(can_cure)
+					damage_multiplier = min(2,damage_multiplier) //Caps it to double.
 				if(host.stat && host.stat == DEAD)
 					host.adjustToxLoss(round(CHANGELING_ZOMBIE_TOXINS_PER_SECOND_DEAD * seconds_per_tick * damage_multiplier,0.1))
 				else

--- a/modular_zubbers/code/modules/changeling_zombies/infection.dm
+++ b/modular_zubbers/code/modules/changeling_zombies/infection.dm
@@ -99,6 +99,15 @@ GLOBAL_VAR_INIT(changeling_zombies_detected,FALSE)
 
 	var/mob/living/carbon/human/host = parent
 
+	if(SPT_PROB(2, seconds_per_tick) && istype(host.loc,/obj/machinery/cryo_cell))
+		var/obj/machinery/cryo_cell/gay_baby_jail = host.loc
+		if(gay_baby_jail.on)
+			gay_baby_jail.visible_message(
+				span_danger("Something thrashes inside [gay_baby_jail]!")
+			)
+			gay_baby_jail.Shake()
+			gay_baby_jail.take_damage(10,armour_penetration=100)
+
 	if(zombified)
 		var/list/healing_options = list()
 		if(host.getBruteLoss() > 0)


### PR DESCRIPTION
## About The Pull Request

Changeling Zombie Toxins are capped when it reaches the curable stage.
Cryotubes will take damage over time if a Changeling Zombie is inside them.

## Why It's Good For The Game

So what I noticed is that because people take too long to actually reach the 100 toxins stage, as well as to get treatment, people usually end up taking a ton of toxins damage per second to the point where even a combination of medicines in cryogenics can't cure them. This PR makes it so that the damage has a cap once it reaches the curable stage, so medical doctors have an easier time curing them.

While making this PR, I realized that this would just encourage doctors to stick patients in cryotubes and then forget about them, which isn't very good as being stuck in a cryotube for an extended period of time (you're taking toxin damage, plus you're getting cured of it so it's a longer process). To prevent this, I've made it so that cryotubes will take damage over time (randomly) if a changeling zombie is inside it while it is activated.

## Proof Of Testing

Draft because untested.

## Changelog

:cl: BurgerBB
balance: Changeling Zombie Toxins are capped when it reaches the curable stage.
balance: Changeling Zombie patients will deal damage to the cryotube if placed inside it while activated.
/:cl:
