### PR TITLE
Removes examine giving real species name in parathesise in favor of health analyzers showing it.

### DIFF
--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -171,7 +171,7 @@ Always compile, always use that verb, and always make sure that it works for wha
 #define PLACE_ISOLATED "isolated" //On isolated ruin z level
 
 ///Map generation defines
-#define DEFAULT_SPACE_RUIN_LEVELS 4
+#define DEFAULT_SPACE_RUIN_LEVELS 4 // Bubber Edit - ORG: 7
 #define DEFAULT_SPACE_EMPTY_LEVELS 1
 
 #define BIOME_LOW_HEAT "low_heat"

--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -171,7 +171,7 @@ Always compile, always use that verb, and always make sure that it works for wha
 #define PLACE_ISOLATED "isolated" //On isolated ruin z level
 
 ///Map generation defines
-#define DEFAULT_SPACE_RUIN_LEVELS 7
+#define DEFAULT_SPACE_RUIN_LEVELS 4
 #define DEFAULT_SPACE_EMPTY_LEVELS 1
 
 #define BIOME_LOW_HEAT "low_heat"

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -348,7 +348,7 @@
 		var/datum/species/targetspecies = humantarget.dna.species
 		var/mutant = HAS_TRAIT(humantarget, TRAIT_HULK)
 
-		render_list += "<span class='info ml-1'>Species: [targetspecies.name][mutant ? "-derived mutant" : ""]</span><br>"
+		render_list += "<span class='info ml-1'>Species: <b>[targetspecies.name][mutant ? "-derived mutant" : ""]</b></span><br>" // Bubber Edit: Bold species name
 		var/core_temperature_message = "Core temperature: [round(humantarget.coretemperature-T0C, 0.1)] &deg;C ([round(humantarget.coretemperature*1.8-459.67,0.1)] &deg;F)"
 		if(humantarget.coretemperature >= humantarget.get_body_temp_heat_damage_limit())
 			render_list += "<span class='alert ml-1'>☼ [core_temperature_message] ☼</span><br>"

--- a/modular_zubbers/master_files/code/modules/mob/living/carbon/human/examine.dm
+++ b/modular_zubbers/master_files/code/modules/mob/living/carbon/human/examine.dm
@@ -12,7 +12,7 @@
 	if(!species_visible)
 		species_name_string = ""
 	else if (!dna.species.lore_protected && dna.features["custom_species"])
-		species_name_string = ", [prefix_a_or_an(dna.features["custom_species"])] <EM>[dna.features["custom_species"]] ([dna.species.name])</EM>"
+		species_name_string = ", [prefix_a_or_an(dna.features["custom_species"])] <EM>[dna.features["custom_species"]]</EM>"
 	else
 		species_name_string = ", [prefix_a_or_an(dna.species.name)] <EM>[dna.species.name]</EM>"
 


### PR DESCRIPTION
## About The Pull Request

Removes (dna.species.name) from being appended to the examine text. At a glance you'll only see custom species name.

![image](https://github.com/user-attachments/assets/da5a8afd-c61e-4b74-8379-188c02fb8438)

## Why It's Good For The Game

I think a little bit of obuscation from noticing these things at a glance isn't the worst thing in the world. Hemophages trying to hide, etc. The health analyzer will show the true species of a person. I also bolded it so it's more noticable on the health analyzer.

## Proof Of Testing

See above

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Species name shows up in bold on the health analyzer.
del: True species name will no longer show up when examining someone.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
