### PR TITLE
Lets Blind People (Actually) Use the Health Analyzer

### DIFF
--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -93,7 +93,7 @@
 	balloon_alert(user, "analyzing vitals")
 	playsound(user.loc, 'sound/items/healthanalyzer.ogg', 50)
 
-	var/readability_check = user.can_read(src) && !user.is_blind()
+	var/readability_check = user.can_read(src)// EDIT CHANGE - Blind people can analyze again - ORIGINAL: user.can_read(src) && !user.is_blind()
 	switch (scanmode)
 		if (SCANMODE_HEALTH)
 			last_scan_text = healthscan(user, M, mode, advanced, tochat = readability_check)

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -93,7 +93,7 @@
 	balloon_alert(user, "analyzing vitals")
 	playsound(user.loc, 'sound/items/healthanalyzer.ogg', 50)
 
-	var/readability_check = user.can_read(src)// EDIT CHANGE - Blind people can analyze again - ORIGINAL: user.can_read(src) && !user.is_blind()
+	var/readability_check = user.can_read(src) // BUBBER EDIT CHANGE - Blind people can analyze again - ORIGINAL: user.can_read(src) && !user.is_blind()
 	switch (scanmode)
 		if (SCANMODE_HEALTH)
 			last_scan_text = healthscan(user, M, mode, advanced, tochat = readability_check)


### PR DESCRIPTION
Fixes an issue with blind people not actually being able to use the health analyzer.
## About The Pull Request
Pretty self explanatory, lets people with the blindness quirk or echolocation quirk actually use the health analyzer. This seems to be intended behaviour judging by the code, but doesn't actually work. Fixing it was a one line modification.
## Why It's Good For The Game
People with those quirks can actually do surgery. Yay for bluespace braille!
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
It's a one line change. It compiles and runs.
</details>

## Changelog
:cl:
fix: Makes blind people able to actually use the health analyzer again.
/:cl:
