### PR TITLE
Enables exploitables access for dauntless spawners

### DIFF
--- a/modular_zubbers/maps/offstation/dauntless/mob_spawns.dm
+++ b/modular_zubbers/maps/offstation/dauntless/mob_spawns.dm
@@ -19,6 +19,15 @@
 	loadout_enabled = TRUE
 	computer_area = /area/ruin/space/has_grav/bubbers/dauntless/service
 	spawner_job_path = /datum/job/dauntless
+	/// If true, this spawner will give it's target exploitables access.
+	var/give_exploitables = TRUE
+
+/obj/effect/mob_spawn/ghost_role/human/dauntless/special(mob/living/spawned_mob, mob/mob_possessor)
+	. = ..()
+
+	if (give_exploitables)
+		spawned_mob.mind?.has_exploitables_override = TRUE
+		spawned_mob.mind?.handle_exploitables_menu()
 
 /obj/effect/mob_spawn/ghost_role/human/dauntless/syndicate
 	name = "Syndicate Operative"
@@ -44,6 +53,7 @@
 	important_text = "You are not an antagonist. You are still bound to the Roleplay Rules regarding escalation. Dauntless personnel can throw you into lava if you antagonize them."
 	outfit = /datum/outfit/dauntless/prisoner
 	computer_area = /area/ruin/space/has_grav/bubbers/dauntless/sec/prison
+	give_exploitables = FALSE
 
 /obj/effect/mob_spawn/ghost_role/human/dauntless/syndicate/service
 	outfit = /datum/outfit/dauntless/syndicate/service


### PR DESCRIPTION
## About The Pull Request

Title.

This has already been merged into persistence, but for parity's sake, it should be added into dauntless.
## Why It's Good For The Game

Enhances interrogations, mostly. Also good for blackmailing people who decide to fuck w/ dauntless.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/0b48f079-d8f2-43e7-8d56-679a837c4d0e)

</details>

## Changelog
:cl:
add: Dauntless now has exploitables
/:cl:
