### PR TITLE
Removes tasteless joke from moonstation

### DIFF
--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -14956,7 +14956,7 @@
 /obj/item/reagent_containers/cup/glass/bottle/holywater{
 	desc = "A flask of holy water allegedly containing the first seed planted in the Garden of Eden";
 	name = "flask of the first holy seed";
-	list_reagents = list(/datum/reagent/consumable/cum = 100);
+	list_reagents = list(/datum/reagent/consumable/nutriment/protein = 5, /datum/reagent/consumable/water/holywater = 95);
 	pixel_y = 2
 	},
 /turf/open/floor/iron/dark,


### PR DESCRIPTION
## About The Pull Request

Changes the contents of a "flask of holy water" containing what decidedly isn't holy water in the name of a tasteless pun to actually contain holy water.

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

"Jokes" of this nature leading to easy pref-breaks should not be tolerated here.

## Proof Of Testing

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->

## Changelog

unneeded

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
