### PR TITLE
Not doing portals no longer kills the dragon

### DIFF
--- a/code/modules/antagonists/space_dragon/carp_rift.dm
+++ b/code/modules/antagonists/space_dragon/carp_rift.dm
@@ -35,6 +35,7 @@
 		return
 	if(locate(/obj/structure/carp_rift) in owner.loc)
 		return
+	owner.remove_movespeed_modifier(/datum/movespeed_modifier/dragon_depression/no_portal) // BUBBER ADDITION
 	var/obj/structure/carp_rift/new_rift = new(get_turf(owner))
 	playsound(owner.loc, 'sound/vehicles/rocketlaunch.ogg', 100, TRUE)
 	dragon.riftTimer = -1

--- a/code/modules/antagonists/space_dragon/space_dragon.dm
+++ b/code/modules/antagonists/space_dragon/space_dragon.dm
@@ -13,7 +13,7 @@
 	/// Current time since the the last rift was activated.  If set to -1, does not increment.
 	var/riftTimer = 0
 	/// Maximum amount of time which can pass without a rift before Space Dragon despawns.
-	var/maxRiftTimer = 80
+	var/maxRiftTimer = 300
 	/// A list of all of the rifts created by Space Dragon.  Used for setting them all to infinite carp spawn when Space Dragon wins, and removing them when Space Dragon dies.
 	var/list/obj/structure/carp_rift/rift_list = list()
 	/// How many rifts have been successfully charged

--- a/code/modules/antagonists/space_dragon/space_dragon.dm
+++ b/code/modules/antagonists/space_dragon/space_dragon.dm
@@ -132,19 +132,21 @@
 /datum/antagonist/space_dragon/proc/rift_checks()
 	if((rifts_charged == 3 || (SSshuttle.emergency.mode == SHUTTLE_DOCKED && rifts_charged > 0)) && !objective_complete)
 		victory()
-		return
-	if(riftTimer == -1)
-		return
-	riftTimer = min(riftTimer + 1, maxRiftTimer + 1)
-	if(riftTimer == (maxRiftTimer - 60))
-		to_chat(owner.current, span_boldwarning("You have a minute left to summon the rift! Get to it!"))
-		return
-	if(riftTimer >= maxRiftTimer)
-		to_chat(owner.current, span_boldwarning("You've failed to summon the rift in a timely manner! You're being pulled back from whence you came!"))
-		destroy_rifts()
-		SEND_SOUND(owner.current, sound('sound/effects/magic/demon_dies.ogg'))
-		owner.current.death(/* gibbed = */ TRUE)
-		QDEL_NULL(owner.current)
+	// BUBBER REMOVAL START
+	// 	return
+	// if(riftTimer == -1)
+	// 	return
+	// riftTimer = min(riftTimer + 1, maxRiftTimer + 1)
+	// if(riftTimer == (maxRiftTimer - 60))
+	// 	to_chat(owner.current, span_boldwarning("You have a minute left to summon the rift! Get to it!"))
+	// 	return
+	// if(riftTimer >= maxRiftTimer)
+	// 	to_chat(owner.current, span_boldwarning("You've failed to summon the rift in a timely manner! You're being pulled back from whence you came!"))
+	// 	destroy_rifts()
+	// 	SEND_SOUND(owner.current, sound('sound/effects/magic/demon_dies.ogg'))
+	// 	owner.current.death(/* gibbed = */ TRUE)
+	// 	QDEL_NULL(owner.current)
+	// BUBBER REMOVAL END
 
 /**
  * Destroys all of Space Dragon's current rifts.

--- a/code/modules/antagonists/space_dragon/space_dragon.dm
+++ b/code/modules/antagonists/space_dragon/space_dragon.dm
@@ -13,7 +13,7 @@
 	/// Current time since the the last rift was activated.  If set to -1, does not increment.
 	var/riftTimer = 0
 	/// Maximum amount of time which can pass without a rift before Space Dragon despawns.
-	var/maxRiftTimer = 300
+	var/maxRiftTimer = 80
 	/// A list of all of the rifts created by Space Dragon.  Used for setting them all to infinite carp spawn when Space Dragon wins, and removing them when Space Dragon dies.
 	var/list/obj/structure/carp_rift/rift_list = list()
 	/// How many rifts have been successfully charged
@@ -132,21 +132,18 @@
 /datum/antagonist/space_dragon/proc/rift_checks()
 	if((rifts_charged == 3 || (SSshuttle.emergency.mode == SHUTTLE_DOCKED && rifts_charged > 0)) && !objective_complete)
 		victory()
-	// BUBBER REMOVAL START
-	// 	return
-	// if(riftTimer == -1)
-	// 	return
-	// riftTimer = min(riftTimer + 1, maxRiftTimer + 1)
-	// if(riftTimer == (maxRiftTimer - 60))
-	// 	to_chat(owner.current, span_boldwarning("You have a minute left to summon the rift! Get to it!"))
-	// 	return
-	// if(riftTimer >= maxRiftTimer)
-	// 	to_chat(owner.current, span_boldwarning("You've failed to summon the rift in a timely manner! You're being pulled back from whence you came!"))
-	// 	destroy_rifts()
-	// 	SEND_SOUND(owner.current, sound('sound/effects/magic/demon_dies.ogg'))
-	// 	owner.current.death(/* gibbed = */ TRUE)
-	// 	QDEL_NULL(owner.current)
-	// BUBBER REMOVAL END
+	if(riftTimer == -1)
+		return
+	riftTimer = min(riftTimer + 1, maxRiftTimer + 1)
+	if(riftTimer == (maxRiftTimer - 60))
+		to_chat(owner.current, span_boldwarning("You have a minute left to summon the rift! Get to it!"))
+		return
+	if(riftTimer >= maxRiftTimer)
+		// BUBBER CHANGE START: dragons don't die to not summoning a rift
+		to_chat(owner.current, span_boldwarning("You've failed to summon the rift in a timely manner! You will be slowed down until you do so!"))
+		owner.current.add_movespeed_modifier(/datum/movespeed_modifier/dragon_depression/no_portal)
+		riftTimer = -1
+		// BUBBER CHANGE END
 
 /**
  * Destroys all of Space Dragon's current rifts.

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -145,6 +145,8 @@
 /datum/movespeed_modifier/dragon_depression
 	multiplicative_slowdown = 5
 
+/datum/movespeed_modifier/dragon_depression/no_portal
+
 /datum/movespeed_modifier/morph_disguised
 	multiplicative_slowdown = -1
 

--- a/code/modules/unit_tests/dragon_expiration.dm
+++ b/code/modules/unit_tests/dragon_expiration.dm
@@ -23,9 +23,12 @@
 	var/datum/antagonist/space_dragon/dragon_antag_datum = dragon_time.mind.add_antag_datum(/datum/antagonist/space_dragon)
 	dragon_time.eat(to_be_consumed)
 
-	dragon_antag_datum.riftTimer = dragon_antag_datum.maxRiftTimer + 1
-	dragon_antag_datum.rift_checks()
+	// BUBBER CHANGE START: dragon doesn't have a riftTimer anymore
+	dragon_time.death()
+	// dragon_antag_datum.riftTimer = dragon_antag_datum.maxRiftTimer + 1
+	// dragon_antag_datum.rift_checks()
 
-	TEST_ASSERT(QDELETED(dragon_time), "The space dragon wasn't deleted after having its rift timer exceeded!")
-	TEST_ASSERT(!QDELETED(to_be_consumed), "After having its rift timer exceeded, the dragon deleted the dummy instead! The dragon should be dead prior to being deleted!")
-	TEST_ASSERT(isturf(to_be_consumed.loc), "After having its rift timer exceeded, the dragon did not eject the dummy! (Dummy's loc: [to_be_consumed.loc])")
+	// TEST_ASSERT(QDELETED(dragon_time), "The space dragon wasn't deleted after having its rift timer exceeded!")
+	TEST_ASSERT(!QDELETED(to_be_consumed), "After eating the dummy and dying, the dragon deleted the dummy instead!")
+	TEST_ASSERT(isturf(to_be_consumed.loc), "After eating the dummy and dying, the dragon did not eject the dummy! (Dummy's loc: [to_be_consumed.loc])")
+	// BUBBER CHANGE END

--- a/code/modules/unit_tests/dragon_expiration.dm
+++ b/code/modules/unit_tests/dragon_expiration.dm
@@ -25,7 +25,7 @@
 
 	// BUBBER CHANGE START: dragon doesn't have a riftTimer anymore
 	dragon_time.death()
-	qdel(dragon_time)
+	QDEL_NULL(dragon_antag_datum.owner.current)
 	// dragon_antag_datum.riftTimer = dragon_antag_datum.maxRiftTimer + 1
 	// dragon_antag_datum.rift_checks()
 

--- a/code/modules/unit_tests/dragon_expiration.dm
+++ b/code/modules/unit_tests/dragon_expiration.dm
@@ -25,6 +25,7 @@
 
 	// BUBBER CHANGE START: dragon doesn't have a riftTimer anymore
 	dragon_time.death()
+	qdel(dragon_time)
 	// dragon_antag_datum.riftTimer = dragon_antag_datum.maxRiftTimer + 1
 	// dragon_antag_datum.rift_checks()
 

--- a/code/modules/unit_tests/dragon_expiration.dm
+++ b/code/modules/unit_tests/dragon_expiration.dm
@@ -24,7 +24,7 @@
 	dragon_time.eat(to_be_consumed)
 
 	// BUBBER CHANGE START: dragon doesn't have a riftTimer anymore
-	dragon_time.death()
+	dragon_time.death(TRUE)
 	QDEL_NULL(dragon_antag_datum.owner.current)
 	// dragon_antag_datum.riftTimer = dragon_antag_datum.maxRiftTimer + 1
 	// dragon_antag_datum.rift_checks()


### PR DESCRIPTION
## About The Pull Request
When the dragon runs out of time to make a rift, instead of deleting the dragon, they are given the dragon depression movespeed debuff.

## Why It's Good For The Game
You are forced to get into full on combat with everyone or be literally deleted, this should give people a chance to RP as dragon, with dragon

## Proof Of Testing
Tested and it confirmed that it did not break the victory condition

## Changelog

:cl:
del: Dragon no longer gets deleted if you don't do rifts, instead you are given dragon depression, which slows you down heavily.
/:cl:

