### PR TITLE
fixes seed ruin logic preventing forced ruins from spawning when budget is zero, fixes map_logging CI test (#87910)

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/DJstation/kitchen_1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation/kitchen_1.dmm
@@ -30,7 +30,6 @@
 /area/ruin/space/djstation)
 "t" = (
 /obj/structure/closet/secure_closet/freezer/fridge/all_access,
-/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,

--- a/_maps/RandomRuins/SpaceRuins/anomaly_research.dmm
+++ b/_maps/RandomRuins/SpaceRuins/anomaly_research.dmm
@@ -351,7 +351,7 @@
 "kp" = (
 /obj/effect/spawner/random/environmentally_safe_anomaly/immobile,
 /turf/template_noop,
-/area/space)
+/area/space/nearstation)
 "kt" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1

--- a/_maps/RandomRuins/SpaceRuins/bus.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bus.dmm
@@ -285,7 +285,7 @@
 /turf/open/misc/asteroid/airless,
 /area/ruin/space)
 "ET" = (
-/mob/living/basic/lizard,
+/mob/living/basic/lizard/space,
 /turf/open/misc/asteroid/airless,
 /area/ruin/space)
 "Fo" = (

--- a/_maps/RandomRuins/SpaceRuins/garbagetruck4.dmm
+++ b/_maps/RandomRuins/SpaceRuins/garbagetruck4.dmm
@@ -122,7 +122,6 @@
 /area/ruin/space/has_grav/garbagetruck/toystore)
 "lm" = (
 /obj/structure/spider/stickyweb,
-/obj/structure/spider/stickyweb/very_sticky,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/garbagetruck/toystore)
 "mf" = (
@@ -182,7 +181,6 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/garbagetruck/toystore)
 "qX" = (
-/obj/structure/spider/stickyweb/very_sticky,
 /obj/item/food/badrecipe/moldy,
 /obj/structure/spider/stickyweb,
 /obj/item/food/spidereggs{

--- a/_maps/RandomRuins/SpaceRuins/prison_shuttle.dmm
+++ b/_maps/RandomRuins/SpaceRuins/prison_shuttle.dmm
@@ -147,8 +147,8 @@
 /turf/open/floor/iron/dark/airless,
 /area/ruin/space/prison_shuttle)
 "O" = (
-/mob/living/basic/cockroach,
 /obj/effect/turf_decal/tile/brown/fourcorners,
+/obj/effect/decal/cleanable/xenoblood/xsplatter,
 /turf/open/floor/iron/dark/airless,
 /area/ruin/space/prison_shuttle)
 "P" = (

--- a/_maps/RandomRuins/SpaceRuins/skyrat/cargodiselost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/cargodiselost.dmm
@@ -1269,7 +1269,7 @@
 /area/ruin/space/has_grav/cargodise_freighter/utility)
 "vH" = (
 /turf/closed/mineral/random/high_chance,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "vJ" = (
 /obj/structure/chair/sofa/right/maroon{
 	dir = 4

--- a/_maps/RandomRuins/SpaceRuins/skyrat/clothing_facility.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/clothing_facility.dmm
@@ -7,7 +7,7 @@
 /area/ruin/space/has_grav/powered/skyrat/clothing_facility)
 "c" = (
 /turf/closed/mineral/random,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "d" = (
 /obj/machinery/destructive_scanner,
 /turf/open/floor/iron/dark,

--- a/_maps/RandomRuins/SpaceRuins/skyrat/crash.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/crash.dmm
@@ -4,67 +4,67 @@
 /area/template_noop)
 "c" = (
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "d" = (
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "e" = (
 /obj/item/storage/toolbox/syndicate,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "g" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "l" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs/down,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "m" = (
 /turf/closed/mineral/random/high_chance,
 /area/ruin/space)
 "t" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "v" = (
 /turf/closed/wall/mineral/titanium/spaceship,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "x" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs/up,
 /obj/effect/turf_decal/sand,
 /turf/open/floor/plating,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "B" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/turf_decal/sand,
 /turf/open/misc/asteroid/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "C" = (
 /obj/machinery/power/shuttle_engine/propulsion{
 	dir = 8
 	},
 /turf/template_noop,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "H" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs/limb{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "I" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "K" = (
 /obj/effect/spawner/random/engineering/flashlight,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "L" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/engineering/material_rare,
@@ -72,40 +72,40 @@
 /obj/effect/spawner/random/engineering/material,
 /obj/effect/spawner/random/engineering/material,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "O" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/engineering/tool_advanced,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "R" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "T" = (
 /obj/effect/spawner/random/engineering/material_cheap,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "U" = (
 /obj/effect/turf_decal/sand,
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "V" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/engineering/toolbox,
 /obj/effect/spawner/random/engineering/toolbox,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "X" = (
 /obj/effect/turf_decal/sand,
 /turf/open/floor/plating,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "Y" = (
 /obj/machinery/power/port_gen/pacman/super,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 
 (1,1,1) = {"
 a

--- a/_maps/RandomRuins/SpaceRuins/skyrat/ghostship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/ghostship.dmm
@@ -10,53 +10,53 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice/passthru,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "ct" = (
 /obj/effect/decal/cleanable/wrapping{
 	pixel_y = 19
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "dj" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/template_noop,
-/area/template_noop)
+/area/ruin/space/has_grav)
 "eL" = (
 /obj/machinery/portable_atmospherics/canister/freon{
 	name = "Coolant canister"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "fj" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice/passthru,
 /obj/machinery/light/small/red/directional/south,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "fo" = (
 /obj/effect/decal/fakelattice/passthru,
 /turf/closed/wall/mineral/titanium/spaceship/nodiagonal{
 	color = "#8ab1ec"
 	},
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "fF" = (
 /obj/structure/frame/computer{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "fM" = (
 /obj/structure/sign/warning,
 /obj/structure/cable,
 /turf/closed/wall/r_wall{
 	color = "#7a9ee0"
 	},
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "go" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -64,14 +64,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "gw" = (
 /obj/effect/decal/cleanable/robot_debris/limb{
 	pixel_y = -7
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "gx" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/tank_holder/oxygen{
@@ -81,14 +81,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice/passthru,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "hf" = (
 /obj/machinery/door/airlock/multi_tile/metal{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "hn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -102,7 +102,7 @@
 	pixel_y = 11
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "hp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -111,16 +111,16 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice/passthru,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "iF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/template_noop,
-/area/template_noop)
+/area/ruin/space/has_grav)
 "ja" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/template_noop,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "jx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -133,14 +133,14 @@
 /obj/effect/decal/fakelattice/passthru,
 /obj/machinery/light/dim/directional/south,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "jA" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/chair/comfy/shuttle,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice/passthru,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "jJ" = (
 /obj/structure/frame/computer{
 	dir = 4
@@ -151,13 +151,13 @@
 	pixel_y = -10
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "jL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/closed/wall/r_wall{
 	color = "#7a9ee0"
 	},
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "jM" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical{
@@ -171,7 +171,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/red/directional/south,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "kg" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/chair/comfy/shuttle,
@@ -179,13 +179,13 @@
 /obj/effect/decal/fakelattice/passthru,
 /obj/machinery/light/dim/directional/west,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "kh" = (
 /obj/effect/decal/cleanable/robot_debris/limb,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice/passthru,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "kQ" = (
 /obj/effect/decal/cleanable/generic{
 	pixel_x = 14
@@ -198,7 +198,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "lw" = (
 /obj/item/ai_module/toy_ai{
 	desc = "A totally real AI, the first of its kind to achieve self-awareness. Totally real.";
@@ -216,7 +216,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "lA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice/passthru,
@@ -225,7 +225,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "lG" = (
 /obj/item/trash/boritos,
 /obj/effect/decal/cleanable/dirt,
@@ -236,7 +236,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "mx" = (
 /obj/structure/table,
 /obj/item/stock_parts/power_store/cell/hyper{
@@ -250,7 +250,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/disk/design_disk/bepis,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "mW" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/cleanable/dirt,
@@ -258,59 +258,59 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "nz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/closed/wall/r_wall{
 	color = "#7a9ee0"
 	},
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "oc" = (
 /obj/machinery/door/airlock/multi_tile/metal{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "oX" = (
 /obj/effect/decal/fakelattice/passthru,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/closed/wall/mineral/titanium/spaceship/nodiagonal{
 	color = "#8ab1ec"
 	},
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "pw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "pD" = (
 /obj/machinery/power/smes,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "qW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/closed/wall/mineral/titanium/spaceship/nodiagonal{
 	color = "#8ab1ec"
 	},
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "rb" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice/passthru,
 /obj/structure/decorative/shelf/soda_milk,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "rp" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/robot_debris/limb,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice/passthru,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "sk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/red/directional/north,
@@ -325,19 +325,19 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "sp" = (
 /obj/structure/cable,
 /turf/closed/wall/mineral/titanium/spaceship/nodiagonal{
 	color = "#8ab1ec"
 	},
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "sz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice/passthru,
 /obj/machinery/light/small/red/directional/north,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "ts" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -349,25 +349,25 @@
 /obj/effect/decal/fakelattice/passthru,
 /obj/machinery/light/dim/directional/west,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "tz" = (
 /turf/closed/wall/mineral/titanium/spaceship/nodiagonal{
 	color = "#8ab1ec"
 	},
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "tV" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice/passthru,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "vi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "wp" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
@@ -376,13 +376,13 @@
 /obj/item/taperecorder/empty,
 /obj/machinery/light/dim/directional/west,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "wH" = (
 /obj/effect/decal/cleanable/robot_debris/limb,
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "wN" = (
 /obj/effect/decal/cleanable/robot_debris/limb{
 	pixel_x = -16;
@@ -391,32 +391,32 @@
 /obj/effect/decal/cleanable/robot_debris,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "xq" = (
 /obj/structure/frame/computer{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "xs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "xF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "xP" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/ruin/space/has_grav)
 "ye" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/asteroid/line{
@@ -425,11 +425,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice/passthru,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "yi" = (
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "yG" = (
 /obj/machinery/door_buttons/access_button{
 	pixel_x = 9;
@@ -438,7 +438,7 @@
 /turf/closed/wall/mineral/titanium/spaceship/nodiagonal{
 	color = "#8ab1ec"
 	},
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "yU" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -446,13 +446,13 @@
 	pixel_y = -10
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "yZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/closed/wall/mineral/titanium/spaceship/nodiagonal{
 	color = "#8ab1ec"
 	},
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "zE" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/chair/comfy/shuttle,
@@ -463,7 +463,7 @@
 /obj/effect/decal/fakelattice/passthru,
 /obj/machinery/light/dim/directional/north,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "zM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -474,14 +474,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice/passthru,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Cc" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/mapping_helpers/apc/unlocked,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Ct" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -498,17 +498,17 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice/passthru,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "DN" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/layer2,
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/ruin/space/has_grav)
 "ER" = (
 /obj/effect/decal/cleanable/plastic,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Ga" = (
 /obj/machinery/portable_atmospherics/canister/plasma{
 	desc = "Plasma gas. Highly fuel efficient. Highly volatile. Highly toxic.";
@@ -519,16 +519,16 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Gq" = (
 /turf/closed/wall/mineral/titanium/spaceship{
 	color = "#8ab1ec"
 	},
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "He" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Ij" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/asteroid/corner{
@@ -538,7 +538,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice/passthru,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Iy" = (
 /obj/effect/decal/cleanable/robot_debris/limb,
 /obj/effect/decal/cleanable/dirt,
@@ -546,7 +546,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "IJ" = (
 /obj/machinery/door_buttons/access_button{
 	pixel_x = 9;
@@ -555,7 +555,7 @@
 /turf/closed/wall/mineral/titanium/spaceship/nodiagonal{
 	color = "#8ab1ec"
 	},
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "JX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -565,44 +565,44 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice/passthru,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Kj" = (
 /obj/item/trash/energybar,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Kt" = (
 /obj/effect/decal/fakelattice/passthru,
 /turf/closed/wall/mineral/titanium/spaceship{
 	color = "#8ab1ec"
 	},
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "KR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer4{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "KZ" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice/passthru,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Li" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass/fifty,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Lk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "LT" = (
 /obj/machinery/airalarm/directional/south{
 	pixel_x = -5
@@ -611,32 +611,32 @@
 /turf/closed/wall/mineral/titanium/spaceship/nodiagonal{
 	color = "#8ab1ec"
 	},
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "LV" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice/passthru,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Mo" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice/passthru,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Mp" = (
 /obj/effect/decal/cleanable/plastic,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice/passthru,
 /obj/machinery/light/small/red/directional/south,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "MQ" = (
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "MY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -646,18 +646,18 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Oj" = (
 /obj/structure/window/reinforced/shuttle/spaceship{
 	color = "#8ab1ec"
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Pr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/crate_loot,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Qc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -673,16 +673,13 @@
 	pixel_y = -25
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered)
-"QC" = (
-/turf/template_noop,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "QF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/tank/air,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "QV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/frame/computer{
@@ -693,13 +690,13 @@
 	pixel_y = -3
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "RQ" = (
 /obj/machinery/power/shuttle_engine/propulsion{
 	dir = 4
 	},
 /turf/template_noop,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "SR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -709,7 +706,7 @@
 /obj/effect/decal/fakelattice/passthru,
 /obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Ta" = (
 /obj/effect/decal/cleanable/generic{
 	pixel_x = 4;
@@ -717,7 +714,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "TM" = (
 /obj/machinery/door_buttons/airlock_controller{
 	pixel_x = 9
@@ -725,7 +722,7 @@
 /turf/closed/wall/mineral/titanium/spaceship/nodiagonal{
 	color = "#8ab1ec"
 	},
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "TW" = (
 /turf/template_noop,
 /area/template_noop)
@@ -736,7 +733,7 @@
 /turf/closed/wall/mineral/titanium/spaceship/nodiagonal{
 	color = "#8ab1ec"
 	},
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Uw" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable,
@@ -747,7 +744,7 @@
 	pixel_y = -24
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "UL" = (
 /obj/machinery/power/shuttle_engine/heater{
 	dir = 4
@@ -755,7 +752,7 @@
 /turf/closed/wall/r_wall{
 	color = "#7a9ee0"
 	},
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Vv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/canister/plasma{
@@ -766,17 +763,17 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "WH" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Xr" = (
 /turf/closed/wall/r_wall{
 	color = "#7a9ee0"
 	},
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Xz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/decorative/fluff/ai_node{
@@ -784,12 +781,12 @@
 	pixel_y = 23
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Yd" = (
 /obj/item/trash/cheesie,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "YN" = (
 /obj/structure/closet,
 /obj/effect/turf_decal/stripes/line{
@@ -799,12 +796,12 @@
 /obj/effect/decal/fakelattice/passthru,
 /obj/machinery/light/dim/directional/west,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "YT" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Zf" = (
 /obj/machinery/power/shuttle_engine/heater{
 	dir = 4
@@ -813,7 +810,7 @@
 /turf/closed/wall/mineral/titanium/spaceship/nodiagonal{
 	color = "#8ab1ec"
 	},
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 
 (1,1,1) = {"
 TW
@@ -1375,8 +1372,8 @@ TW
 TW
 TW
 TW
-QC
-QC
+TW
+TW
 TW
 TW
 TW

--- a/_maps/RandomRuins/SpaceRuins/skyrat/luna.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/luna.dmm
@@ -181,7 +181,7 @@
 /area/ruin/space/has_grav/powered/skyrat/luna)
 "tQ" = (
 /turf/open/misc/asteroid/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "us" = (
 /obj/structure/flora/biolumi/flower/weaklight,
 /obj/structure/flora/bush/grassy,
@@ -323,7 +323,7 @@
 /area/ruin/space/has_grav/powered/skyrat/luna)
 "Fo" = (
 /turf/closed/mineral/random,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Fv" = (
 /obj/structure/flora/grass/jungle,
 /turf/open/misc/grass,
@@ -333,7 +333,7 @@
 	dir = 8
 	},
 /turf/open/misc/asteroid/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "KF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/stone{
@@ -435,7 +435,7 @@
 "TH" = (
 /mob/living/basic/carp,
 /turf/open/misc/asteroid/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Vs" = (
 /obj/structure/flora/bush/leafy,
 /turf/open/misc/grass,

--- a/_maps/RandomRuins/SpaceRuins/skyrat/salvagepost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/salvagepost.dmm
@@ -285,7 +285,7 @@
 "mW" = (
 /obj/structure/sign/warning/chem_diamond,
 /turf/closed/indestructible/opshuttle,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "ni" = (
 /obj/structure/window/reinforced/survival_pod/spawner/directional/east,
 /obj/structure/lattice/catwalk{
@@ -308,7 +308,7 @@
 /area/template_noop)
 "oW" = (
 /turf/closed/wall/material,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "pb" = (
 /obj/machinery/power/shuttle_engine/propulsion{
 	dir = 4
@@ -449,7 +449,7 @@
 "vt" = (
 /obj/structure/sign/warning/fire,
 /turf/closed/indestructible/opshuttle,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "vA" = (
 /obj/structure/window/reinforced/survival_pod/spawner/directional/south,
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
@@ -485,7 +485,7 @@
 "xA" = (
 /obj/machinery/door/poddoor,
 /turf/open/floor/engine/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "yA" = (
 /obj/machinery/power/shuttle_engine/heater{
 	dir = 4
@@ -786,7 +786,7 @@
 /area/template_noop)
 "Ml" = (
 /turf/closed/indestructible/opshuttle,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "Mn" = (
 /obj/item/stack/sheet/mineral/titanium{
 	amount = 11
@@ -1078,7 +1078,7 @@
 /area/template_noop)
 "Zx" = (
 /turf/open/floor/engine/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "ZF" = (
 /turf/closed/wall/mineral/titanium/spaceship{
 	color = "#b49973"

--- a/_maps/RandomRuins/SpaceRuins/skyrat/shuttlescrap.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/shuttlescrap.dmm
@@ -5,66 +5,66 @@
 "b" = (
 /obj/effect/spawner/random/engineering/material_cheap,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "c" = (
 /obj/effect/spawner/random/medical/patient_stretcher,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "e" = (
 /obj/machinery/power/smes,
 /turf/open/floor/plating,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "g" = (
 /obj/effect/spawner/random/structure/crate_loot,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "i" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "j" = (
 /turf/open/floor/plating,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "k" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/ruin/space/has_grav/skyrat)
 "r" = (
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "t" = (
 /obj/structure/closet/crate/radiation,
 /obj/effect/spawner/random/exotic/syndie,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "u" = (
 /obj/structure/closet/crate/secure/engineering,
 /obj/item/pickaxe/drill/jackhammer,
 /obj/item/gun/energy/plasmacutter/adv,
 /obj/effect/spawner/random/medical/medkit,
 /turf/open/floor/plating,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "v" = (
 /obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "w" = (
 /mob/living/simple_animal/hostile/vox/ranged/space/laser,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "y" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list("maint_tunnels")
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "H" = (
 /obj/effect/spawner/random/structure/crate_abandoned,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "K" = (
 /mob/living/simple_animal/hostile/vox/melee,
 /turf/open/floor/plating,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "L" = (
 /obj/structure/closet/crate/radiation,
 /obj/effect/spawner/random/engineering/material_rare,
@@ -77,24 +77,24 @@
 /obj/effect/spawner/random/engineering/material,
 /obj/effect/spawner/random/engineering/material,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "M" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "N" = (
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "O" = (
 /obj/machinery/power/shuttle_engine/propulsion{
 	dir = 8
 	},
 /turf/template_noop,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "P" = (
 /obj/effect/mob_spawn/corpse/human/syndicatecommando,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "Q" = (
 /obj/structure/closet/crate/radiation,
 /obj/effect/spawner/random/engineering/material,
@@ -104,14 +104,14 @@
 /obj/effect/spawner/random/engineering/material_rare,
 /obj/effect/spawner/random/engineering/material_rare,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "Z" = (
 /obj/structure/closet/crate/radiation,
 /obj/effect/spawner/random/contraband/narcotics,
 /obj/effect/spawner/random/contraband/narcotics,
 /obj/effect/spawner/random/contraband/narcotics,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 
 (1,1,1) = {"
 a

--- a/_maps/RandomRuins/SpaceRuins/skyrat/smugglies.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/smugglies.dmm
@@ -31,13 +31,13 @@
 	dir = 4
 	},
 /turf/open/misc/asteroid/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "k" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 1
 	},
 /turf/open/misc/asteroid/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "m" = (
 /turf/open/floor/iron/grimy,
 /area/ruin/space/has_grav/powered/skyrat/smugglies)
@@ -75,7 +75,7 @@
 /area/ruin/space/has_grav/powered/skyrat/smugglies)
 "z" = (
 /turf/closed/mineral/random,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "A" = (
 /obj/structure/chair/office,
 /turf/open/floor/iron/dark,
@@ -90,14 +90,14 @@
 	dir = 1
 	},
 /turf/open/misc/asteroid/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "E" = (
 /obj/machinery/vending/hydronutrients,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/powered/skyrat/smugglies)
 "F" = (
 /turf/open/misc/asteroid/airless,
-/area/ruin/unpowered/no_grav)
+/area/ruin/space/unpowered)
 "H" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/grimy,

--- a/_maps/RandomRuins/SpaceRuins/skyrat/wreckedfriendship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/wreckedfriendship.dmm
@@ -4,13 +4,13 @@
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "aq" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "aC" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -22,43 +22,43 @@
 	icon_state = "medium"
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "aI" = (
 /obj/item/shard{
 	icon_state = "medium"
 	},
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "bf" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "bj" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "bt" = (
 /obj/structure/lattice,
 /obj/item/shard{
 	icon_state = "medium"
 	},
 /turf/template_noop,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "bV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "cb" = (
 /obj/item/stack/sheet/mineral/titanium,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "cD" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -69,7 +69,7 @@
 /obj/effect/mob_spawn/corpse/human/charredskeleton,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "dd" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -84,38 +84,38 @@
 /obj/effect/decal/cleanable/blood,
 /obj/item/stack/sheet/mineral/titanium,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "do" = (
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "du" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
 	},
 /obj/effect/mob_spawn/corpse/human/skeleton,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "dB" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 8
 	},
 /obj/item/ammo_casing/c9mm,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "dL" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /obj/structure/grille/broken,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "dX" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/item/shard{
 	icon_state = "small"
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "ea" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -128,38 +128,38 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "eg" = (
 /obj/structure/grille,
 /turf/template_noop,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "eo" = (
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "eq" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "ev" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/engine/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "fh" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/item/shard{
 	icon_state = "small"
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "fG" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "fN" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -167,11 +167,11 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "fZ" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "gl" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -185,7 +185,7 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/grille/broken,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "gw" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -195,7 +195,7 @@
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "gB" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
@@ -205,14 +205,14 @@
 	},
 /obj/item/shard,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "gI" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "hb" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -225,11 +225,11 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "hi" = (
 /obj/item/ammo_casing/c9mm,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "hy" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -237,32 +237,32 @@
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/structure/grille/broken,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "ic" = (
 /obj/machinery/power/shuttle_engine/heater{
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "id" = (
 /obj/item/ammo_casing/c9mm,
 /obj/item/stack/rods,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "iC" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "iU" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "jj" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
@@ -270,33 +270,33 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "jx" = (
 /obj/effect/turf_decal/bot_red,
 /obj/item/shard{
 	icon_state = "medium"
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "jG" = (
 /obj/item/shard{
 	icon_state = "small"
 	},
 /obj/item/stack/rods,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "kk" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "km" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "kF" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -309,20 +309,20 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "lf" = (
 /obj/effect/mob_spawn/corpse/human/engineer{
 	brute_damage = 200
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "lp" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "lw" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -330,21 +330,21 @@
 /obj/structure/grille/broken,
 /obj/item/shard,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "lE" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "mp" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/stack/sheet/mineral/titanium,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "mx" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/engine/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "mN" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -354,42 +354,42 @@
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "mP" = (
 /obj/effect/turf_decal/trimline/white/filled/line,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "na" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "nv" = (
 /obj/item/shard{
 	icon_state = "medium"
 	},
 /obj/item/stack/rods,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "nF" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "nH" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
 	},
 /obj/item/shard,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "nN" = (
 /obj/item/stack/rods,
 /obj/item/stack/sheet/mineral/titanium,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "nP" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
@@ -397,24 +397,24 @@
 	},
 /obj/item/ammo_casing/c9mm,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "ok" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 10
 	},
 /obj/structure/frame/machine,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "om" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "oo" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "ph" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -427,37 +427,37 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "pl" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "pu" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
 /obj/item/ammo_casing/c9mm,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "pA" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "pZ" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "qv" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "qM" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -470,7 +470,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "qR" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 9
@@ -478,14 +478,14 @@
 /obj/item/ammo_casing/c9mm,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "ry" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "sn" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
@@ -495,7 +495,7 @@
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "sK" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -504,7 +504,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "tc" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -518,24 +518,24 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/frame/machine,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "te" = (
 /obj/item/ammo_casing/c9mm,
 /obj/item/shard{
 	icon_state = "small"
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "tn" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /obj/effect/mob_spawn/corpse/human/engineer,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "tv" = (
 /turf/open/floor/engine/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "tw" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
@@ -543,58 +543,58 @@
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/item/ammo_casing/c9mm,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "tD" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "tE" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "tK" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/mob_spawn/corpse/human/clown,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "tW" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "tX" = (
 /obj/structure/lattice,
 /obj/item/stack/rods,
 /turf/template_noop,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "ub" = (
 /turf/open/floor/carpet/black/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "ud" = (
 /obj/item/stack/rods,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "ui" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
 /obj/effect/mob_spawn/corpse/human/skeleton,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "um" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
 /obj/item/stack/rods,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "us" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -604,22 +604,22 @@
 	icon_state = "small"
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "uB" = (
 /obj/item/stack/sheet/mineral/titanium,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "uO" = (
 /obj/effect/mob_spawn/corpse/human/skeleton,
 /turf/open/floor/engine/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "ve" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
 /obj/effect/mob_spawn/corpse/human/skeleton,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "vm" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -629,30 +629,30 @@
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "vx" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "vA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
 /obj/structure/frame/machine,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "vH" = (
 /obj/structure/lattice,
 /obj/item/stack/sheet/mineral/titanium,
 /turf/template_noop,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "vK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "wo" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -662,26 +662,26 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "wr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "xs" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "xJ" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "xL" = (
 /turf/closed/wall/mineral/titanium,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "xP" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -697,28 +697,28 @@
 	icon_state = "medium"
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "yo" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
 	},
 /obj/item/stack/rods,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "yB" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/item/ammo_casing/c9mm,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "yO" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "yU" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -733,36 +733,36 @@
 /obj/item/ammo_casing/c9mm,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "zd" = (
 /obj/structure/grille/broken,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "zn" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 10
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "zJ" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 5
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "zY" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "AK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "AM" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
@@ -772,21 +772,21 @@
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "AN" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /obj/item/ammo_casing/c9mm,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "AR" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
 	},
 /obj/structure/frame/machine,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Bj" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -799,12 +799,12 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "BO" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/frame/machine,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Cl" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -814,13 +814,13 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Cp" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Cu" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -834,21 +834,21 @@
 	},
 /obj/structure/girder,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "CT" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "DN" = (
 /obj/item/stack/rods,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Er" = (
 /obj/effect/gibspawner/human,
 /obj/effect/mob_spawn/corpse/human/doctor,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "ED" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 9
@@ -856,28 +856,28 @@
 /obj/item/ammo_casing/c9mm,
 /obj/structure/frame/machine,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "EP" = (
 /obj/structure/girder,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "FD" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "FU" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
 	},
 /obj/structure/frame/machine,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Gc" = (
 /obj/item/shard,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Gi" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -887,25 +887,25 @@
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Gn" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Gr" = (
 /obj/effect/gibspawner/human,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "GH" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "GJ" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "GO" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -919,7 +919,7 @@
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "GV" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
@@ -927,7 +927,7 @@
 /obj/item/stack/sheet/mineral/titanium,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Hh" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -940,28 +940,28 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Hi" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Ho" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Hv" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "HL" = (
 /obj/item/shard,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "HX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -970,47 +970,47 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Ic" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/item/ammo_casing/c9mm,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Io" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
 /obj/item/ammo_casing/c9mm,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "IC" = (
 /obj/effect/turf_decal/bot_red,
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "IO" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "IT" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "IU" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /obj/item/ammo_casing/c9mm,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Jc" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Jl" = (
 /obj/effect/turf_decal/trimline/white/filled/corner{
 	dir = 1
@@ -1025,7 +1025,7 @@
 	icon_state = "small"
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Jp" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -1035,21 +1035,21 @@
 	},
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Jx" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Jz" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 4
 	},
 /obj/structure/frame/machine,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "JH" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -1057,7 +1057,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/item/ammo_casing/c9mm,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "JK" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
@@ -1065,14 +1065,14 @@
 /obj/item/stack/rods,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "JR" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
 /obj/item/stack/sheet/mineral/titanium,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "JT" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -1087,13 +1087,13 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "JY" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/mob_spawn/corpse/human/skeleton,
 /obj/item/shard,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Kn" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -1101,14 +1101,14 @@
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Kr" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
 	},
 /obj/structure/frame/machine,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Kx" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -1117,13 +1117,13 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "KH" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "KN" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
@@ -1131,28 +1131,28 @@
 /obj/item/shard,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "KU" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /obj/structure/frame/machine,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Lm" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
 	},
 /obj/item/stack/rods,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Lx" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
 /obj/structure/frame/machine,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "LK" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -1165,7 +1165,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Mh" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -1173,7 +1173,7 @@
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Mu" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -1186,11 +1186,11 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "MK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Ne" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -1199,7 +1199,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "NU" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
@@ -1207,7 +1207,7 @@
 /obj/item/ammo_casing/c9mm,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "NX" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -1220,20 +1220,20 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "NY" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/item/shard{
 	icon_state = "small"
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "OE" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "OK" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -1242,24 +1242,24 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "OY" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Pg" = (
 /obj/structure/girder,
 /obj/item/stack/sheet/mineral/titanium,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Pn" = (
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Pq" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -1267,37 +1267,37 @@
 	},
 /obj/item/ammo_casing/c9mm,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Px" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "PH" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Qd" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Qs" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "QH" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "QN" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -1310,48 +1310,48 @@
 	},
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "QU" = (
 /obj/structure/grille/broken,
 /obj/item/ammo_casing/c9mm,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Rj" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/engine/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Rq" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 10
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Rw" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "RL" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
 	},
 /obj/item/ammo_casing/c9mm,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "RN" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /obj/structure/frame/machine,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "RV" = (
 /obj/effect/turf_decal/trimline/white/filled/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "RZ" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -1365,7 +1365,7 @@
 /obj/effect/turf_decal/tile/purple,
 /obj/item/ammo_casing/c9mm,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Su" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
@@ -1374,7 +1374,7 @@
 /obj/effect/mob_spawn/corpse/human/syndicatesoldier,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "SF" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
@@ -1387,25 +1387,25 @@
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "SS" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Tk" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Tu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "TF" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -1415,24 +1415,24 @@
 	icon_state = "small"
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "TH" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/frame/machine,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "TW" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/mob_spawn/corpse/human/doctor,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Ua" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
 /obj/structure/frame/machine,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Uo" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -1442,7 +1442,7 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "UD" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -1450,12 +1450,12 @@
 /obj/effect/gibspawner/human,
 /obj/effect/mob_spawn/corpse/human/doctor,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Vz" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/structure/frame/machine,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Wy" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -1469,26 +1469,26 @@
 	},
 /obj/item/ammo_casing/c9mm,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "WK" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "WY" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
 /obj/item/ammo_casing/c9mm,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Xp" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/item/ammo_casing/c9mm,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Xw" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -1501,13 +1501,13 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Xy" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "XL" = (
 /turf/template_noop,
 /area/template_noop)
@@ -1519,7 +1519,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "YD" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -1535,7 +1535,7 @@
 /obj/structure/frame/machine,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "YV" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -1550,11 +1550,11 @@
 /obj/structure/mecha_wreckage/ripley,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Zt" = (
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "ZT" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
@@ -1562,14 +1562,14 @@
 /obj/item/ammo_casing/c9mm,
 /obj/structure/frame/machine,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "ZW" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
 /obj/item/shard,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 
 (1,1,1) = {"
 XL

--- a/_maps/RandomRuins/SpaceRuins/skyrat/wreckedhomestead.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/wreckedhomestead.dmm
@@ -3,22 +3,22 @@
 /obj/effect/mob_spawn/corpse/human/skeleton,
 /obj/effect/gibspawner/human,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "aW" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "bQ" = (
 /obj/structure/grille/broken,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "cc" = (
 /obj/machinery/autolathe,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "dL" = (
 /obj/structure/table/optable,
 /obj/effect/mob_spawn/corpse/human/charredskeleton,
@@ -27,53 +27,53 @@
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "dO" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "fA" = (
 /obj/structure/lattice,
 /obj/structure/girder,
 /turf/template_noop,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "iD" = (
 /obj/structure/cable,
 /obj/structure/frame/machine,
 /turf/open/floor/engine/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "iJ" = (
 /obj/machinery/recharger,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "jA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "kf" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "kN" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "kP" = (
 /obj/structure/girder,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "ma" = (
 /obj/structure/frame/computer,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "mj" = (
 /obj/structure/frame/machine,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "mP" = (
 /obj/structure/table/reinforced,
 /obj/item/surgery_tray/full,
@@ -83,56 +83,56 @@
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "on" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "oB" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "qI" = (
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/engine/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "se" = (
 /obj/effect/mob_spawn/corpse/human/scientist,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "sr" = (
 /obj/machinery/power/shuttle_engine/propulsion/burst,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "sx" = (
 /obj/machinery/power/shuttle_engine/heater,
 /turf/closed/wall/mineral/titanium,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "sD" = (
 /obj/effect/gibspawner/human,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "sK" = (
 /obj/structure/frame/computer,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "tH" = (
 /obj/machinery/door/airlock/command/glass,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "tP" = (
 /obj/machinery/cryo_cell,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "ve" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
@@ -140,74 +140,74 @@
 /obj/machinery/light/directional/west,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "wY" = (
 /turf/closed/mineral/random/labormineral,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "xe" = (
 /obj/machinery/stasis,
 /obj/effect/mob_spawn/corpse/human/charredskeleton,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "xy" = (
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "yl" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Bf" = (
 /turf/closed/wall/mineral/titanium,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Bm" = (
 /obj/machinery/door/airlock/external,
 /obj/structure/fans/tiny,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Cl" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Dh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Di" = (
 /turf/open/floor/engine/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "DU" = (
 /obj/machinery/door/window/brigdoor/left/directional/west,
 /obj/machinery/light/directional/east,
 /obj/effect/mob_spawn/corpse/human/skeleton,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Fc" = (
 /obj/machinery/light/directional/south,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Fn" = (
 /obj/machinery/cell_charger,
 /obj/machinery/light/directional/west,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Ge" = (
 /obj/structure/frame/machine,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Jd" = (
 /obj/structure/frame/machine,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "JP" = (
 /turf/template_noop,
 /area/template_noop)
@@ -216,20 +216,20 @@
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "LK" = (
 /turf/open/misc/asteroid/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Mk" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Mn" = (
 /obj/effect/mob_spawn/corpse/human/clown,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Mq" = (
 /obj/effect/mob_spawn/corpse/human/charredskeleton,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
@@ -237,10 +237,10 @@
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "ME" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Pz" = (
 /obj/machinery/computer/operating{
 	dir = 1
@@ -250,39 +250,39 @@
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "RO" = (
 /obj/machinery/door/airlock/research/glass{
 	welded = 1
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Sl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "SO" = (
 /obj/machinery/rnd/production/circuit_imprinter/offstation,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Vy" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "VR" = (
 /obj/structure/frame/computer{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Wp" = (
 /turf/closed/mineral/random/high_chance,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Wv" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 9
@@ -290,26 +290,26 @@
 /obj/effect/mob_spawn/corpse/human/charredskeleton,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Wy" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/template_noop,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Xe" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "XV" = (
 /obj/effect/mob_spawn/corpse/human/skeleton,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Yr" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 
 (1,1,1) = {"
 JP

--- a/_maps/shuttles/whiteship_birdshot.dmm
+++ b/_maps/shuttles/whiteship_birdshot.dmm
@@ -736,7 +736,6 @@
 /turf/open/floor/iron/grimy,
 /area/shuttle/abandoned/crew)
 "yM" = (
-/obj/machinery/light/cold/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken/directional/south,
 /obj/machinery/firealarm/directional/east,
@@ -1084,15 +1083,6 @@
 	},
 /turf/open/floor/iron/small,
 /area/shuttle/abandoned/pod)
-"Jk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth_large,
-/area/shuttle/abandoned/cargo)
 "Jn" = (
 /obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt,
@@ -1712,7 +1702,7 @@ wE
 RX
 gV
 EX
-Jk
+Ui
 kQ
 Jn
 iS

--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -99,6 +99,9 @@ GLOBAL_LIST_INIT(modulo_angle_to_dir, list(NORTH,NORTHEAST,EAST,SOUTHEAST,SOUTH,
 		else
 			return null
 
+///Returns a single dir rotated by x degrees clockwise, adhering to the cardinal directions.
+#define turn_cardinal(dir, rotation) ( angle2dir_cardinal ( dir2angle(dir) + rotation ) )
+
 //Returns the angle in english
 /proc/angle2text(degree)
 	return dir2text(angle2dir(degree))

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -134,7 +134,7 @@ Buildable meters
 	return ..()
 
 /obj/item/pipe/proc/make_from_existing(obj/machinery/atmospherics/make_from)
-	p_init_dir = make_from.initialize_directions
+	p_init_dir = make_from.get_init_directions()
 	setDir(make_from.dir)
 	pipename = make_from.name
 	add_atom_colour(make_from.color, FIXED_COLOUR_PRIORITY)

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -272,9 +272,9 @@
 
 	for(var/Ddir in GLOB.cardinals)
 		if(old_entered_dirs & Ddir)
-			entered_dirs |= angle2dir_cardinal(dir2angle(Ddir) + ang_change)
+			entered_dirs |= turn_cardinal(Ddir, ang_change)
 		if(old_exited_dirs & Ddir)
-			exited_dirs |= angle2dir_cardinal(dir2angle(Ddir) + ang_change)
+			exited_dirs |= turn_cardinal(Ddir, ang_change)
 
 	update_appearance()
 	return ..()

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -26,7 +26,7 @@
 	///Check if the object can be unwrenched
 	var/can_unwrench = FALSE
 	///Bitflag of the initialized directions (NORTH | SOUTH | EAST | WEST)
-	var/initialize_directions = 0
+	var/initialize_directions = NONE
 	///The color of the pipe
 	var/pipe_color = COLOR_VERY_LIGHT_GRAY
 	///What layer the pipe is in (from 1 to 5, default 3)
@@ -41,7 +41,7 @@
 	var/image/pipe_vision_img = null
 
 	///The type of the device (UNARY, BINARY, TRINARY, QUATERNARY)
-	var/device_type = 0
+	var/device_type = NONE
 	///The lists of nodes that a pipe/device has, depends on the device_type var (from 1 to 4)
 	var/list/obj/machinery/atmospherics/nodes
 
@@ -257,8 +257,7 @@
  * Return a list of the nodes that can connect to other machines, get called by atmos_init()
  */
 /obj/machinery/atmospherics/proc/get_node_connects()
-	var/list/node_connects = list()
-	node_connects.len = device_type
+	var/list/node_connects[device_type] //empty list of size device_type
 
 	var/init_directions = get_init_directions()
 	for(var/i in 1 to device_type)

--- a/code/modules/atmospherics/machinery/components/unary_devices/machine_connector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/machine_connector.dm
@@ -57,8 +57,12 @@
 /**
  * Called when the machine has been moved, reconnect to the pipe network
  */
-/datum/gas_machine_connector/proc/moved_connected_machine()
+/datum/gas_machine_connector/proc/moved_connected_machine(obj/machinery/source, atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE)
 	SIGNAL_HANDLER
+	if(forced) // Called from parent doing abstract_move()
+		gas_connector.abstract_move(get_turf(connected_machine))
+		return // No side-effects means no disconnections
+
 	gas_connector.forceMove(get_turf(connected_machine))
 	reconnect_connector()
 

--- a/code/modules/mapfluff/ruins/spaceruin_code/meatderelict.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/meatderelict.dm
@@ -125,6 +125,7 @@
 
 /obj/lightning_thrower/Destroy()
 	. = ..()
+	clear_signals()
 	signal_turfs = null
 	STOP_PROCESSING(SSprocessing, src)
 
@@ -132,6 +133,8 @@
 	var/list/dirs = throw_diagonals ? GLOB.diagonals : GLOB.cardinals
 	throw_diagonals = !throw_diagonals
 	playsound(src, 'sound/effects/magic/lightningbolt.ogg', 25, TRUE, SHORT_RANGE_SOUND_EXTRARANGE, ignore_walls = FALSE)
+	if(length(signal_turfs))
+		clear_signals()
 	for(var/direction in dirs)
 		var/victim_turf = get_step(src, direction)
 		if(isclosedturf(victim_turf))
@@ -143,8 +146,7 @@
 			shock_victim(null, victim)
 	addtimer(CALLBACK(src, PROC_REF(clear_signals)), shock_duration)
 
-/obj/lightning_thrower/proc/clear_signals(datum/source)
-	SIGNAL_HANDLER
+/obj/lightning_thrower/proc/clear_signals()
 	for(var/turf in signal_turfs)
 		UnregisterSignal(turf, COMSIG_ATOM_ENTERED)
 		signal_turfs -= turf

--- a/code/modules/mapping/ruins.dm
+++ b/code/modules/mapping/ruins.dm
@@ -115,7 +115,7 @@
 		if(R.unpickable)
 			continue
 		ruins_available[R] = R.placement_weight
-	while((budget > 0 || mineral_budget > 0) && (ruins_available.len || forced_ruins.len))
+	while(((budget > 0 || mineral_budget > 0) && ruins_available.len) || forced_ruins.len)
 		var/datum/map_template/ruin/current_pick
 		var/forced = FALSE
 		var/forced_z //If set we won't pick z level and use this one instead.

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -99,7 +99,7 @@
 				continue
 			if(on_turf.dir != dir)
 				continue
-			stack_trace("Conflicting double stacked light [on_turf.type] found at ([our_location.x],[our_location.y],[our_location.z])")
+			stack_trace("Conflicting double stacked light [on_turf.type] found at [get_area(our_location)] ([our_location.x],[our_location.y],[our_location.z])")
 			qdel(on_turf)
 
 	if(!mapload) //sync up nightshift lighting for player made lights

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -248,11 +248,6 @@ All ShuttleMove procs go here
 	. = ..()
 	recharging_turf = get_step(loc, dir)
 
-/obj/machinery/atmospherics/afterShuttleMove(turf/oldT, list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir, rotation)
-	. = ..()
-	if(pipe_vision_img)
-		pipe_vision_img.loc = loc
-
 /obj/machinery/computer/auxiliary_base/afterShuttleMove(turf/oldT, list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir, rotation)
 	. = ..()
 	if(is_mining_level(z)) //Avoids double logging and landing on other Z-levels due to badminnery
@@ -260,6 +255,9 @@ All ShuttleMove procs go here
 
 /obj/machinery/atmospherics/afterShuttleMove(turf/oldT, list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir, rotation)
 	. = ..()
+	if(pipe_vision_img)
+		pipe_vision_img.loc = loc
+		
 	var/missing_nodes = FALSE
 	for(var/i in 1 to device_type)
 		if(nodes[i])

--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -82,7 +82,11 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 /obj/machinery/atmospherics/shuttleRotate(rotation, params)
 	var/list/real_node_connect = get_node_connects()
 	for(var/i in 1 to device_type)
-		real_node_connect[i] = angle2dir(rotation+dir2angle(real_node_connect[i]))
+		var/node_dir = real_node_connect[i]
+		if(isnull(node_dir))
+			continue
+
+		real_node_connect[i] = turn(node_dir, -rotation)
 
 	. = ..()
 	set_init_directions()
@@ -90,7 +94,11 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 	var/list/nodes_copy = nodes.Copy()
 
 	for(var/i in 1 to device_type)
-		var/new_pos = supposed_node_connect.Find(real_node_connect[i])
+		var/node_dir = real_node_connect[i]
+		if(isnull(node_dir))
+			continue
+
+		var/new_pos = supposed_node_connect.Find(node_dir)
 		nodes[new_pos] = nodes_copy[i]
 
 //prevents shuttles attempting to rotate this since it messes up sprites


### PR DESCRIPTION
Mirror of https://github.com/tgstation/tgstation/pull/87910

## About The Pull Request

The ruins get added to forced_ruins, quite often after all ruin budget is exhausted and thus they don't get spawned.

This adjusts the logic to ignore the budget when there's forced_ruins to be had.

Also apparently fixes map_logging CI test which was broken by the logic, and makes the stacked_lights test scream at you with the area name for the sake of easier debugging as it can proc on the ruins now

## Why It's Good For The Game

Adjusts some logic to allow multi-ruins to spawn correctly, and to make sure our mappers make good space ruins too