### PR TITLE
Fix Cortial Borers Being Unremovable

### DIFF
--- a/code/__DEFINES/~skyrat_defines/DNA.dm
+++ b/code/__DEFINES/~skyrat_defines/DNA.dm
@@ -57,6 +57,7 @@
 #define ORGAN_SLOT_EXTERNAL_TAUR "taur"
 #define ORGAN_SLOT_EXTERNAL_XENODORSAL "xenodorsal"
 #define ORGAN_SLOT_EXTERNAL_XENOHEAD "xenohead"
+#define ORGAN_SLOT_BORER "borer"
 
 //Defines for an accessory to be randomed
 #define ACC_RANDOM		"random"

--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer.dm
@@ -36,6 +36,7 @@ GLOBAL_LIST_EMPTY(cortical_borers)
 	name = "engorged cortical borer"
 	desc = "the body of a cortical borer, full of human viscera, blood, and more."
 	zone = BODY_ZONE_HEAD
+	slot = ORGAN_SLOT_BORER
 	/// Ref to the borer who this organ belongs to
 	var/mob/living/basic/cortical_borer/borer
 


### PR DESCRIPTION

## About The Pull Request

Borers don't show up on manipulate organs, apparently. This is not intended.

This was caused by the organ slot not being set.

## Why It's Good For The Game

Bug bad, also what the fuck we shouldn't have to debrain someone to get them out.

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/7cc6202f-c835-44fb-836c-7090510b0bd5)
Also removed the thing and it came out without issues.
</details>

## Changelog
:cl:
fix: Cortial borers can be surgically removed again.
/:cl:
