### PR TITLE
Adds Shaft Miners to the antagonist blacklist

### DIFF
--- a/modular_zubbers/code/modules/storyteller/event_defines/crewset/_antagonist_event.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/crewset/_antagonist_event.dm
@@ -29,6 +29,9 @@
 		JOB_CUSTOMS_AGENT,
 		JOB_ENGINEERING_GUARD,
 		JOB_SCIENCE_GUARD,
+
+		// Shaft miners
+		JOB_SHAFT_MINER,
 		)
 
 	/// Restricted roles from the antag roll


### PR DESCRIPTION

## About The Pull Request
Does as the title says and makes it so shaft miners cannot roll antagonists, they should still be able to be converted by bloodsuckers and the like, they just can't directly roll antagonist.
## Why It's Good For The Game
Without fail, every time I see a shaft miner roll antagonist they do the same thing, they spend however long they need getting all the strongest lavaland loot, then they come up and absolutely steamroll security with their funny overpowered gear. I figured this is the best solution to that problem, rather than nerfing the gear and fucking ALL miners over.
## Proof Of Testing
It compiled and ran.
## Changelog
:cl:
balance: shaft miners can no longer roll antagonist
/:cl:
