### PR TITLE
Fix for Issue #1975: 'Character preferences menu has a second, unnecessary scrollbar'

### DIFF
--- a/tgui/packages/tgui/styles/interfaces/PreferencesMenu.scss
+++ b/tgui/packages/tgui/styles/interfaces/PreferencesMenu.scss
@@ -211,7 +211,7 @@ $department_map: (
 
           background: rgba(0, 0, 0, 0.2);
           display: block;
-          height: 80%;
+          height: 100%;
           left: 50%;
           position: relative;
           top: 50%;


### PR DESCRIPTION
## About The Pull Request

Issue Summary
The character preferences menu has a second, unnecessary scrollbar that can hide options

Adjusting height in the PreferencesMenu.scss just a bit taller removed the second scrollbar so the options were not hard to find or hidden at the bottom.

## Why It's Good For The Game

Quality of life improvement, I noticed this problem myself when coming back to Bubberstation. I was missing features because the window wasn't tall enough and I had to find the inner scrollbar to actually find everything else. This will allow new and returning players to easily find everything now without the confusing adjustments of the inner and outer scrollbar on the main character setup screen.


## Proof Of Testing

![Screenshot 2024-11-16 104646](https://github.com/user-attachments/assets/e756d9ba-68d7-4184-a5ce-3f6d735cc058)

## Changelog

:cl:

qol: Adjusted the height parameter for 'Setup Character' Menu to make it taller and easier to navigate/find features.

:cl:
