### PR TITLE
quick fix for a missing cable on Box Station.

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -56265,6 +56265,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/cargo/drone_bay)
 "rrx" = (


### PR DESCRIPTION

## About The Pull Request

This adds a single cable wire under an airlock for the drone bay that I missed out on changing for Boxstation's last PR (https://github.com/Bubberstation/Bubberstation/pull/2545)

## Changelog

:cl:
fix: Places a missing cable leading to the drone bay on Box Station
/:cl:
