### PR TITLE
Make Space Dragons Immune to Crusher Mark

### DIFF
--- a/code/__DEFINES/~~bubber_defines/mob.dm
+++ b/code/__DEFINES/~~bubber_defines/mob.dm
@@ -1,0 +1,3 @@
+
+/// Put in mob_flags (which is unused by TG) to mark a specific mob as immune to crusher marks.
+#define MOB_IGNORES_CRUSHER_MARK (1<<10)

--- a/code/_globalvars/bitfields.dm
+++ b/code/_globalvars/bitfields.dm
@@ -261,6 +261,7 @@ DEFINE_BITFIELD(mob_biotypes, list(
 
 DEFINE_BITFIELD(mob_flags, list(
 	"MOB_HAS_SCREENTIPS_NAME_OVERRIDE" = MOB_HAS_SCREENTIPS_NAME_OVERRIDE,
+	"MOB_IGNORES_CRUSHER_MARK" = MOB_IGNORES_CRUSHER_MARK, // BUBBER EDIT ADDITION: Make mobs able to ignore crusher marks
 ))
 
 DEFINE_BITFIELD(mob_respiration_type, list(

--- a/modular_skyrat/master_files/code/datums/status_effects/debuffs/debuffs.dm
+++ b/modular_skyrat/master_files/code/datums/status_effects/debuffs/debuffs.dm
@@ -11,7 +11,7 @@
 	return ..()
 
 /datum/status_effect/crusher_mark/on_apply()
-	if(owner.mob_size >= MOB_SIZE_LARGE)
+	if(owner.mob_size >= MOB_SIZE_LARGE && !(owner.mob_flags & MOB_IGNORES_CRUSHER_MARK))
 		marked_underlay = mutable_appearance('icons/effects/effects.dmi', "shield2")
 		marked_underlay.pixel_x = -owner.pixel_x
 		marked_underlay.pixel_y = -owner.pixel_y

--- a/modular_zubbers/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
+++ b/modular_zubbers/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
@@ -1,3 +1,4 @@
 
 /mob/living/basic/space_dragon
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, STAMINA = 0.5, OXY = 0)
+	mob_flags = parent_type::mob_flags | MOB_IGNORES_CRUSHER_MARK

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -501,6 +501,7 @@
 #include "code\__DEFINES\~~bubber_defines\footsteps.dm"
 #include "code\__DEFINES\~~bubber_defines\jobs.dm"
 #include "code\__DEFINES\~~bubber_defines\misc.dm"
+#include "code\__DEFINES\~~bubber_defines\mob.dm"
 #include "code\__DEFINES\~~bubber_defines\mood.dm"
 #include "code\__DEFINES\~~bubber_defines\research_categories.dm"
 #include "code\__DEFINES\~~bubber_defines\say.dm"


### PR DESCRIPTION

## About The Pull Request

Tin. Also adds a mob_flag which I've helpfully attached to the var editor for bussed mobs.
## Why It's Good For The Game

Miners take nearly half the mob's HP in one hit (allegedly), this is bad for an antag designed to be at the very least a consistent pain in the ass for the station. It can't do that if it's two-shot by miners with the funny crusher.

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>


https://github.com/user-attachments/assets/dc609e91-d742-43e5-bb75-79cee1b587c1


</details>

## Changelog
:cl:
balance: Space dragon can no longer be marked by the crusher.
admin: Admins can now varedit mob_flags to make mobs immune to crusher marking.
/:cl:
