### PR TITLE
Adds more antags for Predictable Chaos.

### DIFF
--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_predictable.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_predictable.dm
@@ -4,7 +4,7 @@
 	welcome_text = "Waiter, more chaos! That's enough. Thank you, waiter."
 	population_min = 35
 
-	var/crew_per_antag = 20 //Basically this means for every 10 crew, spawn 1 antag. REMEMBER: This is CREW pop, NOT server pop
+	var/crew_per_antag = 15 //Basically this means for every 10 crew, spawn 1 antag. REMEMBER: This is CREW pop, NOT server pop
 
 	tag_multipliers = list(
 


### PR DESCRIPTION
## About The Pull Request

I am legitimately not sure why the number ended up being 20 instead of the hinted at 10. There might've been a good reason so It's now 15.

## Why It's Good For The Game

Predictable Chaos is boring.

## Proof Of Testing

Untested.

## Changelog

:cl: BurgerBB
add: Predictable Chaos now has 50% more antagonists.
/:cl:
