### PR TITLE
Wall-Mounted Cryopod Fix

### DIFF
--- a/modular_skyrat/modules/cryosleep/code/cryopod.dm
+++ b/modular_skyrat/modules/cryosleep/code/cryopod.dm
@@ -211,23 +211,44 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod, 32)
 	if(!control_computer_weakref)
 		find_control_computer(TRUE)
 	if((isnull(target) || isliving(target)) && state_open && !panel_open)
-		..(target)
-		var/mob/living/mob_occupant = occupant
-		if(mob_occupant && mob_occupant.stat != DEAD)
-			to_chat(occupant, span_notice("<b>You feel cool air surround you. You go numb as your senses turn inward.</b>"))
-			stored_ckey = mob_occupant.ckey
-			stored_name = mob_occupant.name
+		state_open = FALSE
+		set_density(density_to_set)
 
-			if(mob_occupant.mind)
-				stored_rank = mob_occupant.mind.assigned_role.title
-				if(isnull(stored_ckey))
-					stored_ckey = mob_occupant.mind.key // if mob does not have a ckey and was placed in cryo by someone else, we can get the key this way
+		if(!target)
+			for(var/atom in loc)
+				if (!(can_be_occupant(atom)))
+					continue
+				var/atom/movable/current_atom = atom
+				if(current_atom.has_buckled_mobs())
+					continue
+				if(isliving(current_atom))
+					var/mob/living/current_mob = atom
+					if(current_mob.buckled || current_mob.mob_size >= MOB_SIZE_LARGE)
+						continue
+				target = atom
 
-		var/mob/living/carbon/human/human_occupant = occupant
-		if(istype(human_occupant) && human_occupant.mind)
-			human_occupant.save_individual_persistence(stored_ckey)
+	var/mob/living/mobtarget = target
+	if(target && !target.has_buckled_mobs() && (!isliving(target) || !mobtarget.buckled))
+		set_occupant(target)
+		target.forceMove(src)
+	update_appearance()
 
-		COOLDOWN_START(src, despawn_world_time, time_till_despawn)
+	var/mob/living/mob_occupant = occupant
+	if(mob_occupant && mob_occupant.stat != DEAD)
+		to_chat(occupant, span_notice("<b>You feel cool air surround you. You go numb as your senses turn inward.</b>"))
+		stored_ckey = mob_occupant.ckey
+		stored_name = mob_occupant.name
+
+		if(mob_occupant.mind)
+			stored_rank = mob_occupant.mind.assigned_role.title
+			if(isnull(stored_ckey))
+				stored_ckey = mob_occupant.mind.key // if mob does not have a ckey and was placed in cryo by someone else, we can get the key this way
+
+	var/mob/living/carbon/human/human_occupant = occupant
+	if(istype(human_occupant) && human_occupant.mind)
+		human_occupant.save_individual_persistence(stored_ckey)
+
+	COOLDOWN_START(src, despawn_world_time, time_till_despawn)
 
 /obj/machinery/cryopod/open_machine(drop = TRUE, density_to_set = FALSE)
 	..()


### PR DESCRIPTION
## About The Pull Request

Issue Summary: 
When attempting to use a wallmounted cryopod it simply does not move the player inside causing the message pop up about entering the cryopod. due to this any situation where someone has to use a wallmounted cryopod they're unable to which is a problem for prisoners as they often only have wallmounted cryopods.

The code for the wall-mounted cryopods in modular_skyrat\modules\cryosleep\code\cryopod.dm were not properly calling the close_machine() proc. The code has been adjusted so that it now properly works as intended.  

PR has been tested and is working. Screenshots provided below as proof.

## Why It's Good For The Game

This makes the wall-mounted cryopods fully functional now, giving map creators more ways to add in exit points for players that need to leave for whatever reason.

Fixes #2040

## Proof Of Testing
![Screenshot 2024-11-16 142241](https://github.com/user-attachments/assets/1dac9eea-39ce-4491-919c-927807a96a00)
![Screenshot 2024-11-16 142310](https://github.com/user-attachments/assets/f983cf91-a14b-4bb2-ae5d-97f838c014de)
![Screenshot 2024-11-16 142317](https://github.com/user-attachments/assets/fb290027-87cb-44b1-bab2-4676ecfce3a0)


## Changelog

:cl: Sparex

fix: Wall-Mounted Cryopods now fully work as intended, player will enter the wall-mounted cryopod. Enter stasis, able to ghost out and be processed to the cryogenic oversight console.

:cl:


