### PR TITLE
Most events have a less chance to run if a related department is severely understaffed.

### DIFF
--- a/modular_zubbers/code/modules/storyteller/_events/_event.dm
+++ b/modular_zubbers/code/modules/storyteller/_events/_event.dm
@@ -12,6 +12,13 @@
 	/// Whether a roundstart event can happen post roundstart. Very important for events which override job assignments.
 	var/can_run_post_roundstart = TRUE
 
+	//Setting this adds a requirement to job slots for this event. This takes department bitflags.
+	//Currently has support for DEPARTMENT_BITFLAG_COMMAND, DEPARTMENT_BITFLAG_ENGINEERING, DEPARTMENT_BITFLAG_SECURITY, DEPARTMENT_BITFLAG_SCIENCE, DEPARTMENT_BITFLAG_MEDICAL
+	//Failing to meet the requirements will divide the final weight by the amount of missing slots plus 1 (ie 2 missing slots means weight is divided by 3).
+	var/restriction_tags
+	//Amount of job slots in each restriction_tag department there must be for this event to run.
+	var/restriction_tag_requirement = 4
+
 /datum/round_event
 	/// Whether the event called its start() yet or not.
 	var/has_started = FALSE

--- a/modular_zubbers/code/modules/storyteller/event_defines/ghostset/ghostset_overrides.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/ghostset/ghostset_overrides.dm
@@ -2,29 +2,41 @@
 	track = EVENT_TRACK_GHOSTSET
 	tags = list(TAG_COMBAT, TAG_SPOOKY)
 	weight = 4
+	restriction_tags = DEPARTMENT_BITFLAG_SECURITY
+	restriction_tag_requirement = 1
 
 /datum/round_event_control/space_dragon
 	track = EVENT_TRACK_GHOSTSET
 	tags = list(TAG_COMBAT, TAG_CHAOTIC)
 	weight = 2
+	restriction_tags = DEPARTMENT_BITFLAG_SECURITY
+	restriction_tag_requirement = 4
 
 /datum/round_event_control/space_ninja
 	track = EVENT_TRACK_GHOSTSET
 	tags = list(TAG_COMBAT)
 	weight = 4
+	restriction_tags = DEPARTMENT_BITFLAG_SECURITY
+	restriction_tag_requirement = 2
 
 /datum/round_event_control/changeling
 	track = EVENT_TRACK_GHOSTSET
 	tags = list(TAG_COMBAT, TAG_CREW_ANTAG)
 	min_players = 20
 	weight = 6
+	restriction_tags = DEPARTMENT_BITFLAG_SECURITY | DEPARTMENT_BITFLAG_MEDICAL
+	restriction_tag_requirement = 2
 
 /datum/round_event_control/alien_infestation
 	track = EVENT_TRACK_GHOSTSET
 	tags = list(TAG_COMBAT, TAG_SPOOKY, TAG_CHAOTIC)
 	weight = 2
+	restriction_tags = DEPARTMENT_BITFLAG_SECURITY | DEPARTMENT_BITFLAG_MEDICAL
+	restriction_tag_requirement = 4
 
 /datum/round_event_control/spider_infestation
 	track = EVENT_TRACK_GHOSTSET
 	tags = list(TAG_COMBAT, TAG_DESTRUCTIVE, TAG_CHAOTIC)
 	weight = 2
+	restriction_tags = DEPARTMENT_BITFLAG_SECURITY | DEPARTMENT_BITFLAG_MEDICAL
+	restriction_tag_requirement = 4

--- a/modular_zubbers/code/modules/storyteller/event_defines/ghostset/lone_infiltrator.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/ghostset/lone_infiltrator.dm
@@ -13,6 +13,9 @@
 	track = EVENT_TRACK_GHOSTSET
 	tags = list(TAG_COMBAT)
 
+	restriction_tags = DEPARTMENT_BITFLAG_SECURITY | DEPARTMENT_BITFLAG_MEDICAL
+	restriction_tag_requirement = 2
+
 /datum/round_event/ghost_role/lone_infiltrator
 	minimum_required = 1
 	role_name = ROLE_LONE_INFILTRATOR

--- a/modular_zubbers/code/modules/storyteller/event_defines/ghostset/voidwalker.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/ghostset/voidwalker.dm
@@ -14,6 +14,9 @@
 
 	track = EVENT_TRACK_GHOSTSET
 
+	restriction_tags = DEPARTMENT_BITFLAG_SECURITY | DEPARTMENT_BITFLAG_MEDICAL
+	restriction_tag_requirement = 2
+
 /datum/round_event/ghost_role/void_walker
 	minimum_required = 30
 	fakeable = FALSE

--- a/modular_zubbers/code/modules/storyteller/event_defines/major/major_overrides.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/major/major_overrides.dm
@@ -1,6 +1,8 @@
 /datum/round_event_control/earthquake
 	track = EVENT_TRACK_MAJOR
 	tags = list(TAG_DESTRUCTIVE)
+	restriction_tags = DEPARTMENT_BITFLAG_ENGINEERING
+	restriction_tag_requirement = 2
 
 /datum/round_event_control/bureaucratic_error
 	track = EVENT_TRACK_MAJOR // Yes, it's annoying.
@@ -11,16 +13,22 @@
 	track = EVENT_TRACK_MAJOR
 	tags = list(TAG_DESTRUCTIVE, TAG_COMBAT, TAG_CHAOTIC)
 	weight = 10
+	restriction_tags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SECURITY | DEPARTMENT_BITFLAG_MEDICAL
+	restriction_tag_requirement = 4
 
 /datum/round_event_control/meteor_wave
 	track = EVENT_TRACK_MAJOR
 	tags = list(TAG_COMMUNAL, TAG_SPACE, TAG_DESTRUCTIVE, TAG_CHAOTIC)
 	weight = 10
 	max_occurrences = 1
+	restriction_tags = DEPARTMENT_BITFLAG_ENGINEERING
+	restriction_tag_requirement = 4
 
 /datum/round_event_control/meteor_wave/meaty
 	weight = 15
 	max_occurrences = 1
+	restriction_tags = DEPARTMENT_BITFLAG_ENGINEERING
+	restriction_tag_requirement = 2
 
 /datum/round_event_control/meteor_wave/threatening
 	weight = 3
@@ -34,15 +42,22 @@
 /datum/round_event_control/radiation_storm
 	track = EVENT_TRACK_MAJOR
 	tags = list(TAG_COMMUNAL)
+	max_occurrences = 2
+	restriction_tags = DEPARTMENT_BITFLAG_MEDICAL
+	restriction_tag_requirement = 3
 
 /datum/round_event_control/wormholes
 	track = EVENT_TRACK_MAJOR
 	tags = list(TAG_COMMUNAL)
+	restriction_tags = DEPARTMENT_BITFLAG_MEDICAL
+	restriction_tag_requirement = 2
 
 /datum/round_event_control/immovable_rod
 	track = EVENT_TRACK_MAJOR
 	tags = list(TAG_DESTRUCTIVE)
 	weight = 20
+	restriction_tags = DEPARTMENT_BITFLAG_ENGINEERING
+	restriction_tag_requirement = 2
 
 /datum/round_event_control/stray_meteor
 	track = EVENT_TRACK_MAJOR
@@ -52,32 +67,48 @@
 /datum/round_event_control/anomaly/anomaly_vortex
 	track = EVENT_TRACK_MAJOR
 	tags = list(TAG_DESTRUCTIVE)
+	restriction_tags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
+	restriction_tag_requirement = 2
 
 /datum/round_event_control/anomaly/anomaly_pyro
 	track = EVENT_TRACK_MAJOR
 	tags = list(TAG_DESTRUCTIVE)
+	restriction_tags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
+	restriction_tag_requirement = 2
 
 /datum/round_event_control/revenant
 	min_players = 20
 	track = EVENT_TRACK_MAJOR
 	tags = list(TAG_DESTRUCTIVE, TAG_SPOOKY)
+	restriction_tags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SECURITY
+	restriction_tag_requirement = 2
 
 /datum/round_event_control/abductor
 	track = EVENT_TRACK_MAJOR
 	tags = list(TAG_COMBAT, TAG_SPOOKY, TAG_CHAOTIC)
+	restriction_tags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SECURITY
+	restriction_tag_requirement = 4
 
 /datum/round_event_control/fugitives
 	track = EVENT_TRACK_MAJOR
 	tags = list(TAG_COMBAT)
+	restriction_tags = DEPARTMENT_BITFLAG_SECURITY
+	restriction_tag_requirement = 2
 
 /datum/round_event_control/voidwalker
 	track = EVENT_TRACK_MAJOR
 	tags = list(TAG_COMBAT, TAG_SPOOKY, TAG_SPACE)
+	restriction_tags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SECURITY
+	restriction_tag_requirement = 2
 
 /datum/round_event_control/cme
 	track = EVENT_TRACK_MAJOR
 	tags = list(TAG_DESTRUCTIVE, TAG_COMMUNAL, TAG_CHAOTIC)
+	restriction_tags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
+	restriction_tag_requirement = 4
 
 /datum/round_event_control/stray_cargo/changeling_zombie
 	track = EVENT_TRACK_MAJOR
 	tags = list(TAG_COMMUNAL, TAG_COMBAT, TAG_CHAOTIC, TAG_SPOOKY)
+	restriction_tags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SECURITY
+	restriction_tag_requirement = 4

--- a/modular_zubbers/code/modules/storyteller/event_defines/moderate/moderate_overrides.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/moderate/moderate_overrides.dm
@@ -1,10 +1,14 @@
 /datum/round_event_control/brand_intelligence
 	track = EVENT_TRACK_MODERATE
 	tags = list(TAG_DESTRUCTIVE, TAG_COMMUNAL, TAG_CHAOTIC)
+	restriction_tags = DEPARTMENT_BITFLAG_ENGINEERING
+	restriction_tag_requirement = 2
 
 /datum/round_event_control/carp_migration
 	track = EVENT_TRACK_MODERATE
 	tags = list(TAG_COMMUNAL)
+	restriction_tags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SECURITY
+	restriction_tag_requirement = 2
 
 /datum/round_event_control/communications_blackout
 	track = EVENT_TRACK_MODERATE
@@ -17,45 +21,60 @@
 /datum/round_event_control/ion_storm
 	track = EVENT_TRACK_MODERATE
 	tags = list(TAG_TARGETED)
+	restriction_tags = DEPARTMENT_BITFLAG_COMMAND
+	restriction_tag_requirement = 1
 
 /datum/round_event_control/processor_overload
 	track = EVENT_TRACK_MODERATE
 	tags = list(TAG_COMMUNAL)
 
-/datum/round_event_control/radiation_storm
-	max_occurrences = 2
-
 /datum/round_event_control/radiation_leak
 	track = EVENT_TRACK_MODERATE
 	tags = list(TAG_COMMUNAL)
+	restriction_tags = DEPARTMENT_BITFLAG_ENGINEERING
+	restriction_tag_requirement = 1
 
 /datum/round_event_control/sandstorm
 	track = EVENT_TRACK_MODERATE
 	tags = list(TAG_DESTRUCTIVE)
+	restriction_tags = DEPARTMENT_BITFLAG_ENGINEERING
+	restriction_tag_requirement = 1
 
 /datum/round_event_control/shuttle_catastrophe
 	track = EVENT_TRACK_MODERATE
 	tags = list(TAG_COMMUNAL)
+	restriction_tags = DEPARTMENT_BITFLAG_ENGINEERING //Unironic chance to get build your own shuttle.
+	restriction_tag_requirement = 2
 
 /datum/round_event_control/vent_clog
 	track = EVENT_TRACK_MODERATE
 	tags = list(TAG_COMMUNAL)
+	restriction_tags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SECURITY //Could be something bad.
+	restriction_tag_requirement = 2
 
 /datum/round_event_control/anomaly
 	weight = 10 // Lower from original 15 because it KEEPS SPAWNING THEM
 	track = EVENT_TRACK_MODERATE
 	tags = list(TAG_COMMUNAL, TAG_DESTRUCTIVE)
+	restriction_tags = DEPARTMENT_BITFLAG_SCIENCE
+	restriction_tag_requirement = 2
 
 /datum/round_event_control/spacevine
 	track = EVENT_TRACK_MODERATE
 	tags = list(TAG_COMMUNAL, TAG_COMBAT, TAG_CHAOTIC)
+	restriction_tags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SECURITY //Could spawn sentient maneaters.
+	restriction_tag_requirement = 4
 
 /datum/round_event_control/portal_storm_syndicate
 	track = EVENT_TRACK_MODERATE
 	tags = list(TAG_COMBAT, TAG_CHAOTIC)
+	restriction_tags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SECURITY
+	restriction_tag_requirement = 4
 
 /datum/round_event_control/mold
 	track = EVENT_TRACK_MODERATE
 	tags = list(TAG_COMMUNAL, TAG_COMBAT, TAG_CHAOTIC)
+	restriction_tags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SECURITY | DEPARTMENT_BITFLAG_ENGINEERING
+	restriction_tag_requirement = 4
 	weight = 0
 	max_occurrences = 0

--- a/modular_zubbers/code/modules/storyteller/event_defines/mundane/mundane_overrides.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/mundane/mundane_overrides.dm
@@ -5,6 +5,8 @@
 /datum/round_event_control/brain_trauma
 	track = EVENT_TRACK_MUNDANE
 	tags = list(TAG_TARGETED)
+	restriction_tags = DEPARTMENT_BITFLAG_MEDICAL
+	restriction_tag_requirement = 1
 
 /datum/round_event_control/camera_failure
 	track = EVENT_TRACK_MUNDANE
@@ -13,6 +15,8 @@
 /datum/round_event_control/disease_outbreak
 	track = EVENT_TRACK_MUNDANE
 	tags = list(TAG_TARGETED)
+	restriction_tags = DEPARTMENT_BITFLAG_MEDICAL
+	restriction_tag_requirement = 2
 
 /datum/round_event_control/space_dust
 	track = EVENT_TRACK_MUNDANE
@@ -46,6 +50,8 @@
 	var/list/run_situations = list()
 	track = EVENT_TRACK_MUNDANE
 	tags = list(TAG_COMMUNAL)
+	restriction_tags = DEPARTMENT_BITFLAG_SECURITY | DEPARTMENT_BITFLAG_MEDICAL //Could loan the cargo shuttle to something bad.
+	restriction_tag_requirement = 2
 
 /datum/round_event_control/mass_hallucination
 	track = EVENT_TRACK_MUNDANE
@@ -58,15 +64,23 @@
 /datum/round_event_control/grey_tide
 	track = EVENT_TRACK_MUNDANE
 	tags = list(TAG_DESTRUCTIVE, TAG_SPOOKY)
+	restriction_tags = DEPARTMENT_BITFLAG_ENGINEERING //Entirely possible to open doors to space.
+	restriction_tag_requirement = 2
 
 /datum/round_event_control/gravity_generator_blackout
 	track = EVENT_TRACK_MUNDANE
 	tags = list(TAG_COMMUNAL, TAG_SPACE)
+	restriction_tags = DEPARTMENT_BITFLAG_ENGINEERING
+	restriction_tag_requirement = 2
 
 /datum/round_event_control/shuttle_insurance
 	track = EVENT_TRACK_MUNDANE
 	tags = list(TAG_COMMUNAL)
+	restriction_tags = DEPARTMENT_BITFLAG_COMMAND
+	restriction_tag_requirement = 2
 
 /datum/round_event_control/tram_malfunction
 	track = EVENT_TRACK_MUNDANE
 	tags = list(TAG_DESTRUCTIVE)
+	restriction_tags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_MEDICAL
+	restriction_tag_requirement = 1

--- a/modular_zubbers/code/modules/storyteller/event_defines/mundane/scrubber_overrides.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/mundane/scrubber_overrides.dm
@@ -1,6 +1,8 @@
 /datum/round_event_control/scrubber_overflow
 	track = EVENT_TRACK_MUNDANE
 	tags = list(TAG_COMMUNAL)
+	restriction_tags = DEPARTMENT_BITFLAG_MEDICAL
+	restriction_tag_requirement = 2
 
 /datum/round_event_control/scrubber_overflow/threatening
 	weight = 0

--- a/modular_zubbers/code/modules/storyteller/gamemode.dm
+++ b/modular_zubbers/code/modules/storyteller/gamemode.dm
@@ -128,6 +128,7 @@ SUBSYSTEM_DEF(gamemode)
 	var/eng_crew = 0
 	var/sec_crew = 0
 	var/med_crew = 0
+	var/sci_crew = 0
 
 	var/wizardmode = FALSE
 
@@ -397,6 +398,8 @@ SUBSYSTEM_DEF(gamemode)
 				med_crew++
 			if(player_role.departments_bitflags & DEPARTMENT_BITFLAG_SECURITY)
 				sec_crew++
+			if(player_role.departments_bitflags & DEPARTMENT_BITFLAG_SCIENCE)
+				sci_crew++
 
 /datum/controller/subsystem/gamemode/proc/TriggerEvent(datum/round_event_control/event)
 	. = event.preRunEvent()

--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/_storyteller.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/_storyteller.dm
@@ -139,6 +139,7 @@
 			weight_total -= event.reoccurence_penalty_multiplier * weight_total * (1 - (event_repetition_multiplier ** occurences))
 		// Apply weight totals based on current jobs.
 		if(weight_total > 0 && event.restriction_tags && event.restriction_tag_requirement > 0)
+			var/datum/controller/subsystem/gamemode/mode = SSgamemode
 			if((event.restriction_tags & DEPARTMENT_BITFLAG_COMMAND) && mode.head_crew < event.restriction_tag_requirement)
 				weight_total *= 1 / (1 + event.restriction_tag_requirement - mode.head_crew)
 			if((event.restriction_tags & DEPARTMENT_BITFLAG_ENGINEERING) && mode.eng_crew < event.restriction_tag_requirement)

--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/_storyteller.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/_storyteller.dm
@@ -137,5 +137,18 @@
 		if(occurences)
 			///If the event has occured already, apply a penalty multiplier based on amount of occurences
 			weight_total -= event.reoccurence_penalty_multiplier * weight_total * (1 - (event_repetition_multiplier ** occurences))
+		// Apply weight totals based on current jobs.
+		if(weight_total > 0 && event.restriction_tags && event.restriction_tag_requirement > 0)
+			if((event.restriction_tags & DEPARTMENT_BITFLAG_COMMAND) && mode.head_crew < event.restriction_tag_requirement)
+				weight_total *= 1 / (1 + event.restriction_tag_requirement - mode.head_crew)
+			if((event.restriction_tags & DEPARTMENT_BITFLAG_ENGINEERING) && mode.eng_crew < event.restriction_tag_requirement)
+				weight_total *= 1 / (1 + event.restriction_tag_requirement - mode.eng_crew)
+			if((event.restriction_tags & DEPARTMENT_BITFLAG_SECURITY) && mode.sec_crew < event.restriction_tag_requirement)
+				weight_total *= 1 / (1 + event.restriction_tag_requirement - mode.sec_crew)
+			if((event.restriction_tags & DEPARTMENT_BITFLAG_MEDICAL) && mode.med_crew < event.restriction_tag_requirement)
+				weight_total *= 1 / (1 + event.restriction_tag_requirement - mode.med_crew)
+			if((event.restriction_tags & DEPARTMENT_BITFLAG_SCIENCE) && mode.sci_crew < event.restriction_tag_requirement)
+				weight_total *= 1 / (1 + event.restriction_tag_requirement - mode.sci_crew)
+			weight_total = FLOOR(weight_total,1)
 		/// Write it
 		event.calculated_weight = weight_total


### PR DESCRIPTION
Remake of #2060

## About The Pull Request

Most events have a less chance to run if a related department is severely understaffed. This does not affect The Clown storyteller.

## Why It's Good For The Game

Storyteller current does not care about departmental population when it comes to running events. It can run deadly virus events with 0 medical staff, and it can run crazy meteor events with no engineering staff. This results in lowpop/midpop shifts being disproportionately affected by chaos as there are a lot of events that can go completely differently (blob, space dragon, meteors) if a department meant to deal with said threat aren't staffed. On these shifts, departments are usually empty because no one wants to play as the sole person in that role because it is extremely painful to do so.

Caring about population only when rolling events results in a lot of people giving up roleplay and suddenly becoming experienced at every single job in the station. Examples include non-medical command members suddenly become knowledgeable about viruses because there are no medical doctors present in a shift. Engineers suddenly becoming experts in chemistry and printing out Mutadone after a radiation storm. Scientists becoming experts in breach repair, supermatter stabilization, and door hacking because there are no engineers to stop the currently exploding supermatter crystal.

This sort of system was in place with the custom Predictable Chaos storyteller, where it would spawn less antagonists based on how empty medical, engineering, and security was. This worked really well, and resulted in pretty fair antagonist encounters. This PR applies that logic to all events, including antag spawn ones, so the station doesn't run into situations where Abductors spawn and there are no medical doctors to remove deadly organ swaps, or security officers to stop kidnappings.

## Proof Of Testing

Untested. I have no way to test this.

## Changelog

:cl: BurgerBB
balance: Most events have a less chance to run if a related department is severely understaffed. This does not affect The Clown storyteller.
/:cl:

