### PR TITLE
Disables "The Bomb" storyteller from being votable because engineering cryos every time it's voted.

### DIFF
--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_destructive.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_destructive.dm
@@ -14,3 +14,4 @@
 	)
 	population_min = 25
 	antag_divisor = 10
+	votable = FALSE


### PR DESCRIPTION
## About The Pull Request

Disables "The Bomb" storyteller from being votable 

## Why It's Good For The Game

Because of the limited amount of destructive events, the bomb tends to:
- Spawn a fuckton of anomalies and only anomalies during minor event rolls.
- Spawn extremely destructive round-ending major event rolls, like meteors.
- Somehow encourages antagonists to do bomb gimmicks because "That's what people voted for."

The bomb is voted for as a meme, much like tram. People want to see other people suffer. Let us put a stop to that.

## Proof Of Testing

Untested.

## Changelog

:cl: BurgerBB
del: Disables "The Bomb" storyteller from being votable because engineering cryos every time it's voted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
