### PR TITLE
Dragons loosing a portal is no longer practically the end

### DIFF
--- a/code/__DEFINES/~~bubber_defines/misc.dm
+++ b/code/__DEFINES/~~bubber_defines/misc.dm
@@ -4,3 +4,6 @@ GLOBAL_DATUM_INIT(noncapital_i, /regex, regex("\\b\[i]\\b", "g")) */ // TODO: RE
 
 // The alpha channel gained upon ghosting
 #define GHOST_ALPHA 180
+
+/// Used for the trait for when a dragon looses a portal
+#define DRAGON_PORTAL_LOSS "dragon_portal_loss"

--- a/code/modules/antagonists/space_dragon/carp_rift.dm
+++ b/code/modules/antagonists/space_dragon/carp_rift.dm
@@ -35,6 +35,7 @@
 		return
 	if(locate(/obj/structure/carp_rift) in owner.loc)
 		return
+	REMOVE_TRAIT(owner, TRAIT_RIFT_FAILURE, REF(dragon)) // BUBBER ADDITION
 	owner.remove_movespeed_modifier(/datum/movespeed_modifier/dragon_depression/no_portal) // BUBBER ADDITION
 	var/obj/structure/carp_rift/new_rift = new(get_turf(owner))
 	playsound(owner.loc, 'sound/vehicles/rocketlaunch.ogg', 100, TRUE)

--- a/code/modules/antagonists/space_dragon/carp_rift.dm
+++ b/code/modules/antagonists/space_dragon/carp_rift.dm
@@ -36,7 +36,7 @@
 	if(locate(/obj/structure/carp_rift) in owner.loc)
 		return
 	REMOVE_TRAIT(owner, TRAIT_RIFT_FAILURE, DRAGON_PORTAL_LOSS) // BUBBER ADDITION
-	owner.remove_movespeed_modifier(/datum/movespeed_modifier/dragon_depression/no_portal) // BUBBER ADDITION
+	owner.remove_movespeed_modifier(/datum/movespeed_modifier/dragon_depression) // BUBBER ADDITION
 	var/obj/structure/carp_rift/new_rift = new(get_turf(owner))
 	playsound(owner.loc, 'sound/vehicles/rocketlaunch.ogg', 100, TRUE)
 	dragon.riftTimer = -1

--- a/code/modules/antagonists/space_dragon/carp_rift.dm
+++ b/code/modules/antagonists/space_dragon/carp_rift.dm
@@ -35,7 +35,7 @@
 		return
 	if(locate(/obj/structure/carp_rift) in owner.loc)
 		return
-	REMOVE_TRAIT(owner, TRAIT_RIFT_FAILURE, REF(dragon)) // BUBBER ADDITION
+	REMOVE_TRAIT(owner, TRAIT_RIFT_FAILURE, DRAGON_PORTAL_LOSS) // BUBBER ADDITION
 	owner.remove_movespeed_modifier(/datum/movespeed_modifier/dragon_depression/no_portal) // BUBBER ADDITION
 	var/obj/structure/carp_rift/new_rift = new(get_turf(owner))
 	playsound(owner.loc, 'sound/vehicles/rocketlaunch.ogg', 100, TRUE)

--- a/code/modules/antagonists/space_dragon/space_dragon.dm
+++ b/code/modules/antagonists/space_dragon/space_dragon.dm
@@ -142,7 +142,7 @@
 	if(riftTimer >= maxRiftTimer)
 		// BUBBER CHANGE START: dragons don't die to not summoning a rift
 		to_chat(owner.current, span_boldwarning("You've failed to summon the rift in a timely manner! You will be slowed down until you do so!"))
-		owner.current.add_movespeed_modifier(/datum/movespeed_modifier/dragon_depression/no_portal)
+		owner.current.add_movespeed_modifier(/datum/movespeed_modifier/dragon_depression)
 		riftTimer = -1
 		// BUBBER CHANGE END
 

--- a/code/modules/antagonists/space_dragon/space_dragon.dm
+++ b/code/modules/antagonists/space_dragon/space_dragon.dm
@@ -13,7 +13,7 @@
 	/// Current time since the the last rift was activated.  If set to -1, does not increment.
 	var/riftTimer = 0
 	/// Maximum amount of time which can pass without a rift before Space Dragon despawns.
-	var/maxRiftTimer = 300
+	var/maxRiftTimer = 30
 	/// A list of all of the rifts created by Space Dragon.  Used for setting them all to infinite carp spawn when Space Dragon wins, and removing them when Space Dragon dies.
 	var/list/obj/structure/carp_rift/rift_list = list()
 	/// How many rifts have been successfully charged
@@ -160,6 +160,9 @@
 	ADD_TRAIT(owner.current, TRAIT_RIFT_FAILURE, REF(src))
 	owner.current.add_movespeed_modifier(/datum/movespeed_modifier/dragon_depression)
 	riftTimer = -1
+	if(rifts_charged != 3 && !objective_complete) // BUBBER ADDITION
+		rift_ability = new() // BUBBER ADDITION
+		rift_ability.Grant(owner.current) // BUBBER ADDITION
 	SEND_SOUND(owner.current, sound('sound/vehicles/rocketlaunch.ogg'))
 	for(var/obj/structure/carp_rift/rift as anything in rift_list)
 		rift.dragon = null

--- a/code/modules/antagonists/space_dragon/space_dragon.dm
+++ b/code/modules/antagonists/space_dragon/space_dragon.dm
@@ -161,6 +161,8 @@
 	owner.current.add_movespeed_modifier(/datum/movespeed_modifier/dragon_depression)
 	riftTimer = -1
 	if(rifts_charged != 3 && !objective_complete) // BUBBER ADDITION
+		if(owner.current.stat == MOB_DEAD)
+			return
 		to_chat(owner.current, span_warning("You will be able to make a new rift in 5 minutes."))
 		addtimer(CALLBACK(src, PROC_REF(give_rift_ability)), 5 MINUTES)
 	SEND_SOUND(owner.current, sound('sound/vehicles/rocketlaunch.ogg'))
@@ -171,6 +173,8 @@
 			QDEL_NULL(rift)
 
 /datum/antagonist/space_dragon/proc/give_rift_ability()
+	if(owner.current.stat == MOB_DEAD)
+		return
 	rift_ability = new()
 	rift_ability.Grant(owner.current)
 

--- a/code/modules/antagonists/space_dragon/space_dragon.dm
+++ b/code/modules/antagonists/space_dragon/space_dragon.dm
@@ -162,7 +162,7 @@
 	riftTimer = -1
 	if(rifts_charged != 3 && !objective_complete) // BUBBER ADDITION
 		to_chat(owner.current, span_warning("You will be able to make a new rift in 5 minutes."))
-		addtimer(CALLBACK(src, PROC_REF(rift_checks)), 5 MINUTES)
+		addtimer(CALLBACK(src, PROC_REF(give_rift_ability)), 5 MINUTES)
 	SEND_SOUND(owner.current, sound('sound/vehicles/rocketlaunch.ogg'))
 	for(var/obj/structure/carp_rift/rift as anything in rift_list)
 		rift.dragon = null

--- a/code/modules/antagonists/space_dragon/space_dragon.dm
+++ b/code/modules/antagonists/space_dragon/space_dragon.dm
@@ -157,7 +157,7 @@
 	if(objective_complete)
 		return
 	rifts_charged = 0
-	ADD_TRAIT(owner.current, TRAIT_RIFT_FAILURE, REF(src))
+	ADD_TRAIT(owner.current, TRAIT_RIFT_FAILURE, DRAGON_PORTAL_LOSS) // BUBBER CHANGE
 	owner.current.add_movespeed_modifier(/datum/movespeed_modifier/dragon_depression)
 	riftTimer = -1
 	if(rifts_charged != 3 && !objective_complete) // BUBBER ADDITION

--- a/code/modules/antagonists/space_dragon/space_dragon.dm
+++ b/code/modules/antagonists/space_dragon/space_dragon.dm
@@ -13,7 +13,7 @@
 	/// Current time since the the last rift was activated.  If set to -1, does not increment.
 	var/riftTimer = 0
 	/// Maximum amount of time which can pass without a rift before Space Dragon despawns.
-	var/maxRiftTimer = 30
+	var/maxRiftTimer = 300
 	/// A list of all of the rifts created by Space Dragon.  Used for setting them all to infinite carp spawn when Space Dragon wins, and removing them when Space Dragon dies.
 	var/list/obj/structure/carp_rift/rift_list = list()
 	/// How many rifts have been successfully charged
@@ -161,14 +161,18 @@
 	owner.current.add_movespeed_modifier(/datum/movespeed_modifier/dragon_depression)
 	riftTimer = -1
 	if(rifts_charged != 3 && !objective_complete) // BUBBER ADDITION
-		rift_ability = new() // BUBBER ADDITION
-		rift_ability.Grant(owner.current) // BUBBER ADDITION
+		to_chat(owner.current, span_warning("You will be able to make a new rift in 5 minutes."))
+		addtimer(CALLBACK(src, PROC_REF(rift_checks)), 5 MINUTES)
 	SEND_SOUND(owner.current, sound('sound/vehicles/rocketlaunch.ogg'))
 	for(var/obj/structure/carp_rift/rift as anything in rift_list)
 		rift.dragon = null
 		rift_list -= rift
 		if(!QDELETED(rift))
 			QDEL_NULL(rift)
+
+/datum/antagonist/space_dragon/proc/give_rift_ability()
+	rift_ability = new()
+	rift_ability.Grant(owner.current)
 
 /**
  * Sets up Space Dragon's victory for completing the objectives.

--- a/code/modules/antagonists/space_dragon/space_dragon.dm
+++ b/code/modules/antagonists/space_dragon/space_dragon.dm
@@ -161,7 +161,7 @@
 	owner.current.add_movespeed_modifier(/datum/movespeed_modifier/dragon_depression)
 	riftTimer = -1
 	if(rifts_charged != 3 && !objective_complete) // BUBBER ADDITION
-		if(owner.current.stat == MOB_DEAD)
+		if(owner.current.stat == DEAD)
 			return
 		to_chat(owner.current, span_warning("You will be able to make a new rift in 5 minutes."))
 		addtimer(CALLBACK(src, PROC_REF(give_rift_ability)), 5 MINUTES)
@@ -173,7 +173,7 @@
 			QDEL_NULL(rift)
 
 /datum/antagonist/space_dragon/proc/give_rift_ability()
-	if(owner.current.stat == MOB_DEAD)
+	if(owner.current.stat == DEAD)
 		return
 	rift_ability = new()
 	rift_ability.Grant(owner.current)

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -145,8 +145,6 @@
 /datum/movespeed_modifier/dragon_depression
 	multiplicative_slowdown = 5
 
-/datum/movespeed_modifier/dragon_depression/no_portal
-
 /datum/movespeed_modifier/morph_disguised
 	multiplicative_slowdown = -1
 


### PR DESCRIPTION
## About The Pull Request
Dragons can now make a portal after 5 minutes after they loose their portal.

## Why It's Good For The Game
Currently dragon is forever slowed down and practically expected to die if they loose a single portal.

## Proof Of Testing

works, tested

## Changelog

:cl:
add: Dragons no longer permanently stuck unable to amke a portal if they loose one, now regaining the ability in 5 minutes
/:cl:

