### PR TITLE
Fix autochange log entries being off by a day

### DIFF
--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -2,7 +2,7 @@ name: Compile changelogs
 
 on:
   schedule:
-  - cron: "0 8 * * *"
+  - cron: "0 6 * * *"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -2,7 +2,7 @@ name: Compile changelogs
 
 on:
   schedule:
-  - cron: "0 6 * * *"
+  - cron: "15 23 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## About The Pull Request

Fixes workflow so auto changelog compile stamps the right dates on changelog entries

## Why It's Good For The Game

Nobody else may notice it's off by a day, but I know, and it bugs me.