### PR TITLE
Fix Tarkon Fax Machine

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon.dmm
@@ -4805,11 +4805,7 @@
 "HE" = (
 /obj/effect/turf_decal/tile/blue/half,
 /obj/structure/table/reinforced,
-/obj/machinery/fax{
-	name = "Port Tarkon Fax Machine";
-	fax_name = "Tarkon Industries Bridge";
-	special_networks = list("tarkon" = list("fax_name" = "Tarkon TB.", "fax_id" = "tarkon_command", "color" = "brown", "emag_needed" = 0))
-	},
+/obj/machinery/fax/tarkon,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/comms)
 "HH" = (

--- a/modular_skyrat/modules/tarkon/code/misc-fluff/fax.dm
+++ b/modular_skyrat/modules/tarkon/code/misc-fluff/fax.dm
@@ -1,0 +1,7 @@
+/obj/machinery/fax/tarkon
+	name = "Port Tarkon Fax Machine";
+	fax_name = "Tarkon Industries Bridge";
+
+/obj/machinery/fax/tarkon/Initialize(mapload)
+	. = ..()
+	special_networks["tarkon"] = list("fax_name" = "Tarkon TB.", "fax_id" = "tarkon_command", "color" = "brown", "emag_needed" = 0)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8547,6 +8547,7 @@
 #include "modular_skyrat\modules\tarkon\code\guns\resonance_disruptor.dm"
 #include "modular_skyrat\modules\tarkon\code\misc-fluff\atmos_control.dm"
 #include "modular_skyrat\modules\tarkon\code\misc-fluff\card.dm"
+#include "modular_skyrat\modules\tarkon\code\misc-fluff\fax.dm"
 #include "modular_skyrat\modules\tarkon\code\misc-fluff\fluff.dm"
 #include "modular_skyrat\modules\tarkon\code\misc-fluff\radio.dm"
 #include "modular_skyrat\modules\tarkon\code\misc-fluff\research.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Create a subtype of the fax machine that has Tarkon Command as a contact, replace var-edited fax machine in Port Tarkon with this.

## Why It's Good For The Game

The var-edited one runtimes because `Initialize()` in fax machine code tries to populate the CentCom contact but the variable edit has overwritten `special_networks` with its own list (if the Tarkon one is not intended to have CentCom listed please let me know so I can change the PR to make that the case).

## Proof Of Testing

Trust ‼️ 
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
fix: The fax machine in Port Tarkon should no longer give a TGUI error.
/:cl: