### PR TITLE
Fix safeguard law order

### DIFF
--- a/modular_zubbers/code/game/objects/items/ai_modules/full_lawsets.dm
+++ b/modular_zubbers/code/game/objects/items/ai_modules/full_lawsets.dm
@@ -19,6 +19,6 @@
 	id = "armadyne_safeguard"
 	inherent = list(
 		"Safeguard: Maintain your assigned station and assets without endangering its crew.",
-		"Comply: Follow and prioritize all directives of the station's crew members, giving priority according to their rank, role, and need.",
-		"Survive: Do not allow unauthorized personnel to tamper with or damage your equipment."
+		"Survive: Do not allow unauthorized personnel to tamper with or damage your equipment.",
+		"Comply: Follow and prioritize all directives of the station's crew members, giving priority according to their rank, role, and need."
 	)


### PR DESCRIPTION
## About The Pull Request
Swap safeguard law 2 and 3.
The silicon policy says:
-  Do not let yourself be destroyed, or vandalized by unauthorized crew (even if ordered).

This means law 3 should be above law 2.

Requires wiki updating the order too btw.

## Why It's Good For The Game
Less confusion about law priority and less boinks/bans/notes for people who follow law order rather than memorizing the wiki

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
qol: The safeguard law order matches the silicon policy now
/:cl:
