### PR TITLE
HoS+QM no longer start with Science Hub

### DIFF
--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -52,7 +52,7 @@
 	starting_programs = list(
 		/datum/computer_file/program/crew_manifest,
 		/datum/computer_file/program/status,
-		/datum/computer_file/program/science,
+		///datum/computer_file/program/science, //BUBBER EDIT: HOS CANNOT HAVE RESEARCH APP
 		/datum/computer_file/program/robocontrol,
 		/datum/computer_file/program/budgetorders,
 		/datum/computer_file/program/records/security,
@@ -112,7 +112,7 @@
 	starting_programs = list(
 		/datum/computer_file/program/crew_manifest,
 		/datum/computer_file/program/status,
-		/datum/computer_file/program/science,
+		///datum/computer_file/program/science, //BUBBER EDIT: QM CANNOT HAVE RESEARCH APP
 		/datum/computer_file/program/robocontrol,
 		/datum/computer_file/program/budgetorders,
 		/datum/computer_file/program/shipping,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Two years ago, a great man declared that in Science and Reason, all Heads were created equal. This was not true, however, as dark clouds gathered on the horizon-- The Head of Security, villain of this story, threatened to ruin the peace in Scienceville by spending dangerous amounts of Science points.

"No, Head of Security," they cried, as their hard-earned harvests were churned into weapons of war, the miners roared, the scientists floored, and it was a dark day indeed.

This PR seeks to solve this problem, by removing the Head of Security and Quartermaster, the two lowest command roles on the rung, from carrying the Science Hub app.
(I'm not super strongly attached to the Quartermaster having this taken off, if you feel the Quartermaster should keep it, let me know and I'll change this to just the Head of Security :>)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game
Heads of Security and Quartermasters can no longer butt out Science with their Science hub access.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Proof Of Testing
It compiles, but I need to check and make sure it works properly first. So, this is a draft.
<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: ReturnToZender
balance: QM+HoS no longer have the Science Hub on their PDAs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
