### PR TITLE
Revert "Nerfs No-Talk Borg Emags"

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -105,10 +105,6 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		if(!mind) //A player mind is required for law procs to run antag checks.
 			to_chat(user, span_warning("[src] is entirely unresponsive!"))
 			return
-		//BUBBER EDIT BEGIN: DIRECT LAW UPLOADS TAKE 2 SECONDS
-		if(!do_after(user, 2 SECONDS))
-			return
-		//BUBBER EDIT END: DIRECT LAW UPLOADS TAKE 2 SECONDS
 		MOD.install(laws, user) //Proc includes a success mesage so we don't need another one
 		return
 
@@ -345,11 +341,7 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		balloon_alert(user, "expose the fires first!")
 		return FALSE
 
-	balloon_alert(user, "hacking interface...") //BUBBER EDIT: CHANGES THIS DESCRIPTION
-	//BUBBER EDIT BEGIN: NERF NO-TALK EMAGS
-	if(!do_after(user, 2 SECONDS))
-		return FALSE
-	//BUBBER EDIT END: NERF NO-TALK EMAGS
+	balloon_alert(user, "interface hacked")
 	emag_cooldown = world.time + 100
 
 	if(connected_ai && connected_ai.mind && connected_ai.mind.has_antag_datum(/datum/antagonist/malf_ai))


### PR DESCRIPTION
Reverts Bubberstation/Bubberstation#1528

## About this PR

Reverts the 2 second emag time. I was kind of vibing with this at the start, but I've really kind of changed my mind and I think this was a sloppy way to handle this mechanic.

## Why it's good for the game

1. Emagged borgs have substantial counters where emagging one already takes quite a bit of time (in the hall) for the average crewmember to do. You need to still hack its cover, crowbar the borg, *then do a 2 second do_after* which makes it not really any feasable. It basically railroads emagging borgs mostly to the roboticist now, which the diffrence between an instant action and a !do_after isn't going to make much of a diffrence.
2. Siliconnect litterally tells anyone who scans the borg who emagged it. See a cover glitch? Use it.
3. It's not uncommon for an AI to immedietly notice that a borg was emagged.
4. You can lock the borg down right after the fact. 
5. Cover glitch, obviously.
6. Flashes are not instant anymore.

Overall borgs have laws. Those laws can be changed. They can get hacked. This is part of playing silicon and I really don't think it's healthy to try balancing this away. But there's also litterally a "this person hacked this borg" right click feature when you see a cover glitch.


🆑
balance: Reverted 2 second emag time on borgs
/:cl: