### PR TITLE
Dragonslayer Nerf Hotfix

### DIFF
--- a/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
+++ b/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
@@ -158,7 +158,6 @@
 		force = initial(force)
 		wound_bonus = initial(wound_bonus)
 		armour_penetration = initial(armour_penetration)
-		block_chance = initial(block_chance)
 		return ..()
 	else
 		force = 18

--- a/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
+++ b/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
@@ -164,7 +164,6 @@
 		force = 18
 		wound_bonus = 8
 		armour_penetration = 15
-		block_chance = 10
 
 /obj/item/claymore/dragonslayer/ranged_interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
 	if(user.IsImmobilized()) // no free dodgerolls


### PR DESCRIPTION

## About The Pull Request
Apparently I GAVE the dragonslayer a block chance on station when it didn't have one previously, this fixes that. Nothing else was changed.
## Why It's Good For The Game
I somehow buffed the sword slightly when trying to nerf it.
## Proof Of Testing
I didn't test it this time, but it should work fine, I only removed two lines of code.
## Changelog
:cl:
fix: fixed the fact I accidentally added a block chance to the dragonslayer onstation.
/:cl:
