### PR TITLE
Fix alternate meow/purr

### DIFF
--- a/code/modules/mob/living/basic/pets/cat/cat.dm
+++ b/code/modules/mob/living/basic/pets/cat/cat.dm
@@ -56,7 +56,7 @@
 	mob_type_allowed_typecache = /mob/living/basic/pet/cat
 	mob_type_blacklist_typecache = list()
 
-/datum/emote/cat/meow
+/datum/emote/living/petmeow // BUBBER EDIT CHANGE - Original: /datum/emote/cat/meow
 	key = "petmeow" // BUBBER EDIT CHANGE - 'meow' used by /datum/emote/living/meow
 	key_third_person = null // BUBBER EDIT CHANGE - 'purr' used by /datum/emote/living/purr
 	message = "meows!"
@@ -64,7 +64,7 @@
 	vary = TRUE
 	sound = SFX_CAT_MEOW
 
-/datum/emote/cat/purr
+/datum/emote/living/petpurr // BUBBER EDIT CHANGE - Original: /datum/emote/cat/purr
 	key = "petpurr" // BUBBER EDIT CHANGE - 'purr' used by /datum/emote/living/purr
 	key_third_person = null // BUBBER EDIT CHANGE - 'purr' used by /datum/emote/living/purr
 	message = "purrs."


### PR DESCRIPTION
## About The Pull Request

Fixes alternate meow/purr from being restricted after an upstream mirror.

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/6b875039-5ede-433b-8392-4d11275ddb10)

</details>

## Changelog

:cl: LT3
fix: Alternate meow and purr emotes work again
/:cl: