### PR TITLE
Fix blood filter filtering toxins

### DIFF
--- a/code/modules/surgery/blood_filter.dm
+++ b/code/modules/surgery/blood_filter.dm
@@ -39,6 +39,10 @@
  * * bloodfilter - The blood filter to check the whitelist of
  */
 /datum/surgery_step/filter_blood/proc/has_filterable_chems(mob/living/carbon/target, obj/item/blood_filter/bloodfilter)
+	// BUBBER EDIT ADDITION BEGIN - Filtration fixes toxins
+	if(target.toxloss > 0)
+		return TRUE
+	// BUBBER EDIT ADDITION END
 	if(!length(target.reagents?.reagent_list))
 		bloodfilter.audible_message(span_notice("[bloodfilter] pings as it reports no chemicals detected in [target]'s blood."))
 		playsound(get_turf(target), 'sound/machines/ping.ogg', 75, TRUE, falloff_exponent = 12, falloff_distance = 1)
@@ -69,7 +73,7 @@
 		for(var/datum/reagent/chem as anything in target.reagents.reagent_list)
 			if(!length(bloodfilter.whitelist) || (chem.type in bloodfilter.whitelist))
 				target.reagents.remove_reagent(chem.type, clamp(round(chem.volume * 0.22, 0.2), 0.4, 10))
-	target.adjustToxLoss(-2, forced = TRUE) //BUBBER EDIT - Filtration fixes toxins
+	target.adjustToxLoss(amount = clamp(round(target.toxloss * -0.07, 2), -2, -10), forced = TRUE) // BUBBER EDIT ADDITION - Filtration fixes toxins
 	display_results(
 		user,
 		target,


### PR DESCRIPTION
## About The Pull Request

Updates the check for the blood filter's toxin removal so that the surgery step is allowed to start. Updates the removal proc to work similar to the new blood filtering clamp.

## Why It's Good For The Game

Toxin filtering to blood filter was added, but the surgery step check won't start unless there's reagents.

## Changelog

:cl: LT3
fix: Blood filter toxin removal feature now starts correctly
/:cl: