### PR TITLE
Fixes a typo when well-trained perk triggers.

### DIFF
--- a/modular_zubbers/code/modules/quirks/code/negative_quirks/well_trained.dm
+++ b/modular_zubbers/code/modules/quirks/code/negative_quirks/well_trained.dm
@@ -31,7 +31,7 @@
 	examine_list += span_purple("You can't look at <b>[dom]</b> for long for long before flustering away")
 
 	if(TIMER_COOLDOWN_FINISHED(dom, DOMINANT_COOLDOWN_EXAMINE))
-		to_chat(dom, span_purple("<b>[source]</b> tries to look at you but immedietly looks away with a red face..."))
+		to_chat(dom, span_purple("<b>[source]</b> tries to look at you but immediately looks away with a red face..."))
 		TIMER_COOLDOWN_START(dom, DOMINANT_COOLDOWN_EXAMINE, 15 SECONDS)
 		INVOKE_ASYNC(quirk_holder, TYPE_PROC_REF(/mob, emote), "blush") // Needs to be aynsc because of the cooldown.
 		quirk_holder.dir = turn(get_dir(quirk_holder, dom), pick(-90, 90))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Literally unplayable.

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

Fixes a typo.

## Proof Of Testing

No.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
spellcheck: Fixed a typo in the message that appeared when someone with the Well-Trained perk examined someone with the Dominant Aura trait.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
