### PR TITLE
Tram spoiler/malf fix #88371

### DIFF
--- a/code/modules/events/tram_malfunction.dm
+++ b/code/modules/events/tram_malfunction.dm
@@ -42,7 +42,7 @@
 
 /datum/round_event/tram_malfunction/end()
 	for(var/datum/transport_controller/linear/tram/malfunctioning_controller as anything in SStransport.transports_by_type[TRANSPORT_TYPE_TRAM])
-		if(malfunctioning_controller.specific_transport_id == specific_transport_id && malfunctioning_controller.malf_active)
+		if(malfunctioning_controller.specific_transport_id == specific_transport_id && malfunctioning_controller.malf_active != TRANSPORT_SYSTEM_NORMAL)
 			malfunctioning_controller.end_malf_event()
 			return
 

--- a/code/modules/transport/tram/tram_controller.dm
+++ b/code/modules/transport/tram/tram_controller.dm
@@ -54,7 +54,7 @@
 	var/recovery_clear_count = 0
 
 	///if the tram's next stop will be the tram malfunction event sequence
-	var/malf_active = FALSE
+	var/malf_active = TRANSPORT_SYSTEM_NORMAL
 
 	///fluff information of the tram, such as ongoing kill count and age
 	var/datum/tram_mfg_info/tram_registration
@@ -259,14 +259,16 @@
 		playsound(paired_cabinet, 'sound/machines/synth/synth_yes.ogg', 40, vary = FALSE, extrarange = SHORT_RANGE_SOUND_EXTRARANGE)
 		paired_cabinet.say("Controller reset.")
 
-	if(malf_active)
-		addtimer(CALLBACK(src, PROC_REF(announce_malf_event)), 1 SECONDS)
-
 	SEND_SIGNAL(src, COMSIG_TRAM_TRAVEL, idle_platform, destination_platform)
 
 	for(var/obj/structure/transport/linear/tram/transport_module as anything in transport_modules) //only thing everyone needs to know is the new location.
 		if(transport_module.travelling) //wee woo wee woo there was a double action queued. damn multi tile structs
 			return //we don't care to undo cover_locked controls, though, as that will resolve itself
+		if(malf_active == TRANSPORT_LOCAL_WARNING)
+			if(transport_module.check_for_humans())
+				throw_chance *= 1.75
+				malf_active = TRANSPORT_LOCAL_FAULT
+				addtimer(CALLBACK(src, PROC_REF(announce_malf_event)), 1 SECONDS)
 		transport_module.verify_transport_contents()
 		transport_module.glide_size_override = DELAY_TO_GLIDE_SIZE(speed_limiter)
 		transport_module.set_travelling(TRUE)
@@ -296,7 +298,7 @@
 		return PROCESS_KILL
 
 	if(!travel_remaining)
-		if(!controller_operational || malf_active)
+		if(!controller_operational || malf_active == TRANSPORT_LOCAL_FAULT)
 			degraded_stop()
 		else
 			normal_stop()
@@ -370,10 +372,10 @@
 		paired_cabinet.say("Controller reset.")
 		log_transport("TC: [specific_transport_id] position data successfully reset. ")
 		speed_limiter = initial(speed_limiter)
-	if(malf_active)
+	if(malf_active == TRANSPORT_LOCAL_FAULT)
 		set_status_code(SYSTEM_FAULT, TRUE)
 		addtimer(CALLBACK(src, PROC_REF(cycle_doors), CYCLE_OPEN), 2 SECONDS)
-		malf_active = FALSE
+		malf_active = TRANSPORT_SYSTEM_NORMAL
 		throw_chance = initial(throw_chance)
 		playsound(paired_cabinet, 'sound/machines/buzz/buzz-sigh.ogg', 60, vary = FALSE, extrarange = SHORT_RANGE_SOUND_EXTRARANGE)
 		paired_cabinet.say("Controller error. Please contact your engineering department.")
@@ -417,6 +419,7 @@
  * Performs a reset of the tram's position data by finding a predetermined reference landmark, then driving to it.
  */
 /datum/transport_controller/linear/tram/proc/reset_position()
+	malf_active = TRANSPORT_SYSTEM_NORMAL
 	if(idle_platform)
 		if(get_turf(idle_platform) == get_turf(nav_beacon))
 			set_status_code(SYSTEM_FAULT, FALSE)
@@ -602,7 +605,8 @@
  * Tram malfunction random event. Set comm error, requiring engineering or AI intervention.
  */
 /datum/transport_controller/linear/tram/proc/start_malf_event()
-	malf_active = TRUE
+	malf_active = TRANSPORT_LOCAL_WARNING
+	paired_cabinet.update_appearance()
 	throw_chance *= 1.25
 	log_transport("TC: [specific_transport_id] starting Tram Malfunction event.")
 
@@ -615,7 +619,8 @@
 /datum/transport_controller/linear/tram/proc/end_malf_event()
 	if(!(malf_active))
 		return
-	malf_active = FALSE
+	malf_active = TRANSPORT_SYSTEM_NORMAL
+	paired_cabinet.update_appearance()
 	throw_chance = initial(throw_chance)
 	log_transport("TC: [specific_transport_id] ending Tram Malfunction event.")
 
@@ -978,7 +983,7 @@
 		. += emissive_appearance(icon, "[base_icon_state]-estop", src, alpha = src.alpha)
 		return
 
-	if(controller_datum.controller_status & SYSTEM_FAULT || controller_datum.malf_active)
+	if(controller_datum.controller_status & SYSTEM_FAULT || controller_datum.malf_active != TRANSPORT_SYSTEM_NORMAL)
 		. += mutable_appearance(icon, "[base_icon_state]-fault")
 		. += emissive_appearance(icon, "[base_icon_state]-fault", src, alpha = src.alpha)
 		return
@@ -1079,7 +1084,7 @@
 		"recoveryMode" = controller_datum.recovery_mode,
 		"currentSpeed" = controller_datum.current_speed,
 		"currentLoad" = controller_datum.current_load,
-		"statusSF" = controller_datum.controller_status & SYSTEM_FAULT,
+		"statusSF" = controller_datum.controller_status & SYSTEM_FAULT || controller_datum.malf_active != TRANSPORT_SYSTEM_NORMAL,
 		"statusCE" = controller_datum.controller_status & COMM_ERROR,
 		"statusES" = controller_datum.controller_status & EMERGENCY_STOP,
 		"statusPD" = controller_datum.controller_status & PRE_DEPARTURE,

--- a/code/modules/transport/tram/tram_structures.dm
+++ b/code/modules/transport/tram/tram_structures.dm
@@ -474,8 +474,8 @@
 	canSmoothWith = null
 	/// Position of the spoiler
 	var/deployed = FALSE
-	/// Malfunctioning due to tampering or emag
-	var/malfunctioning = FALSE
+	/// Locked in position
+	var/locked = FALSE
 	/// Weakref to the tram piece we control
 	var/datum/weakref/tram_ref
 	/// The tram we're attached to
@@ -494,7 +494,7 @@
 		context[SCREENTIP_CONTEXT_LMB] = "repair"
 
 	if(held_item?.tool_behaviour == TOOL_WELDER && atom_integrity >= max_integrity)
-		context[SCREENTIP_CONTEXT_LMB] = "[malfunctioning ? "repair" : "lock"]"
+		context[SCREENTIP_CONTEXT_LMB] = "[locked ? "repair" : "sabotage"]"
 
 	return CONTEXTUAL_SCREENTIP_SET
 
@@ -503,22 +503,19 @@
 	if(obj_flags & EMAGGED)
 		. += span_warning("The electronics panel is sparking occasionally. It can be reset with a [EXAMINE_HINT("multitool.")]")
 
-	if(malfunctioning)
+	if(locked)
 		. += span_warning("The spoiler is [EXAMINE_HINT("welded")] in place!")
 	else
-		. += span_notice("The spoiler can be locked in to place with a [EXAMINE_HINT("welder.")]")
+		. += span_notice("The spoiler can be locked in place with a [EXAMINE_HINT("welder.")]")
 
 /obj/structure/tram/spoiler/proc/set_spoiler(source, controller, controller_active, controller_status, travel_direction)
 	SIGNAL_HANDLER
 
 	var/spoiler_direction = travel_direction
-	if(obj_flags & EMAGGED && !malfunctioning)
-		malfunctioning = TRUE
-
-	if(malfunctioning || controller_status & COMM_ERROR)
+	if(locked || controller_status & COMM_ERROR || obj_flags & EMAGGED)
 		if(!deployed)
 			// Bring out the blades
-			if(malfunctioning)
+			if(locked)
 				visible_message(span_danger("\the [src] locks up due to its servo overheating!"))
 			do_sparks(3, cardinal_only = FALSE, source = src)
 			deploy_spoiler()
@@ -583,14 +580,14 @@
 		return FALSE
 
 	if(atom_integrity >= max_integrity)
-		to_chat(user, span_warning("You begin to weld \the [src], [malfunctioning ? "repairing damage" : "preventing retraction"]."))
+		to_chat(user, span_warning("You begin to weld \the [src], [locked ? "repairing damage" : "preventing retraction"]."))
 		if(!tool.use_tool(src, user, 4 SECONDS, volume = 50))
 			return
-		malfunctioning = !malfunctioning
-		user.visible_message(span_warning("[user] [malfunctioning ? "welds \the [src] in place" : "repairs \the [src]"] with [tool]."), \
-			span_warning("You finish welding \the [src], [malfunctioning ? "locking it in place." : "it can move freely again!"]"), null, COMBAT_MESSAGE_RANGE)
+		locked = !locked
+		user.visible_message(span_warning("[user] [locked ? "welds \the [src] in place" : "repairs \the [src]"] with [tool]."), \
+			span_warning("You finish welding \the [src], [locked ? "locking it in place." : "it can move freely again!"]"), null, COMBAT_MESSAGE_RANGE)
 
-		if(malfunctioning)
+		if(locked)
 			deploy_spoiler()
 
 		update_appearance()
@@ -606,7 +603,7 @@
 
 /obj/structure/tram/spoiler/update_overlays()
 	. = ..()
-	if(deployed && malfunctioning)
+	if(deployed && locked)
 		. += mutable_appearance(icon, "tram-spoiler-welded")
 
 /obj/structure/chair/sofa/bench/tram

--- a/code/modules/transport/transport_module.dm
+++ b/code/modules/transport/transport_module.dm
@@ -171,6 +171,13 @@
 		if(!(movable_contents.loc in locs))
 			remove_item_from_transport(movable_contents)
 
+/obj/structure/transport/linear/proc/check_for_humans()
+	for(var/atom/movable/movable_contents as anything in transport_contents)
+		if(ishuman(movable_contents))
+			return TRUE
+
+	return FALSE
+
 ///signal handler for COMSIG_MOVABLE_UPDATE_GLIDE_SIZE: when a movable in transport_contents changes its glide_size independently.
 ///adds that movable to a lazy list, movables in that list have their glide_size updated when the tram next moves
 /obj/structure/transport/linear/proc/on_changed_glide_size(atom/movable/moving_contents, new_glide_size)

--- a/html/changelogs/AutoChangeLog-pr-88371.yml
+++ b/html/changelogs/AutoChangeLog-pr-88371.yml
@@ -1,0 +1,5 @@
+author: "LT3"
+delete-after: True
+changes:
+  - bugfix: "Tram spoilers correctly provide welder or multitool hints depending on their damage"
+  - bugfix: "Malfunctioning tram controller flashes orange and can be preemptively fixed before it crashes"


### PR DESCRIPTION
Early Pull: https://github.com/tgstation/tgstation/pull/88371

## About The Pull Request

- Fixes emagged tram spoilers from appearing welded/displaying weld hints
- Tram malfunction checks for humans before throwing
- Tram control panel flashes orange when malfunction can be fixed

## Why It's Good For The Game

- Better visual indicator that the tram is malfunctioning and can be reset
- You're correctly told welder or multitool hints depending on if the tram is welded or emagged
- Don't bother running a tram malfunction if nobody is around