### PR TITLE
Removes the magical Shaytan magazine when crafted.

### DIFF
--- a/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/romulus_technology/smg.dm
+++ b/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/romulus_technology/smg.dm
@@ -54,4 +54,6 @@
 /obj/item/gun/ballistic/automatic/rom_smg/give_manufacturer_examine()
 	AddElement(/datum/element/manufacturer_examine, COMPANY_ROMTECH)
 
+/obj/item/gun/ballistic/automatic/rom_smg/no_mag
+	spawnwithmagazine = FALSE
 //Does not have additional examine text.. Yet

--- a/modular_skyrat/modules/sec_haul/code/guns/sec_gun_rs.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/sec_gun_rs.dm
@@ -12,7 +12,7 @@
 
 /datum/crafting_recipe/sol_smg_rapidfire_kit
 	name = "'Shaytan' SMG Conversion" //edited by Bangle
-	result = /obj/item/gun/ballistic/automatic/rom_smg
+	result = /obj/item/gun/ballistic/automatic/rom_smg/no_mag
 	reqs = list(
 		/obj/item/gun/ballistic/automatic/sol_smg = 1,
 		/obj/item/weaponcrafting/gunkit/sol_smg_rapidfire_kit = 1,


### PR DESCRIPTION

## About The Pull Request

Removes the starting magazine from the newly-crafted Shaytan SMG. The spontaneous manifestation of live ammo and a spare magazine was an oversight.

## Why It's Good For The Game

Balancing?

## Proof Of Testing

I did not test. I have copied code that I've seen for pistols spawning without mags and have prayed that it works.

</details>

## Changelog
:cl: Bangle
balance: rebalanced something
fix: fixed a few things
/:cl: