### PR TITLE
Significantly Boosts the chances of the Wizardly Die of Fate event triggering.

### DIFF
--- a/modular_zubbers/code/modules/wizard_dize/wizard_dice_event.dm
+++ b/modular_zubbers/code/modules/wizard_dize/wizard_dice_event.dm
@@ -11,7 +11,7 @@
 
 	min_players = 30
 	max_occurrences = 1
-	weight = 3
+	weight = 10
 	earliest_start = 60 MINUTES
 
 	track = EVENT_TRACK_MODERATE

--- a/modular_zubbers/code/modules/wizard_dize/wizard_dice_event.dm
+++ b/modular_zubbers/code/modules/wizard_dize/wizard_dice_event.dm
@@ -21,7 +21,8 @@
 	announce_when = 5
 
 /datum/round_event/wizard_dice/announce(fake)
-	priority_announce("A magical twenty-sided artifact was detected in the area. Please refrain from interacting with anything that cannot be explained by science.", "Magusologist Expert Warning")
+	if(prob(80)) //Announcement Optimization
+		priority_announce("A magical twenty-sided artifact was detected in the area. Please refrain from interacting with anything that cannot be explained by science.", "Magusologist Expert Warning")
 
 /datum/round_event/wizard_dice/start()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Significantly Boosts the chances of the Wizardly Die of Fate event triggering.
The event now has a 20% chance not to announce the existence of a Wizardly Die of Fate

The event is now as common as the shuttle getting replaces by a disaster.

## Why It's Good For The Game

I've been getting complaints that this event is still extremely rare. This PR should fix that.

People want more wizard rounds. This should grant more wizard rounds.

The announcement chance tweak should also be more interesting.

## Proof Of Testing

Untested.

## Changelog

:cl: BurgerBB
balance: Significantly Boosts the chances of the Wizardly Die of Fate event triggering. The event now has a 20% chance not to announce the existence of a Wizardly Die of Fate
/:cl:
