### PR TITLE
Finally Removes Mold For Good

### DIFF
--- a/modular_zubbers/code/modules/storyteller/event_defines/moderate/moderate_overrides.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/moderate/moderate_overrides.dm
@@ -57,3 +57,5 @@
 /datum/round_event_control/mold
 	track = EVENT_TRACK_MODERATE
 	tags = list(TAG_COMMUNAL, TAG_COMBAT, TAG_CHAOTIC)
+	weight = 0
+	max_occurrences = 0


### PR DESCRIPTION
## About The Pull Request

Finally Removes Mold For Good. It can no longer occur except for admin intervention.

## Why It's Good For The Game

It's a legitimate failure of the maintainer's part to have such a broken event in bubberstation occur without ever being fixed. It's also a massive failure on the maintainer's part to constantly say they're replacing mold with another antag type only for this antag type to constantly get delayed and for no PR to actually remove mold ever get created if we're planning on removing mold.

I love fighting broken spider spawns, broken chem foam spam, and broken mobs meant to be controlled by players. I love fighting waves upon waves of laggy enemies that have their bodies constantly pile up because no one can balance anything correctly anymore.

## Proof Of Testing

If it compiles, it works.

## Changelog

:cl: BurgerBB
del: Finally Removes Mold For Good.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
