### PR TITLE
More Alternate Job Names!

### DIFF
--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -93,6 +93,7 @@
 		"Blueshield",
 		"Command Bodyguard",
 		"Executive Protection Agent",
+		"Command Protection Officer",
 	)
 
 /datum/job/botanist
@@ -269,6 +270,7 @@
 		"Forensic Scientist",
 		"Forensic Technician",
 		"Private Investigator",
+		"CID Officer",
 	)
 
 /datum/job/doctor
@@ -363,6 +365,7 @@
 		"Central Command Representative",
 		"Central Command Liason",
 		"Corporate Liason",
+		"Corporate Consultant",
 	)
 
 /datum/job/orderly
@@ -461,6 +464,8 @@
 		"Security Cadet",
 		"Junior Officer",
 		"Security Assistant",
+		"Security Specialist",
+		"Defense Contractor",
 	)
 
 /datum/job/shaft_miner
@@ -472,6 +477,8 @@
 		"Prospector",
 		"Spelunker",
 		"Apprentice Miner",
+		"Dredger",
+		"Contract Miner",
 	)
 
 /datum/job/station_engineer

--- a/modular_zubbers/code/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_zubbers/code/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -5,6 +5,7 @@
 		"Security Corpsman",
 		"Brig Physician",
 		"Combat Medic",
+		"Special Operations Medic",
 	)
 
 /datum/job/blueshield/New()

--- a/modular_zubbers/code/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_zubbers/code/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -19,3 +19,16 @@
 		"Medical Support Technician",
 	)
 	. = ..()
+
+//New titles for Blacksmith
+/datum/job/blacksmith
+	alt_titles = list(
+		"Ithastrist",
+		"Metalurgist",
+		"Metal Worker",
+		"Metalsmith",
+		"Forge Artisan",
+		"Forgemaster",
+		"Weaponsmith",
+		"Armorsmith",
+	)

--- a/tgui/packages/tgui/interfaces/common/JobToIcon.ts
+++ b/tgui/packages/tgui/interfaces/common/JobToIcon.ts
@@ -105,6 +105,7 @@ const ALTTITLES = {
   // Blueshield - shield-dog
   'Command Bodyguard': BASEICONS['Blueshield'],
   'Executive Protection Agent': BASEICONS['Blueshield'],
+  'Command Protection Officer': BASEICONS['Blueshield'],
   Henchman: BASEICONS['Blueshield'],
   // Botanist - seedling
   Hydroponicist: BASEICONS['Botanist'],
@@ -169,6 +170,7 @@ const ALTTITLES = {
   'Forensic Technician': BASEICONS['Detective'],
   'Private Investigator': BASEICONS['Detective'],
   'Forensic Scientist': BASEICONS['Detective'],
+  'CID Officer': BASEICONS['Detective'],
   // Geneticist - dna
   'Mutation Researcher': BASEICONS['Geneticist'],
   // Head of Personnel - dog
@@ -205,6 +207,7 @@ const ALTTITLES = {
   Pantomimist: BASEICONS['Mime'],
   // Nanotrasen Consultant - clipboard-check
   'Nanotrasen Diplomat': BASEICONS['Nanotrasen Consultant'],
+  'Corporate Consultant': BASEICONS['Nanotrasen Consultant'],
   // Paramedic - truck-medical
   'Emergency Medical Technician': BASEICONS['Paramedic'],
   'Search and Rescue Technician': BASEICONS['Paramedic'],
@@ -256,6 +259,8 @@ const ALTTITLES = {
   'Combat Medic': BASEICONS['Security Medic'],
   // Security Officer - shield-halved
   'Security Operative': BASEICONS['Security Officer'],
+  'Security Specialist': BASEICONS['Security Officer'],
+  'Defense Contractor': BASEICONS['Security Officer'],
   Peacekeeper: BASEICONS['Security Officer'],
   'Security Cadet': BASEICONS['Security Officer'],
   // Shaft Miner - digging
@@ -264,6 +269,8 @@ const ALTTITLES = {
   Spelunker: BASEICONS['Shaft Miner'],
   'Drill Technician': BASEICONS['Shaft Miner'],
   Prospector: BASEICONS['Shaft Miner'],
+  Dredger: BASEICONS['Shaft Miner'],
+  'Contract Miner': BASEICONS['Shaft Miner'],
   // Station Engineer - gears
   'Emergency Damage Control Technician': BASEICONS['Station Engineer'],
   Electrician: BASEICONS['Station Engineer'],


### PR DESCRIPTION
## About The Pull Request

We already have a boat-load; why not more?

**Blueshield:**
- Command Protection Officer

**Detective:**
- CID Officer

**Nanotrasen Representative:**
- Corporate Consultant

**Security Officer:**
- Security Specialist
- Defense Contractor

**Shaft Miner:**
- Dredger
- Contract Miner

I have not tested this. It _shouldn't_ have issues, given it's just a few more alt-job names, all properly formatted.

## Why It's Good For The Game

It gives players more options as far as who they feel they're playing as. I know there's a Security Union, for example, that may want to be represented differently. 

## Changelog

:cl: Bangle
spellcheck: Added some alt titles
/:cl: