### PR TITLE
Beepsky can no longer see potential targets if they don't move

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -493,6 +493,12 @@
 		if((nearby_carbons.name == oldtarget_name) && (world.time < last_found + 100))
 			continue
 
+		//BUBBERSTATION CHANGE START: BEEPSKY IS A DINOSAUR NOW. CAN'T SEE YOU IF YOU DON'T MOVE.
+		if(nearby_carbons.next_move + (4 SECONDS) <= world.time && nearby_carbons.next_click + (4 SECONDS) <= world.time)
+			//Holding still for 4 seconds.
+			continue
+		//BUBBERSTATION CHANGE END: BEEPSKY IS A DINOSAUR NOW. CAN'T SEE YOU IF YOU DON'T MOVE.
+
 		threatlevel = nearby_carbons.assess_threat(judgement_criteria)
 
 		if(threatlevel < THREAT_ASSESS_DANGEROUS)


### PR DESCRIPTION
https://www.youtube.com/watch?v=NOs116aoyo0

## About The Pull Request

If you haven't moved or clicked for the past 4 seconds, Beepsky won't be able to see you, unless you're already being hunted by them.

Damaging Beepsky (somehow) without clicking on them will still agro Beepsky to you. This only affects passive target acquisition. 

## Why It's Good For The Game

Hilarious fix to the problem of Beepsky running into situations while security is talking it out with the criminal.

## Proof Of Testing

I tested it. It just works.

This should be testmerged in case there is fuckery with other interactions or other funny exploits that I did not consider.

## Changelog

:cl: BurgerBB
balance: If you haven't moved or clicked for the past 4 seconds, Beepsky won't be able to see you, unless you're already being hunted by them.
/:cl:

