### PR TITLE
Makes ascensions flavor only

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/ash_lore.dm
@@ -234,7 +234,7 @@
 		color_override = "pink",
 	)
 
-	var/datum/action/cooldown/spell/fire_sworn/circle_spell = new(user.mind)
+	/*var/datum/action/cooldown/spell/fire_sworn/circle_spell = new(user.mind)
 	circle_spell.Grant(user)
 
 	var/datum/action/cooldown/spell/fire_cascade/big/screen_wide_fire_spell = new(user.mind)
@@ -250,4 +250,4 @@
 	fiery_rebirth?.cooldown_time *= 0.16
 
 	if(length(traits_to_apply))
-		user.add_traits(traits_to_apply, MAGIC_TRAIT)
+		user.add_traits(traits_to_apply, MAGIC_TRAIT)*/ // BUBBER EDIT REMOVAL - Pointless ascensions

--- a/code/modules/antagonists/heretic/knowledge/blade_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/blade_lore.dm
@@ -426,7 +426,7 @@
 		sound = 'sound/music/antag/heretic/ascend_blade.ogg',
 		color_override = "pink",
 	)
-	ADD_TRAIT(user, TRAIT_NEVER_WOUNDED, name)
+	/*ADD_TRAIT(user, TRAIT_NEVER_WOUNDED, name)
 	RegisterSignal(user, COMSIG_HERETIC_BLADE_ATTACK, PROC_REF(on_eldritch_blade))
 	user.apply_status_effect(/datum/status_effect/protective_blades/recharging, null, 8, 30, 0.25 SECONDS, 1 MINUTES)
 	user.add_stun_absorption(
@@ -448,6 +448,7 @@
 
 	var/mob/living/carbon/human/heretic = user
 	heretic.physiology.knockdown_mod = 0.75 // Otherwise knockdowns would probably overpower the stun absorption effect.
+	*/ // BUBBER EDIT REMOVAL - Pointless ascensions
 
 /datum/heretic_knowledge/ultimate/blade_final/proc/on_eldritch_blade(mob/living/source, mob/living/target, obj/item/melee/sickly_blade/blade)
 	SIGNAL_HANDLER

--- a/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
@@ -281,7 +281,7 @@
 	. = ..()
 	priority_announce(
 		//text = "[generate_heretic_text()] A Star Gazer has arrived into the station, [user.real_name] has ascended! This station is the domain of the Cosmos! [generate_heretic_text()]", // BUBBER EDIT CHANGE - Changing text to be accurate
-		text = "[generate_heretic_text()] [user.real_name] has ascended! This station is the domain of the Cosmos! [generate_heretic_text()]",
+		text = "[generate_heretic_text()] [user.real_name] has ascended! This station is the domain of the Cosmos! [generate_heretic_text()]", // BUBBER EDIT ADDITION
 		title = "[generate_heretic_text()]",
 		sound = 'sound/music/antag/heretic/ascend_cosmic.ogg',
 		color_override = "pink",

--- a/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
@@ -280,12 +280,13 @@
 /datum/heretic_knowledge/ultimate/cosmic_final/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
 	. = ..()
 	priority_announce(
-		text = "[generate_heretic_text()] A Star Gazer has arrived into the station, [user.real_name] has ascended! This station is the domain of the Cosmos! [generate_heretic_text()]",
+		//text = "[generate_heretic_text()] A Star Gazer has arrived into the station, [user.real_name] has ascended! This station is the domain of the Cosmos! [generate_heretic_text()]", // BUBBER EDIT CHANGE - Changing text to be accurate
+		text = "[generate_heretic_text()] [user.real_name] has ascended! This station is the domain of the Cosmos! [generate_heretic_text()]",
 		title = "[generate_heretic_text()]",
 		sound = 'sound/music/antag/heretic/ascend_cosmic.ogg',
 		color_override = "pink",
 	)
-	var/mob/living/basic/heretic_summon/star_gazer/star_gazer_mob = new /mob/living/basic/heretic_summon/star_gazer(loc)
+	/*var/mob/living/basic/heretic_summon/star_gazer/star_gazer_mob = new /mob/living/basic/heretic_summon/star_gazer(loc)
 	star_gazer_mob.maxHealth = INFINITY
 	star_gazer_mob.health = INFINITY
 	user.AddComponent(/datum/component/death_linked, star_gazer_mob)
@@ -307,4 +308,4 @@
 	blade_upgrade.increase_amount = 2 SECONDS
 
 	var/datum/action/cooldown/spell/conjure/cosmic_expansion/cosmic_expansion_spell = locate() in user.actions
-	cosmic_expansion_spell?.ascended = TRUE
+	cosmic_expansion_spell?.ascended = TRUE*/ // BUBBER EDIT REMOVAL - Pointless Ascensions

--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -332,7 +332,7 @@
 		sound = 'sound/music/antag/heretic/ascend_flesh.ogg',
 		color_override = "pink",
 	)
-
+	/*
 	var/datum/action/cooldown/spell/shapeshift/shed_human_form/worm_spell = new(user.mind)
 	worm_spell.Grant(user)
 
@@ -344,6 +344,6 @@
 	ritual_ghoul.limit *= 3
 	var/datum/heretic_knowledge/limited_amount/starting/base_flesh/blade_ritual = heretic_datum.get_knowledge(/datum/heretic_knowledge/limited_amount/starting/base_flesh)
 	blade_ritual.limit = 999
-
+	*/ // BUBBER EDIT REMOVAL - Pointless ascensions
 #undef GHOUL_MAX_HEALTH
 #undef MUTE_MAX_HEALTH

--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -243,11 +243,11 @@
 		sound = 'sound/music/antag/heretic/ascend_knock.ogg',
 		color_override = "pink",
 	)
-
+	/*
 	// buffs
 	var/datum/action/cooldown/spell/shapeshift/eldritch/ascension/transform_spell = new(user.mind)
 	transform_spell.Grant(user)
 	var/datum/antagonist/heretic/heretic_datum = GET_HERETIC(user)
 	var/datum/heretic_knowledge/blade_upgrade/flesh/lock/blade_upgrade = heretic_datum.get_knowledge(/datum/heretic_knowledge/blade_upgrade/flesh/lock)
 	blade_upgrade.chance += 30
-	new /obj/structure/lock_tear(loc, user.mind)
+	new /obj/structure/lock_tear(loc, user.mind)*/ // BUBBER EDIT REMOVAL - Pointless ascensions

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -212,7 +212,7 @@
 		color_override = "pink",
 	)
 
-	ADD_TRAIT(user, TRAIT_MADNESS_IMMUNE, REF(src))
+	/*ADD_TRAIT(user, TRAIT_MADNESS_IMMUNE, REF(src))
 	user.mind.add_antag_datum(/datum/antagonist/lunatic/master)
 	RegisterSignal(user, COMSIG_LIVING_LIFE, PROC_REF(on_life))
 
@@ -252,7 +252,7 @@
 		)
 		crewmate.equip_in_one_of_slots(amulet, slots, qdel_on_fail = FALSE)
 		crewmate.emote("laugh")
-		amount_of_lunatics += 1
+		amount_of_lunatics += 1*/ // BUBBER EDIT REMOVAL - Pointless ascensions
 
 /datum/heretic_knowledge/ultimate/moon_final/proc/on_life(mob/living/source, seconds_per_tick, times_fired)
 	var/obj/effect/moon_effect = /obj/effect/temp_visual/moon_ringleader

--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -258,12 +258,12 @@
 		sound = 'sound/music/antag/heretic/ascend_rust.ogg',
 		color_override = "pink",
 	)
-	trigger(loc)
+	/*trigger(loc)
 	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
 	RegisterSignal(user, COMSIG_LIVING_LIFE, PROC_REF(on_life))
 	user.client?.give_award(/datum/award/achievement/misc/rust_ascension, user)
 	var/datum/action/cooldown/spell/aoe/rust_conversion/rust_spread_spell = locate() in user.actions
-	rust_spread_spell?.cooldown_time /= 2
+	rust_spread_spell?.cooldown_time /= 2*/ // BUBBER EDIT REMOVAL - Pointless ascensions
 
 // I sure hope this doesn't have performance implications
 /datum/heretic_knowledge/ultimate/rust_final/proc/trigger(turf/center)

--- a/code/modules/antagonists/heretic/knowledge/void_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/void_lore.dm
@@ -250,7 +250,7 @@
 	)
 	user.add_traits(list(TRAIT_RESISTLOWPRESSURE, TRAIT_NEGATES_GRAVITY, TRAIT_MOVE_FLYING, TRAIT_FREE_HYPERSPACE_MOVEMENT), MAGIC_TRAIT)
 
-	// Let's get this show on the road!
+	/*// Let's get this show on the road!
 	sound_loop = new(user, TRUE, TRUE)
 	RegisterSignal(user, COMSIG_LIVING_LIFE, PROC_REF(on_life))
 	RegisterSignal(user, COMSIG_ATOM_PRE_BULLET_ACT, PROC_REF(hit_by_projectile))
@@ -260,7 +260,7 @@
 		var/mob/living/carbon/human/ascended_human = user
 		var/obj/item/organ/internal/eyes/heretic_eyes = ascended_human.get_organ_slot(ORGAN_SLOT_EYES)
 		heretic_eyes?.color_cutoffs = list(30, 30, 30)
-		ascended_human.update_sight()
+		ascended_human.update_sight()*/ // BUBBER EDIT REMOVAL - Pointless ascensions
 
 /datum/heretic_knowledge/ultimate/void_final/on_lose(mob/user, datum/antagonist/heretic/our_heretic)
 	on_death() // Losing is pretty much dying. I think

--- a/modular_zubbers/code/modules/antagonists/heretic/lore.dm
+++ b/modular_zubbers/code/modules/antagonists/heretic/lore.dm
@@ -1,0 +1,28 @@
+/datum/heretic_knowledge/ultimate/rust_final
+	desc = "The ascension ritual of the Path of Rust. \
+		Bring 3 corpses to a transmutation rune on the bridge of the station to complete the ritual."
+
+/datum/heretic_knowledge/ultimate/moon_final
+	desc = "The ascension ritual of the Path of Moon. \
+		Bring 3 corpses with more than 50 brain damage to a transmutation rune to complete the ritual"
+
+/datum/heretic_knowledge/ultimate/knock_final
+	desc = "The ascension ritual of the Path of Knock. \
+		Bring 3 corpses without organs in their torso to a transmutation rune to complete the ritual."
+
+/datum/heretic_knowledge/ultimate/flesh_final
+	desc = "The ascension ritual of the Path of Flesh. \
+		Bring 4 corpses to a transmutation rune to complete the ritual."
+
+/datum/heretic_knowledge/ultimate/blade_final
+	desc = "The ascension ritual of the Path of Blades. \
+		Bring 3 corpses with either no head or a split skull to a transmutation rune to complete the ritual."
+
+/datum/heretic_knowledge/ultimate/ash_final
+	name = "Ashlord's Rite"
+	desc = "The ascension ritual of the Path of Ash. \
+		Bring 3 burning or husked corpses to a transmutation rune to complete the ritual."
+
+/datum/heretic_knowledge/ultimate/void_final
+	desc = "The ascension ritual of the Path of Void. \
+		Bring 3 corpses to a transmutation rune in sub-zero temperatures to complete the ritual."

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8854,6 +8854,7 @@
 #include "modular_zubbers\code\modules\antagonists\bloodsucker\vassal\vassal_types\revenge_vassal.dm"
 #include "modular_zubbers\code\modules\antagonists\ert\names.dm"
 #include "modular_zubbers\code\modules\antagonists\heretic\heretic.dm"
+#include "modular_zubbers\code\modules\antagonists\heretic\lore.dm"
 #include "modular_zubbers\code\modules\antagonists\heretic\transmutation_rune.dm"
 #include "modular_zubbers\code\modules\antagonists\malf\doomsday.dm"
 #include "modular_zubbers\code\modules\antagonists\malf\remove_malf.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

You get an achievement, you functionally ascend, everything. However, you get no buffs.
Rewrites some descs of final rituals and ascension notifications to reflect this.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

A criticism of "removing ascension" is that you're basically removing a core part of heretic. While I disagree, and stipulate that heretic can survive without ascension, I hope this might strike a middle ground, as ascension still exists as an incentive that communicates that you "won".

As previously mentioned, heretic ascensions are incredibly problematic. See https://github.com/Bubberstation/Bubberstation/pull/2078 for my previous criticisms.

I would also like to reflect burger's sentiment that heretic ascension represents a carrot-on-the-stick for our more gamer players, who obtain what is basically a psuedo-murderbone pass upon obtaining it. Escalation is relaxed, and more freedom is given to kill people. For a "gamer" player, this is a holy grail.

By removing the incentive of relaxed escalation and extreme power, we might be able to slow heretic to a point where A. People are more happy to interact with it (cannot actually end the round if we let them go), and B. Heretics are more encouraged to be a bit more creative with their antag

I think this PR should be, at minimum, test-merged, to see what effects it might have

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Proof Of Testing

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->
<details>
<summary>Screenshots/Videos</summary>

I really wish I could load this up and test it, but I am notoriously bad at testing antag changes, esp prog antags
(It compiles, though)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Ascensions no longer have any material impact on the game other than an announcement
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
