### PR TITLE
Security belts can no longer hold guns

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -387,8 +387,6 @@
 		/obj/item/clothing/gloves,
 		/obj/item/flashlight/seclite,
 		/obj/item/food/donut,
-		/obj/item/grenade,
-		/obj/item/gun, //SKYRAT EDIT ADDITION
 		/obj/item/holosign_creator/security,
 		/obj/item/knife/combat,
 		/obj/item/melee/baton,

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -387,6 +387,7 @@
 		/obj/item/clothing/gloves,
 		/obj/item/flashlight/seclite,
 		/obj/item/food/donut,
+		/obj/item/grenade,
 		/obj/item/holosign_creator/security,
 		/obj/item/knife/combat,
 		/obj/item/melee/baton,


### PR DESCRIPTION

## About The Pull Request
The security belt is unable to hold guns such as disablers, dragnets, m1911's and essentially anything that is /obj/item/gun/...

## Why It's Good For The Game

Hoarding guns is a form of powergaming. Noone should be holding 5 guns on themselves at all times, that is why guns were made bulky in the first place with exception of stealthy ones. The problem arises when the issue of storing so many medium-sized objects is made really simple by letting you have at LEAST 3 medium slots on your belt essentially.

 It can end up in ridiculous loadouts such as this one: 
![hosgun](https://github.com/user-attachments/assets/63d991bb-04eb-4697-bb10-6ea1951021b9)


## Changelog

:cl:
balance: Security belts can no longer hold guns
/:cl: