### PR TITLE
Ninja bomb and quirk fix

### DIFF
--- a/code/__DEFINES/~skyrat_defines/antagonists.dm
+++ b/code/__DEFINES/~skyrat_defines/antagonists.dm
@@ -17,7 +17,7 @@
 #define GOLDENEYE_REQUIRED_KEYS_MAXIMUM 3
 
 /// Population requirement for bomb objectives (ninja c4, locate weakpoint, etc.) objectives to appear
-#define BOMB_POP_REQUIREMENT 80
+#define BOMB_POP_REQUIREMENT 30 //BUBBER EDIT: Original 80
 
 // Borer evolution defines
 // The three primary paths that eventually diverge

--- a/code/modules/antagonists/space_ninja/space_ninja.dm
+++ b/code/modules/antagonists/space_ninja/space_ninja.dm
@@ -118,7 +118,6 @@
 	operative.dna.update_dna_identity()
 	operative.dna.species.pre_equip_species_outfit(null, operative)
 	operative.regenerate_icons()
-	SSquirks.AssignQuirks(operative, operative.client, TRUE, TRUE, null, FALSE, operative)
 
 	equip_space_ninja(owner.current)
 	owner.current.add_quirk(/datum/quirk/freerunning)


### PR DESCRIPTION
## About The Pull Request

The bomb objective is now available from 30 active pop.

Quirks no longer load on ninjas

## Why It's Good For The Game

Having your entombed/paraplegic character spawn in as ninja isn't very fun.

Also, we decided to add slightly more destructive shit, so the bomb is one step toward that.

fixes #1701

## Changelog

:cl:
balance: The ninja bomb objective is now available from 30 pop
fix: Ninja no longer spawns with quirks, making you not to randomly die and have a fighting chance
/:cl: