### PR TITLE
Reduces the amount of ruin Z levels

### DIFF
--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -171,7 +171,7 @@ Always compile, always use that verb, and always make sure that it works for wha
 #define PLACE_ISOLATED "isolated" //On isolated ruin z level
 
 ///Map generation defines
-#define DEFAULT_SPACE_RUIN_LEVELS 4
+#define DEFAULT_SPACE_RUIN_LEVELS 4 // Bubber Edit - ORG: 7
 #define DEFAULT_SPACE_EMPTY_LEVELS 1
 
 #define BIOME_LOW_HEAT "low_heat"

--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -171,7 +171,7 @@ Always compile, always use that verb, and always make sure that it works for wha
 #define PLACE_ISOLATED "isolated" //On isolated ruin z level
 
 ///Map generation defines
-#define DEFAULT_SPACE_RUIN_LEVELS 7
+#define DEFAULT_SPACE_RUIN_LEVELS 4
 #define DEFAULT_SPACE_EMPTY_LEVELS 1
 
 #define BIOME_LOW_HEAT "low_heat"


### PR DESCRIPTION
We have memory issues and we need to start cutting down on it. I'd rather keep our ghost roles intact and the Interlink intact with this being the first solution.

Halves the amount of ruin Z levels that spawn. (7 to 4 by default)

