### PR TITLE
Nerfs chasms because I saw someone die to it once.

### DIFF
--- a/code/game/turfs/open/chasm.dm
+++ b/code/game/turfs/open/chasm.dm
@@ -17,10 +17,12 @@
 	. = ..()
 	apply_components(mapload)
 
+/* BUBBERSTATION CHANGE START: CHASM HUGBOX
 /// Lets people walk into chasms.
 /turf/open/chasm/CanAllowThrough(atom/movable/mover, border_dir)
 	. = ..()
 	return TRUE
+BUBBERSTATION CHANGE END: CHASM HUBOX */
 
 /turf/open/chasm/proc/set_target(turf/target)
 	var/datum/component/chasm/chasm_component = GetComponent(/datum/component/chasm)

--- a/modular_zubbers/code/game/turfs/open/chasm.dm
+++ b/modular_zubbers/code/game/turfs/open/chasm.dm
@@ -1,0 +1,9 @@
+/turf/open/chasm/CanAllowThrough(atom/movable/mover, border_dir)
+	. = ..()
+	if(isliving(mover))
+		var/mob/living/mover_as_livng = mover
+		if(mover_as_livng.stat != DEAD) //Only the living can stop themselves.
+			if(mover.loc == src) //If you fall on a chasm, you're dicked.
+				return TRUE
+			return can_cross_safely(mover) //Else, well you stop yourself.
+	return TRUE //Everything else can pass.

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8670,6 +8670,7 @@
 #include "modular_zubbers\code\game\turfs\change_turf.dm"
 #include "modular_zubbers\code\game\turfs\closed\lunar_cave.dm"
 #include "modular_zubbers\code\game\turfs\closed\lunar_surface.dm"
+#include "modular_zubbers\code\game\turfs\open\chasm.dm"
 #include "modular_zubbers\code\game\turfs\open\glass_floor.dm"
 #include "modular_zubbers\code\game\turfs\open\openspace.dm"
 #include "modular_zubbers\code\game\turfs\open\sand.dm"


### PR DESCRIPTION
## About The Pull Request

You can no longer willingly walk into chasms. Does not apply if the chasm is safe to walk on (it has rods on it or something).

You can still fall in a chasm if you're dead, you were thrown onto it, if you are inside something (like a barrel, or a crate), or if you lost your flight while on a chasm or the rods on a chasm were removed while on a chasm.

## Why It's Good For The Game

Chasms are unfun. People walk into them accidentally all the time. It basically round removes you for lagging and in most cases an admin usually sees someone die due to chasms and just respawns them.

"But you can rescue people who fall in chasms!" yeah you can fuckin find someone's brain that was tossed into deep space too. Just because it's possible, doesn't mean people will actually do it.

## Proof Of Testing

Untested. The following needs to be tested.

- [ ] If the prevention actually works.
- [ ] If the prevention actually works with mechs.
- [ ] If thrown mobs can still get chasm'd.
- [ ] If you can still walk on chasms if there are supporting rods.
- [ ] If you can still walk on chasms if you are flying.

## Changelog


:cl: BurgerBB
balance: You can no longer willingly walk into chasms. You can still fall into it via other means (getting thrown, pushed while dead, floor below you turns into a chasm, etc).
/:cl:
