### PR TITLE
Buffs the L6 Saw

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/lmg.dm
+++ b/code/modules/projectiles/ammunition/ballistic/lmg.dm
@@ -1,5 +1,5 @@
 // 7mm (SAW)
-
+// BUBBER BUFFS modular_zubbers\code\modules\projectiles\projectile\bullets\lmg.dm
 /obj/item/ammo_casing/m7mm
 	name = "7mm bullet casing"
 	desc = "A 7mm bullet casing."

--- a/modular_zubbers/code/modules/projectiles/projectile/bullets/lmg.dm
+++ b/modular_zubbers/code/modules/projectiles/projectile/bullets/lmg.dm
@@ -1,0 +1,13 @@
+// Buffs the L6 saw damage ~ 30 percent.
+
+/obj/projectile/bullet/a7mm
+	damage = 39
+
+/obj/projectile/bullet/a7mm/ap
+	damage = 30
+
+/obj/projectile/bullet/incendiary/a7mm
+	damage = 20
+
+/obj/projectile/bullet/a7mm/bouncy
+	damage = 25

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9219,6 +9219,7 @@
 #include "modular_zubbers\code\modules\projectiles\boxes_magazines\external\smg.dm"
 #include "modular_zubbers\code\modules\projectiles\guns\ballistic\automatic.dm"
 #include "modular_zubbers\code\modules\projectiles\guns\energy\pulse.dm"
+#include "modular_zubbers\code\modules\projectiles\projectile\bullets\lmg.dm"
 #include "modular_zubbers\code\modules\projectiles\projectile\bullets\smg.dm"
 #include "modular_zubbers\code\modules\protected_roles\code\antag_restricted_jobs.dm"
 #include "modular_zubbers\code\modules\public_logging\public_logging.dm"


### PR DESCRIPTION
## About The Pull Request

Buffs the L6 saw ~ 30 percent more damage

## Why It's Good For The Game

The l6 saw has always been left behind for a nukie weapon. This will help get it to a better state. 

- /obj/projectile/bullet/a7mm (normal ammo) 30 --> 39
- /obj/projectile/bullet/a7mm/ap (AP ammo) 25 --> 30
- /obj/projectile/bullet/incendiary/a7mm (Incendiary Ammo) 15 --> 20
- /obj/projectile/bullet/a7mm/bouncy (bouncy ammo) 20 --> 25

## Proof Of Testing

It compiles and works.

## Changelog

:cl:
balance: Increases the L6 Saw damage by around 30 percent
/:cl:
