### PR TITLE
[NON-MODULAR] Make Synths Able To Join Crusades

### DIFF
--- a/code/modules/religion/honorbound/honorbound_rites.dm
+++ b/code/modules/religion/honorbound/honorbound_rites.dm
@@ -33,7 +33,7 @@
 		if(possible_crusader.stat != CONSCIOUS)
 			to_chat(user, span_warning("[possible_crusader] needs to be alive and conscious to join the crusade!"))
 			return FALSE
-		if(TRAIT_GENELESS in possible_crusader.dna.species.inherent_traits)
+		if(TRAIT_GENELESS in possible_crusader.dna.species.inherent_traits && !issynthetic(possible_crusader)) // BUBBER EDIT: Allow synths to be part of a crusade: ORIGINAL: if(TRAIT_GENELESS in possible_crusader.dna.species.inherent_traits)
 			to_chat(user, span_warning("This species disgusts [GLOB.deity]! They would never be allowed to join the crusade!"))
 			return FALSE
 		if(possible_crusader in sect.currently_asking)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tin, currently the rite checks for no DNA, which would be fine if we didn't have a race that's all about being a machine.

So I'd say we allow them to join said crusade, considering that if they themselves are the chaplain, they're able to be honorbound AND also start a crusade themselves.


**Also, please stop reporting weird inconsistencies and bugs inside the suggestions channel, thanks. There's a bug report channel that actually gets looked at by coders.**

## Why It's Good For The Game

Let synths get in on the action considering they're already fucked over enough as is.

## Proof Of Testing

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->

It's a one-line change with an added species check, hard to fuck this up.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Synths can now join honorbound crusades.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
