### PR TITLE
Some more clean up items that came up for persistence

### DIFF
--- a/_maps/RandomRuins/IceRuins/bubberstation/icemoon_persistence.dmm
+++ b/_maps/RandomRuins/IceRuins/bubberstation/icemoon_persistence.dmm
@@ -1469,6 +1469,7 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
 	},
+/obj/machinery/light/cold/directional/north,
 /turf/open/floor/pod/dark,
 /area/ruin/space/has_grav/bubbers/persistance/engineering)
 "ev" = (
@@ -2332,13 +2333,6 @@
 /obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/space/has_grav/bubbers/persistance/sec/armory)
-"hp" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/turf/open/floor/carpet/red,
-/area/ruin/space/has_grav/bubbers/persistance/cargo)
 "hq" = (
 /obj/effect/spawner/liquids_spawner/shoulders,
 /obj/structure/chair/sofa/bench{
@@ -3288,6 +3282,7 @@
 /obj/structure/cable,
 /obj/structure/sign/warning/electric_shock/directional/south,
 /obj/machinery/duct,
+/obj/machinery/light/cold/directional/south,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/space/has_grav/bubbers/persistance/service)
 "kr" = (
@@ -3442,11 +3437,6 @@
 /obj/machinery/suit_storage_unit/industrial/commsoperative,
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/bubbers/persistance/command/liason)
-"kP" = (
-/obj/structure/cable,
-/obj/structure/aquarium/bioelec_gen/prefilled,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/space/has_grav/bubbers/persistance/engineering)
 "kQ" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
@@ -4479,7 +4469,7 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
 	},
-/turf/open/floor/pod/dark,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/space/has_grav/bubbers/persistance/engineering)
 "nx" = (
 /obj/structure/cable,
@@ -5422,12 +5412,6 @@
 /obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/space/has_grav/bubbers/persistance/sci/rnd)
-"qi" = (
-/obj/machinery/light/cold/directional/north,
-/obj/structure/cable,
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/space/has_grav/bubbers/persistance/engineering)
 "qj" = (
 /obj/structure/flora/rock/style_random,
 /turf/closed/mineral/random/snow/underground,
@@ -6867,6 +6851,18 @@
 /obj/machinery/biogenerator/medstation/directional/south,
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bubbers/persistance/sec/prison)
+"uf" = (
+/obj/structure/cable,
+/obj/structure/closet/crate/secure/syndicate/arc{
+	name = "Fish storage"
+	},
+/obj/item/fish_feed,
+/obj/item/storage/fish_case/syndicate/persistence,
+/obj/item/storage/fish_case/syndicate/persistence,
+/obj/item/storage/fish_case/syndicate/persistence,
+/obj/item/storage/fish_case/syndicate/persistence,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/space/has_grav/bubbers/persistance/engineering)
 "uk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8
@@ -7014,10 +7010,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/space/has_grav/bubbers/persistance/service)
-"uC" = (
-/obj/machinery/light/cold/directional/north,
-/turf/closed/wall/r_wall/syndicate/cruiser,
-/area/ruin/space/has_grav/bubbers/persistance/sci/robotics)
 "uD" = (
 /obj/structure/reagent_forge,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -7405,8 +7397,6 @@
 	},
 /obj/structure/cable,
 /obj/item/mmi/syndie,
-/obj/item/mmi/posibrain/sphere,
-/obj/item/mmi/posibrain/sphere,
 /obj/item/radio/intercom/directional/east{
 	name = "two-way prisoner intercom";
 	freerange = 1;
@@ -7857,6 +7847,10 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/noslip,
 /area/ruin/space/has_grav/bubbers/persistance/sec/prison)
+"xi" = (
+/obj/structure/aquarium/bioelec_gen/prefilled,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/space/has_grav/bubbers/persistance/engineering)
 "xk" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
@@ -9070,7 +9064,6 @@
 "Bb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/space/has_grav/bubbers/persistance/engineering)
 "Be" = (
@@ -10819,18 +10812,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/ruin/space/has_grav/bubbers/persistance/command/admiral)
-"Gm" = (
-/obj/structure/cable,
-/obj/item/storage/fish_case/syndicate/persistence,
-/obj/item/storage/fish_case/syndicate/persistence,
-/obj/item/storage/fish_case/syndicate/persistence,
-/obj/item/storage/fish_case/syndicate/persistence,
-/obj/item/fish_feed,
-/obj/structure/closet/crate/secure/syndicate/arc{
-	name = "Fish storage"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/space/has_grav/bubbers/persistance/engineering)
 "Go" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -10957,11 +10938,6 @@
 /obj/machinery/duct,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/space/has_grav/bubbers/persistance/service)
-"GG" = (
-/obj/structure/cable,
-/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/space/has_grav/bubbers/persistance/engineering)
 "GI" = (
 /obj/effect/turf_decal/vg_decals/atmos/carbon_dioxide,
 /turf/open/floor/plating/reinforced,
@@ -12448,6 +12424,7 @@
 	default_raw_text = "<h1>SSV Dauntless Cargo Guide</h1><p>The SSV Dauntless has made a corporate deal with Gorlex Industries to test out their new 1100mm rail cannon reverse engineered off the 1500mm delivery system that Nanotrasen utilizes.</p><p>Please note, if at all the base has fallen into the wrong hands, it is required that these boards are to be destroyed as it contains our cryptography private seeds.</p><p>All cargo goods are logged and maintained, any misuse of funds will be traced back to agent, and will be reprimanded.</p><p></p><ul><li>Express Supply Console Computer</li>Install into a computer frame and print a beacon. Wrench the beacon down in a clear area (and ideally away from explosive goods).<li>Ancient Powerator</li>This is used to generate credits for orders. Ideally used to consume excess power from an upgraded turbine.<li>Bounty Pad</li>A quantum pad that teleports any materials of value into our black market vendors. Credits sold is deposited instantaneously into the SSV Dauntless account.<li>Bounty Control Terminal</li>This is used to activate the bounty pad to sell goods. Install into a computer frame and link the bounty pad using a multi-tool.</ul><p>Please note: Physical money can be directly sent to our black market vendors to be exchanged into credits.</p>";
 	name = "paper- 'SSV Dauntless Cargo Guide'"
 	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/carpet/red,
 /area/ruin/space/has_grav/bubbers/persistance/cargo)
 "Lj" = (
@@ -12549,6 +12526,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/mmi/posibrain/sphere,
+/obj/item/mmi/posibrain/sphere,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bubbers/persistance/sci/robotics)
 "Lw" = (
@@ -12852,14 +12832,6 @@
 /obj/machinery/netpod,
 /turf/open/floor/iron/dark/small,
 /area/ruin/space/has_grav/bubbers/persistance/sec/prison)
-"MB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/effect/mapping_helpers/airalarm/syndicate_access,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/space/has_grav/bubbers/persistance/service)
 "MC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -13456,7 +13428,7 @@
 	name = "Energy Shield"
 	},
 /turf/open/lava/plasma/ice_moon,
-/area/icemoon/underground/explored)
+/area/ruin/space/has_grav/bubbers/persistance/command/vault)
 "On" = (
 /obj/effect/turf_decal/skyrat_decals/syndicate/bottom/right,
 /turf/open/floor/mineral/plastitanium/red,
@@ -15030,6 +15002,10 @@
 /obj/item/mod/module/jump_jet,
 /obj/item/mod/module/jump_jet,
 /obj/structure/closet/crate/robust,
+/obj/effect/spawner/random/mod/maint,
+/obj/effect/spawner/random/mod/maint,
+/obj/effect/spawner/random/mod/maint,
+/obj/effect/spawner/random/mod/maint,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bubbers/persistance/sci/robotics)
 "SL" = (
@@ -15269,7 +15245,8 @@
 	pixel_y = -32;
 	all_products_free = 1;
 	onstation = 0;
-	onstation_override = 1
+	onstation_override = 1;
+	density = 0
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/space/has_grav/bubbers/persistance/sec/prison)
@@ -16171,11 +16148,6 @@
 	},
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/bubbers/persistance/sci/xenobio)
-"Wx" = (
-/obj/machinery/light/cold/directional/north,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/space/has_grav/bubbers/persistance/engineering)
 "WA" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -16559,12 +16531,8 @@
 /area/ruin/space/has_grav/bubbers/dauntless/command/vault)
 "XD" = (
 /obj/structure/table/reinforced/plastitaniumglass,
-/obj/effect/spawner/random/mod/maint,
-/obj/effect/spawner/random/mod/maint,
-/obj/effect/spawner/random/mod/maint,
 /obj/machinery/airalarm/directional/south,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
-/obj/item/pai_card,
 /obj/machinery/ecto_sniffer,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bubbers/persistance/sci/robotics)
@@ -16938,6 +16906,7 @@
 "YG" = (
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/space/has_grav/bubbers/persistance/engineering)
 "YH" = (
@@ -18283,9 +18252,9 @@ vN
 XK
 XD
 Tm
-Cc
-Cc
-Cc
+Ug
+uf
+Ug
 dy
 Cc
 Qu
@@ -18354,7 +18323,7 @@ fh
 FB
 Tm
 YG
-aY
+xi
 Cc
 dy
 Cc
@@ -18417,15 +18386,15 @@ jt
 oW
 Gc
 ne
-uC
+Jf
 XU
 um
 fh
 st
 Tm
-Wx
+Ug
 Cc
-Cc
+Ug
 Fr
 Cc
 Qu
@@ -18563,9 +18532,9 @@ xL
 Xk
 vK
 Tm
-Ug
-Gm
-Ug
+Cc
+Cc
+Cc
 bK
 Ev
 zu
@@ -18633,8 +18602,8 @@ gr
 Jw
 Fd
 Tm
-GG
-kP
+Cc
+Cc
 Cc
 GM
 FV
@@ -18703,7 +18672,7 @@ Ma
 la
 sC
 Tm
-qi
+Cc
 Cc
 Bb
 os
@@ -19870,7 +19839,7 @@ QL
 cu
 ya
 cu
-MB
+cu
 cu
 cu
 cV
@@ -20495,7 +20464,7 @@ bH
 zG
 Ll
 Ll
-hp
+Ll
 pg
 BT
 Lf

--- a/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_persistence.dmm
+++ b/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_persistence.dmm
@@ -269,6 +269,10 @@
 	},
 /turf/open/floor/iron/terracotta/diagonal,
 /area/ruin/space/has_grav/bubbers/persistance/command/admiral)
+"aW" = (
+/obj/structure/aquarium/bioelec_gen/prefilled,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/space/has_grav/bubbers/persistance/engineering)
 "bb" = (
 /obj/machinery/atmospherics/miner/nitrogen,
 /obj/structure/window/reinforced/plasma/spawner/directional/south,
@@ -944,7 +948,8 @@
 	pixel_y = -32;
 	all_products_free = 1;
 	onstation = 0;
-	onstation_override = 1
+	onstation_override = 1;
+	density = 0
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/space/has_grav/bubbers/persistance/sec/prison)
@@ -2178,12 +2183,8 @@
 /area/ruin/space/has_grav/bubbers/persistance/sci/rnd)
 "gI" = (
 /obj/structure/table/reinforced/plastitaniumglass,
-/obj/effect/spawner/random/mod/maint,
-/obj/effect/spawner/random/mod/maint,
-/obj/effect/spawner/random/mod/maint,
 /obj/machinery/airalarm/directional/south,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
-/obj/item/pai_card,
 /obj/machinery/ecto_sniffer,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bubbers/persistance/sci/robotics)
@@ -2417,8 +2418,6 @@
 	},
 /obj/structure/cable,
 /obj/item/mmi/syndie,
-/obj/item/mmi/posibrain/sphere,
-/obj/item/mmi/posibrain/sphere,
 /obj/item/radio/intercom/directional/east{
 	name = "two-way prisoner intercom";
 	freerange = 1;
@@ -2484,11 +2483,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/space/has_grav/bubbers/persistance/engineering)
-"hA" = (
-/obj/machinery/light/cold/directional/north,
-/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/space/has_grav/bubbers/persistance/engineering)
 "hC" = (
@@ -4627,6 +4621,7 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
 	},
+/obj/machinery/light/cold/directional/north,
 /turf/open/floor/pod/dark,
 /area/ruin/space/has_grav/bubbers/persistance/engineering)
 "nY" = (
@@ -4654,18 +4649,6 @@
 "od" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/bubbers/persistance/command/liason)
-"oe" = (
-/obj/structure/cable,
-/obj/item/storage/fish_case/syndicate/persistence,
-/obj/item/storage/fish_case/syndicate/persistence,
-/obj/item/storage/fish_case/syndicate/persistence,
-/obj/item/storage/fish_case/syndicate/persistence,
-/obj/item/fish_feed,
-/obj/structure/closet/crate/secure/syndicate/arc{
-	name = "Fish storage"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/space/has_grav/bubbers/persistance/engineering)
 "of" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
@@ -6114,6 +6097,10 @@
 /obj/item/mod/module/jump_jet,
 /obj/item/mod/module/jump_jet,
 /obj/structure/closet/crate/robust,
+/obj/effect/spawner/random/mod/maint,
+/obj/effect/spawner/random/mod/maint,
+/obj/effect/spawner/random/mod/maint,
+/obj/effect/spawner/random/mod/maint,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bubbers/persistance/sci/robotics)
 "sm" = (
@@ -7175,11 +7162,6 @@
 	name = "Robotics Airlock";
 	req_access = list("syndicate")
 	},
-/obj/item/mod/module/jump_jet,
-/obj/item/mod/module/jump_jet,
-/obj/item/mod/module/jump_jet,
-/obj/item/mod/module/jump_jet,
-/obj/item/mod/module/jump_jet,
 /obj/structure/closet/crate/secure/syndicate/self{
 	name = "S.E.L.F. access override crate"
 	},
@@ -8435,7 +8417,6 @@
 /turf/open/floor/iron/terracotta/small,
 /area/ruin/space/has_grav/bubbers/persistance/service/dorms/engineering)
 "yU" = (
-/obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/structure/cable,
@@ -9978,11 +9959,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bubbers/persistance/sec/brigentrance)
-"Dy" = (
-/obj/structure/cable,
-/obj/structure/aquarium/bioelec_gen/prefilled,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/space/has_grav/bubbers/persistance/engineering)
 "Dz" = (
 /turf/closed/wall/r_wall/syndicate/cruiser,
 /area/ruin/space/has_grav/bubbers/persistance/med)
@@ -10431,6 +10407,7 @@
 	default_raw_text = "<h1>SSV Dauntless Cargo Guide</h1><p>The SSV Dauntless has made a corporate deal with Gorlex Industries to test out their new 1100mm rail cannon reverse engineered off the 1500mm delivery system that Nanotrasen utilizes.</p><p>Please note, if at all the base has fallen into the wrong hands, it is required that these boards are to be destroyed as it contains our cryptography private seeds.</p><p>All cargo goods are logged and maintained, any misuse of funds will be traced back to agent, and will be reprimanded.</p><p></p><ul><li>Express Supply Console Computer</li>Install into a computer frame and print a beacon. Wrench the beacon down in a clear area (and ideally away from explosive goods).<li>Ancient Powerator</li>This is used to generate credits for orders. Ideally used to consume excess power from an upgraded turbine.<li>Bounty Pad</li>A quantum pad that teleports any materials of value into our black market vendors. Credits sold is deposited instantaneously into the SSV Dauntless account.<li>Bounty Control Terminal</li>This is used to activate the bounty pad to sell goods. Install into a computer frame and link the bounty pad using a multi-tool.</ul><p>Please note: Physical money can be directly sent to our black market vendors to be exchanged into credits.</p>";
 	name = "paper- 'SSV Dauntless Cargo Guide'"
 	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/carpet/red,
 /area/ruin/space/has_grav/bubbers/persistance/cargo)
 "EK" = (
@@ -10823,21 +10800,10 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bubbers/persistance/service)
-"FL" = (
-/obj/structure/cable,
-/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/space/has_grav/bubbers/persistance/engineering)
 "FN" = (
 /obj/item/storage/backpack/satchel/flat,
 /turf/open/floor/carpet/red,
 /area/ruin/space/has_grav/bubbers/persistance/cargo)
-"FP" = (
-/obj/machinery/light/cold/directional/north,
-/obj/structure/cable,
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/ruin/space/has_grav/bubbers/persistance/engineering)
 "FQ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -11813,6 +11779,7 @@
 "IT" = (
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/space/has_grav/bubbers/persistance/engineering)
 "IU" = (
@@ -14168,7 +14135,6 @@
 "Qk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/space/has_grav/bubbers/persistance/engineering)
 "Ql" = (
@@ -14440,6 +14406,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/mmi/posibrain/sphere,
+/obj/item/mmi/posibrain/sphere,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/bubbers/persistance/sci/robotics)
 "Rc" = (
@@ -14870,6 +14839,7 @@
 /obj/structure/cable,
 /obj/structure/sign/warning/electric_shock/directional/south,
 /obj/machinery/duct,
+/obj/machinery/light/cold/directional/south,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/space/has_grav/bubbers/persistance/service)
 "Sx" = (
@@ -15722,6 +15692,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/smooth,
 /area/ruin/space/has_grav/bubbers/persistance/sci/rnd)
+"Vg" = (
+/obj/structure/cable,
+/obj/structure/closet/crate/secure/syndicate/arc{
+	name = "Fish storage"
+	},
+/obj/item/fish_feed,
+/obj/item/storage/fish_case/syndicate/persistence,
+/obj/item/storage/fish_case/syndicate/persistence,
+/obj/item/storage/fish_case/syndicate/persistence,
+/obj/item/storage/fish_case/syndicate/persistence,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/space/has_grav/bubbers/persistance/engineering)
 "Vh" = (
 /obj/structure/window/reinforced/survival_pod/spawner/directional/south,
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
@@ -16757,10 +16739,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bubbers/persistance/service)
-"Yk" = (
-/obj/machinery/light/cold/directional/north,
-/turf/closed/wall/r_wall/syndicate/cruiser,
-/area/ruin/space/has_grav/bubbers/persistance/sci/robotics)
 "Yl" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/mapping_helpers/apc/syndicate_access,
@@ -17212,13 +17190,6 @@
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/space/has_grav/bubbers/persistance/service)
-"ZG" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
-/turf/open/floor/carpet/red,
-/area/ruin/space/has_grav/bubbers/persistance/cargo)
 "ZI" = (
 /obj/structure/closet/crate/secure/freezer/interdyne/blood,
 /obj/machinery/biogenerator/medstation/directional/north,
@@ -18272,9 +18243,9 @@ Uv
 or
 gI
 Vm
-gV
-gV
-gV
+Mj
+Vg
+Mj
 Rr
 gV
 aT
@@ -18345,7 +18316,7 @@ EK
 gZ
 Vm
 IT
-QD
+aW
 gV
 Rr
 gV
@@ -18410,15 +18381,15 @@ Vd
 iw
 XD
 CF
-Yk
+BT
 xf
 Qy
 EK
 vn
 Vm
-hA
+Mj
 gV
-gV
+Mj
 hF
 gV
 aT
@@ -18560,9 +18531,9 @@ ws
 Yw
 hq
 Vm
-Mj
-oe
-Mj
+gV
+gV
+gV
 tV
 GH
 cZ
@@ -18632,8 +18603,8 @@ xM
 lK
 sa
 Vm
-FL
-Dy
+gV
+gV
 gV
 ZR
 Ic
@@ -18704,7 +18675,7 @@ rb
 Vz
 Gv
 Vm
-FP
+gV
 gV
 Qk
 hm
@@ -20548,7 +20519,7 @@ Io
 OG
 Nz
 Nz
-ZG
+Nz
 Rx
 VC
 zd


### PR DESCRIPTION

## About The Pull Request

Some more clean up items for persistence
Issues addressed

- Moved initial fish tank spawn over one engine slot in engineering to reduce accidental deaths via zappy eels
- Fixed some lights in places they should not be
- Removed collision on the sustenance vendor ~~How did no one notice it had it~~
- Hopefully fixed an issue with one turret not turning off
## Why It's Good For The Game

We like it when stuff works
## Proof Of Testing

Its just some map changes, I'll put something up if I don't forget to before its full merged.
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:

fix: Persistence Fish based power is now 100% more Osha compliant 

/:cl:
