### PR TITLE
Reverts #2263 - restoring beaker capacity to original, original values, plus changes cryo beaker for consistency

### DIFF
--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -224,7 +224,7 @@
 
 /obj/item/reagent_containers/cup/beaker
 	name = "beaker"
-	desc = "A beaker. It can hold up to 60 units." //BubberEdit
+	desc = "A beaker. It can hold up to 50 units."
 	icon = 'icons/obj/medical/chemical.dmi'
 	icon_state = "beaker"
 	inhand_icon_state = "beaker"
@@ -236,8 +236,6 @@
 	pickup_sound = 'sound/items/handling/beaker_pickup.ogg'
 	drop_sound = 'sound/items/handling/beaker_place.ogg'
 	sound_vary = TRUE
-	volume = 60 //BubberEdit addition
-	possible_transfer_amounts = list(5,10,15,20,30,60) //BubberEdit addition
 
 /obj/item/reagent_containers/cup/beaker/Initialize(mapload)
 	. = ..()
@@ -254,22 +252,22 @@
 
 /obj/item/reagent_containers/cup/beaker/large
 	name = "large beaker"
-	desc = "A large beaker. Can hold up to 120 units." //BubberEdit
+	desc = "A large beaker. Can hold up to 100 units."
 	icon_state = "beakerlarge"
 	custom_materials = list(/datum/material/glass= SHEET_MATERIAL_AMOUNT*1.25)
-	volume = 120 //BubberEdit
+	volume = 100
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(5,10,15,20,30,40,60,120) //BubberEdit
+	possible_transfer_amounts = list(5,10,15,20,25,30,50,100)
 	fill_icon_thresholds = list(0, 1, 20, 40, 60, 80, 100)
 
 /obj/item/reagent_containers/cup/beaker/plastic
 	name = "x-large beaker"
-	desc = "An extra-large beaker. Can hold up to 150 units." //BubberEdit
+	desc = "An extra-large beaker. Can hold up to 120 units."
 	icon_state = "beakerwhite"
 	custom_materials = list(/datum/material/glass=SHEET_MATERIAL_AMOUNT*1.25, /datum/material/plastic=SHEET_MATERIAL_AMOUNT * 1.5)
-	volume = 150
+	volume = 120
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(5,10,15,20,25,30,50,75,150) //BubberEdit
+	possible_transfer_amounts = list(5,10,15,20,25,30,60,120)
 	fill_icon_thresholds = list(0, 1, 10, 20, 40, 60, 80, 100)
 
 /obj/item/reagent_containers/cup/beaker/meta
@@ -285,12 +283,11 @@
 /obj/item/reagent_containers/cup/beaker/noreact
 	name = "cryostasis beaker"
 	desc = "A cryostasis beaker that allows for chemical storage without \
-		reactions. Can hold up to 60 units." //BubberEdit
+		reactions. Can hold up to 50 units."
 	icon_state = "beakernoreact"
 	custom_materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT * 1.5)
 	reagent_flags = OPENCONTAINER | NO_REACT
-	volume = 60 //BubberEdit
-	possible_transfer_amounts = list(5,10,15,20,30,60) //BubberEdit addition
+	volume = 50
 	amount_per_transfer_from_this = 10
 
 /obj/item/reagent_containers/cup/beaker/bluespace

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -224,7 +224,7 @@
 
 /obj/item/reagent_containers/cup/beaker
 	name = "beaker"
-	desc = "A beaker. It can hold up to 50 units."
+	desc = "A beaker. It can hold up to 60 units." //BubberEdit
 	icon = 'icons/obj/medical/chemical.dmi'
 	icon_state = "beaker"
 	inhand_icon_state = "beaker"
@@ -236,6 +236,8 @@
 	pickup_sound = 'sound/items/handling/beaker_pickup.ogg'
 	drop_sound = 'sound/items/handling/beaker_place.ogg'
 	sound_vary = TRUE
+	volume = 60 //BubberEdit addition
+	possible_transfer_amounts = list(5,10,15,20,30,60) //BubberEdit addition
 
 /obj/item/reagent_containers/cup/beaker/Initialize(mapload)
 	. = ..()
@@ -252,22 +254,22 @@
 
 /obj/item/reagent_containers/cup/beaker/large
 	name = "large beaker"
-	desc = "A large beaker. Can hold up to 100 units."
+	desc = "A large beaker. Can hold up to 120 units." //BubberEdit
 	icon_state = "beakerlarge"
 	custom_materials = list(/datum/material/glass= SHEET_MATERIAL_AMOUNT*1.25)
-	volume = 100
+	volume = 120 //BubberEdit
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(5,10,15,20,25,30,50,100)
+	possible_transfer_amounts = list(5,10,15,20,30,40,60,120) //BubberEdit
 	fill_icon_thresholds = list(0, 1, 20, 40, 60, 80, 100)
 
 /obj/item/reagent_containers/cup/beaker/plastic
 	name = "x-large beaker"
-	desc = "An extra-large beaker. Can hold up to 120 units."
+	desc = "An extra-large beaker. Can hold up to 150 units." //BubberEdit
 	icon_state = "beakerwhite"
 	custom_materials = list(/datum/material/glass=SHEET_MATERIAL_AMOUNT*1.25, /datum/material/plastic=SHEET_MATERIAL_AMOUNT * 1.5)
-	volume = 120
+	volume = 150
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(5,10,15,20,25,30,60,120)
+	possible_transfer_amounts = list(5,10,15,20,25,30,50,75,150) //BubberEdit
 	fill_icon_thresholds = list(0, 1, 10, 20, 40, 60, 80, 100)
 
 /obj/item/reagent_containers/cup/beaker/meta
@@ -283,11 +285,12 @@
 /obj/item/reagent_containers/cup/beaker/noreact
 	name = "cryostasis beaker"
 	desc = "A cryostasis beaker that allows for chemical storage without \
-		reactions. Can hold up to 50 units."
+		reactions. Can hold up to 60 units." //BubberEdit
 	icon_state = "beakernoreact"
 	custom_materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT * 1.5)
 	reagent_flags = OPENCONTAINER | NO_REACT
-	volume = 50
+	volume = 60 //BubberEdit
+	possible_transfer_amounts = list(5,10,15,20,30,60) //BubberEdit addition
 	amount_per_transfer_from_this = 10
 
 /obj/item/reagent_containers/cup/beaker/bluespace

--- a/modular_skyrat/master_files/code/modules/mapfluff/ruins/spaceruin_code/oldstation/oldstation_cytology.dm
+++ b/modular_skyrat/master_files/code/modules/mapfluff/ruins/spaceruin_code/oldstation/oldstation_cytology.dm
@@ -1,3 +1,3 @@
-// Beakers capacity 50u -> 60u
+// Beakers capacity default is 50
 /obj/item/reagent_containers/cup/beaker/oldstation
-	amount_per_transfer_from_this = 60
+	amount_per_transfer_from_this = 50

--- a/modular_skyrat/master_files/code/modules/mapfluff/ruins/spaceruin_code/oldstation/oldstation_cytology.dm
+++ b/modular_skyrat/master_files/code/modules/mapfluff/ruins/spaceruin_code/oldstation/oldstation_cytology.dm
@@ -1,3 +1,2 @@
-// Beakers capacity default is 50
 /obj/item/reagent_containers/cup/beaker/oldstation
-	amount_per_transfer_from_this = 50
+	amount_per_transfer_from_this = 60

--- a/modular_zubbers/master_files/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/modular_zubbers/master_files/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -1,0 +1,19 @@
+/obj/item/reagent_containers/cup/beaker
+	desc = "A beaker. It can hold up to 60 units."
+	volume = 60
+	possible_transfer_amounts = list(5,10,15,20,30,60)
+
+/obj/item/reagent_containers/cup/beaker/large
+	desc = "A large beaker. Can hold up to 120 units."
+	volume = 120
+	possible_transfer_amounts = list(5,10,15,20,30,40,60,120)
+
+/obj/item/reagent_containers/cup/beaker/plastic
+	desc = "An extra-large beaker. Can hold up to 150 units."
+	possible_transfer_amounts = list(5,10,15,20,25,30,50,75,150)
+
+/obj/item/reagent_containers/cup/beaker/noreact
+	desc = "A cryostasis beaker that allows for chemical storage without \
+		reactions. Can hold up to 60 units."
+	volume = 60
+	possible_transfer_amounts = list(5,10,15,20,30,60)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9353,6 +9353,7 @@
 #include "modular_zubbers\master_files\code\modules\mob\living\carbon\human\species_types\ethereal.dm"
 #include "modular_zubbers\master_files\code\modules\mob\living\carbon\human\species_types\plasmamen.dm"
 #include "modular_zubbers\master_files\code\modules\mod\mod_control.dm"
+#include "modular_zubbers\master_files\code\modules\reagents\reagent_containers\cups\_cup.dm"
 #include "modular_zubbers\master_files\code\modules\research\designs\biogenerator_designs.dm"
 #include "modular_zubbers\master_files\code\modules\research\designs\weapon_designs.dm"
 #include "modular_zubbers\master_files\skyrat\modules\blueshield\code\blueshield.dm"


### PR DESCRIPTION
## About The Pull Request

Reverts #2263 and changes cryo beaker to 60u

## Why It's Good For The Game

Let me be frank, the beaker nerf pr was just pushed through github with most of the players finding out from the changelog - the reaction on discord has been... rather negative, even the #2263 discussion and reacion on github is mostly negative, yet it was merged anyways.

It was a wide scale nerf to both roundstart medsci and service (which cannot print the upgraded beakers...) and it was poorly supported with the main motivation being to make medical cook plastic... which can be easily obtained by just asking... or in 2 different ways from cargo. Nerfing chemistry, medicine, science and service over it is... bad and annoying? 

Reverting the changes avoids the nerfs and pointless disruption to the game. Also more beaker space is good, as https://github.com/Skyrat-SS13/Skyrat-tg/pull/3226 put it...

As for the cryo beaker i mostly did it for consistency with small beakers... and maybe making someone use it.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: beakers are 60u/120u again
balance: changes cryo beaker to 60u from 50u
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
