### PR TITLE
[s] ensure key config is set for any secure request (#88367)

### DIFF
--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -26,7 +26,7 @@
 	var/require_comms_key = FALSE
 
 /datum/world_topic/proc/TryRun(list/input)
-	key_valid = config && (CONFIG_GET(string/comms_key) == input["key"])
+	key_valid = (CONFIG_GET(string/comms_key) == input["key"]) && CONFIG_GET(string/comms_key) && input["key"]
 	input -= "key"
 	if(require_comms_key && !key_valid)
 		. = "Bad Key"


### PR DESCRIPTION
## About The Pull Request
If you set up a server without `COMMS_KEY` set it will be blank, which is a valid key
## Why It's Good For The Game
CommKey validation should fail closed not open

https://github.com/tgstation/tgstation/pull/88367