### PR TITLE
Kilo fixes

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -32847,6 +32847,7 @@
 	dir = 4
 	},
 /obj/structure/sign/poster/random/directional/east,
+/obj/effect/mapping_helpers/airlock/access/all/admin,
 /turf/open/floor/iron/dark/corner{
 	dir = 4
 	},
@@ -61495,7 +61496,7 @@
 "udt" = (
 /obj/machinery/conveyor{
 	dir = 1;
-	id = "mining";
+	id = "packagereturn";
 	name = "crate return belt"
 	},
 /obj/machinery/door/window/left/directional/north{

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -32847,7 +32847,6 @@
 	dir = 4
 	},
 /obj/structure/sign/poster/random/directional/east,
-/obj/effect/mapping_helpers/airlock/access/all/admin,
 /turf/open/floor/iron/dark/corner{
 	dir = 4
 	},

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -70985,7 +70985,8 @@
 "xcj" = (
 /obj/effect/turf_decal/siding/green,
 /obj/machinery/door/window/left{
-	name = "Animal Pen"
+	name = "Animal Pen";
+	req_access = list("maint_tunnels")
 	},
 /turf/open/misc/sandy_dirt,
 /area/station/service/hydroponics/garden)


### PR DESCRIPTION

## About The Pull Request
Adds a maint access requirement to the animal pen on kilostation, so the animals don't just wander out. Fixes a misconfigured package return belt in cargo on Kilo station.
## Why It's Good For The Game
The animals won't wander out, and the belt works properly now.
## Proof Of Testing
It compiles.
## Changelog
:cl:
fix: Added a maint access requirement to the animal pen on kilo, so the animals won't wander out.
fix: Fixed the misconfigured package return belt in cargo on Kilo station.
/:cl:
