### PR TITLE
Make Baklava Pie retain its quality after slicing

### DIFF
--- a/code/game/objects/items/food/pie.dm
+++ b/code/game/objects/items/food/pie.dm
@@ -430,6 +430,7 @@
 	icon_state = "baklavaslice"
 	tastes = list("nuts" = 1, "pie" = 1)
 	foodtypes = NUTS | SUGAR
+	crafting_complexity = FOOD_COMPLEXITY_4
 
 /obj/item/food/pie/frenchsilkpie
 	name = "french silk pie"


### PR DESCRIPTION
## About The Pull Request

Adds the crafting complexity to the slices of baklava, so it doesn't go from very good to nice after you slice it.

## Why It's Good For The Game

If I have one more food suddenly degrade in quality after slicing it into multiple portions I am going to explode the fucking kitchen, especially after having to bother Hydroponics to mutate a plant specifically for it

## Proof Of Testing

![image](https://github.com/user-attachments/assets/b4cd692e-10f8-4701-a772-45aad97e8c43)

</details>

## Changelog

:cl:
fix: Makes a sliced baklava pie keep its complexity after slicing
/:cl:
