### PR TITLE
Halves dragon portal loss slowdown

### DIFF
--- a/modular_zubbers/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
+++ b/modular_zubbers/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
@@ -1,3 +1,8 @@
 
 /mob/living/basic/space_dragon
+	maxHealth = 600
+	health = 600
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, STAMINA = 0.5, OXY = 0)
+
+/datum/movespeed_modifier/dragon_depression
+	multiplicative_slowdown = 2.5

--- a/modular_zubbers/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
+++ b/modular_zubbers/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
@@ -1,7 +1,5 @@
 
 /mob/living/basic/space_dragon
-	maxHealth = 600
-	health = 600
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, STAMINA = 0.5, OXY = 0)
 
 /datum/movespeed_modifier/dragon_depression


### PR DESCRIPTION
## About The Pull Request
as PR title says

## Why It's Good For The Game
Currently dragon tends to absolutely get bodied almost always, and dragon depression currently is 100% a death sentence, that is, the slowdown being far too much for a mainly melee antag to survive.
## Proof Of Testing
tested the slowdown and the other one's just number changes

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
balance: Dragon depression slowdown is now only 2.5, where it used to be 5.
/:cl:

