### PR TITLE
Buffs cyborg health to match human health (135)

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -12,6 +12,8 @@
 	mobility_flags = MOBILITY_FLAGS_CARBON_DEFAULT
 	blocks_emissive = EMISSIVE_BLOCK_NONE
 	living_flags = ALWAYS_DEATHGASP
+	maxHealth = HUMAN_MAXHEALTH // Bubber Edit - Buff cyborg Health
+	health = HUMAN_MAXHEALTH // Bubber Edit - Buff Cyborg Health
 	///List of [/obj/item/organ]s in the mob. They don't go in the contents for some reason I don't want to know.
 	var/list/obj/item/organ/organs = list()
 	///Same as [above][/mob/living/carbon/var/organs], but stores "slot ID" - "organ" pairs for easy access.


### PR DESCRIPTION
## About The Pull Request

Buffs cyborg health to match human health at 135 HP

## Why It's Good For The Game

They are a bit squishy, and while that was fine, the melee changes that slow down borgs got added. I think we should of put cyborg health on par with every other player.

## Proof Of Testing

It works.

## Changelog

:cl:
balance: Buffs cyborg health to 135
/:cl:
