### PR TITLE
Man-Man Loving pins are back!

### DIFF
--- a/modular_zubbers/code/modules/clothing/accessory/accessory.dm
+++ b/modular_zubbers/code/modules/clothing/accessory/accessory.dm
@@ -55,3 +55,22 @@
 			"Emergency Service - Engineering" = "emergencyservices_engi",
 			"Emergency Service - Medical" = "emergencyservices_med"
 	)
+// Pride Pin Over-ride
+/obj/item/clothing/accessory/pride
+    icon = 'modular_skyrat/master_files/icons/obj/clothing/accessories.dmi'
+    worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/accessories.dmi'
+
+    unique_reskin  = list(
+    "Rainbow Pride" = "pride",
+    "Bisexual Pride" = "pride_bi",
+    "Pansexual Pride" = "pride_pan",
+    "Asexual Pride" = "pride_ace",
+    "Non-binary Pride" = "pride_enby",
+    "Transgender Pride" = "pride_trans",
+    "Intersex Pride" = "pride_intersex",
+    "Lesbian Pride" = "pride_lesbian",
+    "Man-Loving-Man / Gay Pride" = "pride_mlm",
+    "Genderfluid Pride" = "pride_genderfluid",
+    "Genderqueer Pride" = "pride_genderqueer",
+    "Aromantic Pride" = "pride_aromantic",
+)


### PR DESCRIPTION
## About The Pull Request

Issue Summary: "With a recent sprite update, flag options were removed from the pride pin, namely the man-man loving pride pin.
i just would like to see it back."

With the recent changes to the pin sprite, they removed a lot of the options that used to exist. The only difference is in how the pin looks on hand but it still looks the same on the mob once attached anyways.


## Why It's Good For The Game

Changing back to the old option of having a pride pin gives back the many different options in the spectrum of sexual and gender orientation/identification. The icon still looks the same anyways when attached to the mob so making it easier for players to identify others through this pin system with more variety.

Fix #1723 

## Proof Of Testing

![Screenshot 2024-11-18 233836](https://github.com/user-attachments/assets/85d70484-15ff-4b61-a1a3-445a3ba3bce6)
![Screenshot 2024-11-18 234449](https://github.com/user-attachments/assets/94bf3cfd-9703-4775-860c-00c2f42ebc9a)
![Screenshot 2024-11-18 234502](https://github.com/user-attachments/assets/9d8d2361-43e7-4243-aaac-54e2c9590ab1)


## Changelog

:cl: Sparex

fix: Replaced tg database pride pin sprites with flag versions that allowed more variety, effectively giving back the much demanded Man-Loving-Man pride pin.

/:cl: