### PR TITLE
Update compile changelogs Github action

### DIFF
--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -2,7 +2,7 @@ name: Compile changelogs
 
 on:
   schedule:
-  - cron: "0 0 * * *"
+  - cron: "0 8 * * *"
   workflow_dispatch:
 
 jobs:
@@ -49,11 +49,11 @@ jobs:
       - name: Commit
         if: steps.value_holder.outputs.ACTIONS_ENABLED
         run: |
-          git config --local user.name "tgstation-ci[bot]"
-          git config --local user.email "179393467+tgstation-ci[bot]@users.noreply.github.com"
+          git config --local user.name "Bubberbot[bot]"
+          git config --local user.email "151680451+Bubberbot@users.noreply.github.com"
           git pull origin master
           git add html/changelogs
-          git commit -m "Automatic changelog compile [ci skip]" -a || true
+          git commit -m "Bubberstation automatic changelog compile [ci skip]" -a || true
 
       - name: Generate App Token
         id: app-token-generation

--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Commit
         if: steps.value_holder.outputs.ACTIONS_ENABLED
         run: |
-          git config --local user.name "Bubberbot[bot]"
+          git config --local user.name "Bubberbot"
           git config --local user.email "151680451+Bubberbot@users.noreply.github.com"
           git pull origin master
           git add html/changelogs


### PR DESCRIPTION
## About The Pull Request

Updates compile_changelogs with Bubberbot information and a different commit name to differentiate the commits from tgstation changelog compiles.

Now that we're a direct downstream, we can automatically compile our changelogs so long as we properly skip tgstation changelog compiles.

## Changelog

n/a