### PR TITLE
Moonstation GMM removal

### DIFF
--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -61126,12 +61126,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/crew_quarters/bar)
-"qUQ" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "qUY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -64627,7 +64621,6 @@
 /area/station/security/brig/entrance)
 "rTb" = (
 /obj/effect/turf_decal/siding/dark,
-/obj/machinery/materials_market,
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
 "rTn" = (
@@ -240197,7 +240190,7 @@ oyB
 fKU
 aIy
 rTb
-qUQ
+bjf
 jAO
 ith
 hwz


### PR DESCRIPTION
#2242 was a dirty map merge and I reverted it.

@YakumoChen byond's native tools are depreciated. Strong.dmm is far better and robust to use, regardless. https://github.com/SpaiR/StrongDMM