### PR TITLE
Make it so claustrophobia does not trigger in vore bellies (hilarious bug)

### DIFF
--- a/code/datums/quirks/negative_quirks/claustrophobia.dm
+++ b/code/datums/quirks/negative_quirks/claustrophobia.dm
@@ -15,6 +15,12 @@
 	if(quirk_holder.stat != CONSCIOUS || quirk_holder.IsSleeping() || quirk_holder.IsUnconscious())
 		return
 
+	// BUBBER EDIT START: Vore
+	if(istype(quirk_holder.loc, /obj/vore_belly))
+		quirk_holder.clear_mood_event("claustrophobia")
+		return
+	// BUBBER EDIT END
+
 	if(HAS_TRAIT(quirk_holder, TRAIT_MIND_TEMPORARILY_GONE) || HAS_TRAIT(quirk_holder, TRAIT_FEARLESS))
 		return
 


### PR DESCRIPTION
## About The Pull Request
This makes it so that the claustrophobia quirk does not trigger inside vore bellies, as requested by @StrangeWeirdKitten 

## Why It's Good For The Game
As hilarious as this emergent gameplay is, it's not really nice to kill people for having any vore scenes when they have the claustrophobia quirk for reasons other than scene-ing.

## Proof Of Testing
I forgot to get a screenshot of the chat - there's just no negative moodlet for claustrophobia in a belly anymore. 

## Changelog

:cl:
fix: Claustrophobia no longer triggers inside vore bellies.
/:cl:
