### PR TITLE
Ethereal Cyborg Charging tweaks

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -62,9 +62,9 @@
 
 	var/charge_amount = recharge_speed * seconds_per_tick
 	if(charge_limit)
-		charge_amount = max(min(charge_amount, charge_limit - target.charge),0) //END BUBBER EDIT, adds new argument
+		charge_amount = max(min(charge_amount, charge_limit - target.charge),0)
 	//charge the cell, account for heat loss from work done
-	var/charge_given = charge_cell(charge_amount, target, grid_only = TRUE)
+	var/charge_given = charge_cell(charge_amount, target, grid_only = TRUE) //END BUBBER EDIT, adds new argument
 	if(charge_given)
 		use_energy((charge_given + active_power_usage) * 0.01)
 

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -57,11 +57,14 @@
  * * obj/item/stock_parts/power_store/cell/target - the cell to charge, optional if provided else will draw power used directly
  * * seconds_per_tick - supplied from process()
  */
-/obj/machinery/recharge_station/proc/charge_target_cell(obj/item/stock_parts/power_store/cell/target, seconds_per_tick)
+/obj/machinery/recharge_station/proc/charge_target_cell(obj/item/stock_parts/power_store/cell/target, seconds_per_tick, charge_limit) //BEGIN BUBBER EDIT
 	PRIVATE_PROC(TRUE)
 
+	var/charge_amount = recharge_speed * seconds_per_tick
+	if(charge_limit)
+		charge_amount = max(min(charge_amount, charge_limit - target.charge),0) //END BUBBER EDIT, adds new argument
 	//charge the cell, account for heat loss from work done
-	var/charge_given = charge_cell(recharge_speed * seconds_per_tick, target, grid_only = TRUE)
+	var/charge_given = charge_cell(charge_amount, target, grid_only = TRUE)
 	if(charge_given)
 		use_energy((charge_given + active_power_usage) * 0.01)
 

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -57,14 +57,14 @@
  * * obj/item/stock_parts/power_store/cell/target - the cell to charge, optional if provided else will draw power used directly
  * * seconds_per_tick - supplied from process()
  */
-/obj/machinery/recharge_station/proc/charge_target_cell(obj/item/stock_parts/power_store/cell/target, seconds_per_tick, charge_limit) //BEGIN BUBBER EDIT
+/obj/machinery/recharge_station/proc/charge_target_cell(obj/item/stock_parts/power_store/cell/target, seconds_per_tick, charge_limit) //BUBBER EDIT BEGIN
 	PRIVATE_PROC(TRUE)
 
 	var/charge_amount = recharge_speed * seconds_per_tick
 	if(charge_limit)
 		charge_amount = max(min(charge_amount, charge_limit - target.charge),0)
 	//charge the cell, account for heat loss from work done
-	var/charge_given = charge_cell(charge_amount, target, grid_only = TRUE) //END BUBBER EDIT, adds new argument
+	var/charge_given = charge_cell(charge_amount, target, grid_only = TRUE) //BUBBER EDIT END
 	if(charge_given)
 		use_energy((charge_given + active_power_usage) * 0.01)
 

--- a/code/modules/surgery/organs/internal/stomach/stomach_ethereal.dm
+++ b/code/modules/surgery/organs/internal/stomach/stomach_ethereal.dm
@@ -40,7 +40,7 @@
 /obj/item/organ/internal/stomach/ethereal/proc/charge(datum/source, datum/callback/charge_cell, seconds_per_tick)
 	SIGNAL_HANDLER
 
-	charge_cell.Invoke(cell, seconds_per_tick / 3.5) // Ethereals don't have NT designed charging ports, so they charge slower.
+	charge_cell.Invoke(cell, seconds_per_tick / 3.5, ETHEREAL_CHARGE_FULL) // Ethereals don't have NT designed charging ports, so they charge slower. //BUBBER EDIT
 
 /obj/item/organ/internal/stomach/ethereal/proc/on_electrocute(datum/source, shock_damage, shock_source, siemens_coeff = 1, flags = NONE)
 	SIGNAL_HANDLER


### PR DESCRIPTION
## About The Pull Request
Special thanks to Waterpig for help with this, this adds a new argument to the recharge station that allows you to set a limit on how much a thing is charged.  And adds an entry within the ethereal stomach that takes advantage of this new argument, allowing them to safely charge at cyborg chargers.  No more shall ethereals invoke the wrath of Zeus upon their compatriots for making the mistake of using a cyborg recharger!

## Why It's Good For The Game

Allows ethereals to safely use cyborg rechargers without instantly invoking the wrath of Zeus upon their fellow crewmen.  Also allows for potential future usage for other things if someone wants to include a reason to restrict the amount a cyborg recharger station can charge.

## Proof Of Testing
Tested locally, works flawlessly.  Borgs charge, modsuits charge, ethereals no longer overcharge from it, it just works.

## Changelog


:cl:
add: Add new argument to cyborg rechargers, allowing an optional limit to be placed upon amount charged.
add: Add new entry within ethereal stomach taking advantage of the new argument
/:cl:
