### PR TITLE
Revert "Loadout adjustments."

### DIFF
--- a/modular_skyrat/master_files/code/modules/loadout/categories/pocket.dm
+++ b/modular_skyrat/master_files/code/modules/loadout/categories/pocket.dm
@@ -150,9 +150,17 @@
 	name = "Random Pizza Box"
 	item_path = /obj/item/pizzabox/random
 
+/datum/loadout_item/pocket_items/medkit
+	name = "First-Aid Kit"
+	item_path = /obj/item/storage/medkit/regular
+
+/datum/loadout_item/pocket_items/deforest_cheesekit
+	name = "Civil Defense Medical Kit"
+	item_path = /obj/item/storage/medkit/civil_defense/stocked
+
 /datum/loadout_item/pocket_items/deforest_frontiermedkit
-	name = "Empty Frontier Medical Kit"
-	item_path = /obj/item/storage/medkit/frontier
+	name = "Frontier Medical Kit"
+	item_path = /obj/item/storage/medkit/frontier/stocked
 
 /datum/loadout_item/pocket_items/ingredients
 	name = "Wildcard Ingredient Box"
@@ -165,6 +173,10 @@
 /datum/loadout_item/pocket_items/six_soda
 	name = "Soda Six-Pack"
 	item_path = /obj/item/storage/cans/sixsoda
+
+/datum/loadout_item/pocket_items/power_cell
+	name = "Standard Power Cell"
+	item_path = /obj/item/stock_parts/power_store/cell
 
 /datum/loadout_item/pocket_items/soap
 	name = "Bar of Soap"


### PR DESCRIPTION
Reverts Bubberstation/Bubberstation#2398

Could we not merge nerfs that get almost purely negative feedback, that even the author was seemingly convinced out of pulling as per the discussion? I don't understand why it was merged... Sorry if it's rude but, i'm just confused.

Edit: people keep discussing the original PR, so when evaluating reverting it, make sure to check the discussion on #2398 