### PR TITLE
depressurizes your glucose injector

### DIFF
--- a/modular_skyrat/modules/food_replicator/code/medical.dm
+++ b/modular_skyrat/modules/food_replicator/code/medical.dm
@@ -39,8 +39,8 @@
 		healed_mob.adjustOxyLoss(-amount_healed)
 
 /obj/item/reagent_containers/hypospray/medipen/glucose
-	name = "pressurised glucose medipen"
-	desc = "A medipen for keeping yourself going during prolonged EVA shifts, injects a dose of glucose into your bloodstream. Recommended for use in low-pressure environments."
+	name = "glucose medipen"
+	desc = "A medipen loaded with synthesized glucose, useful for keeping yourself going during prolonged EVA shifts or as emergency nutrition in medical settings."
 	icon = 'modular_skyrat/modules/food_replicator/icons/medicine.dmi'
 	icon_state = "glupen"
 	inhand_icon_state = "stimpen"
@@ -48,19 +48,3 @@
 	volume = 15
 	amount_per_transfer_from_this = 15
 	list_reagents = list(/datum/reagent/consumable/nutriment/glucose = 15)
-
-/obj/item/reagent_containers/hypospray/medipen/glucose/inject(mob/living/affected_mob, mob/user)
-	if(lavaland_equipment_pressure_check(get_turf(user)))
-		amount_per_transfer_from_this = initial(amount_per_transfer_from_this)
-		return ..()
-
-	if(DOING_INTERACTION(user, DOAFTER_SOURCE_SURVIVALPEN))
-		to_chat(user,span_notice("You are too busy to use \the [src]!"))
-		return
-
-	to_chat(user,span_notice("You start manually releasing the low-pressure gauge..."))
-	if(!do_after(user, 10 SECONDS, affected_mob, interaction_key = DOAFTER_SOURCE_SURVIVALPEN))
-		return
-
-	amount_per_transfer_from_this = initial(amount_per_transfer_from_this) * 0.5
-	return ..()

--- a/modular_skyrat/modules/food_replicator/code/replicator_designs/replicator_food.dm
+++ b/modular_skyrat/modules/food_replicator/code/replicator_designs/replicator_food.dm
@@ -44,7 +44,7 @@
 
 ///Despite being in the medical.dm file, it's still used to fill your hunger up, as such, technically, is food.
 /datum/design/glucose
-	name = "EVA Glucose Injector"
+	name = "Glucose Injector"
 	id = "slavic_glupen"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass = 150)


### PR DESCRIPTION
## About The Pull Request

Removes pressure check from the glucose medipen, and changes the description a bit.

## Why It's Good For The Game

Why are we gating glucose behind a pressure check like miner healing pens again? No one uses this thing.

## Proof Of Testing

Simple change, but I did actually test it on localhost.

## Changelog

:cl:
balance: removes pressure check from the glucose medipen and changes its description
/:cl:
