### PR TITLE
Replaces Uplink + Alien Surgery Romerol with Changeling Zombie Virus

### DIFF
--- a/modular_zubbers/code/modules/changeling_zombies/surgery.dm
+++ b/modular_zubbers/code/modules/changeling_zombies/surgery.dm
@@ -1,0 +1,53 @@
+/datum/design/surgery/necrotic_revival
+	name = "Changeling Zombie Revival"
+	desc = "An experimental surgical procedure that stimulates the growth of a Changeling Zombie virus inside the patient's head. Requires zombie powder or rezadone."
+
+/datum/surgery/advanced/necrotic_revival
+	name = "Changeling Zombie Revival"
+	desc = "An experimental surgical procedure that stimulates the growth of a Changeling Zombie virus inside the patient's head. Requires zombie powder or rezadone."
+	steps = list(
+		/datum/surgery_step/incise,
+		/datum/surgery_step/retract_skin,
+		/datum/surgery_step/saw,
+		/datum/surgery_step/clamp_bleeders,
+		/datum/surgery_step/changeling_zombie,
+		/datum/surgery_step/close,
+	)
+
+/datum/surgery_step/changeling_zombie
+	name = "start changeling zombie growth (syringe)"
+	implements = list(
+		/obj/item/reagent_containers/syringe = 100,
+		/obj/item/pen = 30
+	)
+	time = 50
+	chems_needed = list(/datum/reagent/toxin/zombiepowder, /datum/reagent/medicine/rezadone)
+	require_all_chems = FALSE
+
+/datum/surgery_step/changeling_zombie/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+
+	display_results(
+		user,
+		target,
+		span_notice("You begin to stimulate growth on [target]'s brain..."),
+		span_notice("[user] begins to tinker with [target]'s brain..."),
+		span_notice("[user] begins to perform surgery on [target]'s brain."),
+	)
+
+	display_pain(target, "Your head pounds with unimaginable pain!") // Same message as other brain surgeries
+
+/datum/surgery_step/changeling_zombie/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
+
+	display_results(
+		user,
+		target,
+		span_notice("You succeed in stimulate growth in [target]'s brain."),
+		span_notice("[user] successfully stimulates growth on [target]'s brain!"),
+		span_notice("[user] completes the surgery on [target]'s brain."),
+	)
+
+	display_pain(target, "Your head goes totally numb for a moment, the pain is overwhelming!")
+
+	target.AddComponent(/datum/component/changeling_zombie_infection)
+
+	return ..()

--- a/modular_zubbers/code/modules/changeling_zombies/uplink.dm
+++ b/modular_zubbers/code/modules/changeling_zombies/uplink.dm
@@ -1,0 +1,33 @@
+/datum/uplink_item/stealthy_weapons/romerol_kit
+	name = "Modifiable Changeling Zombie Virus"
+	desc = "A highly experimental bioterror agent which creates dormant nodules to be etched into the host. \
+		On death, these nodules take control of the dead body, causing the infectious variant of Changeling Zombie virus to manifest. \
+		This does not turn you into a real Changeling, just a failed experimental one that can still be useful to spread chaos with. \
+		This virus can be modified if you're not too happy with the initial symptoms! Virus food not included."
+	item = /obj/item/storage/box/syndie_kit/changeling_zombie
+	cost = 25
+	purchasable_from = UPLINK_ALL_SYNDIE_OPS
+	cant_discount = TRUE
+
+/obj/item/reagent_containers/cup/bottle/changeling_zombie
+	name = "Changeling Zombie culture bottle"
+	desc = "A small bottle. Contains the infamous Changeling Zombie virus, stolen from a Nanotrasen research facility."
+	amount_per_transfer_from_this = 5
+	spawned_disease = /datum/disease/advance/changelingzombie
+
+/obj/item/storage/box/syndie_kit/changeling_zombie/PopulateContents()
+	new /obj/item/reagent_containers/cup/bottle/changeling_zombie(src)
+	new /obj/item/reagent_containers/syringe(src)
+	new /obj/item/reagent_containers/dropper(src)
+
+/datum/uplink_item/role_restricted/changeling_zombie
+	name = "Modifiable Changeling Zombie Virus"
+	desc = "A highly experimental bioterror agent which creates dormant nodules to be etched into the host. \
+		On death, these nodules take control of the dead body, causing the infectious variant of Changeling Zombie virus to manifest. \
+		This does not turn you into a real Changeling, just a failed experimental one that can still be useful to spread chaos with. \
+		This virus can be modified if you're not too happy with the initial symptoms! Virus food not included."
+	item = /obj/item/storage/box/syndie_kit/changeling_zombie
+	cost = 20
+	restricted_roles = list(JOB_RESEARCH_DIRECTOR, JOB_SCIENTIST, JOB_MEDICAL_DOCTOR, JOB_CHIEF_MEDICAL_OFFICER)
+	surplus = 0
+

--- a/modular_zubbers/code/modules/changeling_zombies/uplink.dm
+++ b/modular_zubbers/code/modules/changeling_zombies/uplink.dm
@@ -20,14 +20,3 @@
 	new /obj/item/reagent_containers/syringe(src)
 	new /obj/item/reagent_containers/dropper(src)
 
-/datum/uplink_item/role_restricted/changeling_zombie
-	name = "Modifiable Changeling Zombie Virus"
-	desc = "A highly experimental bioterror agent which creates dormant nodules to be etched into the host. \
-		On death, these nodules take control of the dead body, causing the infectious variant of Changeling Zombie virus to manifest. \
-		This does not turn you into a real Changeling, just a failed experimental one that can still be useful to spread chaos with. \
-		This virus can be modified if you're not too happy with the initial symptoms! Virus food not included."
-	item = /obj/item/storage/box/syndie_kit/changeling_zombie
-	cost = 20
-	restricted_roles = list(JOB_RESEARCH_DIRECTOR, JOB_SCIENTIST, JOB_MEDICAL_DOCTOR, JOB_CHIEF_MEDICAL_OFFICER)
-	surplus = 0
-

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8857,6 +8857,8 @@
 #include "modular_zubbers\code\modules\changeling_zombies\infection.dm"
 #include "modular_zubbers\code\modules\changeling_zombies\items.dm"
 #include "modular_zubbers\code\modules\changeling_zombies\reagent.dm"
+#include "modular_zubbers\code\modules\changeling_zombies\surgery.dm"
+#include "modular_zubbers\code\modules\changeling_zombies\uplink.dm"
 #include "modular_zubbers\code\modules\changeling_zombies\virus.dm"
 #include "modular_zubbers\code\modules\client\examine_tgui.dm"
 #include "modular_zubbers\code\modules\client\ssd.dm"


### PR DESCRIPTION
## About The Pull Request

Replaces the Romerol Kit in the Nuke Ops uplink with an Infectious Changeling Zombie Virus Kit. You can use virology to tweak the virus to your liking. This costs 25TC.

Replaces the Romerol Surgery in Alien Tech with Infectious Changeling Zombie surgery.

## Why It's Good For The Game

This is something I completely forgot to do when Changeling Zombies were merged. I was only reminded because there was a recent round where romerol was used in a round.

Romerol is kind of unbalanced right now. Skyrat tried replacing it with RNA zombies, and that didn't work out, so I am finishing what they started by replacing it with Changeling Zombies. It is way too easy to obtain (just needs alien tech) and is very easy to abuse because of how romerol tumors work (grinding them up gives you free romerol juice).

The uplink version is very powerful as it gives you the virology-compatible virus itself with a few symptoms attached to it. This means you can make it super infectious, stealthy, or whatever with virology mechanics, and people can spread the virus without needing to be transformed. If you're extra crazy, you could use viral bonding as well...

The surgery is less powerful, but it still gives you the infectious Changeling Zombie variant (attacking with the changeling armblade infects; it doesn't spread like a virology virus). I think this is more balanaced than being able to farm the Romerol reagent so you can make unlimited Romerol.

Per feedback on Changeling Zombies, I think it's a suitable replacement to Romerol. I've been told that a lot of infectious Changeling Zombie outbreaks can get out of control, just like Romerol, so this isn't too much of a nerf.

## Proof Of Testing

Draft because untested and feedback is needed if an uplink cost needs to be tweaked. It is possible to also add this to Scientist/Medical doctor traitor options as well if needed.

## Changelog

:cl: BurgerBB
balance: Replaces the Romerol Kit in the Nuke Ops uplink with an Infectious Changeling Zombie Virus Kit. You can use virology to tweak the virus to your liking. This costs 25TC. Replaces the Romerol Surgery in Alien Tech with Infectious Changeling Zombie surgery.
/:cl:
