### PR TITLE
xeno queen can't be KO'd anymore

### DIFF
--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/queen.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/queen.dm
@@ -5,6 +5,7 @@
 	desc = "A hulking beast of an alien, for some reason this one seems more important than the others, you should probably quit staring at it and do something."
 	caste = "queen"
 	maxHealth = 500
+	status_flags = NONE //can't shove or KO the queen, kiddo.
 	health = 500
 	icon_state = "alienqueen"
 	melee_damage_lower = 30


### PR DESCRIPTION
## About The Pull Request
ditto as per PR title, TG queens have this, but not skyrat's

## Why It's Good For The Game

## Proof Of Testing
mechs nor punches no longer KO queens, confirmed by testing


## Changelog

:cl:
add: Skyrat xeno queen can no longer be KO'd, just like TG queens cannot.
/:cl:

