### PR TITLE
fix bokken wielded damage

### DIFF
--- a/modular_skyrat/modules/reagent_forging/code/forge_weapons.dm
+++ b/modular_skyrat/modules/reagent_forging/code/forge_weapons.dm
@@ -314,7 +314,7 @@
 /obj/item/forging/reagent_weapon/bokken
 	name = "reagent bokken"
 	desc = "A bokken that is capable of blocking attacks when wielding in two hands, possibly including bullets should the user be brave enough."
-	force = 16
+	force = 8
 	icon_state = "bokken"
 	inhand_icon_state = "bokken"
 	worn_icon_state = "bokken_back"
@@ -349,7 +349,7 @@
 	. = ..()
 	RegisterSignal(src, COMSIG_TWOHANDED_WIELD, PROC_REF(on_wield))
 	RegisterSignal(src, COMSIG_TWOHANDED_UNWIELD, PROC_REF(on_unwield))
-	AddComponent(/datum/component/two_handed, force_multiplier = 0.5)
+	AddComponent(/datum/component/two_handed, force_multiplier = 1.5)
 
 /obj/item/forging/reagent_weapon/bokken/proc/on_wield()
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request
Wierdly enough, bokkens revert to 8 force when wielded, and 16 damage when not, i'm not sure if this was intended or not but the description nor commits seem to indicate so, thus I'm setting the force of bokken to 8 and making wielded go up to the original 16 force when unwielded, as it seemed reversed beforehand

## Why It's Good For The Game

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
fix: Fixes the bokken having 16 damage when unwielded, and 8 when it is
/:cl:

