### PR TITLE
[Config Edit] Drastically increases space ruin budget

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -471,7 +471,7 @@ BOMBCAP 20
 ## a less lootfilled or smaller or less round effecting ruin costs less to
 ## spawn, while the converse is true. Alter this number to affect the amount
 ## of ruins.
-LAVALAND_BUDGET 60
+LAVALAND_BUDGET 80
 
 ## Ice Moon Budget
 ICEMOON_BUDGET 90
@@ -480,7 +480,7 @@ ICEMOON_BUDGET 90
 OCEAN_BUDGET 60
 
 ## Space Ruin Budget
-Space_Budget 16
+Space_Budget 80
 
 ## Time in ds from when a player latejoins till the arrival shuttle docks at the station
 ## Must be at least 30. At least 55 recommended to be visually/aurally appropriate


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Someone made the space ruin budget 16. Six-friggin'-teen. That's insane, that means a couple asteroids and a small ruin or two will spawn and nothing else out in space. I'm bumping it to 80 to not only give more incentive to those like myself to make some new ruins, but also to let people who are new to SS13 in general and have Bubber as their first server get a chance to see these themselves.

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

Space ruins and spacetiding is fun, and the amount of loot you can get isn't that bad since basicmobs are more dangerous than simplemobs, on top of some of these ruins having turrets and stuff. Would give normal crew a chance to find their own ship and make it so exiling antags into space gives them less reason to come back to station.

## Proof Of Testing

It's a config edit so it should work

## Changelog

:cl:
config: Changed spaceruin budget from 16 to 80
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
