### PR TITLE
Replaces the Monkeycube Biogenerator recipe with monkey powder because I lagged once.

### DIFF
--- a/modular_zubbers/code/modules/research/designs/biogenerator_designs.dm
+++ b/modular_zubbers/code/modules/research/designs/biogenerator_designs.dm
@@ -1,0 +1,5 @@
+/datum/design/monkey_cube
+	name = "Monkey Powder"
+	materials = list(/datum/material/biomass = 1)
+	build_path = null
+	make_reagent = /datum/reagent/monkey_powder

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9125,6 +9125,7 @@
 #include "modular_zubbers\code\modules\reagents\reagent_containers\cups\glassbottle.dm"
 #include "modular_zubbers\code\modules\recycling\disposal\bin.dm"
 #include "modular_zubbers\code\modules\research\designs\ai_module_designs.dm"
+#include "modular_zubbers\code\modules\research\designs\biogenerator_designs.dm"
 #include "modular_zubbers\code\modules\research\designs\comp_board_designs.dm"
 #include "modular_zubbers\code\modules\research\designs\experisci_designs.dm"
 #include "modular_zubbers\code\modules\research\designs\machine_board_designs.dm"


### PR DESCRIPTION

## About The Pull Request

Replaces the Monkeycube Biogenerator recipe with Monkey Powder.
Instead of 50 biomass to make 1 monkey cube, it's 1 biomass to make 1 monkey powder (50 monkey powder makes 1 monkey when mixed with water).

## Why It's Good For The Game

If I had a nickel for every time I lagged out due to someone creating 50 monkey cubes on the biogenerator and then spraying water, I'd have four nickels, which isn't a lot but still weird.

This PR makes it harder to spam lag-inducing monkeys with little effort. You now have to actually put in effort if you want to spam 50 monkeys, either by doing xenobiology or by using a bluespace beaker.

This does unfortunately impact chefs. Instead of getting 5-8 monkey cubes for meat, they now have to bring 3-4 large beakers with them in order to harvest monkeys. However, I've been told that most chefs just print processed meat, or just get the botanist to grow meatwheat.

## Proof Of Testing

Draft because untested + feedback.

## Changelog


:cl: BurgerBB
balance: Replaces the Monkeycube Biogenerator recipe with monkey powder
/:cl:

