### PR TITLE
Buffs Xeno Weed temperature survivability in hotter environments.

### DIFF
--- a/modular_zubbers/code/game/objects/structures/aliens.dm
+++ b/modular_zubbers/code/game/objects/structures/aliens.dm
@@ -1,2 +1,2 @@
 /obj/structure/alien/weeds/should_atmos_process(datum/gas_mixture/air, exposed_temperature)
-	return exposed_temperature >= 350 //Slightly less than moonstation external atmos.
+	return exposed_temperature >= 350 //Slightly higher than moonstation external atmos.

--- a/modular_zubbers/code/game/objects/structures/aliens.dm
+++ b/modular_zubbers/code/game/objects/structures/aliens.dm
@@ -1,0 +1,2 @@
+/obj/structure/alien/weeds/should_atmos_process(datum/gas_mixture/air, exposed_temperature)
+	return exposed_temperature >= 350 //Slightly less than moonstation external atmos.

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8721,6 +8721,7 @@
 #include "modular_zubbers\code\game\objects\items\storage\boxes.dm"
 #include "modular_zubbers\code\game\objects\items\storage\briefcase.dm"
 #include "modular_zubbers\code\game\objects\items\storage\garment.dm"
+#include "modular_zubbers\code\game\objects\structures\aliens.dm"
 #include "modular_zubbers\code\game\objects\structures\chalkboard.dm"
 #include "modular_zubbers\code\game\objects\structures\ore_vent.dm"
 #include "modular_zubbers\code\game\objects\structures\trash_pile.dm"


### PR DESCRIPTION
## About The Pull Request

Buffs Xeno Weed temperature survivability in hotter environments. It was increased from 300K to 350K, which is only slightly higher than Moon Station's external temperature of 347.65K.

## Why It's Good For The Game

This should allow xenos to build nests in Moonstation while still suffering from flamethrowers.

## Proof Of Testing

If it compiles, it werks.

## Changelog

:cl: BurgerBB
balance: Buffs Xeno Weed temperature survivability in hotter environments. It was increased from 300K to 350K, which is only slightly higher than Moon Station's external temperature of 347.65K.
/:cl:
