### PR TITLE
Fix mislabeled airlocks in Metastation arrivals

### DIFF
--- a/_maps/skyrat/automapper/templates/metastation/metastation_arrivals.dmm
+++ b/_maps/skyrat/automapper/templates/metastation/metastation_arrivals.dmm
@@ -222,14 +222,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Library"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Arrivals"
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
@@ -801,17 +801,6 @@
 /obj/structure/chair/sofa/bench/right,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"zH" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Library"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "zW" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -860,7 +849,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/airlock/public/glass{
-	name = "Library"
+	name = "Arrivals"
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
@@ -1545,7 +1534,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/public/glass{
-	name = "Library"
+	name = "Arrivals"
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
@@ -2997,7 +2986,7 @@ Oy
 sV
 NO
 Vq
-zH
+Vj
 zd
 bb
 bb
@@ -3039,7 +3028,7 @@ xW
 dq
 Rb
 Vq
-zH
+Vj
 Yc
 QB
 Hg
@@ -3097,7 +3086,7 @@ rs
 NO
 gO
 NO
-zH
+Vj
 NO
 RG
 bO


### PR DESCRIPTION
## About The Pull Request

Fixes some airlocks in the Meta arrivals dock being labeled as "Library"

## Why It's Good For The Game

There's no library there

## Proof Of Testing

🐱 

## Changelog

:cl:
map: fixes mislabeled airlocks in Metastation arrivals.
/:cl:
