### PR TITLE
Fixes Moonstation Lighting being too dark.

### DIFF
--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -94,7 +94,7 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/box/red,
 /obj/machinery/atmospherics/components/unary/portables_connector,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hallway)
@@ -210,7 +210,7 @@
 	},
 /obj/machinery/light_switch/directional/south,
 /obj/machinery/airalarm/directional/east,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "adN" = (
@@ -278,7 +278,7 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
 	},
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/machinery/newscaster/directional/east,
 /obj/structure/filingcabinet/medical,
 /turf/open/floor/iron/dark,
@@ -335,7 +335,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
@@ -613,7 +613,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/camera/autoname/security/directional/north,
 /turf/open/floor/iron/dark,
@@ -823,7 +823,7 @@
 /turf/open/floor/plating/rust/moonstation,
 /area/moonstation/surface)
 "all" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/effect/turf_decal/bot,
 /obj/machinery/suit_storage_unit/engine,
 /turf/open/floor/plating,
@@ -966,7 +966,7 @@
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
 "anI" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/effect/turf_decal/siding/purple{
 	dir = 8
 	},
@@ -1142,7 +1142,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/central/fore)
 "aqj" = (
@@ -1214,7 +1214,7 @@
 "arj" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/toolbox,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -1394,7 +1394,7 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit)
 "ato" = (
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
@@ -1628,7 +1628,7 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/quartermaster,
 /obj/machinery/firealarm/directional/east,
@@ -1773,7 +1773,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /turf/open/misc/beach/sand,
 /area/station/common/pool)
 "ayT" = (
@@ -2160,7 +2160,7 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/waste)
 "aEm" = (
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/structure/chair/sofa/bench/right{
 	dir = 4
 	},
@@ -2838,7 +2838,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/caution,
 /obj/structure/railing,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /turf/open/floor/iron/edge,
 /area/station/terminal/lobby)
 "aMd" = (
@@ -3046,7 +3046,7 @@
 /turf/open/floor/plating,
 /area/station/command/secure_bunker)
 "aPz" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
@@ -3290,7 +3290,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison/work)
 "aSf" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/effect/landmark/start/detective,
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
@@ -3934,13 +3934,13 @@
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 1
 	},
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "bbq" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/structure/closet/emcloset,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -4232,7 +4232,7 @@
 /obj/effect/turf_decal/tile/dark_green/half/contrasted,
 /obj/effect/turf_decal/trimline/white/arrow_ccw,
 /obj/structure/sign/warning/biohazard/directional/south,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bfQ" = (
@@ -5371,7 +5371,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/wood,
 /area/station/science/research)
 "bzj" = (
@@ -6189,7 +6189,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
@@ -6229,11 +6229,11 @@
 	},
 /obj/effect/spawner/random/medical/minor_healing,
 /obj/item/book/manual/wiki/security_space_law,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "bMb" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/effect/turf_decal/stripes/line,
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
@@ -6301,7 +6301,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/aft)
 "bNO" = (
@@ -6763,7 +6763,7 @@
 /obj/structure/table/wood{
 	name = "Jim Norton's Quebecois Coffee desk"
 	},
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/cafeteria)
 "bUs" = (
@@ -7089,7 +7089,7 @@
 /obj/machinery/requests_console/auto_name/directional/east,
 /obj/effect/mapping_helpers/requests_console/supplies,
 /obj/effect/mapping_helpers/requests_console/assistance,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/effect/mapping_helpers/requests_console/information,
 /obj/machinery/camera/autoname/security/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7178,7 +7178,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "caB" = (
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
 	dir = 8
 	},
@@ -7702,7 +7702,7 @@
 /turf/open/floor/iron/dark,
 /area/station/science/circuits)
 "cif" = (
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/machinery/light_switch/directional/west,
 /obj/machinery/libraryscanner,
 /turf/open/floor/carpet,
@@ -7755,7 +7755,7 @@
 /obj/structure/chair/sofa/corp{
 	dir = 1
 	},
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -7909,7 +7909,7 @@
 /obj/effect/mapping_helpers/requests_console/information,
 /obj/effect/mapping_helpers/requests_console/ore_update,
 /obj/effect/mapping_helpers/requests_console/supplies,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/mineral/gold,
 /area/station/command/heads_quarters/qm)
@@ -7974,7 +7974,7 @@
 /area/station/ai_monitored/turret_protected/ai_upload)
 "ckR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/space_heater,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
@@ -8784,7 +8784,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "czv" = (
@@ -8929,7 +8929,7 @@
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance)
 "cBT" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
@@ -8998,7 +8998,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "cCP" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/blue,
@@ -9022,7 +9022,7 @@
 "cDg" = (
 /obj/structure/closet/wardrobe/engineering_yellow,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "cDk" = (
@@ -9332,7 +9332,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "cIE" = (
@@ -9461,7 +9461,7 @@
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
 "cKB" = (
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/effect/turf_decal/tile/holiday/rainbow/half/contrasted{
 	dir = 1
 	},
@@ -9499,7 +9499,7 @@
 /obj/item/grenade/chem_grenade/smart_metal_foam,
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "cLi" = (
@@ -9881,7 +9881,7 @@
 /turf/open/floor/iron/grimy,
 /area/station/terminal/lobby)
 "cQX" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /obj/structure/sign/poster/official/random/directional/south,
 /obj/structure/disposalpipe/segment{
@@ -10194,7 +10194,7 @@
 /turf/open/floor/wood/tile,
 /area/station/hallway/primary/aft)
 "cUq" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron/dark,
@@ -10311,7 +10311,7 @@
 "cVB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/iron/checker,
 /area/station/engineering/atmos/control_center)
@@ -10398,7 +10398,7 @@
 /turf/open/floor/catwalk_floor/rust/moonstation,
 /area/moonstation/underground)
 "cWR" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/structure/fermenting_barrel,
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
@@ -10475,7 +10475,7 @@
 	dir = 4
 	},
 /obj/machinery/newscaster/directional/east,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/port)
 "cYe" = (
@@ -11109,7 +11109,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/central/fore)
 "dgM" = (
@@ -11145,7 +11145,7 @@
 	dir = 1
 	},
 /obj/structure/drain,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
@@ -11348,7 +11348,7 @@
 /obj/effect/turf_decal/siding/purple{
 	dir = 4
 	},
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "dju" = (
@@ -11369,7 +11369,7 @@
 "djw" = (
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /obj/structure/sign/poster/official/random/directional/south,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -11738,7 +11738,7 @@
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/machinery/status_display/evac/directional/west,
 /obj/machinery/computer/monitor{
 	dir = 4
@@ -12051,7 +12051,7 @@
 	dir = 1
 	},
 /obj/structure/sign/warning/electric_shock/directional/north,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
 "dtM" = (
@@ -12147,14 +12147,14 @@
 /obj/structure/flora/coconuts{
 	pixel_y = 5
 	},
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/misc/beach/sand,
 /area/station/science/genetics)
 "dvq" = (
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/radio/intercom/directional/east,
@@ -12542,7 +12542,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/machinery/camera/autoname/directional/west{
 	dir = 10
 	},
@@ -12724,7 +12724,7 @@
 /area/station/science/genetics)
 "dCX" = (
 /obj/machinery/power/port_gen/pacman,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "dDg" = (
@@ -13093,7 +13093,7 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "dHS" = (
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/machinery/rnd/production/techfab/department/security,
 /obj/effect/turf_decal/siding/dark{
 	dir = 6
@@ -13476,7 +13476,7 @@
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/central/aft)
 "dNU" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
@@ -13968,7 +13968,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/mechbay)
 "dVu" = (
@@ -13987,7 +13987,7 @@
 /turf/closed/wall/rust,
 /area/station/engineering/atmos/control_center)
 "dVK" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
@@ -14072,7 +14072,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_office)
 "dXv" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/airalarm/directional/south,
 /obj/structure/disposalpipe/segment{
@@ -14281,7 +14281,7 @@
 	pixel_y = 4
 	},
 /obj/item/grenade/chem_grenade/cleaner,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/item/radio/intercom/directional/east,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/item/reagent_containers/spray/cleaner{
@@ -14460,7 +14460,7 @@
 	dir = 8
 	},
 /obj/machinery/status_display/ai/directional/west,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -14626,7 +14626,7 @@
 /turf/open/floor/plating,
 /area/station/terminal/lobby)
 "efG" = (
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/engine,
 /area/station/engineering/rbmk2/chamber)
@@ -15419,7 +15419,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/misc/beach/sand,
 /area/station/common/pool)
@@ -15641,7 +15641,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /turf/open/floor/iron,
 /area/station/terminal/interlink)
 "err" = (
@@ -16266,7 +16266,7 @@
 	},
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/machinery/airalarm/directional/east,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/arrivals)
 "eAd" = (
@@ -16369,7 +16369,7 @@
 /obj/structure/cable,
 /obj/structure/sign/departments/rndserver/directional/north,
 /obj/effect/turf_decal/siding/purple,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "eBl" = (
@@ -16645,7 +16645,7 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms)
@@ -17037,7 +17037,7 @@
 /area/station/common/pool/sauna)
 "eKv" = (
 /obj/machinery/firealarm/directional/north,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/machinery/computer/prisoner/management,
 /obj/machinery/requests_console/auto_name/directional/east,
 /obj/effect/mapping_helpers/requests_console/assistance,
@@ -17155,7 +17155,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname/directional/south,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "eMH" = (
@@ -17218,7 +17218,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hallway)
 "eNb" = (
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "eNe" = (
@@ -17306,7 +17306,7 @@
 /obj/machinery/camera/autoname/engineering/directional/west{
 	dir = 10
 	},
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/engine,
 /area/station/engineering/main)
@@ -17365,7 +17365,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/item/radio/intercom/directional/west,
 /obj/structure/table,
 /obj/item/storage/box/deputy,
@@ -17391,7 +17391,7 @@
 /area/moonstation/surface)
 "eQf" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/machinery/atmospherics/components/tank/oxygen{
 	dir = 8
 	},
@@ -17794,7 +17794,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "eVU" = (
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
@@ -18095,7 +18095,7 @@
 /area/station/engineering/atmos/hallway)
 "fac" = (
 /obj/effect/turf_decal/tile/brown/fourcorners,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "QMLoad"
@@ -18305,7 +18305,7 @@
 /turf/open/misc/moonstation_rock,
 /area/moonstation/underground)
 "fcS" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/structure/closet/crate/wooden{
 	name = "music crate"
 	},
@@ -18484,7 +18484,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/office)
@@ -18635,7 +18635,7 @@
 /obj/effect/mapping_helpers/requests_console/information,
 /obj/effect/mapping_helpers/requests_console/supplies,
 /obj/effect/turf_decal/tile/green/half/contrasted,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "fgG" = (
@@ -18762,7 +18762,7 @@
 /turf/open/floor/engine,
 /area/station/engineering/atmos/project)
 "fjm" = (
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/structure/sign/poster/official/random/directional/west,
 /obj/structure/grandfatherclock,
 /turf/open/floor/wood,
@@ -18959,7 +18959,7 @@
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/newscaster/directional/east,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -19113,7 +19113,7 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/station/cargo/office)
@@ -19210,7 +19210,7 @@
 /obj/effect/turf_decal/tile/dark_green/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -19264,7 +19264,7 @@
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/box/blue,
 /obj/machinery/atmospherics/components/unary/portables_connector,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hallway)
 "fqI" = (
@@ -19552,7 +19552,7 @@
 /obj/machinery/camera/autoname/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/east,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /turf/open/floor/iron,
 /area/station/terminal/interlink)
 "fus" = (
@@ -19858,7 +19858,7 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/effect/turf_decal/vg_decals/numbers/two,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
@@ -20175,7 +20175,7 @@
 "fBj" = (
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted,
 /obj/machinery/keycard_auth/wall_mounted/directional/south,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "fBn" = (
@@ -20406,7 +20406,7 @@
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -20531,7 +20531,7 @@
 /area/station/security/brig/entrance)
 "fGX" = (
 /obj/effect/turf_decal/tile/green/half/contrasted,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/central/aft)
 "fHe" = (
@@ -20776,7 +20776,7 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -22042,7 +22042,7 @@
 /obj/item/storage/medkit/toxin,
 /obj/item/gps/mining,
 /obj/item/perfume/iron,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "gbn" = (
@@ -22246,13 +22246,13 @@
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "geY" = (
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
 "gfh" = (
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -22268,7 +22268,7 @@
 /area/station/security/courtroom)
 "gfr" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/engine,
 /area/station/engineering/rbmk2)
 "gft" = (
@@ -24173,7 +24173,7 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "gKb" = (
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
 /obj/machinery/computer/cargo/request,
@@ -24795,7 +24795,7 @@
 /turf/closed/wall/r_wall,
 /area/station/construction)
 "gTz" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -24945,7 +24945,7 @@
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/west,
@@ -25072,7 +25072,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/command/cc_dock)
@@ -25280,7 +25280,7 @@
 /area/station/maintenance/port)
 "gZP" = (
 /obj/effect/turf_decal/box,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
@@ -25540,7 +25540,7 @@
 /turf/open/floor/catwalk_floor/rust/moonstation,
 /area/moonstation/surface)
 "heT" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/asteroid_lobby)
@@ -25834,7 +25834,7 @@
 /turf/open/floor/plating,
 /area/station/engineering/rbmk2/chamber)
 "hiV" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/effect/turf_decal/loading_area{
 	dir = 8
 	},
@@ -26078,7 +26078,7 @@
 "hlA" = (
 /obj/effect/spawner/random/vending/colavend,
 /obj/machinery/newscaster/directional/north,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/laundry)
 "hlH" = (
@@ -26532,7 +26532,7 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/mineral/gold,
 /area/station/command/heads_quarters/qm)
@@ -26553,7 +26553,7 @@
 	},
 /obj/effect/turf_decal/box,
 /obj/machinery/airalarm/directional/north,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
 "hsG" = (
@@ -26633,7 +26633,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -26646,7 +26646,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "htI" = (
@@ -26656,7 +26656,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/central/fore)
 "htP" = (
@@ -26938,7 +26938,7 @@
 	pixel_x = 5;
 	pixel_y = 9
 	},
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/wood,
 /area/station/maintenance/abandon_psych)
 "hxy" = (
@@ -27509,7 +27509,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "hEw" = (
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
 	},
@@ -27521,7 +27521,7 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/central/fore)
 "hED" = (
@@ -27574,7 +27574,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
 "hFm" = (
@@ -27709,7 +27709,7 @@
 /area/station/maintenance/aux_eva)
 "hGW" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/structure/railing/corner/end{
 	dir = 4
 	},
@@ -27885,7 +27885,7 @@
 /turf/open/floor/iron/checker,
 /area/station/hallway/primary/central/aft)
 "hJg" = (
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
@@ -28286,7 +28286,7 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "hRl" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/sign/poster/official/random/directional/east,
 /turf/open/floor/iron,
@@ -28411,7 +28411,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "hSC" = (
@@ -28427,7 +28427,7 @@
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/secondary/exit)
 "hSD" = (
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/machinery/camera/autoname/directional/west,
 /obj/effect/turf_decal/bot,
 /obj/machinery/newscaster/directional/west,
@@ -28522,7 +28522,7 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/underground)
 "hUv" = (
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/computer/station_alert,
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
@@ -28615,7 +28615,7 @@
 /area/moonstation/underground)
 "hVQ" = (
 /obj/structure/table,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/item/stack/cable_coil,
 /obj/item/stock_parts/power_store/cell/high,
 /obj/effect/mapping_helpers/requests_console/assistance,
@@ -28686,7 +28686,7 @@
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/aft)
 "hXj" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
@@ -29540,7 +29540,7 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/tank_dispenser/oxygen,
 /obj/structure/sign/warning/secure_area/directional/south,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "ikn" = (
@@ -30677,7 +30677,7 @@
 /area/station/engineering/atmos)
 "iBW" = (
 /obj/structure/filingcabinet,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -30711,7 +30711,7 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "iCv" = (
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 1
 	},
@@ -30787,7 +30787,7 @@
 	},
 /area/station/hallway/primary/central/fore)
 "iDB" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/machinery/button/door/directional/south{
 	id = "bar_kitchen_counter";
 	name = "Bar-Kitchen Counter Shutters";
@@ -31073,7 +31073,7 @@
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/effect/landmark/start/psychologist,
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/wood,
@@ -31520,7 +31520,7 @@
 /area/station/maintenance/starboard/aft)
 "iNP" = (
 /obj/structure/bookcase/random/fiction,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/structure/sign/painting/library{
 	pixel_y = -32
 	},
@@ -31657,7 +31657,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "iQd" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder{
@@ -32027,7 +32027,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "iUr" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/wood/parquet,
@@ -32657,7 +32657,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "jcu" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
@@ -33392,7 +33392,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/machinery/camera/autoname/directional/north,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark/corner{
@@ -33465,7 +33465,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "jmo" = (
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/machinery/announcement_system,
 /obj/structure/sign/departments/telecomms/directional/west,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -33890,7 +33890,7 @@
 "jsU" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/machinery/airalarm/directional/south,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/item/kirbyplants/random,
 /obj/machinery/camera/autoname/prison/directional/south,
 /turf/open/floor/iron/dark,
@@ -34141,7 +34141,7 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/atmos/asteroid)
 "jxn" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/structure/chair/sofa/bench/left{
 	dir = 8
 	},
@@ -34510,7 +34510,7 @@
 /area/station/engineering/main)
 "jDL" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/chemistry)
 "jDQ" = (
@@ -34637,7 +34637,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/machinery/conveyor{
 	dir = 1;
 	id = "QMLoad"
@@ -34824,7 +34824,7 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/library)
 "jIR" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/structure/sign/poster/official/random/directional/east,
 /obj/machinery/modular_computer/preset/id{
 	dir = 8
@@ -34860,7 +34860,7 @@
 /area/station/engineering/rbmk2)
 "jJh" = (
 /obj/machinery/firealarm/directional/west,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/machinery/atmospherics/components/unary/portables_connector/layer2{
 	dir = 4
 	},
@@ -35002,7 +35002,7 @@
 	dir = 1;
 	filter_type = list(/datum/gas/nitrogen)
 	},
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/engineering/rbmk2)
 "jMg" = (
@@ -35816,7 +35816,7 @@
 	},
 /area/station/common/wrestling/arena)
 "jWl" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
@@ -36386,7 +36386,7 @@
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/starboard)
 "keN" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
 	},
@@ -36676,7 +36676,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/waste)
 "kjN" = (
@@ -36764,7 +36764,7 @@
 /area/station/service/library)
 "klh" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/item/radio/intercom/directional/south,
 /obj/item/clothing/head/cone,
 /turf/open/floor/iron,
@@ -36847,7 +36847,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
 "klX" = (
@@ -36886,7 +36886,7 @@
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/central/aft)
 "kmI" = (
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/glass/reinforced/scrape_below,
 /area/station/security/courtroom)
@@ -37414,7 +37414,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 8
 	},
@@ -37429,7 +37429,7 @@
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "kud" = (
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/machinery/light_switch/directional/west,
 /obj/machinery/hydroponics/constructable{
 	dir = 4
@@ -37475,7 +37475,7 @@
 /obj/effect/spawner/random/engineering/tool,
 /obj/effect/spawner/random/engineering/tool,
 /obj/effect/spawner/random/engineering/tool,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/item/book/manual/wiki/research_and_development,
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -38150,7 +38150,7 @@
 /area/moonstation/surface/unexplored)
 "kDT" = (
 /obj/effect/spawner/random/trash/botanical_waste,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/structure/sign/poster/contraband/ambrosia_vulgaris/directional/west,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -38309,7 +38309,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/eva)
 "kHv" = (
@@ -38385,7 +38385,7 @@
 /area/station/security/brig/entrance)
 "kIw" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "kID" = (
@@ -38582,7 +38582,7 @@
 /obj/effect/turf_decal/tile/dark_green/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/item/storage/box/monkeycubes{
 	pixel_x = 6;
 	pixel_y = 9
@@ -38806,7 +38806,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "kOv" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
@@ -38881,7 +38881,7 @@
 /obj/effect/spawner/random/entertainment/coin,
 /obj/item/paper/guides/jobs/hydroponics,
 /obj/machinery/light_switch/directional/north,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
@@ -39148,7 +39148,7 @@
 /area/station/biodome)
 "kSS" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
@@ -39288,7 +39288,7 @@
 /area/station/maintenance/disposal/incinerator)
 "kUK" = (
 /obj/effect/turf_decal/tile/brown/fourcorners,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "QMLoad2"
@@ -39477,7 +39477,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "kXB" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/structure/table,
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/fax/auto_name,
@@ -39654,7 +39654,7 @@
 	dir = 5
 	},
 /obj/machinery/firealarm/directional/south,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "kZE" = (
@@ -40080,7 +40080,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -40113,7 +40113,7 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/machinery/status_display/supply{
 	pixel_x = 32
 	},
@@ -40372,7 +40372,7 @@
 /turf/open/floor/plating/elevatorshaft,
 /area/station/cargo/miningelevators)
 "ljs" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
 "ljI" = (
@@ -40676,7 +40676,7 @@
 	dir = 1
 	},
 /obj/item/kirbyplants/random,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "loo" = (
@@ -40705,7 +40705,7 @@
 	dir = 4
 	},
 /obj/structure/table/glass,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "loG" = (
@@ -41512,7 +41512,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/pool_maintenance)
 "lzr" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
@@ -41773,7 +41773,7 @@
 /obj/structure/chair/pew/right{
 	dir = 1
 	},
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/wood/tile,
 /area/station/common/pool/sauna)
 "lDb" = (
@@ -41857,7 +41857,7 @@
 /area/station/ai_monitored/turret_protected/aisat/maint)
 "lEP" = (
 /obj/structure/rack,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/effect/spawner/random/techstorage/tcomms_all,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -41912,7 +41912,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
@@ -42235,7 +42235,7 @@
 /turf/open/floor/pod,
 /area/station/cargo/miningfoundry/event_protected)
 "lJe" = (
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 5
@@ -42463,7 +42463,7 @@
 /turf/open/floor/plating/rust/moonstation,
 /area/moonstation/surface)
 "lLr" = (
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/station/terminal/lobby)
@@ -42832,7 +42832,7 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "lQL" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
@@ -42985,7 +42985,7 @@
 /obj/machinery/computer/atmos_alert{
 	dir = 8
 	},
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/structure/cable/multilayer/connected,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -43083,7 +43083,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/vending/snackvend,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central/aft)
 "lVN" = (
@@ -43132,7 +43132,7 @@
 /area/lavaland/underground)
 "lWr" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/machinery/button/door/directional/north{
 	id = "rbmk2_shutters_south";
 	name = "Radiation Shutters Control";
@@ -43192,7 +43192,7 @@
 	},
 /obj/structure/closet/secure_closet/quartermaster,
 /obj/item/reagent_containers/spray/spraytan,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/machinery/status_display/department_balance{
 	pixel_y = -32
 	},
@@ -43446,7 +43446,7 @@
 	dir = 8
 	},
 /obj/structure/table,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/machinery/firealarm/directional/west,
 /obj/item/radio/off{
 	pixel_x = -6;
@@ -44318,7 +44318,7 @@
 /turf/closed/wall,
 /area/station/medical/surgery)
 "mmS" = (
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 8
 	},
@@ -44371,7 +44371,7 @@
 /obj/structure/table/wood,
 /obj/item/papercutter,
 /obj/item/hand_labeler,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/hop)
@@ -44468,7 +44468,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/engine,
 /area/station/engineering/rbmk2)
 "mpg" = (
@@ -44725,7 +44725,7 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/corrections_officer)
@@ -45195,7 +45195,7 @@
 "mAK" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/airalarm/directional/south,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/machinery/recharge_station,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
@@ -45265,7 +45265,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -45294,7 +45294,7 @@
 	dir = 10
 	},
 /obj/structure/chair/wood,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/wood/tile,
 /area/station/terminal/lobby)
@@ -45406,7 +45406,7 @@
 /obj/structure/chair/pew/left{
 	dir = 1
 	},
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/wood/tile,
 /area/station/common/pool/sauna)
 "mDx" = (
@@ -45437,7 +45437,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/canister/water_vapor,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/plating,
 /area/station/engineering/rbmk2/chamber)
 "mEc" = (
@@ -45466,7 +45466,7 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "mEO" = (
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/machinery/status_display/ai/directional/north,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45568,7 +45568,7 @@
 /area/station/science/genetics)
 "mGo" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/spawner/costume/mafia,
 /turf/open/floor/iron/dark,
@@ -45904,7 +45904,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "mLq" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
@@ -46618,7 +46618,7 @@
 "mUi" = (
 /obj/structure/table/wood,
 /obj/item/gun/ballistic/shotgun/doublebarrel,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/item/camera,
 /obj/machinery/computer/security/telescreen/bar/directional/north,
 /obj/item/holosign_creator/robot_seat/bar{
@@ -46748,7 +46748,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science/research)
 "mWf" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
@@ -47351,7 +47351,7 @@
 /area/station/security/prison/upper)
 "nfa" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -47680,7 +47680,7 @@
 "nkH" = (
 /obj/structure/table/wood,
 /obj/machinery/fax/auto_name,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
 "nkI" = (
@@ -47973,7 +47973,7 @@
 /obj/structure/bodycontainer/morgue/beeper_off{
 	dir = 8
 	},
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
@@ -48112,7 +48112,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/aux_eva)
 "nqy" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/glass/reinforced/scrape_below,
 /area/station/security/courtroom)
@@ -48529,7 +48529,7 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/terminal/maintenance/aft)
 "nwa" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "nwb" = (
@@ -48610,7 +48610,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/caution,
 /obj/structure/railing,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/tram/left)
 "nxF" = (
@@ -48689,7 +48689,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/caution,
 /obj/structure/railing,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/tram/left)
 "nyN" = (
@@ -48901,7 +48901,7 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit)
@@ -49203,7 +49203,7 @@
 /obj/machinery/airalarm/directional/east,
 /obj/structure/bed,
 /obj/item/bedsheet/hop,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
 "nGI" = (
@@ -49371,7 +49371,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wood,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
@@ -49734,7 +49734,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/structure/rack,
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/camera/autoname/directional/south{
@@ -49800,7 +49800,7 @@
 /obj/structure/table/reinforced/rglass,
 /obj/item/fur_dyer,
 /obj/item/lipstick/quantum,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/vaporwave,
 /area/station/service/barber)
@@ -50098,7 +50098,7 @@
 	req_access = list("robotics")
 	},
 /obj/machinery/vending/wardrobe/robo_wardrobe,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/machinery/camera/autoname/science/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
@@ -50831,7 +50831,7 @@
 "odJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/station/terminal/lobby)
@@ -50963,7 +50963,7 @@
 	},
 /area/station/hallway/primary/aft)
 "ofq" = (
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
 	},
@@ -50982,7 +50982,7 @@
 /turf/open/floor/iron,
 /area/station/terminal/lobby)
 "ofy" = (
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
@@ -51322,7 +51322,7 @@
 "okb" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/bot,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/atmos/storage/gas)
 "okd" = (
@@ -51853,13 +51853,13 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/structure/sign/poster/official/random/directional/north,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "orX" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/structure/sign/warning/radiation/directional/south,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/waste)
@@ -52005,7 +52005,7 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 1
 	},
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -52124,7 +52124,7 @@
 /turf/open/misc/beach/sand,
 /area/station/hallway/secondary/exit/departure_lounge)
 "owx" = (
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/button/door/directional/west{
 	id = "atmosmixblast";
@@ -52432,7 +52432,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/control_center)
 "oBO" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/sign/delam_procedure/directional/south,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
@@ -52532,7 +52532,7 @@
 /area/station/service/library)
 "oDw" = (
 /obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
 "oDx" = (
@@ -52840,7 +52840,7 @@
 /turf/open/floor/plating,
 /area/station/biodome)
 "oGQ" = (
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/turf_decal/tile/holiday/rainbow/anticorner/contrasted{
 	dir = 1
@@ -52924,7 +52924,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/checker,
 /area/station/hallway/primary/central/aft)
@@ -52941,7 +52941,7 @@
 /area/station/service/chapel)
 "oIK" = (
 /obj/machinery/washing_machine,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/laundry)
 "oIL" = (
@@ -53039,7 +53039,7 @@
 	},
 /obj/structure/sign/warning/electric_shock/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
 "oKd" = (
@@ -53379,7 +53379,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -53489,7 +53489,7 @@
 /obj/machinery/camera/autoname/engineering/directional/north{
 	dir = 9
 	},
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "oQZ" = (
@@ -54135,7 +54135,7 @@
 /area/lavaland/underground)
 "oZk" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
@@ -55254,7 +55254,7 @@
 /turf/open/floor/plating,
 /area/station/commons/storage/tools)
 "pqb" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/structure/reagent_water_basin,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted,
 /turf/open/floor/iron/checker,
@@ -55752,7 +55752,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
 "pwz" = (
@@ -56044,7 +56044,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -56796,7 +56796,7 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/emitter)
 "pLS" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/sign/poster/official/wtf_is_co2/directional/east,
 /turf/open/floor/iron,
@@ -56877,7 +56877,7 @@
 	dir = 10
 	},
 /obj/machinery/pdapainter/supply,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/mineral/gold,
 /area/station/command/heads_quarters/qm)
 "pMT" = (
@@ -56980,7 +56980,7 @@
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/qm)
 "pOp" = (
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
 /area/station/engineering/asteroid_lobby)
@@ -57072,7 +57072,7 @@
 /turf/open/floor/plating/rust/moonstation,
 /area/moonstation/surface)
 "pPT" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/machinery/keycard_auth/wall_mounted/directional/east,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
@@ -57404,7 +57404,7 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/waste)
 "pUW" = (
@@ -57489,7 +57489,7 @@
 "pVF" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/bot,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "pVN" = (
@@ -58025,7 +58025,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/caution,
 /obj/structure/railing,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /turf/open/floor/iron/edge,
 /area/station/terminal/lobby)
 "qcQ" = (
@@ -58820,7 +58820,7 @@
 /turf/open/floor/iron/checker,
 /area/station/engineering/storage/tech)
 "qnD" = (
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/sign/warning/no_smoking/directional/west,
 /turf/open/floor/iron,
@@ -58935,7 +58935,7 @@
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/underground)
 "qqz" = (
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
@@ -59127,12 +59127,12 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "qtD" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/effect/spawner/random/burgerstation/atmos,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/supermatter/room)
 "qtI" = (
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
@@ -59834,7 +59834,7 @@
 	},
 /area/station/engineering/rbmk2/chamber)
 "qBx" = (
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
@@ -59876,7 +59876,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -60135,7 +60135,7 @@
 /area/station/security/corrections_officer)
 "qGZ" = (
 /obj/structure/extinguisher_cabinet/directional/north,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/machinery/computer/mech_bay_power_console,
 /obj/effect/turf_decal/siding/dark{
 	dir = 6
@@ -61124,7 +61124,7 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/machinery/airalarm/directional/south,
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron/dark,
@@ -61363,7 +61363,7 @@
 /obj/effect/turf_decal/siding/blue{
 	dir = 8
 	},
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "qYX" = (
@@ -62145,7 +62145,7 @@
 /area/station/maintenance/starboard/fore)
 "rjD" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/supermatter/room)
@@ -63212,7 +63212,7 @@
 "rzW" = (
 /obj/structure/sign/poster/official/random/directional/south,
 /obj/structure/table/wood,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
@@ -63389,7 +63389,7 @@
 /turf/open/floor/engine,
 /area/station/engineering/storage/eva)
 "rBY" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/machinery/airalarm/directional/south,
 /obj/structure/cable,
@@ -63562,7 +63562,7 @@
 "rEu" = (
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -63601,7 +63601,7 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central/fore)
 "rFm" = (
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet)
@@ -63652,7 +63652,7 @@
 /area/station/hallway/primary/starboard)
 "rGp" = (
 /obj/effect/turf_decal/tile/green/half/contrasted,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -63713,7 +63713,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "rHz" = (
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/recharge_station,
 /turf/open/floor/iron/dark,
@@ -64222,7 +64222,7 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/machinery/camera/autoname/directional/south{
 	dir = 5
 	},
@@ -64340,7 +64340,7 @@
 /area/station/commons/lounge)
 "rPC" = (
 /obj/effect/spawner/random/trash/graffiti,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "rPF" = (
@@ -64355,7 +64355,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/rbmk2)
 "rQy" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/iron/white,
 /area/station/hallway/secondary/exit)
 "rQB" = (
@@ -64798,7 +64798,7 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit)
 "rXl" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
 /obj/item/radio/intercom/directional/south,
@@ -65139,7 +65139,7 @@
 /area/station/terminal/lobby)
 "scP" = (
 /obj/structure/closet/firecloset/full,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/structure/sign/warning/no_smoking/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -65186,7 +65186,7 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central/fore)
 "sdx" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -65217,7 +65217,7 @@
 "sdR" = (
 /obj/structure/bed,
 /obj/item/bedsheet/captain,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/item/disk/nuclear{
 	pixel_x = 7;
 	pixel_y = -4
@@ -65248,7 +65248,7 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/structure/sign/departments/court/directional/north,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
@@ -65403,7 +65403,7 @@
 /turf/open/floor/glass/reinforced/scrape_below,
 /area/station/terminal/interlink)
 "sgD" = (
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/structure/cable,
 /obj/machinery/power/smes,
 /turf/open/floor/iron/dark,
@@ -65477,7 +65477,7 @@
 "shs" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/structure/extinguisher_cabinet/directional/south,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/corrections_officer)
 "shG" = (
@@ -65792,7 +65792,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark/corner,
 /area/station/commons/dorms)
@@ -65888,7 +65888,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "snB" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
@@ -65985,7 +65985,7 @@
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "soL" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical{
 	pixel_y = 8
@@ -66128,7 +66128,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/structure/tank_dispenser,
 /turf/open/floor/engine,
 /area/station/engineering/atmos/project)
@@ -66183,7 +66183,7 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/underground)
 "srt" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/structure/rack,
 /obj/item/clipboard,
 /obj/item/clipboard,
@@ -66326,7 +66326,7 @@
 /turf/open/floor/engine,
 /area/station/maintenance/disposal)
 "ssU" = (
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /turf/open/floor/iron/grimy,
 /area/station/service/library)
 "sta" = (
@@ -67013,7 +67013,7 @@
 "sCW" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/bot,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "sDg" = (
@@ -67506,7 +67506,7 @@
 /turf/open/floor/iron/checker,
 /area/station/hallway/secondary/exit/departure_lounge)
 "sKm" = (
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/showroomfloor,
@@ -67554,7 +67554,7 @@
 /area/station/cargo/miningfoundry/event_protected)
 "sLk" = (
 /obj/machinery/disposal/bin,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/machinery/light_switch/directional/north,
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/disposalpipe/trunk,
@@ -67589,7 +67589,7 @@
 /turf/closed/wall/r_wall/rust,
 /area/station/ai_monitored/command/nuke_storage)
 "sLQ" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 8
 	},
@@ -67745,7 +67745,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/effect/spawner/random/burgerstation/atmos,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -67780,7 +67780,7 @@
 /turf/open/floor/iron/dark,
 /area/station/terminal/interlink)
 "sOy" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/station/terminal/lobby)
@@ -67871,7 +67871,7 @@
 "sPL" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/structure/closet/emcloset,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -68723,7 +68723,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/secondary/recreation)
@@ -69153,7 +69153,7 @@
 /area/station/cargo/miningfoundry/event_protected)
 "tij" = (
 /obj/structure/filingcabinet,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 4
 	},
@@ -69342,7 +69342,7 @@
 /turf/open/floor/plating,
 /area/station/terminal/lobby)
 "tkF" = (
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/structure/table/glass,
 /obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/machinery/airalarm/directional/west,
@@ -69453,7 +69453,7 @@
 /area/ruin/unpowered/ash_walkers)
 "tme" = (
 /obj/machinery/power/emitter,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "tmf" = (
@@ -69671,7 +69671,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
@@ -69681,7 +69681,7 @@
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -69721,7 +69721,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/machinery/defibrillator_mount/directional/west,
 /obj/machinery/camera/autoname/directional/west,
 /obj/structure/table/glass,
@@ -69740,7 +69740,7 @@
 /turf/closed/wall/rust,
 /area/station/common/pool)
 "tqZ" = (
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -69928,7 +69928,7 @@
 /turf/open/floor/iron/checker,
 /area/station/commons/storage/primary)
 "ttl" = (
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "ttu" = (
@@ -69946,7 +69946,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/command/cc_dock)
@@ -70034,7 +70034,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/firealarm/directional/east,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/station/common/cryopods)
 "tvQ" = (
@@ -70056,7 +70056,7 @@
 /turf/open/floor/wood/tile,
 /area/station/hallway/primary/starboard)
 "twh" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron,
@@ -70074,7 +70074,7 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "two" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
 	},
@@ -70347,7 +70347,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -70835,7 +70835,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "tFQ" = (
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/effect/spawner/random/burgerstation/atmos,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/supermatter/room)
@@ -71176,7 +71176,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/machinery/digital_clock/directional/south,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/central/fore)
@@ -71354,7 +71354,7 @@
 /area/station/maintenance/space_hut)
 "tNi" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron,
@@ -71395,7 +71395,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "tNM" = (
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
 	},
@@ -71578,7 +71578,7 @@
 /turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
 "tQA" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/structure/chair/sofa/right/brown{
 	dir = 8
 	},
@@ -72224,7 +72224,7 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/crew_quarters/bar)
 "tZW" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/effect/turf_decal/tile/dark_red/opposingcorners{
 	dir = 8
 	},
@@ -72686,7 +72686,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/machinery/computer/mech_bay_power_console,
 /obj/machinery/firealarm/directional/north,
 /obj/effect/turf_decal/stripes/line{
@@ -72947,7 +72947,7 @@
 /area/station/maintenance/port/aft)
 "ujV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/meter/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -73219,7 +73219,7 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/crew_quarters/bar)
 "unI" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron,
@@ -73309,7 +73309,7 @@
 /obj/effect/turf_decal/siding/blue{
 	dir = 5
 	},
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
@@ -73376,7 +73376,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/radio/intercom/directional/south,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/starboard)
 "upX" = (
@@ -73417,7 +73417,7 @@
 /turf/open/floor/plating,
 /area/station/common/night_club/back_stage)
 "uqW" = (
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
@@ -73705,7 +73705,7 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs)
 "uwk" = (
@@ -73930,7 +73930,7 @@
 /area/station/engineering/main)
 "uyV" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
@@ -74057,7 +74057,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/machinery/camera/autoname/prison/directional/west,
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
@@ -74378,7 +74378,7 @@
 /turf/open/floor/glass/reinforced/scrape_below,
 /area/station/common/pool)
 "uFd" = (
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/structure/bed/dogbed/renault{
 	name = "Alpine's Bed"
 	},
@@ -74427,7 +74427,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "uFB" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/item/radio/intercom/directional/south,
 /obj/structure/closet/radiation,
@@ -74669,7 +74669,7 @@
 	dir = 1;
 	id = "QMLoad2"
 	},
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "uIN" = (
@@ -74853,7 +74853,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/firealarm/directional/east,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/station/common/cryopods/aux)
 "uMI" = (
@@ -74875,7 +74875,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname/directional/west,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -75036,7 +75036,7 @@
 /turf/open/floor/plating/rust/moonstation,
 /area/moonstation/underground)
 "uPP" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/effect/turf_decal/tile/dark_green/half/contrasted{
 	dir = 4
 	},
@@ -75398,7 +75398,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /turf/open/floor/iron/checker,
 /area/station/cargo/blacksmith)
 "uVi" = (
@@ -75491,7 +75491,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "uVR" = (
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/machinery/chem_master/condimaster,
 /obj/effect/spawner/random/food_or_drink/cups,
 /obj/effect/turf_decal/tile/dark_red/opposingcorners{
@@ -75764,7 +75764,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/machinery/button/door/directional/south{
 	id = "rbmk2_shutters_north";
 	name = "Radiation Shutters Control";
@@ -75836,7 +75836,7 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/item/clothing/head/helmet/toggleable/justice,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
@@ -75878,7 +75878,7 @@
 /area/station/security/prison/workout)
 "vcL" = (
 /obj/machinery/firealarm/directional/east,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/effect/spawner/random/vending/colavend,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
@@ -76287,7 +76287,7 @@
 /turf/open/floor/circuit,
 /area/station/science/robotics/mechbay)
 "viG" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -76306,7 +76306,7 @@
 	dir = 6
 	},
 /obj/structure/chair/wood,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/wood/tile,
 /area/station/terminal/lobby)
@@ -76353,7 +76353,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/checker,
 /area/station/hallway/primary/central/fore)
@@ -76449,7 +76449,7 @@
 /area/station/engineering/atmos/control_center)
 "vlt" = (
 /obj/structure/cable,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
@@ -77315,7 +77315,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig/entrance)
 "vwV" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
@@ -77323,7 +77323,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
 "vxz" = (
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "vxF" = (
@@ -77524,7 +77524,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/secondary/command)
 "vAI" = (
@@ -77567,7 +77567,7 @@
 	},
 /obj/item/radio/intercom/directional/north,
 /obj/structure/rack/shelf,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/spawner/random/maintenance/four,
 /turf/open/floor/wood,
@@ -77970,7 +77970,7 @@
 /obj/machinery/computer/crew{
 	dir = 1
 	},
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/machinery/computer/security/telescreen/prison/directional/south,
 /turf/open/floor/iron/dark/small,
 /area/station/security/warden)
@@ -78097,7 +78097,7 @@
 /area/station/science/genetics)
 "vJL" = (
 /obj/effect/turf_decal/siding/dark,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/effect/spawner/random/vending/colavend,
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark,
@@ -78654,7 +78654,7 @@
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/machinery/status_display/evac/directional/east,
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -78672,7 +78672,7 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "vSV" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/machinery/camera/autoname/directional/east,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
@@ -78714,7 +78714,7 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/machinery/light_switch/directional/east,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
@@ -79084,7 +79084,7 @@
 /turf/closed/wall/r_wall/rust,
 /area/station/maintenance/disposal)
 "vYN" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/structure/closet/crate/freezer,
 /obj/item/reagent_containers/cup/soda_cans/pwr_game,
 /obj/item/reagent_containers/cup/soda_cans/pwr_game,
@@ -79221,7 +79221,7 @@
 /obj/machinery/camera/autoname/engineering/directional/east{
 	dir = 6
 	},
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/structure/sign/warning/electric_shock/directional/east,
 /turf/open/floor/engine,
 /area/station/engineering/main)
@@ -79315,7 +79315,7 @@
 /area/station/service/lawoffice)
 "wbK" = (
 /obj/machinery/portable_atmospherics/scrubber/huge/movable,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
@@ -79416,7 +79416,7 @@
 	dir = 8
 	},
 /obj/structure/flora/coconuts,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /turf/open/misc/beach/sand,
 /area/station/medical/virology)
 "wdJ" = (
@@ -79447,7 +79447,7 @@
 	pixel_x = -6;
 	pixel_y = -2
 	},
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /turf/open/floor/wood,
 /area/station/engineering/break_room)
 "wdN" = (
@@ -79459,7 +79459,7 @@
 /obj/structure/sign/painting/library_secure{
 	pixel_y = -32
 	},
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/item/gun/ballistic/automatic/pistol/deagle/gold{
 	can_misfire = 1;
 	misfire_probability = 99;
@@ -80049,7 +80049,7 @@
 /area/moonstation/surface)
 "wlW" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "wmd" = (
@@ -80414,7 +80414,7 @@
 /area/station/hallway/primary/starboard)
 "wsu" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
 	},
@@ -80518,7 +80518,7 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 8
 	},
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/iron/checker,
 /area/station/engineering/atmos/asteroid)
 "wuk" = (
@@ -80789,7 +80789,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
@@ -81016,7 +81016,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/radio/intercom/directional/north,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -81158,7 +81158,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/north,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "wEb" = (
@@ -81357,7 +81357,7 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "wGH" = (
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/machinery/button/door/directional/west{
 	id = "hos_office_shutters";
 	name = "Internal Privacy Shutters Control";
@@ -81399,7 +81399,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/structure/sign/departments/med_alt/directional/east,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/central/aft)
@@ -81532,7 +81532,7 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "wII" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "wIL" = (
@@ -81666,7 +81666,7 @@
 	desc = "A frontiersman's classic, closer to a shortsword than a knife. It boasts a full-tanged build, a brass handguard and pommel, a wicked sharp point, and a large, heavy blade, It's almost everything you could want in a knife, besides portability. Seems a little dull due to excessive use against space bears."
 	},
 /obj/effect/turf_decal/tile/purple/half/contrasted,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/structure/closet{
 	name = "animal control closet"
 	},
@@ -81834,7 +81834,7 @@
 /obj/effect/turf_decal/trimline/white/arrow_ccw{
 	dir = 1
 	},
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "wNt" = (
@@ -82687,7 +82687,7 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit)
@@ -83302,7 +83302,7 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "xjA" = (
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/machinery/firealarm/directional/north,
 /obj/effect/spawner/random/structure/table,
 /obj/structure/towel_bin,
@@ -83366,7 +83366,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/aft)
 "xle" = (
@@ -83413,7 +83413,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "xlx" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -83468,7 +83468,7 @@
 	dir = 4
 	},
 /obj/structure/sign/departments/telecomms/directional/west,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
 "xmP" = (
@@ -83507,7 +83507,7 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "xnp" = (
@@ -83521,7 +83521,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "xnO" = (
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/sign/warning/no_smoking/directional/south,
 /turf/open/floor/iron,
@@ -83576,7 +83576,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
@@ -83948,7 +83948,7 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/east,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "xuf" = (
@@ -84552,7 +84552,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -85063,7 +85063,7 @@
 	dir = 10
 	},
 /obj/machinery/firealarm/directional/south,
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -85159,7 +85159,7 @@
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
@@ -85190,7 +85190,7 @@
 	dir = 1
 	},
 /obj/machinery/meter,
-/obj/machinery/light/warm/directional/north,
+/obj/machinery/light/moonstation/directional/north,
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
 "xKb" = (
@@ -85221,7 +85221,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "xKs" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/structure/cable,
 /obj/structure/sign/warning/rad_shelter/directional/north,
 /obj/machinery/power/port_gen/pacman/pre_loaded,
@@ -86023,7 +86023,7 @@
 /area/station/maintenance/space_hut)
 "xVt" = (
 /obj/machinery/airalarm/directional/east,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/structure/filingcabinet/security,
 /turf/open/floor/iron/dark/small,
 /area/station/security/warden)
@@ -86263,7 +86263,7 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/maintenance/abandon_art_studio)
 "xYJ" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "xYR" = (
@@ -86423,7 +86423,7 @@
 /area/moonstation/surface)
 "yay" = (
 /obj/machinery/meter,
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/moonstation/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 4
 	},
@@ -86905,7 +86905,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/moonstation/directional/west,
 /obj/machinery/defibrillator_mount/directional/west,
 /obj/structure/table/glass,
 /turf/open/floor/iron/white,
@@ -86998,7 +86998,7 @@
 	code = 69
 	},
 /obj/item/paper/guides/jobs/engi/rbmk2,
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/plating,
 /area/station/engineering/rbmk2/chamber)
 "yhM" = (
@@ -87076,7 +87076,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/machinery/light/warm/directional/south,
+/obj/machinery/light/moonstation/directional/south,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/aft)
 "yjq" = (

--- a/modular_zubbers/code/modules/power/lighting/light_mapping_helpers.dm
+++ b/modular_zubbers/code/modules/power/lighting/light_mapping_helpers.dm
@@ -1,0 +1,22 @@
+/obj/machinery/light/moonstation
+
+	brightness = 10
+	bulb_power = 0.6
+	bulb_colour = "#FFE3BA"
+
+	nightshift_brightness = 10
+	nightshift_light_power = 0.6
+	nightshift_light_color = "#E4C9FF"
+
+	bulb_low_power_brightness_mul = 0.25
+	bulb_low_power_colour = "#FF7272"
+	bulb_low_power_pow_mul = 0.75
+	bulb_low_power_pow_min = 0.6
+
+	fire_brightness = 9
+	fire_power = 0.6
+	fire_colour = "#FF803A"
+
+	nightshift_allowed = TRUE
+
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/moonstation, 0)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9031,6 +9031,7 @@
 #include "modular_zubbers\code\modules\pollution\code\perfumes.dm"
 #include "modular_zubbers\code\modules\pollution\code\pollutants_generic.dm"
 #include "modular_zubbers\code\modules\power\powerator.dm"
+#include "modular_zubbers\code\modules\power\lighting\light_mapping_helpers.dm"
 #include "modular_zubbers\code\modules\power\supermatter\supermatter_gas.dm"
 #include "modular_zubbers\code\modules\projectiles\ammunition\ballistic\smg.dm"
 #include "modular_zubbers\code\modules\projectiles\boxes_magazines\external\smg.dm"


### PR DESCRIPTION

## About The Pull Request

Fixes Moonstation Lighting being too dark.

I solved this by creating my own moonstation subtype of light fixtures so they can't be fucked with by upstream.

## Why It's Good For The Game

Fixes good.

## Proof Of Testing

Tested. Forgot to take a screenshot.

## Changelog

:cl: BurgerBB
fix: Fixes Moonstation Lighting being too dark.
/:cl:

