### PR TITLE
Added generic_maintenance_spawn points to Moonstation.dmm

### DIFF
--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -450,6 +450,9 @@
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 1
 	},
+/obj/effect/landmark/generic_maintenance_landmark,
+/obj/effect/landmark/generic_maintenance_landmark,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "agV" = (
@@ -1673,6 +1676,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "awZ" = (
@@ -1775,6 +1779,14 @@
 /obj/machinery/light/moonstation/directional/east,
 /turf/open/misc/beach/sand,
 /area/station/common/pool)
+"ayN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/generic_maintenance_landmark,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "ayT" = (
 /obj/structure/stone_tile/slab,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
@@ -1957,8 +1969,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"aBB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "aBD" = (
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
@@ -2655,6 +2678,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/cult_chapel)
+"aJK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/central)
 "aJU" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 5
@@ -2978,6 +3009,16 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
+"aOo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/central)
 "aOu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -3163,6 +3204,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "aQh" = (
@@ -3312,6 +3354,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/maintenance,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/terminal/maintenance/aft)
 "aSu" = (
@@ -3780,6 +3823,7 @@
 "aZn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "aZs" = (
@@ -3884,6 +3928,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "baK" = (
@@ -4906,6 +4951,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bqR" = (
@@ -5711,6 +5757,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/construction)
+"bDR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "bDU" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/maintenance/starboard/aft)
@@ -5828,14 +5882,14 @@
 /turf/closed/wall/rust,
 /area/station/maintenance/eva_shed)
 "bFz" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/central)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/structure/sign/poster/random/directional/east,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/department/engine)
 "bFM" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/exit)
@@ -5875,6 +5929,7 @@
 "bGx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/terminal/maintenance/aft)
 "bGH" = (
@@ -6038,6 +6093,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "bJH" = (
@@ -6408,6 +6464,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "bPt" = (
@@ -6686,6 +6743,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/maintenance,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/terminal/maintenance/aft)
 "bTg" = (
@@ -7932,6 +7990,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "ckx" = (
@@ -7987,6 +8046,7 @@
 /area/station/maintenance/port/aft)
 "ckV" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "ckW" = (
@@ -8696,6 +8756,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "cyf" = (
@@ -8924,6 +8985,7 @@
 "cBy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "cBB" = (
@@ -9459,6 +9521,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
 "cKB" = (
@@ -10679,6 +10742,14 @@
 	can_atmos_pass = 0
 	},
 /area/station/maintenance/department/public_mining)
+"dbG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "dbM" = (
 /obj/structure/chair/sofa/right/brown{
 	dir = 4
@@ -11221,6 +11292,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
 "dig" = (
@@ -11433,6 +11505,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "dkV" = (
@@ -12405,6 +12478,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"dyX" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "dzc" = (
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
@@ -12780,6 +12861,7 @@
 /obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
 	dir = 8
 	},
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "dEa" = (
@@ -12887,11 +12969,14 @@
 /area/station/science/ordnance/bomb)
 "dEY" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plating,
-/area/station/maintenance/central)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/department/engine)
 "dFa" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/structure/cable,
@@ -14616,6 +14701,17 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
 /area/station/terminal/lobby)
+"efy" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/generic_maintenance_landmark,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/central)
 "efG" = (
 /obj/machinery/light/moonstation/directional/north,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -15287,6 +15383,7 @@
 "emO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small/directional/south,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/iron/grimy,
 /area/station/service/library/abandoned)
 "emU" = (
@@ -15311,6 +15408,14 @@
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/ai_monitored/turret_protected/ai)
+"ent" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/central)
 "env" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15714,6 +15819,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating/foam,
 /area/station/maintenance/department/public_mining)
 "esO" = (
@@ -16202,6 +16308,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/public_mining)
 "eyV" = (
@@ -16556,6 +16663,7 @@
 	dir = 4
 	},
 /obj/structure/sign/poster/random/directional/north,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "eDN" = (
@@ -19078,6 +19186,7 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "fnT" = (
@@ -21149,6 +21258,7 @@
 	dir = 4
 	},
 /obj/structure/sign/poster/random/directional/south,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "fOv" = (
@@ -23252,6 +23362,7 @@
 "gum" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "guv" = (
@@ -24593,6 +24704,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/maintenance,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "gQj" = (
@@ -25211,6 +25323,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/engine)
 "gYK" = (
@@ -25618,6 +25731,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "hfz" = (
@@ -25684,6 +25798,14 @@
 	initial_gas_mix = "n2=100;TEMP=293.15"
 	},
 /area/station/maintenance/gag_room)
+"hgr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/delivery,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/central)
 "hgI" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
@@ -26149,6 +26271,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "hmK" = (
@@ -26728,6 +26851,13 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
 /area/station/terminal/interlink)
+"huy" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "huz" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
@@ -27341,6 +27471,7 @@
 "hCX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/public_mining)
 "hDf" = (
@@ -28705,6 +28836,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/effect/landmark/generic_maintenance_landmark,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "hXi" = (
@@ -29192,6 +29325,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/prison/upper)
+"idC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/space)
 "idI" = (
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
@@ -30192,6 +30332,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/sign/warning/cold_temp/directional/east,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "iuE" = (
@@ -31165,6 +31306,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "iHX" = (
@@ -31256,6 +31398,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/sign/poster/random/directional/north,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "iJq" = (
@@ -32280,6 +32423,7 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/engine)
 "iXt" = (
@@ -32611,6 +32755,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "jbj" = (
@@ -32905,6 +33050,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/engine)
 "jeZ" = (
@@ -33624,6 +33770,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/decoration/glowstick,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/public_mining)
 "joe" = (
@@ -34304,6 +34451,7 @@
 "jyP" = (
 /obj/structure/sign/warning/biohazard/directional/north,
 /obj/effect/spawner/random/trash/grille_or_waste,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "jyZ" = (
@@ -34807,6 +34955,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/navigate_destination/autoname,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "jIr" = (
@@ -34949,6 +35098,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "jKA" = (
@@ -34959,6 +35109,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/sign/departments/engineering/directional/east,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/terminal/maintenance/aft)
 "jKZ" = (
@@ -35009,6 +35160,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "jLN" = (
@@ -35160,6 +35312,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/random/maintenance,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/engine)
 "jNo" = (
@@ -35475,6 +35628,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "jRe" = (
@@ -35753,6 +35907,7 @@
 /obj/effect/turf_decal/siding/dark_red{
 	dir = 4
 	},
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/aft)
 "jUY" = (
@@ -37467,6 +37622,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"ktY" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/space)
 "kuc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/disposal/bin,
@@ -37537,6 +37699,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/sign/warning/biohazard/directional/east,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "kvc" = (
@@ -37753,6 +37916,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "kyH" = (
@@ -37912,6 +38076,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "kAg" = (
@@ -38053,6 +38218,13 @@
 	},
 /turf/open/lava/smooth/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
+"kCo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "kCq" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/effect/turf_decal/tile/red/opposingcorners{
@@ -38442,6 +38614,12 @@
 /obj/structure/closet/wardrobe/cargotech,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"kIS" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/space)
 "kIX" = (
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/structure/disposalpipe/segment,
@@ -40025,6 +40203,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "ldZ" = (
@@ -40427,6 +40606,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/maintenance,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "ljU" = (
@@ -43685,6 +43865,7 @@
 	dir = 4
 	},
 /obj/structure/sign/poster/random/directional/north,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "mcJ" = (
@@ -44336,6 +44517,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/maintenance,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/public_mining)
 "mmf" = (
@@ -44892,6 +45074,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "mvh" = (
@@ -47176,6 +47359,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "nci" = (
@@ -47189,6 +47373,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/public_mining)
 "ncq" = (
@@ -47673,6 +47858,10 @@
 /obj/effect/landmark/start/bitrunner,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/cargo/bitrunning/den)
+"njZ" = (
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/closed/wall,
+/area/station/maintenance/port/aft)
 "nkb" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 4
@@ -48581,6 +48770,7 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/terminal/maintenance/aft)
 "nwa" = (
@@ -49110,6 +49300,7 @@
 "nEL" = (
 /obj/structure/sign/warning/vacuum/external/directional/south,
 /obj/effect/spawner/random/trash/grime,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/terminal/maintenance/aft)
 "nEN" = (
@@ -49276,6 +49467,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "nGY" = (
@@ -50693,6 +50885,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/duct,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "obI" = (
@@ -50789,6 +50982,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/poster/random/directional/east,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "ocI" = (
@@ -51247,6 +51441,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "oig" = (
@@ -51369,6 +51564,16 @@
 /obj/structure/marker_beacon/bronze,
 /turf/open/floor/catwalk_floor/rust/moonstation,
 /area/moonstation/surface)
+"ojV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "ojZ" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -52574,6 +52779,7 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/spawner/random/trash/hobo_squat,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
 "oDq" = (
@@ -53017,6 +53223,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "oIO" = (
@@ -53183,6 +53390,13 @@
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/common/night_club)
+"oKJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/central)
 "oKV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53495,6 +53709,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/abandon_arcade)
 "oQq" = (
@@ -54560,6 +54775,11 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/crematorium,
 /turf/open/floor/plating,
 /area/station/maintenance/coffin_supply)
+"pei" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/iron/grimy,
+/area/station/service/library/abandoned)
 "peq" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -56535,6 +56755,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "pGJ" = (
@@ -57121,6 +57342,7 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard)
 "pPx" = (
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/public_mining)
 "pPC" = (
@@ -57410,6 +57632,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/engine)
 "pUi" = (
@@ -59902,6 +60125,15 @@
 /obj/machinery/computer/order_console/bitrunning,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
+"qBF" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/generic_maintenance_landmark,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "qBL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -59970,6 +60202,7 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
 "qCW" = (
@@ -60032,6 +60265,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "qDL" = (
@@ -60097,6 +60331,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/abandoned,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_arcade)
 "qFm" = (
@@ -60775,6 +61010,7 @@
 /area/station/maintenance/aft)
 "qQo" = (
 /obj/effect/spawner/random/trash/mess,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "qQy" = (
@@ -60810,6 +61046,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/delivery,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "qQV" = (
@@ -60927,6 +61164,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/spawner/random/maintenance,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "qSp" = (
@@ -62136,12 +62374,15 @@
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "riO" = (
-/obj/effect/spawner/random/maintenance,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/department/engine)
 "riS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/machinery/meter,
@@ -62396,6 +62637,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "rmH" = (
@@ -62443,6 +62685,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/public_mining)
 "rnp" = (
@@ -62940,6 +63183,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/terminal/maintenance/aft)
 "rvx" = (
@@ -63145,6 +63389,7 @@
 /obj/structure/cable,
 /obj/effect/spawner/random/maintenance,
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "ryy" = (
@@ -64395,6 +64640,14 @@
 /obj/machinery/airalarm/directional/east,
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/aisat/service)
+"rQd" = (
+/obj/effect/spawner/random/maintenance,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/central)
 "rQs" = (
 /turf/open/floor/iron/dark,
 /area/station/engineering/rbmk2)
@@ -64656,6 +64909,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/public_mining)
 "rUJ" = (
@@ -64700,6 +64954,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/trash/graffiti,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/public_mining)
 "rVR" = (
@@ -64740,6 +64995,7 @@
 /area/station/service/cafeteria)
 "rVZ" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/terminal/maintenance/aft)
 "rWd" = (
@@ -65119,6 +65375,7 @@
 	dir = 9
 	},
 /obj/effect/spawner/random/decoration/glowstick,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/public_mining)
 "sci" = (
@@ -65273,6 +65530,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/broken_floor,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/abandon_arcade)
 "sdV" = (
@@ -65564,6 +65822,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "siP" = (
@@ -68891,6 +69150,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "tds" = (
@@ -69453,6 +69713,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "tlL" = (
@@ -69940,6 +70201,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "tsZ" = (
@@ -70644,6 +70906,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/abandon_arcade)
 "tDf" = (
@@ -74021,6 +74284,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "uzt" = (
@@ -74577,6 +74841,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "uHk" = (
@@ -74700,6 +74965,7 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "uIL" = (
@@ -77402,6 +77668,14 @@
 /obj/structure/stone_tile/slab/cracked,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
+"vyi" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/generic_maintenance_landmark,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/central)
 "vyk" = (
 /obj/machinery/door/airlock{
 	name = "Kitchen"
@@ -77626,12 +77900,10 @@
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/commissary)
 "vBA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
+/obj/effect/spawner/random/trash/graffiti,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
-/area/station/maintenance/central)
+/area/station/maintenance/disposal)
 "vBB" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -77988,6 +78260,14 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/cargo/lobby)
+"vFQ" = (
+/obj/structure/sign/poster/random/directional/north,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/central)
 "vFX" = (
 /obj/structure/ladder,
 /turf/open/floor/plating/rust/moonstation,
@@ -78471,6 +78751,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/terminal/maintenance/aft)
 "vPK" = (
@@ -80346,6 +80627,7 @@
 "wqJ" = (
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/public_mining)
 "wqN" = (
@@ -80899,6 +81181,7 @@
 /obj/structure/sign/warning/xeno_mining/directional/east,
 /obj/effect/spawner/random/trash/bucket,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "wzL" = (
@@ -82017,6 +82300,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "wPD" = (
@@ -82093,6 +82377,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "wQo" = (
@@ -82211,6 +82496,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "wSc" = (
@@ -82529,6 +82815,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "wWt" = (
@@ -86755,6 +87042,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "ydO" = (
@@ -87297,6 +87585,7 @@
 "ylv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/terminal/maintenance/aft)
 "yly" = (
@@ -118576,7 +118865,7 @@ sQW
 uaK
 qQo
 wzB
-hiK
+vBA
 dDS
 tCj
 cfv
@@ -240429,7 +240718,7 @@ uwv
 eGq
 rdH
 jiU
-sKH
+kCo
 lxU
 rdH
 eVU
@@ -240440,7 +240729,7 @@ qZz
 nRb
 rdH
 wku
-eDQ
+huy
 lxU
 qBf
 wYP
@@ -240686,7 +240975,7 @@ jHn
 lXl
 rdH
 aFl
-sKH
+kCo
 eBC
 rdH
 hZR
@@ -240697,7 +240986,7 @@ aUA
 pMp
 rdH
 oWr
-eDQ
+ayN
 fLq
 jch
 wYP
@@ -240954,7 +241243,7 @@ jch
 rdH
 rdH
 jfS
-eDQ
+huy
 nhx
 jch
 wYP
@@ -241200,18 +241489,18 @@ rdH
 rdH
 fYU
 ckS
-qrm
-vAC
+ojV
+dbG
 fnP
-qDk
-qDk
+dyX
+dyX
 awT
-qDk
-qDk
+qBF
+qBF
 awT
-qDk
-qDk
-qDk
+dyX
+qBF
+dyX
 wWs
 qBf
 wYP
@@ -243019,7 +243308,7 @@ afE
 xyQ
 dif
 qCV
-ccY
+pei
 emO
 cZX
 rBx
@@ -243256,7 +243545,7 @@ fhd
 xYe
 rdH
 qVN
-tOR
+aBB
 itb
 vXD
 wpV
@@ -243533,8 +243822,8 @@ gKn
 sHo
 dif
 cKs
-ccY
-ccY
+pei
+pei
 riC
 bgV
 lKS
@@ -243770,7 +244059,7 @@ eYc
 mXB
 rdH
 jXD
-tOR
+aBB
 itb
 pQk
 mnR
@@ -243795,7 +244084,7 @@ bao
 rdH
 bML
 rNv
-eDQ
+huy
 rFv
 lzB
 hiB
@@ -244049,10 +244338,10 @@ rdH
 rdH
 rdH
 rdH
-rdH
-rdH
+njZ
+njZ
 iZb
-eDQ
+huy
 rdH
 rdH
 cbc
@@ -244302,14 +244591,14 @@ rdH
 rdH
 gcM
 rdH
-rdH
+njZ
 dkU
 dkU
 uzs
 hmG
 pGF
 dkU
-eDQ
+huy
 bIp
 nGF
 ujT
@@ -244554,12 +244843,12 @@ rZm
 sBY
 itb
 jKl
-oKV
+bDR
 ydN
-oKV
+bDR
 hft
 wQm
-vAC
+dbG
 bJB
 itb
 itb
@@ -250188,7 +250477,7 @@ mGB
 gdq
 iSf
 qQU
-hVi
+riO
 xCq
 bku
 uLQ
@@ -250657,7 +250946,7 @@ pOK
 sDO
 oci
 lkv
-oFf
+ktY
 oFf
 oFf
 oFf
@@ -250682,7 +250971,7 @@ crh
 xAV
 xAV
 xAV
-bFz
+aOo
 xAV
 gmb
 uEi
@@ -250702,7 +250991,7 @@ eIQ
 arM
 xCq
 aHP
-hVi
+riO
 xCq
 wdL
 ahb
@@ -251452,7 +251741,7 @@ bUL
 wKR
 xAV
 iTX
-bFz
+aOo
 jTr
 eOD
 wjy
@@ -251482,7 +251771,7 @@ lsK
 lsK
 xCq
 coN
-aQr
+dEY
 gEG
 vih
 vih
@@ -251741,9 +252030,9 @@ gXi
 jeX
 iXp
 jNn
+bFz
 asH
-asH
-asH
+bFz
 fbZ
 caS
 gQF
@@ -251966,7 +252255,7 @@ hoQ
 gTh
 xAV
 pbX
-sSh
+oKJ
 shG
 eOD
 wjy
@@ -252223,7 +252512,7 @@ jRy
 xAV
 xAV
 okH
-sSh
+oKJ
 jTr
 ubz
 wjy
@@ -252480,7 +252769,7 @@ xAV
 xAV
 xJs
 coT
-sSh
+oKJ
 jTr
 eOD
 wjy
@@ -252729,15 +253018,15 @@ kBe
 wVn
 vKy
 cLi
-sSh
-sSh
-sSh
+oKJ
+oKJ
+oKJ
 ljI
-sSh
-vBA
-sSh
-sSh
-sSh
+oKJ
+ent
+oKJ
+oKJ
+oKJ
 jVx
 ubz
 wjy
@@ -252986,7 +253275,7 @@ gWc
 lQu
 oqg
 xAV
-sSh
+oKJ
 jVx
 xAV
 xAV
@@ -252994,7 +253283,7 @@ dwJ
 xAV
 xAV
 jTr
-riO
+rQd
 jTr
 eOD
 wjy
@@ -253251,7 +253540,7 @@ smN
 jTr
 xAV
 xAV
-vBA
+ent
 xAV
 ubz
 ubz
@@ -253498,9 +253787,9 @@ aFS
 hje
 wXK
 mea
-dEY
-sSh
-dEY
+hgr
+oKJ
+hgr
 jTr
 xAV
 iRN
@@ -253508,7 +253797,7 @@ fIo
 sIm
 xAV
 jTr
-sSh
+oKJ
 dKw
 jVx
 jTr
@@ -253766,16 +254055,16 @@ xAV
 xAV
 uQZ
 iuc
-dEY
-sSh
-sSh
-sSh
-sSh
-sSh
+hgr
+oKJ
+oKJ
+oKJ
+oKJ
+oKJ
 kyE
 jmO
-jmO
-jmO
+aJK
+aJK
 bDf
 nBr
 fXs
@@ -254029,7 +254318,7 @@ wwT
 jTr
 jTr
 jVx
-bFz
+aOo
 jTr
 uUa
 jTr
@@ -254286,7 +254575,7 @@ xAV
 xAV
 xAV
 xAV
-bFz
+efy
 jTr
 crA
 xAV
@@ -254800,8 +255089,8 @@ jmn
 fgR
 sCg
 xAV
-bFz
-sSh
+aOo
+oKJ
 jTr
 xAV
 ybW
@@ -255058,7 +255347,7 @@ cyW
 vsW
 xAV
 pYx
-sSh
+oKJ
 jVx
 xAV
 efZ
@@ -255315,8 +255604,8 @@ qbx
 jwe
 upq
 woM
-sSh
-sSh
+oKJ
+oKJ
 xAV
 jrF
 uTK
@@ -255573,7 +255862,7 @@ hXX
 xAV
 xAV
 cxk
-sSh
+oKJ
 xAV
 ezI
 bzo
@@ -255830,7 +256119,7 @@ riN
 xQz
 xAV
 jTr
-sSh
+oKJ
 xAV
 abV
 laZ
@@ -256087,7 +256376,7 @@ mFu
 rSU
 xAV
 jTr
-sSh
+oKJ
 xAV
 xAV
 xDD
@@ -256344,8 +256633,8 @@ kpb
 fUE
 pJW
 smN
-sSh
-sSh
+oKJ
+oKJ
 xAV
 bmI
 lXJ
@@ -256602,7 +256891,7 @@ sBP
 xAV
 xAV
 xAV
-sSh
+oKJ
 xAV
 kqZ
 sgz
@@ -256859,7 +257148,7 @@ kLQ
 nNh
 qFO
 xAV
-vBA
+ent
 xAV
 nXR
 beP
@@ -257116,7 +257405,7 @@ ncI
 ncI
 tdM
 xAV
-xOT
+vFQ
 xAV
 xAV
 xAV
@@ -257374,10 +257663,10 @@ ncI
 oEP
 xAV
 kuV
-sSh
+oKJ
 kuV
-riO
-sSh
+rQd
+vyi
 xAV
 lFE
 unx
@@ -257891,7 +258180,7 @@ kZo
 wkp
 eOD
 xCf
-dEY
+hgr
 jcI
 qkm
 fjX
@@ -258148,7 +258437,7 @@ bsN
 wkp
 eOD
 hFK
-sSh
+oKJ
 xAV
 hMC
 fjX
@@ -258405,7 +258694,7 @@ sBP
 sBP
 xAV
 jyP
-sSh
+oKJ
 xAV
 dPj
 fjX
@@ -258661,8 +258950,8 @@ eKF
 eeq
 nYs
 xAV
-sSh
-sSh
+vyi
+oKJ
 ppz
 ftX
 nLU
@@ -258918,7 +259207,7 @@ cgU
 quf
 swg
 xAV
-sSh
+oKJ
 ppz
 ppz
 xok
@@ -259689,7 +259978,7 @@ cgU
 quf
 swg
 xAV
-sSh
+oKJ
 ppz
 dfL
 dfL
@@ -266830,7 +267119,7 @@ sUN
 tLW
 mQg
 uVw
-uVw
+kIS
 uVw
 rZW
 pqO
@@ -271979,7 +272268,7 @@ stM
 stM
 stM
 xxu
-dNf
+idC
 uPQ
 jgX
 whT

--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -3230,7 +3230,6 @@
 "aRh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "aRi" = (
@@ -7654,12 +7653,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
-"chy" = (
-/obj/structure/chair/stool/bar/directional/north,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/landmark/generic_maintenance_landmark,
-/turf/open/floor/wood,
-/area/station/service/abandoned_gambling_den)
 "chB" = (
 /turf/closed/wall/rust,
 /area/station/common/cryopods/aux)
@@ -10599,14 +10592,6 @@
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/wood/tile,
 /area/station/hallway/secondary/recreation)
-"cZU" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/landmark/generic_maintenance_landmark,
-/turf/open/floor/wood,
-/area/station/service/library/abandoned)
 "cZX" = (
 /turf/closed/wall,
 /area/station/maintenance/cult_chapel)
@@ -10626,7 +10611,6 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "daj" = (
@@ -11193,7 +11177,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/generic_maintenance_landmark,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
@@ -20627,7 +20610,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small/red/directional/south,
-/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/cult_chapel)
 "fHR" = (
@@ -21420,7 +21402,6 @@
 "fRv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/generic_maintenance_landmark,
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/gamer_lair)
@@ -23202,7 +23183,6 @@
 /area/station/maintenance/starboard/aft)
 "gtp" = (
 /obj/structure/chair/stool/bar/directional/north,
-/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "gtr" = (
@@ -23272,7 +23252,6 @@
 "gum" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "guv" = (
@@ -27750,7 +27729,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/generic_maintenance_landmark,
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/plating,
 /area/station/maintenance/aux_eva)
@@ -30677,7 +30655,6 @@
 /area/station/common/pool)
 "iBa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/science/research/abandoned)
 "iBf" = (
@@ -40413,7 +40390,6 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/science/xenobiology)
 "liY" = (
-/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
 "ljk" = (
@@ -59969,7 +59945,6 @@
 "qCj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_holding_cell)
 "qCG" = (
@@ -60489,7 +60464,6 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/food/tomato_smudge,
-/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/iron,
 /area/station/maintenance/abandon_cafeteria)
 "qKS" = (
@@ -61742,19 +61716,6 @@
 /obj/effect/turf_decal/tile/red/real_red/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"rdO" = (
-/obj/effect/landmark/generic_maintenance_landmark,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port)
 "rdT" = (
 /turf/open/floor/plating/rust,
 /area/station/maintenance/space_hut/cabin)
@@ -66028,7 +65989,6 @@
 /area/station/medical/treatment_center)
 "sog" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/generic_maintenance_landmark,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_cafeteria/hydro)
@@ -66525,7 +66485,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "suk" = (
-/obj/effect/landmark/generic_maintenance_landmark,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/eva_shed)
@@ -72185,7 +72144,6 @@
 "tYp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "tYz" = (
@@ -236550,7 +236508,7 @@ fzs
 ckk
 tCA
 bCp
-rdO
+hcf
 tCA
 otZ
 dEg
@@ -240220,7 +240178,7 @@ rdH
 nMT
 dKV
 xlT
-chy
+wso
 aUA
 sJO
 rdH
@@ -243316,7 +243274,7 @@ rdH
 fTI
 pyR
 ccY
-cZU
+dif
 oDk
 xzV
 xzV


### PR DESCRIPTION
## About The Pull Request

Issue Summary:
On Moon Station while observing I signed up for nightmare, I was the sole player signed up for it. once the timer ended. I did not spawn in as nightmare, admin responded in chat:

STAFF (Sexmaster) says, "ADMIN LOG: No valid generic_maintenance_landmark landmarks found, aborting..."

Generic_landmark_spawn locations were added to the map in areas that satisfy the specific criteria for a nightmare to spawn.
Was able to repro the issue and fix it in the map.



## Why It's Good For The Game

It allows more antagonists roles to be played on Moonstation, potentially seeing it played more with antag spawn points added.

Fixes #2391 

## Proof Of Testing
![Screenshot 2024-11-16 203416](https://github.com/user-attachments/assets/6a3d0ff9-3e5e-43ed-bf94-d5a6a3ca0f02)
![Screenshot 2024-11-16 203451](https://github.com/user-attachments/assets/00e2c02e-e57b-4233-842b-e2b6d7b572b6)


## Changelog
:cl: Sparex

map: Added generic_maintenance_spawn points to fix the issue with the Nightmare not being able to spawn. They will now spawn as they should.

:cl:
