### PR TITLE
Regenerative Crossbreed  Slime Cores only work on the dead, and not the living + adjusts how it heals.

### DIFF
--- a/modular_zubbers/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/modular_zubbers/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -1,0 +1,23 @@
+/obj/item/slimecross/regenerative
+	desc = "It's filled with a milky substance, and pulses like a heartbeat. It seems to have an avoidance to living tissue."
+
+/obj/item/slimecross/regenerative/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+	if(!isliving(interacting_with))
+		return
+	var/mob/living/H = interacting_with
+	if(H.stat != DEAD)
+		to_chat(user, span_warning("[src] will not work on the living!"))
+		return ITEM_INTERACT_BLOCKING
+	if(H != user)
+		user.visible_message(span_notice("[user] crushes [src] over [H], the milky goo quickly regenerating all of [H.p_their()] injuries!"),
+			span_notice("You squeeze [src], and it bursts over [H], the milky goo regenerating [H.p_their()] injuries."))
+	else
+		user.visible_message(span_notice("[user] crushes [src] over [user.p_them()]self, the milky goo quickly regenerating all of [user.p_their()] injuries!"),
+			span_notice("You squeeze [src], and it bursts in your hand, splashing you with milky goo which quickly regenerates your injuries!"))
+	core_effect_before(H, user)
+	user.do_attack_animation(interacting_with)
+	H.revive(HEAL_ALL)
+	core_effect(H, user)
+	playsound(H, 'sound/effects/splat.ogg', 40, TRUE)
+	qdel(src)
+	return ITEM_INTERACT_SUCCESS

--- a/modular_zubbers/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/modular_zubbers/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -16,7 +16,7 @@
 			span_notice("You squeeze [src], and it bursts in your hand, splashing you with milky goo which quickly regenerates your injuries!"))
 	core_effect_before(H, user)
 	user.do_attack_animation(interacting_with)
-	H.revive(HEAL_ALL)
+	H.revive(HEAL_DAMAGE)
 	core_effect(H, user)
 	playsound(H, 'sound/effects/splat.ogg', 40, TRUE)
 	qdel(src)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9141,6 +9141,7 @@
 #include "modular_zubbers\code\modules\research\designs\misc_designs.dm"
 #include "modular_zubbers\code\modules\research\designs\nerd_designs.dm"
 #include "modular_zubbers\code\modules\research\techweb\all_nodes.dm"
+#include "modular_zubbers\code\modules\research\xenobiology\crossbreeding\regenerative.dm"
 #include "modular_zubbers\code\modules\security\secmed\automapper.dm"
 #include "modular_zubbers\code\modules\security\secmed\secmed_clothes.dm"
 #include "modular_zubbers\code\modules\security\secmed\security_medic.dm"


### PR DESCRIPTION
## About The Pull Request

Regenerative Crossbreed Slime Cores only work on the dead, and not the living.
Regenerative Crossbreed  Slime Cores heal only damage (brute, burn, tox, oxy, stamina) and not things like diseases, blood, and wounds.

## Why It's Good For The Game

Regenerative Slimes Cores are more powerful and more long lasting than Legion Regen Cores. It doesn't make sense that this interferes with a mechanic that already exists, especially when it's better.

One might argue this stepson medicals toes, however medical is generally quite quick to revive someone by healing all damage (wound tending), and this doesn't affect other sources of damage like blood loss and wounds.

This should be a good balance alternative.

## Proof Of Testing

If it compiles, it works.

## Changelog

:cl: BurgerBB
balance: Regenerative Crossbreed Slime Cores only work on the dead, and not the living.
balance: Regenerative Crossbreed  Slime Cores heal only damage (brute, burn, tox, oxy, stamina) and not things like diseases, blood, and wounds.
/:cl:
