### PR TITLE
Reverts the custom map rotation code because it seems to keep causing more problems than it solves

### DIFF
--- a/code/controllers/subsystem/persistence/_persistence.dm
+++ b/code/controllers/subsystem/persistence/_persistence.dm
@@ -1,5 +1,5 @@
 #define FILE_RECENT_MAPS "data/RecentMaps.json"
-#define KEEP_ROUNDS_MAP 2 //BUBBERSTATION CHANGE: 3 TO 2.
+#define KEEP_ROUNDS_MAP 3
 
 SUBSYSTEM_DEF(persistence)
 	name = "Persistence"
@@ -109,7 +109,7 @@ SUBSYSTEM_DEF(persistence)
 		for(var/name in SSpersistence.saved_maps)
 			if(VM.map_name == name)
 				run++
-		if(run >= 1) //If run twice in the last KEEP_ROUNDS_MAP + 1 (including current) rounds, disable map for voting and rotation. //BUBBERSTATION CHANGE 2 TO 1.
+		if(run >= 2) //If run twice in the last KEEP_ROUNDS_MAP + 1 (including current) rounds, disable map for voting and rotation.
 			blocked_maps += VM.map_name
 
 ///Updates the list of the most recent maps.

--- a/code/datums/votes/map_vote.dm
+++ b/code/datums/votes/map_vote.dm
@@ -25,22 +25,6 @@
 		return FALSE
 
 	choices -= get_choices_invalid_for_population()
-
-	//BUBBERSTATION EDIT START, CHOICE SAFETY STUFF.
-	//This basically just re-does map selection, but ignores persistent blocked maps and the currently voted map.
-	//Prevents situations where there are no maps to vote.
-	if(length(choices <= 3))
-		var/list/maps = shuffle(global.config.maplist)
-		for(var/map in maps)
-			var/datum/map_config/possible_config = config.maplist[map]
-			if(!possible_config.votable)
-				continue
-			choices += possible_config.map_name
-		choices -= get_choices_invalid_for_population()
-		if(SSmapping.config && length(choices >= 4)) //Remove the current map if there is more than 4 possible maps.
-			choices -= SSmapping.config.map_name
-	//BUBBERSTATION EDIT END.
-
 	if(length(choices) == 1) // Only one choice, no need to vote. Let's just auto-rotate it to the only remaining map because it would just happen anyways.
 		var/datum/map_config/change_me_out = global.config.maplist[choices[1]]
 		finalize_vote(choices[1])// voted by not voting, very sad.


### PR DESCRIPTION
## About The Pull Request

See name

## Why It's Good For The Game

Fixes empty votes being created, autorotation just picking a map because there's nothing else for it to pick, etc, etc

## Proof Of Testing

Werks fine on local

## Changelog

:cl:
del: Reverted map voting back to the tg system
/:cl:


