### PR TITLE
Fixes some cells not being in the mechfab

### DIFF
--- a/modular_zubbers/code/modules/autolathe_components_adv/advpartdisks.dm
+++ b/modular_zubbers/code/modules/autolathe_components_adv/advpartdisks.dm
@@ -25,7 +25,7 @@
 /datum/design/adv_matter_bin
 	build_type = PROTOLATHE | AWAY_LATHE | AUTOLATHE
 /datum/design/super_cell
-	build_type = PROTOLATHE | AWAY_LATHE | AUTOLATHE
+	build_type = PROTOLATHE | AWAY_LATHE | AUTOLATHE | MECHFAB
 /datum/design/water_recycler
 	build_type = PROTOLATHE | AWAY_LATHE | AUTOLATHE
 /datum/design/card_reader
@@ -55,9 +55,9 @@
 /datum/design/super_matter_bin
 	build_type = PROTOLATHE | AWAY_LATHE | AUTOLATHE
 /datum/design/hyper_cell
-	build_type = PROTOLATHE | AWAY_LATHE | AUTOLATHE
+	build_type = PROTOLATHE | AWAY_LATHE | AUTOLATHE | MECHFAB
 /datum/design/hyper_battery
-	build_type = PROTOLATHE | AWAY_LATHE | AUTOLATHE
+	build_type = PROTOLATHE | AWAY_LATHE | AUTOLATHE | MECHFAB
 
 /datum/design/adv_part_disk
 	name = "Advanced components design disk"


### PR DESCRIPTION

## About The Pull Request
Closes https://github.com/Bubberstation/Bubberstation/issues/2530

Turns out when we made the autolathe disks we overrode a bunch of stock part printability code, which would have been fine except mechfabs were left out of the new code.
## Why It's Good For The Game
Bugs are bad
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/9331636a-0556-4a28-bec3-241b56f9a6fa)

![image](https://github.com/user-attachments/assets/d4959bb5-89b2-4b04-ac74-cd2790096362)

</details>

## Changelog
:cl:
fix: fixed hyper and super cells not being in mechfabs like the rest of the cells
/:cl:
