### PR TITLE
Refrence Tracking - DO NOT MERGE

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -56,7 +56,7 @@
 
 /// If this is uncommented, we set up the ref tracker to be used in a live environment
 /// And to log events to [log_dir]/harddels.log
-//#define REFERENCE_DOING_IT_LIVE
+#define REFERENCE_DOING_IT_LIVE
 #ifdef REFERENCE_DOING_IT_LIVE
 // compile the backend
 #define REFERENCE_TRACKING


### PR DESCRIPTION
This PR enables live refrence tracking in the compile options incase I might need it as a simple test merge. DO NOT MERGE