### PR TITLE
Fixes some weird conflict that appeared 6 months ago and nobody reported

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -24,10 +24,6 @@
 	new /obj/item/gun/energy/e_gun(src)
 	new /obj/item/storage/belt/sabre(src)
 
-/obj/structure/closet/secure_closet/captains/populate_contents_immediate()
-	new /obj/item/gun/energy/e_gun(src)
-	new /obj/item/storage/belt/sabre(src)
-
 /obj/structure/closet/secure_closet/hop
 	name = "head of personnel's locker"
 	icon_state = "hop"
@@ -77,14 +73,6 @@
 	new /obj/item/circuitboard/machine/techfab/department/security(src)
 	new /obj/item/storage/photo_album/hos(src)
 	new /obj/item/card/id/departmental_budget/sec(src) //SKYRAT EDIT ADDITION
-
-/obj/structure/closet/secure_closet/hos/populate_contents_immediate()
-	. = ..()
-
-	// Traitor steal objectives
-	new /obj/item/gun/energy/e_gun/hos(src)
-	new /obj/item/pinpointer/nuke(src)
-	new /obj/item/gun/ballistic/shotgun/automatic/combat/compact(src)
 
 /obj/structure/closet/secure_closet/hos/populate_contents_immediate()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

The cap and HoS lockers had double the gun in them for some reason. Of course, nobody reported this because it was double the gun.

## Why It's Good For The Game

No more double the gun

## Proof Of Testing

If it compiles it most likely works

## Changelog

:cl:
fix: Captain and HoS locker now have the right amount of sabres and guns respectively
/:cl:
