### PR TITLE
Makes Space Dragons immune to toxin + oxy damage because I saw a Space Dragon die to simplemobs on Moonstation Once

### DIFF
--- a/modular_zubbers/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
+++ b/modular_zubbers/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
@@ -1,3 +1,3 @@
 
 /mob/living/basic/space_dragon
-	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, STAMINA = 0.25, OXY = 0)
+	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, STAMINA = 0.5, OXY = 0)

--- a/modular_zubbers/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
+++ b/modular_zubbers/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
@@ -1,3 +1,3 @@
 
 /mob/living/basic/space_dragon
-	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, STAMINA = 0, OXY = 0)
+	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, STAMINA = 0.25, OXY = 0)

--- a/modular_zubbers/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
+++ b/modular_zubbers/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
@@ -1,0 +1,3 @@
+
+/mob/living/basic/space_dragon
+	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, STAMINA = 0, OXY = 0)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9020,6 +9020,7 @@
 #include "modular_zubbers\code\modules\mob\living\basic\moonstation\cazador.dm"
 #include "modular_zubbers\code\modules\mob\living\basic\moonstation\scorpion.dm"
 #include "modular_zubbers\code\modules\mob\living\basic\pets\dog\_dog.dm"
+#include "modular_zubbers\code\modules\mob\living\basic\space_fauna\space_dragon\space_dragon.dm"
 #include "modular_zubbers\code\modules\mob\living\basic\trooper\nanotrasen.dm"
 #include "modular_zubbers\code\modules\mob\living\basic\vermin\mouse.dm"
 #include "modular_zubbers\code\modules\mob\living\carbon\alien\adult\adult.dm"


### PR DESCRIPTION
## About The Pull Request

Makes Space Dragons immune to toxin + oxy damage because I saw a Space Dragon die to simplemobs on Moonstation Once

## Why It's Good For The Game

This is pretty much a moonstation exclusive problem since a whole bunch of toxic enemies spawn outside so yeah.

## Proof Of Testing

If it compiles, it works.

## Changelog

:cl: BurgerBB
balance: Makes Space Dragons immune to toxin + oxy damage because I saw a Space Dragon die to simplemobs on Moonstation Once
/:cl:
