### PR TITLE
Adds yt-dlp authentication

### DIFF
--- a/config/bubbers/bubbers_config.txt
+++ b/config/bubbers/bubbers_config.txt
@@ -16,3 +16,13 @@ INTERN_THRESHOLD_COMMAND 20
 # Vetted player system
 ## If enabled, it will use checks to determine if a player is vetted or not in different parts of the game
 #CHECK_VETTED
+
+## YT-DLP AUTHENTICATION - WARNING DO NOT PUT PASSWORDS ON ANY PUBLIC FACING REPOS
+## Uncomment to enable yt-dlp authentication
+#YOUTUBE_AUTH
+
+##Authentication username
+#YOUTUBE_USERNAME your_username_here
+
+##Authentication Password
+#YOUTUBE_PASSWORD yourpassword123

--- a/modular_skyrat/modules/admin/code/localsound.dm
+++ b/modular_skyrat/modules/admin/code/localsound.dm
@@ -18,7 +18,8 @@
 	var/duration = 0
 	if(istext(input))
 		var/shell_scrubbed_input = shell_url_scrub(input)
-		var/list/output = world.shelleo("[ytdl] --geo-bypass --format \"bestaudio\[ext=mp3]/best\[ext=mp4]\[height <= 360]/bestaudio\[ext=m4a]/bestaudio\[ext=aac]\" --dump-single-json --no-playlist -- \"[shell_scrubbed_input]\"")
+		// BUBBER EDIT - YOUTUB AUTHENTICATION
+		var/list/output = world.shelleo("[ytdl] --geo-bypass [CONFIG_GET(flag/youtube_auth) ? "--username [CONFIG_GET(string/youtube_username)] --password [CONFIG_GET(string/youtube_password)]": ""] --format \"bestaudio\[ext=mp3]/best\[ext=mp4]\[height <= 360]/bestaudio\[ext=m4a]/bestaudio\[ext=aac]\" --dump-single-json --no-playlist -- \"[shell_scrubbed_input]\"")
 		var/errorlevel = output[SHELLEO_ERRORLEVEL]
 		var/stdout = output[SHELLEO_STDOUT]
 		var/stderr = output[SHELLEO_STDERR]

--- a/modular_skyrat/modules/admin/code/localsound.dm
+++ b/modular_skyrat/modules/admin/code/localsound.dm
@@ -18,8 +18,13 @@
 	var/duration = 0
 	if(istext(input))
 		var/shell_scrubbed_input = shell_url_scrub(input)
-		// BUBBER EDIT - YOUTUB AUTHENTICATION
-		var/list/output = world.shelleo("[ytdl] --geo-bypass [CONFIG_GET(flag/youtube_auth) ? "--username [CONFIG_GET(string/youtube_username)] --password [CONFIG_GET(string/youtube_password)]": ""] --format \"bestaudio\[ext=mp3]/best\[ext=mp4]\[height <= 360]/bestaudio\[ext=m4a]/bestaudio\[ext=aac]\" --dump-single-json --no-playlist -- \"[shell_scrubbed_input]\"")
+		// BUBBER EDIT - YOUTUBE AUTHENTICATION
+		var/list/output
+		if(CONFIG_GET(flag/youtube_auth))
+			output = world.shelleo("[ytdl] --geo-bypass --username [CONFIG_GET(string/youtube_username)] --password [CONFIG_GET(string/youtube_password)] --format \"bestaudio\[ext=mp3]/best\[ext=mp4]\[height <= 360]/bestaudio\[ext=m4a]/bestaudio\[ext=aac]\" --dump-single-json --no-playlist -- \"[shell_scrubbed_input]\"")
+		else
+			output = world.shelleo("[ytdl] --geo-bypass --format \"bestaudio\[ext=mp3]/best\[ext=mp4]\[height <= 360]/bestaudio\[ext=m4a]/bestaudio\[ext=aac]\" --dump-single-json --no-playlist -- \"[shell_scrubbed_input]\"")
+		// BUBBER EDIT END
 		var/errorlevel = output[SHELLEO_ERRORLEVEL]
 		var/stdout = output[SHELLEO_STDOUT]
 		var/stderr = output[SHELLEO_STDERR]

--- a/modular_zubbers/code/controllers/configuration/entries/general.dm
+++ b/modular_zubbers/code/controllers/configuration/entries/general.dm
@@ -1,0 +1,7 @@
+/datum/config_entry/flag/youtube_auth
+
+/datum/config_entry/string/youtube_username
+	protection = CONFIG_ENTRY_LOCKED | CONFIG_ENTRY_HIDDEN
+
+/datum/config_entry/string/youtube_password
+	protection = CONFIG_ENTRY_LOCKED | CONFIG_ENTRY_HIDDEN

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8598,6 +8598,7 @@
 #include "modular_zubbers\code\_globalvars\lists\quirks.dm"
 #include "modular_zubbers\code\_globalvars\lists\~maintenance_loot.dm"
 #include "modular_zubbers\code\_onclick\hud\screen_objects\hud_timer.dm"
+#include "modular_zubbers\code\controllers\configuration\entries\general.dm"
 #include "modular_zubbers\code\controllers\configuration\entries\nsfw.dm"
 #include "modular_zubbers\code\controllers\subsystem\air.dm"
 #include "modular_zubbers\code\controllers\subsystem\mapping.dm"


### PR DESCRIPTION
Adds some authentication configs for the yt-dlp command so I can hopefully have the server use a throwaway account for internet request sounds.