### PR TITLE
Cargo shelves now drop crates upon being destroyed

### DIFF
--- a/modular_zubbers/code/modules/shelves/shelf.dm
+++ b/modular_zubbers/code/modules/shelves/shelf.dm
@@ -33,7 +33,9 @@
 	return
 
 /obj/structure/cargo_shelf/Destroy()
-	QDEL_LIST(shelf_contents)
+	for(var/obj/structure/closet/crate/crate in shelf_contents)
+		crate.forceMove(loc)
+	shelf_contents = null
 	return ..()
 
 /obj/structure/cargo_shelf/examine(mob/user)


### PR DESCRIPTION
## About The Pull Request

See name

## Why It's Good For The Game

It shouldnt just magically delete crates

## Proof Of Testing

It worked on my machine

## Changelog

:cl:
fix: Cargo shelves now drop crates upon being destroyed
/:cl: