### PR TITLE
Makes ruin generation like a million times faster

### DIFF
--- a/_maps/moonstation.json
+++ b/_maps/moonstation.json
@@ -18,7 +18,7 @@
 			"Mining": true,
 			"Linkage": null,
 			"Gravity": true,
-			"Lava Ruins": true,
+			"Moonstation Ruins": true,
 			"Baseturf": "/turf/open/lava/smooth/lava_land_surface",
 			"No Parallax": true
 		},

--- a/modular_zubbers/code/__DEFINES/moonstation_defines.dm
+++ b/modular_zubbers/code/__DEFINES/moonstation_defines.dm
@@ -2,3 +2,4 @@
 #define MOONSTATION_ATMOS_CAVE LAVALAND_DEFAULT_ATMOS
 
 #define ZTRAIT_SANDSTORM "Weather_Sandstorm"
+#define ZTRAIT_MOONSTATION_RUINS "Moonstation Ruins"

--- a/modular_zubbers/code/controllers/subsystem/mapping.dm
+++ b/modular_zubbers/code/controllers/subsystem/mapping.dm
@@ -3,12 +3,12 @@
 /datum/controller/subsystem/mapping/setup_rivers()
 	. = ..()
 	// Generate mining ruins
-	var/list/lava_ruins = levels_by_trait(ZTRAIT_LAVA_RUINS)
+	var/list/lava_ruins = levels_by_trait(ZTRAIT_MOONSTATION_RUINS)
 	for (var/lava_z in lava_ruins)
 		spawn_rivers(lava_z, 4, /turf/open/lava/smooth/lava_land_surface, /area/lavaland/underground/unexplored)
 
 /datum/controller/subsystem/mapping/setup_ruins()
 	. = ..()
-	var/list/lava_ruins = levels_by_trait(ZTRAIT_LAVA_RUINS)
+	var/list/lava_ruins = levels_by_trait(ZTRAIT_MOONSTATION_RUINS)
 	if (lava_ruins.len)
 		seedRuins(lava_ruins, CONFIG_GET(number/lavaland_budget), list(/area/lavaland/underground/unexplored), themed_ruins[ZTRAIT_LAVA_RUINS], clear_below = TRUE)


### PR DESCRIPTION
## About The Pull Request
Create a separate ZTRAIT for the lowest level of moonstation, use that when running the moonstation-specific ruin generation (still pulls from the lavaland ruin pool). This is because currently ruin generation runs twice on every map, the first time with an area whitelist of Lavaland Wastes (the /area used for the actual lavaland z-level), and then again with an area whitelist of Lavaland Caves (the /area used for the lowest z-level of moonstation). Each map only contains one of those two areas, meaning one of the generation runs will fail for every single ruin, exhausting 100 attempts per ruin, every time. 

## Why It's Good For The Game
Faster server load times and hopefully no CI timing out.

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
Before:

![image](https://github.com/user-attachments/assets/62b03010-b80c-48a7-8803-96315a21b9ef)

After:

![image](https://github.com/user-attachments/assets/ce210eb0-ce3d-45fe-855d-7408b1f37be5)

</details>

## Changelog
:cl:
fix: The game should no longer run ruin generation twice.
/:cl:
