### PR TITLE
Reworks the Druggy Effect to cause less eye strain.

### DIFF
--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -157,6 +157,10 @@
 	icon = 'icons/hud/screen_gen.dmi'
 	screen_loc = "WEST,SOUTH to EAST,NORTH"
 	icon_state = "druggy"
+	alpha = 255
+	plane = LIGHTING_PLANE
+	layer = LIGHTING_ABOVE_ALL + 1 //Infinity plus one (not actually)
+	blend_mode = BLEND_MULTIPLY
 
 /atom/movable/screen/fullscreen/color_vision
 	icon = 'icons/hud/screen_gen.dmi'


### PR DESCRIPTION
Early pull of https://github.com/tgstation/tgstation/pull/87811

## Preamble

I suffer from Light Sensitivity and it's gotten worse over the years, and a previous round where there was an n2o leak made the round near unplayable for me because of the shifting colors and how bright it was, even with my screen's brightness set to 0. It made things extremely difficult to see. I was incredibly disheartened to see my removal of the druggy effect get speedclosed, so I made it up on /tg/ and made an early pull of it here.

Below is just a copy of the PR, with screenshots from /tg/.

## About The Pull Request

Reworks the Druggy visual effect to cause less eye strain.
The visual effect now targets the lighting layer and now adds color blending operations to it, based on a custom sprite.

https://github.com/user-attachments/assets/6ff34083-8733-4158-aef0-58cb1ac51ef1

![image](https://github.com/user-attachments/assets/7a92fafb-fa3e-41fd-89a8-926dedfb6c1a)

## Why It's Good For The Game

Makes it so that people with Light Sensitivity (me) can no longer get blinded by getting injected with weed or breathing in n2o. Other than that, I think the effect is cooler (probably biased) and feels more in line with the "woah pretty colors dude" meme. 

If people find this is too intense, it can easily be adjusted via code to reduce the color change effect.

## Changelog

:cl: BurgerBB
qol: Reworks the Druggy visual effect to cause less eye strain.
/:cl:

