### PR TITLE
expands your lunchbox

### DIFF
--- a/modular_zubbers/code/modules/lunchbox/code/lunchbox.dm
+++ b/modular_zubbers/code/modules/lunchbox/code/lunchbox.dm
@@ -13,10 +13,14 @@
 
 /obj/item/storage/lunchbox/Initialize(mapload)
 	. = ..()
-	atom_storage.max_slots = 4
+	atom_storage.max_slots = 8
 	atom_storage.set_holdable(list(
 		/obj/item/food,
 		/obj/item/reagent_containers/cup,
+		/obj/item/reagent_containers/condiment,
+		/obj/item/storage/box/gum,
+		/obj/item/storage/fancy/cigarettes,
+		/obj/item/lighter,
 		))
 
 /obj/item/storage/lunchbox/nanotrasen


### PR DESCRIPTION

## About The Pull Request

Doubles lunchbox storage from 4 to 8 slots, lets them hold condiments, gum, ciggys and lighters

## Why It's Good For The Game

lunchboxes currently kinda suck, there's no real reason to use them over cardboard boxes which you can get from food vending machines

## Proof Of Testing

I did compile it to check, it's just a simple edit so...

## Changelog

:cl:
balance: NT's bluespace technology doubles lunchbox storage from 4 to 8 items with special lining
add: lunchboxes can also hold condiments and gum now... and cigarettes and lighters, at the insistence of our sponsors in the space tobacco industry
/:cl:
