### PR TITLE
Entombed suits no longer add tox damage if their occupant is dead.

### DIFF
--- a/modular_zubbers/code/datums/quirks/neutral_quirks/entombed.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/entombed.dm
@@ -24,6 +24,10 @@
 
 /datum/quirk/equipping/entombed/process(seconds_per_tick)
 	var/mob/living/carbon/human/human_holder = quirk_holder
+	if(human_holder.stat == DEAD)
+		// We don't want to be smacking permanent tox damage if the person is dead. It doesn't make sense, and it's a huge pain in the ass for revival.
+		// This also helps for when the modsuit is out of power, as (to my awareness), there is no way currently to turn on someone else's entombed modsuit.
+		return
 	if (!modsuit || life_support_failed)
 		// we've got no modsuit or life support. take damage ow
 		human_holder.adjustToxLoss(ENTOMBED_TICK_DAMAGE * seconds_per_tick, updating_health = TRUE, forced = TRUE)


### PR DESCRIPTION
## About The Pull Request

This has been a long annoyance for me; now, people with the entombed quirk will no longer take tox damage if they're dead  (and their modsuit is dead).
This shouldn't apply after revival, as they'll no longer be dead.

## Why It's Good For The Game

It doesn't make sense with how the quirk is explained, as the suit is keeping the person alive. I don't think the suit's pumping toxins into the user when dead, so this stops that.

## Proof Of Testing

TBD

## Changelog

:cl:
fix: Entombed modsuits no longer cause stacking toxin loss if the entombed is dead.
/:cl: