### PR TITLE
Fix job title in head arrival radio messages being empty

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -561,7 +561,7 @@ SUBSYSTEM_DEF(job)
 /datum/controller/subsystem/job/proc/EquipRank(mob/living/equipping, datum/job/job, client/player_client)
 	// SKYRAT EDIT ADDITION BEGIN - ALTERNATIVE_JOB_TITLES
 	// The alt job title, if user picked one, or the default
-	var/alt_title = player_client?.prefs.alt_job_titles[job.title]
+	var/alt_title = player_client?.prefs.alt_job_titles[job.title] || job.title
 	// SKYRAT EDIT ADDITION END
 
 	equipping.job = job.title


### PR DESCRIPTION
## About The Pull Request

Add back the `|| job.title` fallback for if the user isn't using an alt job title for a given job, because it went missing in https://github.com/Skyrat-SS13/Skyrat-tg/pull/23990 for some reason

## Why It's Good For The Game

Fixes #2214 

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/6a857a35-1f0f-49b0-b61b-2a615be04183)

</details>

## Changelog

:cl:
fix: fixed department head arrival radio messages missing their job title
/:cl:
