### PR TITLE
American Sausage can now be created again!

### DIFF
--- a/modular_skyrat/modules/customization/modules/food_and_drinks/food/scottish.dm
+++ b/modular_skyrat/modules/customization/modules/food_and_drinks/food/scottish.dm
@@ -68,9 +68,6 @@
 	foodtypes = MEAT | BREAKFAST | FRIED
 	crafting_complexity = FOOD_COMPLEXITY_3
 
-/obj/item/food/sausage/make_processable()
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/salami, 6, 3 SECONDS, table_required = TRUE,  screentip_verb = "Slice")
-
 /obj/item/food/cookie/shortbread
 	name = "shortbread"
 	desc = "A rectangular piece of cooked flour. Said to control the sun during Hogmanay."


### PR DESCRIPTION
## About The Pull Request

Fixes #1514 

Issue Summary
Normally when you cut up a cooked sausage with a sharp object, you get a small menu that pops up asking if you want to cut it into pieces of salami or cut it into an "american sausage" with the tip missing. Haha. This wouldn't be a problem if not for the fact that this makes two very, very specific cooking recipes which use the american sausage impossible. Very urgent I know.

Basically, using the knife on the sausage would automatically cut it into Salami. The choice pop-up to choose between salami and American Sausage was not occurring. Now, the dialogue pops up properly so the user can choose between the two ingredients instead of always being forced to cut into Salami.

## Why It's Good For The Game

There is a very specific recipe in tg database "Budae-Jjigae" that is reliant on that sole ingredient. This gives players back the ability to make this dish.. or make jokes about having the skin cut off the tip of a sausage. 

## Proof Of Testing

![Screenshot 2024-11-17 180920](https://github.com/user-attachments/assets/053773ba-e54d-4023-a333-11b4afbe7fa8)
![Screenshot 2024-11-17 180954](https://github.com/user-attachments/assets/e4b16cc9-e9d9-4eb6-ab13-9c34ab106503)
![Screenshot 2024-11-17 181015](https://github.com/user-attachments/assets/bafcead9-0d95-47e3-9a98-b836a5a10d09)


## Changelog

:cl: Sparex

fix: When using the knife on a sausage, the choice pop-up wheel to cut into Salami or American Sausage has been fixed and you can now properly circumcise sausages again.

:cl:

