### PR TITLE
lol progressive traitor

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -300,7 +300,7 @@ GLOBAL_LIST_INIT(human_invader_antagonists, list(
 #define MAROON_PROB 30
 
 /// How many telecrystals a normal traitor starts with
-#define TELECRYSTALS_DEFAULT 25 // BUBBER EDIT - GIMMICK TRAITOR
+#define TELECRYSTALS_DEFAULT 20 // BUBBER EDIT - GIMMICK TRAITOR
 /// How many telecrystals mapper/admin only "precharged" uplink implant
 #define TELECRYSTALS_PRELOADED_IMPLANT 10
 /// The normal cost of an uplink implant; used for calcuating how many

--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -300,7 +300,7 @@ GLOBAL_LIST_INIT(human_invader_antagonists, list(
 #define MAROON_PROB 30
 
 /// How many telecrystals a normal traitor starts with
-#define TELECRYSTALS_DEFAULT 20 // BUBBER EDIT - GIMMICK TRAITOR
+#define TELECRYSTALS_DEFAULT 20
 /// How many telecrystals mapper/admin only "precharged" uplink implant
 #define TELECRYSTALS_PRELOADED_IMPLANT 10
 /// The normal cost of an uplink implant; used for calcuating how many

--- a/code/modules/station_goals/meteor_shield.dm
+++ b/code/modules/station_goals/meteor_shield.dm
@@ -171,8 +171,9 @@
 			say("Warning. Further tampering has been reported.")
 			priority_announce("Warning. Tampering of meteor satellites puts the station at risk of exotic, deadly meteor collisions. Please intervene by checking your GPS devices for strange signals, and dismantling the tampered meteor shields.", "Strange Meteor Signal Warning")
 		if(EMAGGED_METEOR_SHIELD_THRESHOLD_FOUR)
-			say("Warning. Warning. Dark Matt-eor on course for station.")
-			force_event_async(/datum/round_event_control/dark_matteor, "an array of tampered meteor satellites")
+			say("Warning. Warning. Twin tunguska meteors on course for station.")
+			//force_event_async(/datum/round_event_control/dark_matteor, "an array of tampered meteor satellites") BUBBER EDIT
+			spawn_meteors(2, /obj/effect/meteor/tunguska) // BUBBER EDIT END
 
 /obj/machinery/satellite/meteor_shield/proc/change_meteor_chance(mod)
 	// Update the weight of all meteor events

--- a/modular_zubbers/code/game/gamemodes/objectives/overrides.dm
+++ b/modular_zubbers/code/game/gamemodes/objectives/overrides.dm
@@ -9,7 +9,3 @@
 	steal_objective.owner = owner
 	steal_objective.find_target()
 	return steal_objective
-
-/datum/uplink_handler/generate_objectives()
-	on_update()
-	return FALSE

--- a/modular_zubbers/code/game/gamemodes/objectives/overrides.dm
+++ b/modular_zubbers/code/game/gamemodes/objectives/overrides.dm
@@ -9,3 +9,36 @@
 	steal_objective.owner = owner
 	steal_objective.find_target()
 	return steal_objective
+
+/datum/traitor_objective_category/final_objective
+	name = "Final Objective"
+	objectives = list(
+//		/datum/traitor_objective/ultimate/battlecruiser = 1, Debatable.
+		/datum/traitor_objective/ultimate/battle_royale = 1,
+		/datum/traitor_objective/ultimate/dark_matteor = 1,
+		/datum/traitor_objective/ultimate/infect_ai = 1,
+//		/datum/traitor_objective/ultimate/romerol = 1, Meh.
+//		/datum/traitor_objective/ultimate/supermatter_cascade = 1, Engineering doesn't need to cook this spaghetti today.
+	)
+
+/datum/traitor_objective/ultimate/dark_matteor // lol fuck no, just two big rocks instead. This objective was non-modularly editted.
+	name = "Summon twin tunguska meteors to rip through the station."
+	description = "Go to %AREA%, and receive the smuggled satellites + emag. Set up and emag the satellites, \
+	after enough have been recalibrated by the emag."
+
+/obj/item/paper/dark_matteor_summoning // SLIGHT REWORDING FROM DARK METEOR TO TUNGUSKA
+	name = "notes - twin tunguska meteor summoning"
+	default_raw_text = {"
+		Summoning twin tunguska meteor.<br>
+		<br>
+		<br>
+		Operative, this crate contains 10+1 spare meteor shield satellites stolen from NT’s supply lines. Your mission is to
+		deploy them in space near the station and recalibrate them with the provided emag. Be careful: you need a 30 second
+		cooldown between each hack, and NT will detect your interference after seven recalibrations. That means you
+		have at least 5 minutes of work and 1 minute of resistance.<br>
+		<br>
+		This is a high-risk operation. You’ll need backup, fortification, and determination. The reward?
+		A spectacular display of twin meteors ripping through the station.<br>
+		<br>
+		<b>**Death to Nanotrasen.**</b>
+"}

--- a/modular_zubbers/code/modules/storyteller/event_defines/roleset/crew_antagonists/heretic.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/roleset/crew_antagonists/heretic.dm
@@ -7,8 +7,8 @@
 	weight = 4
 	min_players = 40
 
-	base_antags = 2
-	maximum_antags = 3
+	base_antags = 1
+	maximum_antags = 2
 
 	tags = list(TAG_COMBAT, TAG_SPOOKY, TAG_CREW_ANTAG)
 

--- a/modular_zubbers/code/modules/storyteller/event_defines/roleset/crew_antagonists/spies.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/roleset/crew_antagonists/spies.dm
@@ -5,7 +5,9 @@
 	antag_flag = ROLE_SPY
 	antag_datum = /datum/antagonist/spy
 	weight = 4
-
+	min_players = 40
+	base_antags = 2
+	maximum_antags = 3
 	tags = list(TAG_CREW_ANTAG)
 
 /datum/round_event_control/antagonist/solo/spy/midround

--- a/modular_zubbers/code/modules/storyteller/event_defines/roleset/crew_antagonists/traitor.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/roleset/crew_antagonists/traitor.dm
@@ -4,7 +4,10 @@
 
 	antag_flag = ROLE_TRAITOR
 	antag_datum = /datum/antagonist/traitor
-	weight = 6
+	min_players = 40
+	weight = 5
+	base_antags = 1
+	maximum_antags = 2
 
 	tags = list(TAG_CREW_ANTAG)
 
@@ -12,3 +15,4 @@
 	name = "Sleeper Agents (Traitors)"
 	roundstart = FALSE
 	weight = 7
+	antag_datum = /datum/antagonist/traitor/infiltrator/sleeper_agent

--- a/tgui/packages/tgui/styles/interfaces/Orbit.scss
+++ b/tgui/packages/tgui/styles/interfaces/Orbit.scss
@@ -1,7 +1,7 @@
 .JobIcon {
   background: black;
   height: 20px;
-  overflow: clip;
+  overflow: hidden;
   padding: 1px 1px 0 1px;
   width: 20px;
 }


### PR DESCRIPTION
## About The Pull Request

I will consider the existence of progressive traitor again, after some gauging on staff and other maintainers. This **might** be test merged. This **might** be closed. Overall I've included some edits in the final objectives. 

- Dark Matt-eor was turned into two tunguska meteors.
- Battle Royal
- Infect AI

Battlecruiser is debatable, but might be reconsidered. Romerol is lame. We don't need traitor engineers cooking the supermatter speghetti.

## Why It's Good For The Game

I don't really scarcity. TG during our time removed Prog-Tot from sleeper agent and it's only roundstart traitor. Well, we have control of how many round start traitors can spawn.

## Proof Of Testing

It's 3 AM trust me bro (I'll test it later and most of it requires testing on live anyway)

## Changelog

:cl:
add: Progtot is back
balance: Hacking meteor satallites will instead send two tunguska meteors at the station instead of a Dark Matt-eor.
/:cl: