### PR TITLE
Major Mold Nerfs and Removals

### DIFF
--- a/modular_skyrat/modules/mold/code/mold.dm
+++ b/modular_skyrat/modules/mold/code/mold.dm
@@ -265,6 +265,7 @@
  * toxin-filled foam, and is purple - which, as we all know, is the colour of the poison
  * in the poison flask Hearthstone card.
  */
+ /* BUBBERSTATION CHANGE: REMOVES TOXIC MOLD.
 /datum/mold_type/toxic
 	name = "toxic"
 	mold_color = "#cb37f5"
@@ -290,6 +291,7 @@
 		reagent_capacity = TEMP_REAGENT_HOLDER_CAPACITY_LARGE,
 		reagent_to_add = /datum/reagent/toxin,
 		)
+*/
 
 
 /**

--- a/modular_skyrat/modules/mold/code/mold_controller.dm
+++ b/modular_skyrat/modules/mold/code/mold_controller.dm
@@ -1,7 +1,7 @@
 #define SPREAD_PROCESS 2
 #define SPREAD_STALLED_PROCESS 10
 
-#define PROGRESSION_FOR_STRUCTURE 20
+#define PROGRESSION_FOR_STRUCTURE 30 //BUBBERSTATION CHANGE: INCREASED.
 #define PROGRESSION_RETALIATED 5
 #define STRUCTURE_PROGRESSION_START 20
 
@@ -150,7 +150,7 @@
 
 		if(!forbidden)
 			structure_progression -= PROGRESSION_FOR_STRUCTURE
-			var/random = rand(1,3)
+			var/random = pick(1,1,1,1,2,3,3) //BUBBERSTATION CHANGE, LESS CHANCE OF SPAWNERS
 			spawn_structure_loc(random, ownturf)
 
 	//Check if we can attack an airlock

--- a/modular_skyrat/modules/mold/code/mold_event.dm
+++ b/modular_skyrat/modules/mold/code/mold_event.dm
@@ -1,14 +1,14 @@
 #define MOLDIES_SPAWN_LOWPOP_MIN 1
 #define MOLDIES_SPAWN_LOWPOP_MAX 1
 #define MOLDIES_SPAWN_HIGHPOP_MIN 1
-#define MOLDIES_SPAWN_HIGHPOP_MAX 2
+#define MOLDIES_SPAWN_HIGHPOP_MAX 1 //BUBBERSTATION CHANGE: 1 MOLD PER EVENT.
 
 /datum/round_event_control/mold
 	name = "Moldies"
 	description = "A mold outbreak on the station. The mold will spread across the station if not contained."
 	typepath = /datum/round_event/mold
 	max_occurrences = 1
-	earliest_start = 30 MINUTES
+	earliest_start = 60 MINUTES //BUBBERSTATION CHANGE: NO EARLY MOLDS.
 	min_players = EVENT_LOWPOP_THRESHOLD
 	category = EVENT_CATEGORY_ENTITIES
 

--- a/modular_skyrat/modules/mold/code/mold_mobs.dm
+++ b/modular_skyrat/modules/mold/code/mold_mobs.dm
@@ -56,9 +56,9 @@
 	ai_controller = /datum/ai_controller/basic_controller/oil_shambler
 
 	/// The chance to apply fire stacks on melee hit
-	var/ignite_chance = 20
+	var/ignite_chance = 5 //BUBBERSTATION CHANGE: 20 TO 5.
 	/// How many fire stacks to apply on hit
-	var/additional_fire_stacks = 2
+	var/additional_fire_stacks = 1 //BUBBERSTATION CHANGE: 2 TO 1.
 
 /mob/living/basic/mold/oil_shambler/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request


The mold event has a minimum start time of 60 minutes (as opposed to 30).
Only 1 maximum mold can be spawned per event.

Mold now spawns major structures (vents, spawners, bulbs, etc) 33% slower.
Mold now has a less chance to spawn spawners.

Fire Mold Oil Shamblers now have a 5% chance to apply fire stacks (previously 20%), and apply 1 fire stack at a time (previously 2). Fire Mold Oil Chamblers can still ignite if you have fire stacks from other sources (covered in oil or whatever).

Disables toxic mold completely (the one with the spiders).

## Why It's Good For The Game

People have had significant issues with mold. It's usually too early, and hits too hard with certain types. Most people also blame storyteller for it spawning 2 molds, when actually it's just the mold event that spawns 2.

Mob spam was awful so spawners take longer to spawn, and have a lesser chance to actually spawn.

Toxic mold is likely extremely bugged since it just shits out spiders despite limitations set. I can't be bothered to fix this so I'm just disabling it.

Fire mold is awful because of the shambler ignite.

## Proof Of Testing

Untested.

## Changelog

:cl: BurgerBB
balance: Nerfs mold across the board.

/:cl:

