### PR TITLE
Increases Stabilized Bluespace Extract cooldown from 2 minutes to 10 minutes. 

### DIFF
--- a/modular_zubbers/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/modular_zubbers/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -1,0 +1,2 @@
+/datum/status_effect/bluespacestabilization
+	duration = 10 MINUTES

--- a/modular_zubbers/code/modules/research/xenobiology/crossbreeding/stabilized.dm
+++ b/modular_zubbers/code/modules/research/xenobiology/crossbreeding/stabilized.dm
@@ -1,0 +1,2 @@
+/obj/item/slimecross/stabilized/bluespace
+	effect_desc = "On a ten minute cooldown, when the owner has taken more than 5 damage, they are teleported to a safe place."

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9141,6 +9141,8 @@
 #include "modular_zubbers\code\modules\research\designs\misc_designs.dm"
 #include "modular_zubbers\code\modules\research\designs\nerd_designs.dm"
 #include "modular_zubbers\code\modules\research\techweb\all_nodes.dm"
+#include "modular_zubbers\code\modules\research\xenobiology\crossbreeding\_status_effects.dm"
+#include "modular_zubbers\code\modules\research\xenobiology\crossbreeding\stabilized.dm"
 #include "modular_zubbers\code\modules\security\secmed\automapper.dm"
 #include "modular_zubbers\code\modules\security\secmed\secmed_clothes.dm"
 #include "modular_zubbers\code\modules\security\secmed\security_medic.dm"


### PR DESCRIPTION
## About The Pull Request

Increases Stabilized Bluespace Extract cooldown from 2 minutes to 10 minutes. 

## Why It's Good For The Game

A 2 minute instant teleport cooldown when you take damage is absurd. 10 minutes seems more fair for what it actually does.

## Proof Of Testing

If it compiles, it works.

## Changelog

:cl: BurgerBB
balance: A 2 minute instant teleport cooldown when you take damage is absurd. 10 minutes seems more fair for what it actually does.

/:cl:
