### PR TITLE
Heretic Transmutation Runes can no longer have Fingerprints.

### DIFF
--- a/modular_zubbers/code/modules/antagonists/heretic/transmutation_rune.dm
+++ b/modular_zubbers/code/modules/antagonists/heretic/transmutation_rune.dm
@@ -1,0 +1,5 @@
+/obj/effect/heretic_rune/add_fingerprint(...)
+	return
+
+/obj/effect/heretic_rune/add_fingerprint_list(...)
+	return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8796,6 +8796,7 @@
 #include "modular_zubbers\code\modules\antagonists\bloodsucker\vassal\vassal_types\favorite_vassal.dm"
 #include "modular_zubbers\code\modules\antagonists\bloodsucker\vassal\vassal_types\revenge_vassal.dm"
 #include "modular_zubbers\code\modules\antagonists\heretic\heretic.dm"
+#include "modular_zubbers\code\modules\antagonists\heretic\transmutation_rune.dm"
 #include "modular_zubbers\code\modules\antagonists\malf\doomsday.dm"
 #include "modular_zubbers\code\modules\antagonists\malf\remove_malf.dm"
 #include "modular_zubbers\code\modules\antagonists\nightmare\nightmare_species.dm"


### PR DESCRIPTION
## About The Pull Request

Heretic Transmutation Runes can no longer have Fingerprints.
This does not affect "hidden" fingerprints aka fingerprints for admin logs.
This does not affect clothing fibers. 

## Why It's Good For The Game

It's funny that if you interact with a rune, your fingerprints are applied to it. This results in heretics getting caught extremely easily and early. It doesn't make sense to me that interacting with an eldritch rune would do this.

## Proof Of Testing

Untested.

## Changelog

:cl: BurgerBB
balance: Heretic Transmutation Runes can no longer have Fingerprints.
/:cl:
