### PR TITLE
buffs bloodsucker leveling

### DIFF
--- a/modular_zubbers/code/__DEFINES/bloodsucker_defines.dm
+++ b/modular_zubbers/code/__DEFINES/bloodsucker_defines.dm
@@ -30,7 +30,7 @@
 #define HUMANITY_LOST_MAXIMUM 50
 
 /// Level up blood cost define, max_blood * this = blood cost
-#define BLOODSUCKER_LEVELUP_PERCENTAGE 0.45
+#define BLOODSUCKER_LEVELUP_PERCENTAGE 0.35
 #define BLOODSUCKER_LEVELUP_PERCENTAGE_VENTRUE BLOODSUCKER_LEVELUP_PERCENTAGE - 0.1
 
 ///The level when at a bloodsucker becomes snobby about who they drink from and gain their non-fledling reputation

--- a/modular_zubbers/code/__DEFINES/bloodsucker_defines.dm
+++ b/modular_zubbers/code/__DEFINES/bloodsucker_defines.dm
@@ -30,7 +30,7 @@
 #define HUMANITY_LOST_MAXIMUM 50
 
 /// Level up blood cost define, max_blood * this = blood cost
-#define BLOODSUCKER_LEVELUP_PERCENTAGE 0.35
+#define BLOODSUCKER_LEVELUP_PERCENTAGE 0.40
 #define BLOODSUCKER_LEVELUP_PERCENTAGE_VENTRUE BLOODSUCKER_LEVELUP_PERCENTAGE - 0.1
 
 ///The level when at a bloodsucker becomes snobby about who they drink from and gain their non-fledling reputation


### PR DESCRIPTION

## About The Pull Request
makes it easier for bloodsucker to level up, setting the percentage to 40% of blood volume

## Why It's Good For The Game
It's kind of really rough to level up as a bloodsucker, hopefully this helps

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
balance: Bloodsuckers now only need 40% blood to level up.
/:cl:

