### PR TITLE
Defaults a single list to null to save about 24 bytes an item

### DIFF
--- a/modular_skyrat/master_files/code/modules/clothing/base_clothes.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/base_clothes.dm
@@ -33,7 +33,7 @@
 	var/greyscale_config_worn_taur_hoof
 
 	/// Used for BODYSHAPE_CUSTOM: Needs to follow this syntax: a list() with the x and y coordinates of the pixel you want to get the color from. Colors are filled in as GAGs values for fallback.
-	var/list/species_clothing_color_coords[3]
+	var/list/species_clothing_color_coords = null
 
 /obj/item/clothing/head
 	supports_variations_flags = CLOTHING_SNOUTED_VARIATION

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/custom_bodytype.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/custom_bodytype.dm
@@ -120,7 +120,8 @@
 		var/list/color_list = list()
 
 		for(var/i in 1 to expected_num_colors)
-			if(length(item.species_clothing_color_coords) < i)
+			if(isnull(item.species_clothing_color_coords) || \
+			length(item.species_clothing_color_coords) < i)
 				color_list += COLOR_DARK
 				continue
 			var/coord = item.species_clothing_color_coords[i]


### PR DESCRIPTION
## About The Pull Request

Sets the species_clothing_color_coords list to null by default, freeing 24 bytes from every non-clothing `/obj/item`

## Why It's Good For The Game

With about 100k items existing at roundstart this saves quite a bit.

## Proof Of Testing

Worked on my machine, no changes noticed on tesh clothes.

## Changelog

:cl:
code: Frees a bit of memory by killing a shitty skyrat list
/:cl:
