### PR TITLE
Fixes upgraded power cell not showing a charge indicator

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -51,9 +51,11 @@
 	custom_materials = list(/datum/material/glass=SMALL_MATERIAL_AMOUNT*0.5)
 	chargerate = STANDARD_CELL_RATE * 0.5
 
+/* BUBBER EDIT REMOVAL BEGIN - New icon in modular_skyrat/modules/aesthetics/cells/cell.dm
 /obj/item/stock_parts/power_store/cell/upgraded/Initialize(mapload)
 	AddElement(/datum/element/update_icon_blocker)
 	return ..()
+*/// BUBBER EDIT REMOVAL END
 
 /obj/item/stock_parts/power_store/cell/upgraded/plus
 	name = "upgraded power cell+"


### PR DESCRIPTION
## About The Pull Request

Does as it says on the tin

## Why It's Good For The Game

Bugs bad, full batteries don't look like they're empty.

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/a148bfe7-b2f9-4bc2-aea6-b8fd772506fd)

</details>

## Changelog

:cl: LT3
fix: Fixed upgraded power cells always showing red/empty.
/:cl: