### PR TITLE
Revert "Disables "The Bomb" storyteller from being votable because engineering cryos every time it's voted."

### DIFF
--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_destructive.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_destructive.dm
@@ -14,4 +14,3 @@
 	)
 	population_min = 25
 	antag_divisor = 10
-	votable = FALSE


### PR DESCRIPTION
Reverts Bubberstation/Bubberstation#2053

We specifically discussed this in the maintainer team like a month ago. Removals are not to be speedmerged unless something is too gamebreaking. This was merged in an hour of being open