### PR TITLE
Grey bull fits on belts - honoring the age-old tradition of drinking on the job

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -75,6 +75,7 @@
 		/obj/item/wirecutters,
 		/obj/item/wrench,
 		/obj/item/spess_knife,
+		/obj/item/reagent_containers/cup/soda_cans/grey_bull,
 		/obj/item/melee/sickly_blade/lock,
 	))
 


### PR DESCRIPTION

## About The Pull Request

the grey bull can fits on storage belts. There's so little value to be had from using it to store other reagents that it's not worth it, but grey bull on a belt lets people do more micro in backpacks. Yes, I could do it without this, yes, it'd be easier if I didn't have to juggle to have my kidney stone juice. 

## Why It's Good For The Game
![myargument](https://github.com/user-attachments/assets/c53bbf46-cc30-411b-bd12-1c0ad1ea87f3)

QOL and if it fits I commits (to PR)


:cl:
qol: Grey bull cans fit on toolbelts
/:cl:
