### PR TITLE
Moonstation Space Fixes + Mapping Errors + Upstream induced mapping errors

### DIFF
--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -23930,6 +23930,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/button/crematorium{
+	id = "crematoriumCold";
+	pixel_x = -26
+	},
 /turf/open/floor/fake_snow/safe{
 	initial_gas_mix = "o2=26;n2=97;TEMP=259.15"
 	},
@@ -32302,9 +32306,11 @@
 /turf/open/floor/iron,
 /area/station/terminal/lobby)
 "jbu" = (
-/obj/effect/gibspawner/human/bodypartless,
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 9
+	},
+/obj/structure/bodycontainer/crematorium/creamatorium{
+	id = "crematoriumCold"
 	},
 /turf/open/floor/fake_snow/safe{
 	initial_gas_mix = "o2=26;n2=97;TEMP=259.15"
@@ -44096,6 +44102,7 @@
 /obj/effect/mapping_helpers/airlock/welded,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/barricade/wooden/crude,
 /turf/open/floor/fake_snow/safe{
 	initial_gas_mix = "o2=26;n2=97;TEMP=259.15"
 	},

--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -4683,13 +4683,13 @@
 	id = "cargodisposals";
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/west,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/machinery/plumbing/floor_pump/input/on{
 	dir = 4
 	},
+/obj/machinery/computer/security/telescreen/disposals/directional/west,
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
 "bnz" = (
@@ -6511,6 +6511,7 @@
 "bQH" = (
 /obj/item/kirbyplants/random/fullysynthetic,
 /obj/effect/turf_decal/tile/purple/fourcorners,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "bQJ" = (
@@ -7441,7 +7442,6 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
-/obj/machinery/firealarm/directional/east,
 /obj/structure/sign/warning/test_chamber/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/circuits)
@@ -8911,8 +8911,8 @@
 /area/station/science/xenobiology)
 "cBn" = (
 /obj/structure/cable,
-/obj/machinery/airalarm/directional/east,
 /obj/effect/landmark/start/cyborg,
+/obj/machinery/computer/security/telescreen/aiupload/directional/east,
 /turf/open/floor/catwalk_floor,
 /area/station/ai_monitored/turret_protected/aisat/service)
 "cBy" = (
@@ -11390,10 +11390,10 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/machinery/computer/security/telescreen/interrogation/directional/east,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
+/obj/machinery/computer/security/telescreen/interrogation/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "dkA" = (
@@ -16391,6 +16391,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/computer/security/telescreen/cmo/directional/north,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "eCZ" = (
@@ -16816,6 +16817,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/landmark/start/engineering_guard,
 /obj/machinery/airalarm/directional/east,
+/obj/machinery/computer/security/telescreen/engine/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "eIR" = (
@@ -23775,7 +23777,6 @@
 /obj/effect/turf_decal/tile/dark_red/opposingcorners{
 	dir = 8
 	},
-/obj/structure/sign/warning/no_smoking/circle/directional/south,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25680,6 +25681,7 @@
 	},
 /obj/item/radio/intercom/command/directional/west,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/computer/security/telescreen/commandbunker/directional/south,
 /turf/open/floor/circuit,
 /area/station/command/secure_bunker)
 "hjr" = (
@@ -25720,13 +25722,6 @@
 	},
 /turf/open/floor/plating/rust/moonstation,
 /area/moonstation/underground)
-"hjG" = (
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance_hatch,
-/turf/open/floor/iron/white,
-/area/station/science/lab)
 "hjP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28717,6 +28712,7 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/computer/security/telescreen/prison/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "iaJ" = (
@@ -31530,9 +31526,9 @@
 "iSo" = (
 /obj/item/kirbyplants/random/fullysynthetic,
 /obj/effect/turf_decal/tile/purple/fourcorners,
-/obj/machinery/airalarm/directional/east,
 /obj/structure/sign/departments/xenobio/directional/south,
 /obj/machinery/camera/autoname/science/directional/south,
+/obj/machinery/computer/security/telescreen/xeno/directional/east,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "iSp" = (
@@ -32374,7 +32370,7 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/computer/security/telescreen/prison,
+/obj/machinery/computer/security/telescreen/prison/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "jcw" = (
@@ -32883,7 +32879,7 @@
 	pixel_y = 4
 	},
 /obj/item/watertank/pepperspray,
-/obj/machinery/computer/security/telescreen/isolation/interrogation,
+/obj/machinery/computer/security/telescreen/isolation/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/corrections_officer)
 "jjk" = (
@@ -33170,6 +33166,7 @@
 "jmo" = (
 /obj/machinery/light/warm/directional/west,
 /obj/machinery/announcement_system,
+/obj/machinery/computer/security/telescreen/tcomms/directional/west,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/tcommsat/computer)
 "jmy" = (
@@ -34905,7 +34902,7 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/computer/security/telescreen/rd/directional/west,
+/obj/machinery/computer/security/telescreen/rd/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "jOj" = (
@@ -37637,7 +37634,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/computer/security/telescreen/aiupload,
+/obj/machinery/computer/security/telescreen/aiupload/directional/west,
 /turf/open/floor/iron/dark/small,
 /area/station/ai_monitored/turret_protected/aisat/teleporter)
 "kBx" = (
@@ -40635,7 +40632,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "lry" = (
-/obj/machinery/computer/security/telescreen/commandbunker/directional/north,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/small/dim/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -41598,8 +41594,8 @@
 /area/station/medical/pharmacy)
 "lFk" = (
 /obj/machinery/modular_computer/preset/id,
-/obj/machinery/computer/security/telescreen/ce,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/computer/security/telescreen/ce/directional/north,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "lFo" = (
@@ -41930,6 +41926,7 @@
 /obj/structure/cable,
 /obj/machinery/light/small/red/directional/east,
 /obj/effect/landmark/start/cyborg,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/catwalk_floor,
 /area/station/ai_monitored/turret_protected/aisat/service)
 "lJh" = (
@@ -42856,10 +42853,10 @@
 /obj/structure/closet/secure_closet/quartermaster,
 /obj/item/reagent_containers/spray/spraytan,
 /obj/machinery/light/warm/directional/south,
-/obj/machinery/computer/security/telescreen/vault/directional/west,
 /obj/machinery/status_display/department_balance{
 	pixel_y = -32
 	},
+/obj/machinery/computer/security/telescreen/vault/directional/east,
 /turf/open/floor/mineral/gold,
 /area/station/command/heads_quarters/qm)
 "lXn" = (
@@ -43004,6 +43001,7 @@
 	},
 /obj/item/radio/intercom/command/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/computer/security/telescreen/commandbunker/directional/south,
 /turf/open/floor/circuit,
 /area/station/command/secure_bunker)
 "lYK" = (
@@ -46214,6 +46212,7 @@
 /obj/item/gun/ballistic/shotgun/doublebarrel,
 /obj/machinery/light/warm/directional/north,
 /obj/item/camera,
+/obj/machinery/computer/security/telescreen/bar/directional/north,
 /turf/open/floor/iron/grimy,
 /area/station/service/bar/backroom)
 "mUk" = (
@@ -47860,6 +47859,7 @@
 /obj/structure/cable,
 /obj/machinery/power/terminal,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/computer/security/telescreen/vault/directional/north,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/disposal/incinerator)
 "nsH" = (
@@ -51363,6 +51363,7 @@
 "orJ" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/item/kirbyplants/random,
+/obj/machinery/computer/security/telescreen/tcomms/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "orM" = (
@@ -51835,12 +51836,12 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/light/warm/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/closet/firecloset,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "oyU" = (
@@ -52515,9 +52516,9 @@
 	dir = 4
 	},
 /obj/structure/table/glass,
-/obj/item/construction/plumbing/research,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/item/construction/plumbing,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "oJq" = (
@@ -63897,12 +63898,9 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/library)
 "rPM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/airlock/maintenance,
-/turf/open/floor/engine,
-/area/station/maintenance/department/engine)
+/obj/machinery/airalarm/directional/east,
+/turf/closed/wall/r_wall,
+/area/station/ai_monitored/turret_protected/aisat/service)
 "rQs" = (
 /turf/open/floor/iron/dark,
 /area/station/engineering/rbmk2)
@@ -67389,8 +67387,11 @@
 /turf/open/floor/iron,
 /area/station/common/pool)
 "sPn" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron,
 /area/station/cargo/sorting)
 "sPy" = (
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
@@ -68641,7 +68642,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison/safe)
 "the" = (
-/obj/machinery/computer/security/telescreen/minisat,
+/obj/machinery/computer/security/telescreen/minisat/directional/east,
 /turf/open/floor/iron/dark/small,
 /area/station/command/bridge)
 "thF" = (
@@ -70853,6 +70854,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/computer/security/telescreen/cargo_sec/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/supply)
 "tMJ" = (
@@ -77485,8 +77487,8 @@
 /obj/machinery/computer/crew{
 	dir = 1
 	},
-/obj/machinery/computer/security/telescreen/prison/directional/north,
 /obj/machinery/light/warm/directional/west,
+/obj/machinery/computer/security/telescreen/prison/directional/south,
 /turf/open/floor/iron/dark/small,
 /area/station/security/warden)
 "vGA" = (
@@ -78857,6 +78859,7 @@
 /area/station/medical/surgery)
 "wbS" = (
 /obj/effect/spawner/random/decoration/statue,
+/obj/machinery/computer/security/telescreen/engine/directional/east,
 /turf/open/floor/wood,
 /area/station/engineering/break_room)
 "wcq" = (
@@ -79985,9 +79988,9 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "wtb" = (
-/obj/machinery/computer/security/telescreen/engine,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/computer/security/telescreen/engine/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "wtd" = (
@@ -81111,7 +81114,7 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/computer/security/telescreen/ordnance/directional/west,
+/obj/machinery/computer/security/telescreen/ordnance/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "wJK" = (
@@ -81980,7 +81983,6 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
 	},
-/obj/machinery/computer/security/telescreen/cmo/directional/west,
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
@@ -85170,6 +85172,7 @@
 	dir = 1;
 	target_pressure = 2000
 	},
+/obj/machinery/computer/security/telescreen/engine_waste/directional/east,
 /turf/open/floor/catwalk_floor,
 /area/station/engineering/supermatter/room)
 "xRx" = (
@@ -243147,7 +243150,7 @@ hYX
 ckk
 oyJ
 epR
-epR
+sPn
 oVZ
 gDI
 wPN
@@ -243402,9 +243405,9 @@ qHD
 bXl
 iKG
 ckk
-sPn
+gDI
 bYF
-sPn
+gDI
 gDI
 gDI
 wXW
@@ -245209,7 +245212,7 @@ hZl
 wHW
 cSG
 iju
-mnG
+oyd
 tMF
 etm
 hZE
@@ -246910,8 +246913,8 @@ wte
 ovy
 ovy
 ovy
-ovy
-ovy
+rPM
+rPM
 fLe
 ydw
 iTO
@@ -251797,9 +251800,9 @@ gbX
 ubP
 gbX
 ulH
-ulH
-ulH
-ulH
+jSp
+jSp
+jSp
 jjh
 drs
 xPg
@@ -255265,7 +255268,7 @@ xKj
 xKj
 hht
 hVi
-rPM
+xXZ
 xKj
 xKj
 bbx
@@ -269099,7 +269102,7 @@ nsm
 rZN
 qmL
 quB
-hjG
+rZN
 qwl
 nWR
 uJk

--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -5296,7 +5296,7 @@
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/wood,
-/area/moonstation/surface/unexplored)
+/area/station/maintenance/console_room)
 "byn" = (
 /obj/structure/fluff/tram_rail/electric/anchor,
 /turf/open/misc/moonstation_sand,
@@ -12806,7 +12806,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
-/area/moonstation/surface/unexplored)
+/area/station/maintenance/console_room)
 "dEM" = (
 /obj/effect/turf_decal/tile/holiday/rainbow/half/contrasted{
 	dir = 1
@@ -14850,7 +14850,7 @@
 	},
 /obj/effect/spawner/random/trash/grime,
 /turf/open/floor/wood,
-/area/moonstation/surface/unexplored)
+/area/station/maintenance/console_room)
 "ejO" = (
 /obj/machinery/firealarm/directional/east,
 /obj/structure/filingcabinet/employment,
@@ -18407,7 +18407,7 @@
 /obj/machinery/status_display/evac/directional/east,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/wood,
-/area/moonstation/surface/unexplored)
+/area/station/maintenance/console_room)
 "ffn" = (
 /turf/open/floor/glass/reinforced/scrape_below,
 /area/station/command/bridge)
@@ -30423,7 +30423,7 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
-/area/moonstation/surface/unexplored)
+/area/station/maintenance/console_room)
 "iCo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
@@ -41947,7 +41947,7 @@
 "lJt" = (
 /obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/wood,
-/area/moonstation/surface/unexplored)
+/area/station/maintenance/console_room)
 "lJx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/arrows/white{
@@ -45798,7 +45798,7 @@
 /obj/effect/spawner/random/trash/hobo_squat,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
-/area/moonstation/surface/unexplored)
+/area/station/maintenance/console_room)
 "mPH" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/dark,
@@ -47367,7 +47367,7 @@
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/wood,
-/area/moonstation/surface/unexplored)
+/area/station/maintenance/console_room)
 "nmn" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/mapping_helpers/dead_body_placer,
@@ -56917,7 +56917,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/moonstation/surface/unexplored)
+/area/station/maintenance/console_room)
 "pUU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -79854,7 +79854,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood,
-/area/moonstation/surface/unexplored)
+/area/station/maintenance/console_room)
 "wrb" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/structure/showcase/cyborg/old{
@@ -82580,7 +82580,7 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood,
-/area/moonstation/surface/unexplored)
+/area/station/maintenance/console_room)
 "xfP" = (
 /turf/closed/wall/rust,
 /area/station/commons/public_mining)

--- a/_maps/moonstation.json
+++ b/_maps/moonstation.json
@@ -36,7 +36,7 @@
 			"Mining": true,
 			"Linkage": null,
 			"Gravity": true,
-			"Baseturf": "/turf/open/chasm/moonstation",
+			"Baseturf": "/turf/open/misc/moonstation_rock",
 			"No Parallax": true,
 			"Weather_Sandstorm": true
 		}

--- a/_maps/moonstation.json
+++ b/_maps/moonstation.json
@@ -36,7 +36,7 @@
 			"Mining": true,
 			"Linkage": null,
 			"Gravity": true,
-			"Baseturf": "/turf/open/misc/moonstation_rock",
+			"Baseturf": "/turf/open/openspace/moonstation",
 			"No Parallax": true,
 			"Weather_Sandstorm": true
 		}


### PR DESCRIPTION
## About The Pull Request

Fixes moonstation having space turfs on turf destruction on the upper level.
Fixes weirdly placed camera monitors due to upstream changes.
Fixes a few randomly placed doors in some areas.

## Changelog


:cl: BurgerBB
fix: Fixes moonstation having space turfs on turf destruction on the upper level. Fixes weirdly placed camera monitors due to upstream changes. Fixes a few randomly placed doors in some areas.
/:cl:

