### PR TITLE
Buffs the Automated First Aid Device Healing found under Cargo's "company imports"

### DIFF
--- a/modular_skyrat/modules/cargo/code/items/AFAD.dm
+++ b/modular_skyrat/modules/cargo/code/items/AFAD.dm
@@ -1,5 +1,5 @@
-#define PHYSICAL_DAMAGE_HEALING -0.2
-#define EXOTIC_DAMAGE_HEALING -0.1
+#define PHYSICAL_DAMAGE_HEALING -0.6
+#define EXOTIC_DAMAGE_HEALING -0.3
 
 /obj/item/gun/medbeam/afad
 	name = "Automated First Aid Device"


### PR DESCRIPTION
## About The Pull Request
Triples the healing done by the Automated First Aid Device found in company imports.  Triple is still not much higher, than before, Brute and Burn 0.6 and Toxin and Oxygen 0.3.

For reference the Real Medibeam gun is 4 per tick for Brute Burn, 1 Per tick for Toxin and Oxygen.  Can easily adjust the numbers if need be.
## Why It's Good For The Game
Buffing items is good so they are no longer considered a waste of a cargo purchase, without overshadowing other means of healing.
## Proof Of Testing
I did not test as this is my first PR, and it was only two lines of code changed.
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
balance: Buffed healing numbers on AFAD found under medical cargo imports by 3x

/:cl:
