### PR TITLE
Crew monitor alarm doesn't trigger in medbay

### DIFF
--- a/modular_zubbers/code/game/machinery/crew_monitor.dm
+++ b/modular_zubbers/code/game/machinery/crew_monitor.dm
@@ -16,15 +16,21 @@
 	canalarm = FALSE
 
 	for(var/mob/living/carbon/human/mob in GLOB.suit_sensors_list)
-
 		if(!istype(mob))
 			continue
+
 		if(mob.z != src.z  && !HAS_TRAIT(mob, TRAIT_MULTIZ_SUIT_SENSORS))
 			continue
+
 		var/obj/item/clothing/under/uniform = mob.w_uniform
 		if(uniform.sensor_mode == SENSOR_COORDS && (uniform.has_sensor != BROKEN_SENSORS) && (HAS_TRAIT(mob, TRAIT_CRITICAL_CONDITION) || mob.stat == DEAD))
 			if(mob.get_dnr()) // DNR won't beep anymore
 				continue
+
+			var/area/mob_area = get_area(mob)
+			if(istype(mob_area, /area/station/medical))
+				continue
+
 			canalarm = TRUE
 			break // Why wasn't this here?
 


### PR DESCRIPTION
## About The Pull Request

Adjusts the crew monitor alarm so that bodies dead in medical don't set off the alarm.

## Why It's Good For The Game

Less false alarms

## Changelog

:cl: LT3
qol: Crew monitor alarm now excludes patients in medbay
/:cl:
