### PR TITLE
Removes some significant effects from Path of Flesh, Moon, Rust, and Void ascensions.

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -333,9 +333,10 @@
 		color_override = "pink",
 	)
 
+	/* BUBBERSTATION CHANGE: NO MORE WORM.
 	var/datum/action/cooldown/spell/shapeshift/shed_human_form/worm_spell = new(user.mind)
 	worm_spell.Grant(user)
-
+	*/
 
 	var/datum/antagonist/heretic/heretic_datum = IS_HERETIC(user)
 	var/datum/heretic_knowledge/limited_amount/flesh_grasp/grasp_ghoul = heretic_datum.get_knowledge(/datum/heretic_knowledge/limited_amount/flesh_grasp)

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -216,6 +216,7 @@
 	user.mind.add_antag_datum(/datum/antagonist/lunatic/master)
 	RegisterSignal(user, COMSIG_LIVING_LIFE, PROC_REF(on_life))
 
+	/* BUBBERSTATION CHANGE: REMOVES LUNATICS
 	// Roughly 1/5th of the station will rise up as lunatics to the heretic
 	for (var/mob/living/carbon/human/crewmate as anything in GLOB.human_list)
 		// How many lunatics we have
@@ -253,6 +254,7 @@
 		crewmate.equip_in_one_of_slots(amulet, slots, qdel_on_fail = FALSE)
 		crewmate.emote("laugh")
 		amount_of_lunatics += 1
+	*/
 
 /datum/heretic_knowledge/ultimate/moon_final/proc/on_life(mob/living/source, seconds_per_tick, times_fired)
 	var/obj/effect/moon_effect = /obj/effect/temp_visual/moon_ringleader

--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -258,7 +258,7 @@
 		sound = 'sound/ambience/antag/heretic/ascend_rust.ogg',
 		color_override = "pink",
 	)
-	trigger(loc)
+	//trigger(loc) BUBBBERSTATION CHANGE: NO MORE MASS RUSTING.
 	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
 	RegisterSignal(user, COMSIG_LIVING_LIFE, PROC_REF(on_life))
 	user.client?.give_award(/datum/award/achievement/misc/rust_ascension, user)

--- a/code/modules/antagonists/heretic/knowledge/void_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/void_lore.dm
@@ -223,10 +223,12 @@
 	)
 	ADD_TRAIT(user, TRAIT_RESISTLOWPRESSURE, MAGIC_TRAIT)
 
+	/*BUBBERSTATION CHANGE: NERFS VOID ASCENSION.
 	// Let's get this show on the road!
 	sound_loop = new(user, TRUE, TRUE)
 	RegisterSignal(user, COMSIG_LIVING_LIFE, PROC_REF(on_life))
 	RegisterSignal(user, COMSIG_LIVING_DEATH, PROC_REF(on_death))
+	BUBBERSTATION CHANGE END*/
 
 /datum/heretic_knowledge/ultimate/void_final/on_lose(mob/user, datum/antagonist/heretic/our_heretic)
 	on_death() // Losing is pretty much dying. I think

--- a/modular_zubbers/code/modules/antagonists/heretic/knowledge/nerfed_ascensions.dm
+++ b/modular_zubbers/code/modules/antagonists/heretic/knowledge/nerfed_ascensions.dm
@@ -1,0 +1,21 @@
+/datum/heretic_knowledge/ultimate/rust_final
+	desc = "The ascension ritual of the Path of Rust. \
+		Bring 3 corpses to a transmutation rune on the bridge of the station to complete the ritual. \
+		Yu will become extremely resilient on rust, healing at triple the rate \
+		and becoming immune to many effects and dangers \ You will be able to rust almost anything upon ascending."
+/datum/heretic_knowledge/ultimate/moon_final
+	desc = "The ascension ritual of the Path of Moon. \
+		Bring 3 corpses with more than 50 brain damage to a transmutation rune to complete the ritual. \
+		When completed, you become a harbinger of madness gaining and aura of passive sanity decrease, \
+		confusion increase and, if their sanity is low enough, brain damage and blindness."
+
+/datum/heretic_knowledge/ultimate/flesh_final
+	desc = "The ascension ritual of the Path of Flesh. \
+		Bring 4 corpses to a transmutation rune to complete the ritual. \
+		When completed, yu can summon three times as many Ghouls and Voiceless Dead, \
+		and can create unlimited blades to arm them all."
+
+/datum/heretic_knowledge/ultimate/void_final
+	desc = "The ascension ritual of the Path of Void. \
+		Bring 3 corpses to a transmutation rune in sub-zero temperatures to complete the ritual. \
+		When completed you will become entirely immune to the effects of space."

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8789,6 +8789,7 @@
 #include "modular_zubbers\code\modules\antagonists\bloodsucker\vassal\vassal_types\ex_vassal.dm"
 #include "modular_zubbers\code\modules\antagonists\bloodsucker\vassal\vassal_types\favorite_vassal.dm"
 #include "modular_zubbers\code\modules\antagonists\bloodsucker\vassal\vassal_types\revenge_vassal.dm"
+#include "modular_zubbers\code\modules\antagonists\heretic\knowledge\nerfed_ascensions.dm"
 #include "modular_zubbers\code\modules\antagonists\malf\doomsday.dm"
 #include "modular_zubbers\code\modules\antagonists\malf\remove_malf.dm"
 #include "modular_zubbers\code\modules\antagonists\nightmare\nightmare_species.dm"


### PR DESCRIPTION
## About The Pull Request

- Removes the worm spell from Path of Flesh.
- Removes the 1/3rd "crew" antag conversion from Path of Moon.
- Removes the mass station rusting from Path of Rust.
- Removes the voidstorm kill weather from Path of Void.

## Why It's Good For The Game

The goal here is to make heretics no longer a round-ending threat. It doesn't make sense to me that we have an antag type where multiple  of that type can spawn and ascend and effectively end the round.

I'd like to remove Ascensions overall, but this is the best middle of the road option I can do. People have been saying since forever "Just nerf Ascensions instead of removing them, easy peasy" and so here it is.


## Stuff that was removed

### Worm Spell
- Deals too much damage.
- Near unkillable.
- Absurdly strong overall.

### Moon Conversion
- Doesn't actually just affect crew. Can affect ghost roles too.
- Giving 1/3rd the server pop antag status is silly.
- Don't think this respects antags prefs or bans.

### Path of Rust mass rustification.
- Station gets converted into rust without control is silly.
- Can't stop it. You literally cannot stop it.
- Rust on its way to interupt the horny admin team's erp in dorms (they are now angry and will ban half the server).

### Voidstorm
- Weather effect that is often laggy (clientside + serverside) and will kill anyone dead.
- Doesn't care if you have suit protection. You're just dead.
- Weather subsystem is limited to areas so expect to get fucked if a mapper made an area really big.
- Anti-lizard.


## Proof Of Testing

Untested. If it compiles, it werks.

## Changelog

:cl: BurgerBB
del: Removes some significant effects from Path of Flesh, Moon, Rust, and Void ascensions.
/:cl:
