### PR TITLE
Removes the druggy rainbow overlay because it fucked my eyes.

### DIFF
--- a/code/datums/status_effects/debuffs/drugginess.dm
+++ b/code/datums/status_effects/debuffs/drugginess.dm
@@ -12,7 +12,7 @@
 	RegisterSignal(owner, COMSIG_LIVING_DEATH, PROC_REF(remove_drugginess))
 
 	owner.add_mood_event(id, /datum/mood_event/high)
-	owner.overlay_fullscreen(id, /atom/movable/screen/fullscreen/high)
+	// owner.overlay_fullscreen(id, /atom/movable/screen/fullscreen/high) BUBBERSTATION CHANGE: REMOVES HIGH OVERLAY.
 	owner.sound_environment_override = SOUND_ENVIRONMENT_DRUGGED
 	owner.grant_language(/datum/language/beachbum, source = id)
 	return TRUE


### PR DESCRIPTION
## About The Pull Request

Removes the druggy rainbow overlay from being high.

## Why It's Good For The Game

Hurts my eyes.

## Proof Of Testing

If it compiles, it works.

## Changelog

:cl: BurgerBB
del: Removes the druggy rainbow overlay because it fucked my eyes.
/:cl:

