### PR TITLE
Disables Space Sandstorms because the server died to it once

### DIFF
--- a/modular_zubbers/code/modules/storyteller/event_defines/moderate/moderate_overrides.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/moderate/moderate_overrides.dm
@@ -32,6 +32,8 @@
 /datum/round_event_control/sandstorm
 	track = EVENT_TRACK_MODERATE
 	tags = list(TAG_DESTRUCTIVE)
+	weight = 0
+	max_occurrences = 0
 
 /datum/round_event_control/shuttle_catastrophe
 	track = EVENT_TRACK_MODERATE


### PR DESCRIPTION
## About The Pull Request

Disables sandstorms from occurring via events.

## Why It's Good For The Game

Causes the server to freeze/hang/whatever.


## Proof Of Testing

If it compiles, it werks.

## Changelog

:cl: BurgerBB
del: Disables sandstorms from occurring via events.
/:cl:

