### PR TITLE
Remove random space air alarm from boxstation

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -55192,7 +55192,6 @@
 /turf/open/floor/eighties,
 /area/station/maintenance/abandon_arcade)
 "sad" = (
-/obj/machinery/airalarm/directional/west,
 /obj/effect/spawner/random/structure/grille,
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,


### PR DESCRIPTION
## About The Pull Request

Removes the air alarm that's out in space near the incinerator on BoxStation because I don't think it's supposed to be there and it just gives a priority alert to Engineers all round that there's no air in Space.

## Why It's Good For The Game

I don't think we need to monitor the atmosphere in Space.

## Proof Of Testing

Trust me (or check the map diff)

## Changelog

:cl:
del: Remove air alarm in Space from BoxStation.
/:cl: