### PR TITLE
Added science bag to SciDrobe

### DIFF
--- a/modular_zubbers/code/modules/vending/wardrobe.dm
+++ b/modular_zubbers/code/modules/vending/wardrobe.dm
@@ -127,6 +127,7 @@
 		/obj/item/clothing/under/rank/rnd/scientist/bunnysuit = 3,
 		/obj/item/clothing/suit/toggle/labcoat/doctor_tailcoat/science = 3,
 		/obj/item/clothing/neck/tie/bunnytie/scientist = 3,
+		/obj/item/storage/bag/xeno = 3,
 	)
 
 /obj/machinery/vending/wardrobe/robo_wardrobe


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Very tiny PR. Adds the science bag to the SciDrobe.

## Why It's Good For The Game

There are only 2 science bags in xeno. If they both get lost, you can't really do Xeno anymore. I mean you CAN, but it really sucks.

## Proof Of Testing

Ran the Runtime Station. Spawned a SciDrobe. Science bag is in there.

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Midiwidi
add: Added science bag to SciDrobe
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
