### PR TITLE
Removes the Mannequin in Moonstation engineering because a shaft miner died to it 5 times.

### DIFF
--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -483,10 +483,8 @@
 /area/station/cargo/sorting)
 "ahy" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/mob/living/basic/statue/mannequin/suspicious{
-	dir = 1;
-	name = "mannequin";
-	desc = "Who left this here?"
+/obj/structure/mannequin/wood{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/station/construction)


### PR DESCRIPTION
## About The Pull Request

Removes the Mannequin in Moonstation engineering because a shaft miner died to it 5 times.

## Why It's Good For The Game

Removes the Mannequin in Moonstation engineering because a shaft miner died to it 5 times.

## Proof Of Testing

Removes the Mannequin in Moonstation engineering because a shaft miner died to it 5 times.

## Changelog

:cl: BurgerBB
del: Removes the Mannequin in Moonstation engineering because a shaft miner died to it 5 times.
/:cl:

