### PR TITLE
Scrubber overflow reagent adjustment

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -1109,7 +1109,7 @@
 	. = ..()
 	if(SPT_PROB(2.5, seconds_per_tick))
 		// 20u = 1x1, 45u = 2x2, 80u = 3x3
-		var/volume_to_radius = FLOOR(sqrt(volume/5), 1) - 1
+		var/volume_to_radius = FLOOR(sqrt(volume/3), 1) - 1 // BUBBER EDIT CHANGE - Original: volume/5
 		var/suck_range = clamp(volume_to_radius, 0, 3)
 
 		if(!suck_range)

--- a/modular_zubbers/code/modules/storyteller/_events/scrubber_overflow.dm
+++ b/modular_zubbers/code/modules/storyteller/_events/scrubber_overflow.dm
@@ -10,10 +10,10 @@
 		/datum/reagent/consumable/condensedcapsaicin,
 		/datum/reagent/consumable/cream,
 		/datum/reagent/consumable/ethanol/antifreeze,
-		/datum/reagent/consumable/ethanol/beer,
-		/datum/reagent/consumable/ethanol/fernet_cola,
 		/datum/reagent/consumable/ethanol/sugar_rush,
+		/datum/reagent/consumable/ethanol/singulo,
 		/datum/reagent/consumable/ethanol/synthanol,
+		/datum/reagent/consumable/ethanol/whiskey,
 		/datum/reagent/consumable/flour,
 		/datum/reagent/consumable/ice,
 		/datum/reagent/consumable/laughter,
@@ -43,3 +43,11 @@
 		/datum/reagent/water/salt,
 		/datum/reagent/yuck,
 	)
+	reagents_amount = 40
+
+/datum/round_event/scrubber_overflow/threatening
+	reagents_amount = 60
+
+/datum/round_event/scrubber_overflow/catastrophic
+	reagents_amount = 80
+


### PR DESCRIPTION
## About The Pull Request

Small changes to scrubber overflow. Reduces the amount of reagent by roughly 30%, Adjustment to ethanol chems.

## Why It's Good For The Game

Flooding people with 120+ units of something has an effect lasting too long, this should tamper it down a bit. The ethanol dose shouldn't mean guaranteed liver death or being drunk for a half hour.

## Changelog

:cl: LT3
balance: Minor reduction to the strength of scrubber overflows
/:cl: