### PR TITLE
Phasic strilka ammo no longer printable

### DIFF
--- a/modular_zubbers/code/modules/projectiles/ammunition/ballistic/rifle.dm
+++ b/modular_zubbers/code/modules/projectiles/ammunition/ballistic/rifle.dm
@@ -1,0 +1,2 @@
+/obj/item/ammo_casing/strilka310/phasic
+	can_be_printed = FALSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9171,6 +9171,7 @@
 #include "modular_zubbers\code\modules\power\powerator.dm"
 #include "modular_zubbers\code\modules\power\lighting\light_mapping_helpers.dm"
 #include "modular_zubbers\code\modules\power\supermatter\supermatter_gas.dm"
+#include "modular_zubbers\code\modules\projectiles\ammunition\ballistic\rifle.dm"
 #include "modular_zubbers\code\modules\projectiles\ammunition\ballistic\smg.dm"
 #include "modular_zubbers\code\modules\projectiles\boxes_magazines\external\smg.dm"
 #include "modular_zubbers\code\modules\projectiles\guns\ballistic\automatic.dm"


### PR DESCRIPTION
## About The Pull Request

Title

## Why It's Good For The Game

There's no reason people should be running around with it

## Proof Of Testing

I didn't test it

## Changelog


:cl:
del: Phasic strilka ammo is no longer printable.
/:cl:
