### PR TITLE
Abductor machines no longer check for species when deciding if you can use it or not

### DIFF
--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -133,7 +133,7 @@
 	return can_interact(user)
 
 /obj/machinery/computer/camera_advanced/abductor/can_use(mob/user)
-	if(!isabductor(user))
+	if(user && !HAS_MIND_TRAIT(user, TRAIT_ABDUCTOR_TRAINING)) // # BUBBER CHANGE, abductor machinery checks for abductor training
 		return FALSE
 	return ..()
 

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -178,6 +178,7 @@
 			eyeobj.setLoc(camera_location)
 		else
 			unset_machine()
+			to_chat(user, span_warning("[src] could not find a valid camera to connect to."))
 	else
 		give_eye_control(L)
 		eyeobj.setLoc(eyeobj.loc)

--- a/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
+++ b/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
@@ -76,7 +76,8 @@
 	if(marked == target)
 		to_chat(user, span_warning("This specimen is already marked!"))
 		return
-	if(isabductor(target) || iscow(target))
+	var/mob/target_mob = target // # BUBBER CHANGE START, abductor machinery checks for abductor training
+	if(ismob(target) && HAS_MIND_TRAIT(target_mob, TRAIT_ABDUCTOR_TRAINING) || iscow(target)) // # BUBBER END
 		marked_target_weakref = WEAKREF(target)
 		to_chat(user, span_notice("You mark [target] for future retrieval."))
 	else
@@ -228,7 +229,7 @@
 	fail_message = "<span class='abductor'>Firing error, please contact Command.</span>"
 
 /obj/item/firing_pin/abductor/pin_auth(mob/living/user)
-	. = isabductor(user)
+	. = HAS_MIND_TRAIT(user, TRAIT_ABDUCTOR_TRAINING) // # BUBBER CHANGE, abductor machinery checks for abductor training
 
 /obj/item/gun/energy/alien
 	name = "alien pistol"

--- a/code/modules/antagonists/abductor/equipment/gear/abductor_posters.dm
+++ b/code/modules/antagonists/abductor/equipment/gear/abductor_posters.dm
@@ -12,7 +12,7 @@
 	poster_item_icon_state = "rolled_abductor"
 
 /obj/structure/sign/poster/abductor/tear_poster(mob/user)
-	if(!isabductor(user))
+	if(!isabductor(user) || !HAS_MIND_TRAIT(user, TRAIT_ABDUCTOR_TRAINING)) // # BUBBER CHANGE, abductor machinery checks for abductor training
 		balloon_alert(user, "it won't budge!")
 		return
 	return ..()

--- a/code/modules/antagonists/abductor/machinery/camera.dm
+++ b/code/modules/antagonists/abductor/machinery/camera.dm
@@ -47,6 +47,7 @@
 	return HAS_TRAIT(H, TRAIT_ABDUCTOR_SCIENTIST_TRAINING)
 
 /obj/machinery/computer/camera_advanced/abductor/connect_to_shuttle(mapload, obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
+	networks += "[port.shuttle_id]_[CAMERANET_NETWORK_ABDUCTOR]"
 	return
 
 /obj/machinery/computer/camera_advanced/abductor/proc/link_to_team(team_id)

--- a/code/modules/antagonists/abductor/machinery/camera.dm
+++ b/code/modules/antagonists/abductor/machinery/camera.dm
@@ -27,6 +27,10 @@
 	eyeobj.icon_state = "abductor_camera"
 	eyeobj.SetInvisibility(INVISIBILITY_OBSERVER)
 
+/obj/machinery/computer/camera_advanced/abductor/connect_to_shuttle(mapload, obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
+	networks += "[port.shuttle_id]"
+	return
+
 /obj/machinery/computer/camera_advanced/abductor/GrantActions(mob/living/carbon/user)
 	if(!abduct_created)
 		abduct_created = TRUE

--- a/code/modules/antagonists/abductor/machinery/camera.dm
+++ b/code/modules/antagonists/abductor/machinery/camera.dm
@@ -27,10 +27,6 @@
 	eyeobj.icon_state = "abductor_camera"
 	eyeobj.SetInvisibility(INVISIBILITY_OBSERVER)
 
-/obj/machinery/computer/camera_advanced/abductor/connect_to_shuttle(mapload, obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
-	networks += "[port.shuttle_id]"
-	return
-
 /obj/machinery/computer/camera_advanced/abductor/GrantActions(mob/living/carbon/user)
 	if(!abduct_created)
 		abduct_created = TRUE

--- a/code/modules/antagonists/abductor/machinery/console.dm
+++ b/code/modules/antagonists/abductor/machinery/console.dm
@@ -200,8 +200,14 @@
 
 /obj/machinery/abductor/console/post_machine_initialize()
 	. = ..()
+	link_machines()
+
+/obj/machinery/abductor/console/proc/link_machines()
 	if(!team_number)
 		return
+	experiment = null
+	pad = null
+	camera = null
 
 	for(var/obj/machinery/abductor/pad/p as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/abductor/pad))
 		if(p.team_number == team_number)
@@ -257,13 +263,25 @@
 	vest = V
 	return TRUE
 
-/obj/machinery/abductor/console/base_item_interaction(mob/living/user, obj/item/tool, list/modifiers) // BUBBER CHANGE, attack_by no longer runs on item interact
+/obj/machinery/abductor/console/item_interaction(mob/living/user, obj/item/tool, list/modifiers) // BUBBER CHANGE, attack_by no longer runs on item interact
 	if(istype(tool, /obj/item/abductor/gizmo) && AddGizmo(tool))
 		to_chat(user, span_notice("You link the tool to the console."))
+		return ITEM_INTERACT_SUCCESS
 	else if(istype(tool, /obj/item/clothing/suit/armor/abductor/vest) && AddVest(tool))
 		to_chat(user, span_notice("You link the vest to the console."))
+		return ITEM_INTERACT_SUCCESS
 	else
 		return ..()
+
+/obj/machinery/abductor/console/attack_ghost(mob/user)
+	if(!user?.client.holder)
+		return ..()
+	var/input = tgui_input_number(user, "Set a new team number for the console.", "Team Number", 0, INFINITY, 0, round_value = 1)
+	if(!input)
+		return
+	to_chat(user, span_notice("Team number set to [input], remember to set the team_number on the other machines beforehand!"))
+	team_number = input
+	link_machines()
 
 /obj/machinery/abductor/console/proc/Dispense(items_list, cost=1)
 	if(experiment && experiment.credits >= cost)

--- a/code/modules/antagonists/abductor/machinery/console.dm
+++ b/code/modules/antagonists/abductor/machinery/console.dm
@@ -72,7 +72,7 @@
 			TeleporterSend()
 
 /obj/machinery/abductor/console/ui_status(mob/user, datum/ui_state/state)
-	if(!isabductor(user) && !isobserver(user))
+	if(!HAS_MIND_TRAIT(user, TRAIT_ABDUCTOR_TRAINING) && !isobserver(user)) // # BUBBER CHANGE, abductor machinery checks for abductor training
 		return UI_CLOSE
 	return ..()
 
@@ -257,10 +257,10 @@
 	vest = V
 	return TRUE
 
-/obj/machinery/abductor/console/attackby(obj/O, mob/user, params)
-	if(istype(O, /obj/item/abductor/gizmo) && AddGizmo(O))
+/obj/machinery/abductor/console/base_item_interaction(mob/living/user, obj/item/tool, list/modifiers) // BUBBER CHANGE, attack_by no longer runs on item interact
+	if(istype(tool, /obj/item/abductor/gizmo) && AddGizmo(tool))
 		to_chat(user, span_notice("You link the tool to the console."))
-	else if(istype(O, /obj/item/clothing/suit/armor/abductor/vest) && AddVest(O))
+	else if(istype(tool, /obj/item/clothing/suit/armor/abductor/vest) && AddVest(tool))
 		to_chat(user, span_notice("You link the vest to the console."))
 	else
 		return ..()

--- a/code/modules/antagonists/abductor/machinery/dispenser.dm
+++ b/code/modules/antagonists/abductor/machinery/dispenser.dm
@@ -23,7 +23,7 @@
 		amounts[i] = rand(1,5)
 
 /obj/machinery/abductor/gland_dispenser/ui_status(mob/user, datum/ui_state/state)
-	if(!isabductor(user) && !isobserver(user))
+	if(!HAS_MIND_TRAIT(user, TRAIT_ABDUCTOR_TRAINING) && !isobserver(user)) // # BUBBER CHANGE, abductor machinery checks for abductor training
 		return UI_CLOSE
 	return ..()
 

--- a/code/modules/antagonists/abductor/machinery/experiment.dm
+++ b/code/modules/antagonists/abductor/machinery/experiment.dm
@@ -197,3 +197,18 @@
 /obj/machinery/abductor/experiment/update_icon_state()
 	icon_state = "experiment[state_open ? "-open" : null]"
 	return ..()
+
+
+/obj/machinery/abductor/experiment/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	. = ..()
+	var/obj/item/abductor/gizmo/science_tool = tool
+	if(!HAS_TRAIT(user, TRAIT_ABDUCTOR_SCIENTIST_TRAINING) || !istype(science_tool))
+		return NONE
+	if(science_tool?.console && science_tool.console.team_number != null)
+		balloon_alert(user, "linked [src] to controller console!")
+		team_number = science_tool.console.team_number
+		science_tool.console.experiment = src
+		console = science_tool.console
+	else
+		balloon_alert(user, "[tool] is not linked to controller console!")
+	return ITEM_INTERACT_SUCCESS

--- a/code/modules/antagonists/abductor/machinery/experiment.dm
+++ b/code/modules/antagonists/abductor/machinery/experiment.dm
@@ -24,7 +24,7 @@
 	return ..()
 
 /obj/machinery/abductor/experiment/mouse_drop_receive(mob/target, mob/user, params)
-	if(!ishuman(target) || isabductor(target))
+	if(!ishuman(target) || HAS_MIND_TRAIT(target, TRAIT_ABDUCTOR_TRAINING)) // # BUBBER CHANGE, abductor machinery checks for abductor training
 		return
 	close_machine(target)
 
@@ -34,7 +34,8 @@
 
 /obj/machinery/abductor/experiment/close_machine(mob/target, density_to_set = TRUE)
 	for(var/A in loc)
-		if(isabductor(A))
+		var/mob/mob_target = A // BUBBER CHANGE START, abductor machinery checks for abductor training
+		if(ismob(A) && HAS_MIND_TRAIT(mob_target, TRAIT_ABDUCTOR_TRAINING)) // # BUBBER END
 			return
 	if(state_open && !panel_open)
 		..(target)

--- a/code/modules/antagonists/abductor/machinery/pad.dm
+++ b/code/modules/antagonists/abductor/machinery/pad.dm
@@ -50,6 +50,20 @@
 	new /obj/effect/temp_visual/teleport_abductor(place)
 	addtimer(CALLBACK(src, PROC_REF(doPadToLoc), place), 8 SECONDS)
 
+/obj/machinery/abductor/pad/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	. = ..()
+	var/obj/item/abductor/gizmo/science_tool = tool
+	if(!HAS_TRAIT(user, TRAIT_ABDUCTOR_SCIENTIST_TRAINING) || !istype(science_tool))
+		return NONE
+	if(science_tool?.console && science_tool.console.team_number != null)
+		balloon_alert(user, "linked camera console to controller console!")
+		team_number = science_tool.console.team_number
+		science_tool.console.pad = src
+		console = science_tool.console
+	else
+		balloon_alert(user, "[tool] is not linked to controller console!")
+	return ITEM_INTERACT_SUCCESS
+
 /obj/effect/temp_visual/teleport_abductor
 	name = "Huh"
 	icon = 'icons/obj/antags/abductor.dmi'


### PR DESCRIPTION
Changes abductor machines to no longer randomly check for both species and traits, instead they will check for the TRAIT_ABDUCTOR_TRAINING
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
We have abductor species that you can spawn as from roundstart, it makes more sense that only the antags that are supposed to use this stuff, can.
Also fixes the gizmo's being unlinkable due to item interaction changes
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game
Need it for a upcoming event, moreso, secondly, currently crew-abductors can use these devices which is probably not good for them to be able to use antag machines
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Now you can re-link abductor machines using a science tool if one of them happens to become unlinked.
admin: Admins can click on a abductor console(not the camera one, but the other one that controls equipment) to change it's team ID.
balance: Abductor machines are now locked based on the TRAIT_ABDUCTOR_TRAINING instead of randomly checking for both training and abductor species
fix: You can now again link abductor gizmos with a abductor console
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
