### PR TITLE
Adds Global Event Cooldowns for Storyteller

### DIFF
--- a/modular_zubbers/code/modules/storyteller/_events/_event.dm
+++ b/modular_zubbers/code/modules/storyteller/_events/_event.dm
@@ -11,6 +11,8 @@
 	var/static/list/shared_occurences = list()
 	/// Whether a roundstart event can happen post roundstart. Very important for events which override job assignments.
 	var/can_run_post_roundstart = TRUE
+	//Prevents point gains from time for this amount of seconds when ran. Set this for high chaos events.
+	var/breathing_room_to_add = 0 SECONDS
 
 /datum/round_event
 	/// Whether the event called its start() yet or not.

--- a/modular_zubbers/code/modules/storyteller/gamemode.dm
+++ b/modular_zubbers/code/modules/storyteller/gamemode.dm
@@ -782,6 +782,7 @@ SUBSYSTEM_DEF(gamemode)
 				if(last_points)
 					next = round((upper - lower) / last_points / STORYTELLER_WAIT_TIME * 40 / 6) / 10
 				next = max(next,round(src.breathing_room / 6)/10)
+				next = max(next,round(src.next_track_event_run[track] / 6)/10)
 				dat += "<tr style='vertical-align:top; background-color: [background_cl];'>"
 				dat += "<td>[track]</td>" //Track
 				dat += "<td>[percent]% ([lower]/[upper])</td>" //Progress

--- a/modular_zubbers/code/modules/storyteller/gamemode.dm
+++ b/modular_zubbers/code/modules/storyteller/gamemode.dm
@@ -133,6 +133,17 @@ SUBSYSTEM_DEF(gamemode)
 
 	var/storyteller_voted = FALSE
 
+	var/list/next_track_event_run = list(
+		EVENT_TRACK_MUNDANE = 0,
+		EVENT_TRACK_MODERATE = 0,
+		EVENT_TRACK_MAJOR = 0,
+		EVENT_TRACK_CREWSET = 0,
+		EVENT_TRACK_GHOSTSET = 0
+	)
+
+	//If this value is over 0, then stop point gains. Lowers over time.
+	var/breathing_room = 0
+
 /datum/controller/subsystem/gamemode/Initialize(time, zlevel)
 	. = ..()
 	// Populate event pools
@@ -180,6 +191,9 @@ SUBSYSTEM_DEF(gamemode)
 		update_crew_infos()
 		next_storyteller_process = world.time + STORYTELLER_WAIT_TIME
 		storyteller.process(STORYTELLER_WAIT_TIME * 0.1)
+
+	if(breathing_room > 0)
+		breathing_room = max(0,breathing_room - wait)
 
 	//cache for sanic speed (lists are references anyways)
 	var/list/currentrun = src.currentrun
@@ -767,6 +781,7 @@ SUBSYSTEM_DEF(gamemode)
 				var/last_points = last_point_gains[track]
 				if(last_points)
 					next = round((upper - lower) / last_points / STORYTELLER_WAIT_TIME * 40 / 6) / 10
+				next = max(next,round(src.breathing_room / 6)/10)
 				dat += "<tr style='vertical-align:top; background-color: [background_cl];'>"
 				dat += "<td>[track]</td>" //Track
 				dat += "<td>[percent]% ([lower]/[upper])</td>" //Progress

--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/_storyteller.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/_storyteller.dm
@@ -86,7 +86,7 @@
 
 	if(SSshuttle.emergency.mode == SHUTTLE_IDLE) //Only do serious shit if the emergency shuttle is at Central Command and not in transit.
 
-		var/crew_role_chance = max(50,100 - (world.time/(60 MINUTES))*100) //Ghost roles will have an equal chance to spawn with crew roles at the 60 minute mark.
+		var/crew_role_chance = max(50,100 - (STATION_TIME_PASSED/(60 MINUTES))*100) //Ghost roles will have an equal chance to spawn with crew roles at the 60 minute mark.
 
 		if(prob(crew_role_chance))
 			//Prioritize crew role.

--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/_storyteller.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/_storyteller.dm
@@ -48,9 +48,9 @@
 
 	//Cooldowns.
 	var/antag_event_delay = 5 MINUTES
-	var/mundane_event_delay = 10 MINUTES
+	var/mundane_event_delay = 5 MINUTES
 	var/moderate_event_delay = 30 MINUTES
-	var/major_event_delay = 90 MINUTES
+	var/major_event_delay = 60 MINUTES
 
 	COOLDOWN_DECLARE(antag_event_cooldown)
 	COOLDOWN_DECLARE(mundane_event_cooldown)

--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/_storyteller.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/_storyteller.dm
@@ -86,7 +86,7 @@
 
 	if(SSshuttle.emergency.mode == SHUTTLE_IDLE) //Only do serious shit if the emergency shuttle is at Central Command and not in transit.
 
-		var/crew_role_chance = max(50,100 - (STATION_TIME_PASSED/(60 MINUTES))*100) //Ghost roles will have an equal chance to spawn with crew roles at the 60 minute mark.
+		var/crew_role_chance = max(50,100 - (STATION_TIME_PASSED()/(60 MINUTES))*100) //Ghost roles will have an equal chance to spawn with crew roles at the 60 minute mark.
 
 		if(prob(crew_role_chance))
 			//Prioritize crew role.

--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/_storyteller.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/_storyteller.dm
@@ -85,9 +85,20 @@
 		return FALSE
 
 	if(SSshuttle.emergency.mode == SHUTTLE_IDLE) //Only do serious shit if the emergency shuttle is at Central Command and not in transit.
-		if(find_and_buy_event_from_track(EVENT_TRACK_ROLESET))
-			COOLDOWN_START(src,antag_event_cooldown,antag_event_delay)
-			return TRUE
+
+		var/crew_role_chance = max(50,100 - (world.time/(60 MINUTES))*100) //Ghost roles will have an equal chance to spawn with crew roles at the 60 minute mark.
+
+		if(prob(crew_role_chance))
+			//Prioritize crew role.
+			if(find_and_buy_event_from_track(EVENT_TRACK_CREWSET) || find_and_buy_event_from_track(EVENT_TRACK_GHOSTSET))
+				COOLDOWN_START(src,antag_event_cooldown,antag_event_delay)
+				return TRUE
+		else
+			//Prioritize ghost role.
+			if(find_and_buy_event_from_track(EVENT_TRACK_GHOSTSET) || find_and_buy_event_from_track(EVENT_TRACK_CREWSET))
+				COOLDOWN_START(src,antag_event_cooldown,antag_event_delay)
+				return TRUE
+
 		if(COOLDOWN_FINISHED(src,major_event_cooldown) && find_and_buy_event_from_track(EVENT_TRACK_MAJOR))
 			COOLDOWN_START(src, major_event_cooldown, major_event_delay)
 			COOLDOWN_START(src, moderate_event_cooldown, moderate_event_delay)


### PR DESCRIPTION
## About The Pull Request

Adds a "breathing room" feature for storyteller that prevents storyteller point gains if a chaotic event ran.

Adds minimum cooldowns for all track types, preventing two tracks firing in quick succession due to excessive points.


## Why It's Good For The Game

Minimum cooldowns and breathing room prevent the storyteller from suddenly waking up and deciding "Hey lets spawn blob, spiders, and meteors at the same time because we can now afford all these events now." While Blob, Spiders, and Meteors can still all occur in the same round, it just won't spawn them all within 1 minute of eachother.

## Proof Of Testing

Can't really test. Recommend testmerge.

## Changelog

:cl: BurgerBB
add: Adds Cooldowns for Storyteller
/:cl:
