### PR TITLE
Balances Godslayer Armor for Icemoon

### DIFF
--- a/modular_zubbers/code/modules/mining/equipment/explorer_gear.dm
+++ b/modular_zubbers/code/modules/mining/equipment/explorer_gear.dm
@@ -1,0 +1,19 @@
+/obj/item/clothing/suit/hooded/cloak/godslayer
+		clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL | LAVAPROTECT
+		resistance_flags = FIRE_PROOF | ACID_PROOF | FREEZE_PROOF | LAVA_PROOF
+
+/datum/armor/cloak_godslayer
+	melee = 65
+	bullet = 15
+	laser = 40
+	energy = 40
+	bomb = 70
+	bio = 60
+	fire = 100
+	acid = 100
+	wound = 10
+
+
+/obj/item/clothing/head/hooded/cloakhood/godslayer
+		clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL | SNUG_FIT | LAVAPROTECT
+		resistance_flags = FIRE_PROOF | ACID_PROOF | FREEZE_PROOF | LAVA_PROOF

--- a/modular_zubbers/code/modules/mining/equipment/explorer_gear.dm
+++ b/modular_zubbers/code/modules/mining/equipment/explorer_gear.dm
@@ -3,10 +3,10 @@
 		resistance_flags = FIRE_PROOF | ACID_PROOF | FREEZE_PROOF | LAVA_PROOF
 
 /datum/armor/cloak_godslayer
-	melee = 65
+	melee = 75
 	bullet = 15
-	laser = 40
-	energy = 40
+	laser = 30
+	energy = 30
 	bomb = 70
 	bio = 60
 	fire = 100

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9088,6 +9088,7 @@
 #include "modular_zubbers\code\modules\mapping\ss13_construct\areas.dm"
 #include "modular_zubbers\code\modules\mining\abandoned_crates.dm"
 #include "modular_zubbers\code\modules\mining\shelters.dm"
+#include "modular_zubbers\code\modules\mining\equipment\explorer_gear.dm"
 #include "modular_zubbers\code\modules\mining\equipment\survival_pod.dm"
 #include "modular_zubbers\code\modules\mining\lavaland\megafauna_loot.dm"
 #include "modular_zubbers\code\modules\mining\lavaland\equipment\explorer_gear.dm"


### PR DESCRIPTION

## About The Pull Request

I know what you're immediately thinking this is a nerf for mining again. No. This one is actually a buff. Let me explain.
Godslayer Armor is supposed to be the penultimate reward for Icebox. It requires beating all three unique megafauna, the Demonic Frost Miner, the Wendigo, and the Clockwork Knight (as pathetic as it is). You would think that this armor would then be good and useful for the Icemoon... but no. It's not.

The armor stats are less than Drake Armor, and if this was Lavaland, that'd be fine. However on the Icemoon, Ice Whelps are exceedingly common at vents and in the wild, so you can have six or more suits of Drake Armor in a single round to just pass around to the crew because you can, given you likely have your seventeen lux pens and implanted legion core. **_This PR balances the armor stats to be the similar to Drake Armor, actually making it viable for fauna combat while still having poor bullet resistance for station conflicts._** This specific change means: higher melee protection (V -> VIII [50 -> 75 compared to Drake's 65]); lower bullet (III -> II [25 -> 15 same as Drake]), laser (III -> III [25 -> 30 compared to Drake's 40]), and energy (III -> III [25 -> 30 compared to Drake's 40]) protection.

But, I also went further with this PR. **_I've added innate Lavaproofing to the Godslayer Armor._** I felt it needed something else to make it stand out. No one wears the armor, so no one actually knows the suit also has a natural pressure seal, meaning it can be worn in space. But since there's no aspects where you'll ever be wearing this in space given that Icebox is a planetary map, so I wanted to make that pressure seal also be lavaproof, meaning the wearer can walk in the plasma river on the bottom layer of the map.

## Why It's Good For The Game

People may actually wear this unique armor again instead of making it, looking at the armor values, and tossing it aside.

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

Drake Armor base stats:
![dreamseeker_2024-11-23_20-25-29](https://github.com/user-attachments/assets/75f4a20b-f244-41e5-9bf2-d5480e5290b8)

Edited Godslayer stats:
![dreamseeker_2024-11-23_21-24-51](https://github.com/user-attachments/assets/9a4ed699-dbe0-4fec-882a-5d3c0c5a5682)

Drake Armor in lava:
![dreamseeker_2024-11-23_20-28-06](https://github.com/user-attachments/assets/c9df5bb1-33c4-419c-bf58-4c2d64e06592)

Godslayer Armor in lava:
![dreamseeker_2024-11-23_20-42-13](https://github.com/user-attachments/assets/2a200755-0803-4fa8-b26d-67e8fd863b48)

</details>

## Changelog

:cl:
add: Developments with Godslayer Armor have unlocked its true armor potential.
/:cl: