### PR TITLE
[EARLY PULL] Fixes benches attempting to add a nonexisting armrest overlay (#87368)

### DIFF
--- a/code/game/objects/structures/beds_chairs/sofa.dm
+++ b/code/game/objects/structures/beds_chairs/sofa.dm
@@ -74,6 +74,7 @@ COLORED_SOFA(/obj/structure/chair/sofa, maroon, SOFA_MAROON)
 	icon_state = "bench_middle"
 	greyscale_config = /datum/greyscale_config/bench_middle
 	greyscale_colors = "#af7d28"
+	has_armrest = FALSE
 
 /obj/structure/chair/sofa/bench/left
 	icon_state = "bench_left"
@@ -101,6 +102,7 @@ COLORED_SOFA(/obj/structure/chair/sofa, maroon, SOFA_MAROON)
 	max_integrity = 60
 	buildstacktype = /obj/item/stack/sheet/mineral/bamboo
 	buildstackamount = 3
+	has_armrest = FALSE
 
 /obj/structure/chair/sofa/bamboo/left
 	icon_state = "bamboo_sofaend_left"


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/tgstation/pull/87368

Fixes the error overlay when buckled to a bench!

## Why It's Good For The Game

Bug bad, fix good!

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/8df42276-10df-401c-912b-d2e9e563ed17)

</details>

## Changelog
:cl: Profakos
fix: Benches no longer produce an Error overlay when buckled
/:cl:
