### PR TITLE
Re-enables "The Fragile" (Do Not Merge)

### DIFF
--- a/modular_zubbers/code/modules/storyteller/storytellers/storyteller_fragile.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/storyteller_fragile.dm
@@ -1,4 +1,3 @@
-/*
 /datum/storyteller/fragile
 	name = "The Fragile"
 	desc = "The Fragile will limit destructive and combat-focused events, and you'll rarely see midround antagonist roles that usually cause it."
@@ -33,4 +32,3 @@
 		TAG_TEAM_ANTAG = 0.5,
 		TAG_OUTSIDER_ANTAG = 0.25
 	)
-*/

--- a/modular_zubbers/code/modules/storyteller/storytellers/storyteller_fragile.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/storyteller_fragile.dm
@@ -32,3 +32,5 @@
 		TAG_TEAM_ANTAG = 0.5,
 		TAG_OUTSIDER_ANTAG = 0.25
 	)
+
+	antag_divisor = 8


### PR DESCRIPTION
## About The Pull Request

Re-enables "The Fragile" storyteller.

## Why It's Good For The Game

I am not sure why it was disabled, but I remember it somehow breaking storyteller for some reason. If anyone has any idea about this, please post here so I can resolve it.

The Fragile is a good alternative to sleeper where things can still happen, but weights are specifically applied to prevent dangerous antag types and events from being rolled frequently.

## Proof Of Testing

Untested. :)

## Changelog

:cl: BurgerBB
add: Re-enables "The Fragile" storyteller.
/:cl:
