### PR TITLE
Removes the Butler title (because it was added upstream)

### DIFF
--- a/modular_zubbers/code/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_zubbers/code/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -6,6 +6,3 @@
 		"Brig Physician",
 		"Combat Medic",
 	)
-/datum/job/assistant/New()
-	alt_titles += list("Butler")
-	. = ..()


### PR DESCRIPTION
## About The Pull Request

Title.


## Why It's Good For The Game

It was added upstream. It's no longer needed down here.

## Changelog
:cl:
del: Duplicate Butler title is gone.
/:cl:

