### PR TITLE
Change huff emote from *huffs to *huff

### DIFF
--- a/modular_skyrat/modules/emote_panel/code/emote_panel.dm
+++ b/modular_skyrat/modules/emote_panel/code/emote_panel.dm
@@ -756,7 +756,7 @@
 /mob/living/proc/emote_huff()
 	set name = "~ Huff"
 	set category = "Emotes+"
-	usr.emote("huffs", intentional = TRUE)
+	usr.emote("huff", intentional = TRUE)
 
 /mob/living/proc/emote_etwitch()
 	set name = "~ Ears twitch"

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -332,7 +332,7 @@
 	message = "rolls their eyes."
 
 /datum/emote/living/huff
-	key = "huffs"
+	key = "huff"
 	key_third_person = "huffs"
 	message = "huffs!"
 


### PR DESCRIPTION
## About The Pull Request

Change key for huff emote from *huffs to *huff

## Why It's Good For The Game

*huffs breaks the pattern that every other emote uses and I thought it was a custom emote people were doing because of it

## Proof Of Testing

It compiles

## Changelog

:cl:
qol: *huffs has been changed to *huff.
/:cl:
