### PR TITLE
Add a missing period to PDA typing message

### DIFF
--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -633,7 +633,7 @@
 		return FALSE
 
 	// SKYRAT EDIT BEGIN - PDA messages show a visible message; again!
-	sender.visible_message(span_notice("[sender]'s PDA rings out with the soft sound of keypresses"), vision_distance = COMBAT_MESSAGE_RANGE)
+	sender.visible_message(span_notice("[sender]'s PDA rings out with the soft sound of keypresses."), vision_distance = COMBAT_MESSAGE_RANGE)
 	// SKYRAT EDIT END
 
 	var/shell_addendum = ""


### PR DESCRIPTION
## About The Pull Request
Add a missing period to the PDA typing message.
## Changelog
:cl:
spellcheck: Added a missing period to the PDA typing message.
/:cl:
