### PR TITLE
Lustwish holobarrier can be used for saunas

### DIFF
--- a/modular_zubbers/code/modules/lewd_machinery/sex_barrier.dm
+++ b/modular_zubbers/code/modules/lewd_machinery/sex_barrier.dm
@@ -3,11 +3,12 @@
 	desc = "Despite the name, it does not project sex, however it does create a non-blocking barrier that informs those who wish to enter that there is sex inside."
 	max_signs = 4
 	creation_time = 10
-	holosign_type = /obj/structure/holosign/sexsign
+	holosign_type = /obj/structure/holosign/barrier/atmos/sex
 	//The janitor sign is also purple so no need to make custom sprites here.
 
-/obj/structure/holosign/sexsign
+/obj/structure/holosign/barrier/atmos/sex
 	name = "sex sign"
-	desc = "The words flicker DON'T SEX OPEN INSIDE. I think this means that there is sex beyond this door and that you should probably not enter, unless of course you are prepared for unforeseen consequences."
+	desc = "The words flicker: DON'T SEX OPEN INSIDE. I think this means that there is sex beyond this door and that you should probably not enter, unless of course you are prepared for unforeseen consequences."
 	icon = 'modular_zubbers/icons/effects/sex_barrier.dmi'
 	icon_state = "yes_i_spent_time_on_this"
+	max_integrity = 150

--- a/modular_zubbers/code/modules/lewd_machinery/sex_barrier.dm
+++ b/modular_zubbers/code/modules/lewd_machinery/sex_barrier.dm
@@ -7,8 +7,8 @@
 	//The janitor sign is also purple so no need to make custom sprites here.
 
 /obj/structure/holosign/barrier/atmos/sex
-	name = "sex sign"
-	desc = "The words flicker: DON'T SEX OPEN INSIDE. I think this means that there is sex beyond this door and that you should probably not enter, unless of course you are prepared for unforeseen consequences."
+	name = "sex barrier"
+	desc = "The words flicker: DON'T SEX OPEN INSIDE. I think this means that there is sex beyond this door and that you should probably not enter, unless of course you are prepared for unforeseen consequences.\n\nThe holographic warning reads: Barriers work best when they are used correctly every time you perform engineering. Even one act of engineering without using a barrier can result in unplanned atmospheric consequences. If your barrier breaks or becomes dislodged during engineering, or if you forget or are unable to use it, you may want to consider emergency atmospherics containment."
 	icon = 'modular_zubbers/icons/effects/sex_barrier.dmi'
 	icon_state = "yes_i_spent_time_on_this"
 	max_integrity = 150


### PR DESCRIPTION
## About The Pull Request

Makes the lustwish holobarrier block atmos passing so it can be used for setting up saunas.

## Why It's Good For The Game

Facilitate sauna building without flooding the corridor with steam.

## Changelog

:cl: LT3
balance: Lustwish holobarrier is usable for sauna construction
/:cl: