### PR TITLE
Experimentally changes the thermal volume of space from 7000L to 25L

### DIFF
--- a/code/__DEFINES/atmospherics/atmos_core.dm
+++ b/code/__DEFINES/atmospherics/atmos_core.dm
@@ -124,7 +124,7 @@
 /// a hack for now
 #define WINDOW_HEAT_TRANSFER_COEFFICIENT 0.1
 /// a hack to help make vacuums "cold", sacrificing realism for gameplay
-#define HEAT_CAPACITY_VACUUM 7000
+#define HEAT_CAPACITY_VACUUM 1 // BUBBER EDIT: SPACE IS A POOR WAY TO REMOVE HEAT AND IT ISNT HOT OR COLD
 
 //FIRE
 ///Minimum temperature for fire to move to the next turf (150 °C or 433 K)

--- a/code/__DEFINES/atmospherics/atmos_core.dm
+++ b/code/__DEFINES/atmospherics/atmos_core.dm
@@ -124,7 +124,7 @@
 /// a hack for now
 #define WINDOW_HEAT_TRANSFER_COEFFICIENT 0.1
 /// a hack to help make vacuums "cold", sacrificing realism for gameplay
-#define HEAT_CAPACITY_VACUUM 1 // BUBBER EDIT: SPACE IS A POOR WAY TO REMOVE HEAT AND IT ISNT HOT OR COLD
+#define HEAT_CAPACITY_VACUUM 25 // BUBBER EDIT: SPACE IS A POOR WAY TO REMOVE HEAT AND IT ISNT HOT OR COLD
 
 //FIRE
 ///Minimum temperature for fire to move to the next turf (150 °C or 433 K)

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -679,7 +679,7 @@ Then we space some of our heat, and think about if we should stop conducting.
 		return
 	// Heat should be positive in most cases
 	// coefficient applied first because some turfs have very big heat caps.
-	var/heat = CALCULATE_CONDUCTION_ENERGY(thermal_conductivity * delta_temperature, HEAT_CAPACITY_VACUUM, heat_capacity)
+	var/heat = CALCULATE_CONDUCTION_ENERGY(thermal_conductivity * delta_temperature, /*HEAT_CAPACITY_VACUUM*/ 7000, heat_capacity) // BUBBER EDIT
 	temperature -= heat / heat_capacity
 
 /turf/open/proc/temperature_share_open_to_solid(turf/sharer)


### PR DESCRIPTION

## About The Pull Request

This is mostly an atmos change- it makes space behave more realistic. As a consequence, your bone stock SM setup where you don't touch anything at all is no longer safe on three emitters. 
## Why It's Good For The Game

Space violating the laws of thermodynamics is silly, and well, I think everything atmos-wise having that as a crutch removed the upper gameplay ceiling. This shouldn't make basic atmos harder, thermal machines which still violate the laws are still fully functional. This just makes space itself behave more like an absence of anything, than a constant -270k cold source.

## Proof Of Testing
<summary></summary>

![dreamseeker_pyTxK7Exmv](https://github.com/user-attachments/assets/91b16bce-7de6-412c-b85a-d074e74e7199)
</summary>

## Changelog
:cl:
balance: space becomes a vacuum instead of a freezer
/:cl:
