### PR TITLE
Remove tajaran tongue from feline traits

### DIFF
--- a/modular_skyrat/modules/quirks/neutral.dm
+++ b/modular_skyrat/modules/quirks/neutral.dm
@@ -238,7 +238,7 @@ GLOBAL_VAR_INIT(DNR_trait_overlay, generate_DNR_trait_overlay())
 
 /datum/quirk/feline_aspect/add_unique(client/client_source)
 	var/mob/living/carbon/human/human_holder = quirk_holder
-	var/obj/item/organ/internal/tongue/cat/tajaran/new_tongue = new(get_turf(human_holder)) // BUBBER EDIT CHANGE - Tajaran Traits - Original: var/obj/item/organ/internal/tongue/cat/new_tongue = new(get_turf(human_holder))
+	var/obj/item/organ/internal/tongue/cat/new_tongue = new(get_turf(human_holder))
 
 	new_tongue.copy_traits_from(human_holder.get_organ_slot(ORGAN_SLOT_TONGUE))
 	new_tongue.Insert(human_holder, special = TRUE, movement_flags = DELETE_IF_REPLACED)

--- a/modular_zubbers/code/modules/mob/living/carbon/human/species/tajaran.dm
+++ b/modular_zubbers/code/modules/mob/living/carbon/human/species/tajaran.dm
@@ -40,6 +40,10 @@
 //Insert russion translations here (sorry russions)
 	speech_args[SPEECH_MESSAGE] = message
 
+/datum/augment_item/organ/tongue/tajaran
+	name = "Tajaran tongue"
+	path = /obj/item/organ/internal/tongue/cat/tajaran
+
 //Tajara have the innate ability to see in the dark better than most
 /obj/item/organ/internal/eyes/tajaran
 	name = "tajaran eyes"


### PR DESCRIPTION
## About The Pull Request

Removes the tajaran tongue override from https://github.com/Bubberstation/Bubberstation/pull/1985 instead moving the tongue to the augments menu, like the lizard forked tongue.

## Why It's Good For The Game

Consistency, people can equip Feline Traits to get the felinid features.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/user-attachments/assets/d3df9672-a202-46d8-8f5a-cc959c7d6c7e)

</details>

## Changelog

:cl: LT3
code: Tajaran tongue moved from Feline Traits quirk to augments menu
/:cl: