### PR TITLE
[FUCK] Unfucks Loadout Clearing

### DIFF
--- a/code/modules/loadout/loadout_menu.dm
+++ b/code/modules/loadout/loadout_menu.dm
@@ -31,10 +31,12 @@
 		select_item(interacted_item)
 	return TRUE
 
+/* BUBBER EDIT REMOVAL: Multiple loadout presets: Handled in the modular file.
 /datum/preference_middleware/loadout/proc/action_clear_all(list/params, mob/user)
 	PRIVATE_PROC(TRUE)
 	preferences.update_preference(GLOB.preference_entries[/datum/preference/loadout], null)
 	return TRUE
+*/
 
 /datum/preference_middleware/loadout/proc/action_toggle_job_outfit(list/params, mob/user)
 	PRIVATE_PROC(TRUE)

--- a/modular_zubbers/master_files/code/modules/loadout/loadout_menu.dm
+++ b/modular_zubbers/master_files/code/modules/loadout/loadout_menu.dm
@@ -84,3 +84,7 @@
 	var/list/loadout_entries = preferences.read_preference(/datum/preference/loadout)
 	loadout_entries[preferences.read_preference(/datum/preference/loadout_index)] = loadout
 	preferences.update_preference(GLOB.preference_entries[/datum/preference/loadout], loadout_entries)
+
+/datum/preference_middleware/loadout/action_clear_all(list/params, mob/user)
+	save_current_loadout(list())
+	return TRUE

--- a/modular_zubbers/master_files/code/modules/loadout/loadout_menu.dm
+++ b/modular_zubbers/master_files/code/modules/loadout/loadout_menu.dm
@@ -85,6 +85,6 @@
 	loadout_entries[preferences.read_preference(/datum/preference/loadout_index)] = loadout
 	preferences.update_preference(GLOB.preference_entries[/datum/preference/loadout], loadout_entries)
 
-/datum/preference_middleware/loadout/action_clear_all(list/params, mob/user)
+/datum/preference_middleware/loadout/proc/action_clear_all(list/params, mob/user)
 	save_current_loadout(list())
 	return TRUE


### PR DESCRIPTION

## About The Pull Request

Okay, now this is actually a big issue, I may or may not have entirely forgot to check the clear loadout proc...

It wipes your entire loadout preference! AAAAAAAA!!!

Please merge before another unfortunate soul gets bluescreen'd or loses their whole loadout!

## Why It's Good For The Game

Loadout wipe bad!

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/ecf18632-232e-4d04-841a-92a8d536549c)
![image](https://github.com/user-attachments/assets/5ce542c5-d871-446d-82a8-c89defaebbb7)
Swap to another loadout to prove it didn't wipe everything
![image](https://github.com/user-attachments/assets/d1894922-de02-4dc4-9835-78860cef6027)

</details>

## Changelog
:cl:
fix: Using the clear loadout button should no longer brick your loadout data. Woops.
/:cl:
