### PR TITLE
Fix storyteller null event runtime

### DIFF
--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/_storyteller.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/_storyteller.dm
@@ -138,4 +138,4 @@
 			///If the event has occured already, apply a penalty multiplier based on amount of occurences
 			weight_total -= event.reoccurence_penalty_multiplier * weight_total * (1 - (event_repetition_multiplier ** occurences))
 		/// Write it
-		event.calculated_weight = weight_total
+		event.calculated_weight = round(weight_total, 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a semi-frequent runtime in storyteller code that causes CI to fail, see: 
https://github.com/Bubberstation/Bubberstation/actions/runs/11641923588/job/32420967445
https://github.com/Bubberstation/Bubberstation/actions/runs/11641923588/job/32420968238

for examples, this is caused by calculated weights for events often being non-whole numbers, which are then fed into `pick_weight` which is explicitly designed to only handle integers. 

Fixes https://github.com/Bubberstation/Bubberstation/issues/1969

## Why It's Good For The Game

One less cause of checks randomly failing.

## Proof Of Testing

Hard to prove lack of errors but I did a unit test that ran `find_and_buy_event_from_track` 200 times in a row and before this change it always failed and after this change it doesn't.

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: find_and_buy_event_from_track should no longer randomly fail.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
