### PR TITLE
Tajaran cat ass photocopier fix

### DIFF
--- a/modular_zubbers/code/modules/mob/living/carbon/human/species/tajaran.dm
+++ b/modular_zubbers/code/modules/mob/living/carbon/human/species/tajaran.dm
@@ -110,7 +110,7 @@
 	return to_add
 
 /obj/item/bodypart/chest/tajaran/get_butt_sprite()
-	return icon('modular_skyrat/master_files/icons/mob/butts.dmi', BUTT_SPRITE_VULP)
+	return icon('icons/mob/butts.dmi', BUTT_SPRITE_CAT)
 
 /datum/species/tajaran/get_species_description() //Something basic until I make lore later
 	return list("The Tajara are a race of humanoids that possess markedly felinoid traits that include \

--- a/modular_zubbers/code/modules/mob/living/carbon/human/species/tajaran.dm
+++ b/modular_zubbers/code/modules/mob/living/carbon/human/species/tajaran.dm
@@ -109,7 +109,7 @@
 
 	return to_add
 
-/obj/item/bodypart/chest/tajaran/get_butt_sprite()
+/obj/item/bodypart/chest/mutant/tajaran/get_butt_sprite()
 	return icon('icons/mob/butts.dmi', BUTT_SPRITE_CAT)
 
 /datum/species/tajaran/get_species_description() //Something basic until I make lore later


### PR DESCRIPTION

## About The Pull Request

Changes Tajaran butt sprite on the photocopier from Vulp to Cat

fixes: #2248 

## Why It's Good For The Game

Simple little change unless someone wants to make a whole new sprite, this should be more accurate.

## Proof Of Testing

Spawned in a photocopier, hopped on as a Tajaran. Cat ass.

![image](https://github.com/user-attachments/assets/d2bbddd1-8570-4e5f-855b-862ec30151cd)

</details>

## Changelog

fix: Give Tajaran the ass they deserve when photocopying.
