### PR TITLE
meridine overdose removal

### DIFF
--- a/modular_skyrat/modules/deforest_medical_items/code/injectors.dm
+++ b/modular_skyrat/modules/deforest_medical_items/code/injectors.dm
@@ -113,7 +113,7 @@
 	base_icon_state = "meridine"
 	icon_state = "meridine"
 	list_reagents = list(
-		/datum/reagent/medicine/ammoniated_mercury = 10,
+		/datum/reagent/medicine/ammoniated_mercury = 9,
 		/datum/reagent/medicine/potass_iodide = 10,
 		/datum/reagent/nitrous_oxide = 5,
 	)


### PR DESCRIPTION
## About The Pull Request

meridine no longer ODs you

## Why It's Good For The Game

the medipen being literally on the edge of overdose feels really silly

## Proof Of Testing

it's a single number change

## Changelog

:cl:
balance: meridine has 1u less ammoniated mercury
/:cl:
