### PR TITLE
Removes The Clown storyteller making all event weights the same.

### DIFF
--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_clown.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_clown.dm
@@ -16,9 +16,3 @@
 	threshold_major = 3200
 	threshold_crewset = 1000
 	threshold_ghostset = 3200
-
-// All the weights are the same to the clown
-/datum/storyteller/clown/calculate_weights(track)
-	for(var/datum/round_event_control/event as anything in SSgamemode.event_pools[track])
-		if(event.weight)
-			event.calculated_weight = 1


### PR DESCRIPTION
## About The Pull Request

Removes The Clown storyteller making all event weights the same.

## Why It's Good For The Game

This is a feature many don't know about. I just learned about this feature looking through the code and this set off warning flags in my head.

The code sets all weights to 1 for each of the tracks. This means that meteors has the same chance as a electrical storm. I'm sure there is some nuiance I'm missing here (such as the interactions with thresholds), but that's still insane to me.

## Proof Of Testing

If it compiles, it works.

## Changelog

:cl: BurgerBB
del: Removes The Clown storyteller making all event weights the same.
/:cl:
