### PR TITLE
Borer action button fixes

### DIFF
--- a/modular_skyrat/modules/cortical_borer/code/abilities/_borer_abilities.dm
+++ b/modular_skyrat/modules/cortical_borer/code/abilities/_borer_abilities.dm
@@ -433,9 +433,9 @@
 	if(!owner.Adjacent(human_target))
 		owner.balloon_alert(owner, "chosen target too far")
 		return FALSE
-	// if(considered_afk(human_target.mind))
-	// 	owner.balloon_alert(owner, "mind inactive!")
-	// 	return FALSE
+	if(considered_afk(human_target.mind))
+		owner.balloon_alert(owner, "mind inactive!")
+		return FALSE
 
 	incite_fear(target)
 	StartCooldown()
@@ -449,10 +449,10 @@
 	if(cortical_owner.host_sugar())
 		owner.balloon_alert(owner, "cannot function with sugar in host")
 		return FALSE
-	// if(cortical_owner.human_host)
-	// 	if(considered_afk(cortical_owner.human_host.mind))
-	// 		owner.balloon_alert(owner, "mind inactive!")
-	// 		return FALSE
+	if(cortical_owner.human_host)
+		if(considered_afk(cortical_owner.human_host.mind))
+			owner.balloon_alert(owner, "mind inactive!")
+			return FALSE
 	return TRUE
 
 /datum/action/cooldown/mob_cooldown/borer/fear_human/pre_intercept_trigger(trigger_flags, atom/target)

--- a/modular_skyrat/modules/cortical_borer/code/abilities/_borer_abilities.dm
+++ b/modular_skyrat/modules/cortical_borer/code/abilities/_borer_abilities.dm
@@ -27,7 +27,21 @@
 	name = "[initial(name)][compiled_string]"
 
 /datum/action/cooldown/mob_cooldown/borer/Trigger(trigger_flags, atom/target)
+	if(!can_trigger(trigger_flags, target))
+		unset_click_ability(owner)
+		return FALSE
+	if(!pre_intercept_trigger(trigger_flags, target))
+		return FALSE
 	. = ..()
+
+	return . == FALSE ? FALSE : TRUE //. can be null, true, or false. There's a difference between null and false here
+
+/// Called on Trigger() after borer sanity checks, because calling parent in Trigger will cause funky stuff like
+/// ClickCatcher to be added, or PreActivate to be called. Return FALSE to prevent Trigger from calling parent.
+/datum/action/cooldown/mob_cooldown/borer/proc/pre_intercept_trigger(trigger_flags, atom/target)
+	return TRUE
+
+/datum/action/cooldown/mob_cooldown/borer/proc/can_trigger(trigger_flags, atom/target)
 	if(!iscorticalborer(owner))
 		to_chat(owner, span_warning("You must be a cortical borer to use this action!"))
 		return FALSE
@@ -43,8 +57,7 @@
 	if(cortical_owner.stat_evolution < stat_evo_points)
 		cortical_owner.balloon_alert(cortical_owner, "need [stat_evo_points] stat points")
 		return FALSE
-
-	return . == FALSE ? FALSE : TRUE //. can be null, true, or false. There's a difference between null and false here
+	return TRUE
 
 //inject chemicals into your host
 /datum/action/cooldown/mob_cooldown/borer/inject_chemical
@@ -410,7 +423,6 @@
 	button_icon_state = "fear"
 
 /datum/action/cooldown/mob_cooldown/borer/fear_human/Activate(target)
-	. = ..()
 	if(!ishuman(target)) //no nonhuman hosts
 		owner.balloon_alert(owner, "not human!")
 		return FALSE
@@ -421,13 +433,15 @@
 	if(!owner.Adjacent(human_target))
 		owner.balloon_alert(owner, "chosen target too far")
 		return FALSE
-	if(considered_afk(human_target.mind))
-		owner.balloon_alert(owner, "mind inactive!")
-		return FALSE
+	// if(considered_afk(human_target.mind))
+	// 	owner.balloon_alert(owner, "mind inactive!")
+	// 	return FALSE
+
 	incite_fear(target)
+	StartCooldown()
 	return TRUE
 
-/datum/action/cooldown/mob_cooldown/borer/fear_human/Trigger(trigger_flags, atom/target)
+/datum/action/cooldown/mob_cooldown/borer/fear_human/can_trigger(trigger_flags, atom/target)
 	. = ..()
 	if(!.)
 		return FALSE
@@ -435,14 +449,20 @@
 	if(cortical_owner.host_sugar())
 		owner.balloon_alert(owner, "cannot function with sugar in host")
 		return FALSE
+	// if(cortical_owner.human_host)
+	// 	if(considered_afk(cortical_owner.human_host.mind))
+	// 		owner.balloon_alert(owner, "mind inactive!")
+	// 		return FALSE
+	return TRUE
+
+/datum/action/cooldown/mob_cooldown/borer/fear_human/pre_intercept_trigger(trigger_flags, atom/target)
+	var/mob/living/basic/cortical_borer/cortical_owner = owner
 	if(cortical_owner.human_host)
-		if(considered_afk(cortical_owner.human_host.mind))
-			owner.balloon_alert(owner, "mind inactive!")
-			return FALSE
 		incite_internal_fear()
 		unset_click_ability(owner, FALSE)
 		StartCooldown()
-		return TRUE
+		return FALSE
+	return TRUE
 
 /datum/action/cooldown/mob_cooldown/borer/fear_human/proc/incite_fear(mob/living/carbon/human/singular_fear)
 	var/mob/living/basic/cortical_borer/cortical_owner = owner
@@ -496,17 +516,22 @@
 	button_icon_state = "speak"
 	click_to_activate = FALSE
 
-/datum/action/cooldown/mob_cooldown/borer/force_speak/Trigger(trigger_flags, atom/target)
+
+/datum/action/cooldown/mob_cooldown/borer/force_speak/can_trigger(trigger_flags, atom/target)
 	. = ..()
 	if(!.)
 		return FALSE
 	var/mob/living/basic/cortical_borer/cortical_owner = owner
 	if(cortical_owner.host_sugar())
 		owner.balloon_alert(owner, "cannot function with sugar in host")
-		return
+		return FALSE
 	if(!cortical_owner.inside_human())
 		owner.balloon_alert(owner, "must be in a host")
-		return
+		return FALSE
+	return TRUE
+
+/datum/action/cooldown/mob_cooldown/borer/force_speak/Activate(atom/target)
+	var/mob/living/basic/cortical_borer/cortical_owner = owner
 	// Don't encode as say will do that for usq
 	var/borer_message = tgui_input_text(cortical_owner, "What would you like to force your host to say?", "Force Speak", "", MAX_MESSAGE_LEN, FALSE, FALSE)
 	if(!borer_message)
@@ -515,17 +540,21 @@
 	// check if it's a good message and give feedback to the borer (IC filters)
 	if(!owner.try_speak(borer_message))
 		return
+
 	var/mob/living/carbon/human/cortical_host = cortical_owner.human_host
 	to_chat(cortical_host, span_boldwarning("Your voice moves without your permission!"))
 	var/obj/item/organ/internal/brain/victim_brain = cortical_owner.human_host.get_organ_slot(ORGAN_SLOT_BRAIN)
 	if(victim_brain)
 		cortical_owner.human_host.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2 * cortical_owner.host_harm_multiplier)
+
 	cortical_host.say(borer_message, forced = "forced by [owner]", filterproof = TRUE) // don't filter it again, allow a admin borer to bypass the filter
+
 	var/turf/human_turf = get_turf(cortical_owner.human_host)
 	var/logging_text = "[key_name(cortical_owner)] forced [key_name(cortical_owner.human_host)] to say [borer_message] at [loc_name(human_turf)]"
+
 	cortical_owner.log_message(logging_text, LOG_GAME)
 	cortical_owner.human_host.log_message(logging_text, LOG_GAME)
-	StartCooldown()
+	. = ..() // start the cooldown
 
 //we need a way to produce offspring
 /datum/action/cooldown/mob_cooldown/borer/produce_offspring

--- a/modular_skyrat/modules/cortical_borer/code/abilities/_borer_abilities.dm
+++ b/modular_skyrat/modules/cortical_borer/code/abilities/_borer_abilities.dm
@@ -409,6 +409,24 @@
 	cooldown_time = 12 SECONDS
 	button_icon_state = "fear"
 
+/datum/action/cooldown/mob_cooldown/borer/fear_human/Activate(target)
+	. = ..()
+	if(!ishuman(target)) //no nonhuman hosts
+		owner.balloon_alert(owner, "not human!")
+		return FALSE
+	var/mob/living/carbon/human/human_target = target
+	if(human_target.stat == DEAD) //no dead hosts
+		owner.balloon_alert(owner, "dead!")
+		return FALSE
+	if(!owner.Adjacent(human_target))
+		owner.balloon_alert(owner, "chosen target too far")
+		return FALSE
+	if(considered_afk(human_target.mind))
+		owner.balloon_alert(owner, "mind inactive!")
+		return FALSE
+	incite_fear(target)
+	return TRUE
+
 /datum/action/cooldown/mob_cooldown/borer/fear_human/Trigger(trigger_flags, atom/target)
 	. = ..()
 	if(!.)
@@ -416,32 +434,15 @@
 	var/mob/living/basic/cortical_borer/cortical_owner = owner
 	if(cortical_owner.host_sugar())
 		owner.balloon_alert(owner, "cannot function with sugar in host")
-		return
+		return FALSE
 	if(cortical_owner.human_host)
+		if(considered_afk(cortical_owner.human_host.mind))
+			owner.balloon_alert(owner, "mind inactive!")
+			return FALSE
 		incite_internal_fear()
+		unset_click_ability(owner, FALSE)
 		StartCooldown()
-		return
-	var/list/potential_freezers = list()
-	for(var/mob/living/carbon/human/listed_human in range(1, cortical_owner))
-		if(!ishuman(listed_human)) //no nonhuman hosts
-			continue
-		if(listed_human.stat == DEAD) //no dead hosts
-			continue
-		if(considered_afk(listed_human.mind)) //no afk hosts
-			continue
-		potential_freezers += listed_human
-	if(length(potential_freezers) == 1)
-		incite_fear(potential_freezers[1])
-		return
-	var/mob/living/carbon/human/choose_fear = tgui_input_list(cortical_owner, "Choose who you will fear!", "Fear Choice", potential_freezers)
-	if(!choose_fear)
-		owner.balloon_alert(owner, "no target chosen")
-		return
-	if(get_dist(choose_fear, cortical_owner) > 1)
-		owner.balloon_alert(owner, "chosen target too far")
-		return
-	incite_fear(choose_fear)
-	StartCooldown()
+		return TRUE
 
 /datum/action/cooldown/mob_cooldown/borer/fear_human/proc/incite_fear(mob/living/carbon/human/singular_fear)
 	var/mob/living/basic/cortical_borer/cortical_owner = owner
@@ -506,17 +507,20 @@
 	if(!cortical_owner.inside_human())
 		owner.balloon_alert(owner, "must be in a host")
 		return
-	var/borer_message = input(cortical_owner, "What would you like to force your host to say?", "Force Speak") as message|null
+	// Don't encode as say will do that for usq
+	var/borer_message = tgui_input_text(cortical_owner, "What would you like to force your host to say?", "Force Speak", "", MAX_MESSAGE_LEN, FALSE, FALSE)
 	if(!borer_message)
 		owner.balloon_alert(owner, "no message given")
 		return
-	borer_message = sanitize(borer_message)
+	// check if it's a good message and give feedback to the borer (IC filters)
+	if(!owner.try_speak(borer_message))
+		return
 	var/mob/living/carbon/human/cortical_host = cortical_owner.human_host
 	to_chat(cortical_host, span_boldwarning("Your voice moves without your permission!"))
 	var/obj/item/organ/internal/brain/victim_brain = cortical_owner.human_host.get_organ_slot(ORGAN_SLOT_BRAIN)
 	if(victim_brain)
 		cortical_owner.human_host.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2 * cortical_owner.host_harm_multiplier)
-	cortical_host.say(message = borer_message, forced = TRUE)
+	cortical_host.say(borer_message, forced = "forced by [owner]", filterproof = TRUE) // don't filter it again, allow a admin borer to bypass the filter
 	var/turf/human_turf = get_turf(cortical_owner.human_host)
 	var/logging_text = "[key_name(cortical_owner)] forced [key_name(cortical_owner.human_host)] to say [borer_message] at [loc_name(human_turf)]"
 	cortical_owner.log_message(logging_text, LOG_GAME)

--- a/modular_skyrat/modules/cortical_borer/code/abilities/host_movement.dm
+++ b/modular_skyrat/modules/cortical_borer/code/abilities/host_movement.dm
@@ -5,7 +5,6 @@
 	button_icon_state = "host"
 
 /datum/action/cooldown/mob_cooldown/borer/choosing_host/Activate(atom/target)
-	. = ..()
 	if(!owner.Adjacent(target))
 		owner.balloon_alert(owner, "too far")
 		return FALSE
@@ -13,19 +12,17 @@
 		owner.balloon_alert(owner, "not human")
 		return FALSE
 	var/mob/living/basic/cortical_borer/cortical_owner = owner
+	cortical_owner.face_atom(target)
 	if(!cortical_owner.try_enter_host(target))
 		return FALSE
-	unset_click_ability(owner)
+	StartCooldown()
 	return TRUE
 
-/datum/action/cooldown/mob_cooldown/borer/choosing_host/Trigger(trigger_flags, atom/target)
-	. = ..()
-	if(!.)
-		return FALSE
+/datum/action/cooldown/mob_cooldown/borer/choosing_host/pre_intercept_trigger(trigger_flags, atom/target)
 	// Check if we already have a human_host
 	var/mob/living/basic/cortical_borer/cortical_owner = owner
 	if(!cortical_owner.human_host)
-		return FALSE
+		return TRUE
 	if(cortical_owner.try_leave_host())
 		StartCooldown()
-	return TRUE
+	return FALSE

--- a/modular_skyrat/modules/cortical_borer/code/abilities/host_movement.dm
+++ b/modular_skyrat/modules/cortical_borer/code/abilities/host_movement.dm
@@ -3,19 +3,19 @@
 	name = "Inhabit/Uninhabit Host"
 	cooldown_time = 10 SECONDS
 	button_icon_state = "host"
-	click_to_activate = TRUE
 
 /datum/action/cooldown/mob_cooldown/borer/choosing_host/Activate(atom/target)
-	if(get_dist(owner, target) > 1)
+	. = ..()
+	if(!owner.Adjacent(target))
 		owner.balloon_alert(owner, "too far")
-		return
+		return FALSE
 	if(!ishuman(target))
 		owner.balloon_alert(owner, "not human")
-		return
+		return FALSE
 	var/mob/living/basic/cortical_borer/cortical_owner = owner
 	if(!cortical_owner.try_enter_host(target))
-		return
-	. = ..()
+		return FALSE
+	unset_click_ability(owner)
 	return TRUE
 
 /datum/action/cooldown/mob_cooldown/borer/choosing_host/Trigger(trigger_flags, atom/target)
@@ -25,7 +25,7 @@
 	// Check if we already have a human_host
 	var/mob/living/basic/cortical_borer/cortical_owner = owner
 	if(!cortical_owner.human_host)
-		return
+		return FALSE
 	if(cortical_owner.try_leave_host())
 		StartCooldown()
-	return .
+	return TRUE

--- a/modular_zubbers/code/modules/borer_hud/borer.dm
+++ b/modular_zubbers/code/modules/borer_hud/borer.dm
@@ -18,13 +18,13 @@
 	static_inventory += using
 
 	using = new /atom/movable/screen/navigate
-	using.screen_loc = ui_alien_navigate_menu
 	using.hud = src
 	static_inventory += using
 
 	healthdoll = new /atom/movable/screen/healthdoll/living()
 	healthdoll.hud = src
 	infodisplay += healthdoll
+
 /mob/living/basic/cortical_borer/Life(seconds_per_tick, times_fired)
 	. = ..()
 	update_health_hud() // it literally won't otherwise.


### PR DESCRIPTION

## About The Pull Request
Fixes borer stun ability not working properly, stun and infest abilities should now properly toggle off when they've been used appropiately, borer say will no longer sanitize text itself and allows say to sanitize them to prevent ' being sanitizied into a unreadable mess that lets you meta borers.
Also fixes the action buttons appearing sort of active sometimes, hopefully.

## Why It's Good For The Game
Good fixes are always good.

## Proof Of Testing

Thoroughly tested ingame

## Changelog

:cl:
fix: Borer stun should no longer randomly fail to work
fix: Borer say no longer badly sanitizes your messages causing issues with what you say.
fix: Borer action buttons shouldn't stay "active".
fix: Borer Infest will no longer cooldown if you fail to enter a host.
/:cl:

