### PR TITLE
Nerfs mantis blades from 25 to 20

### DIFF
--- a/modular_skyrat/modules/implants/code/augments_arms.dm
+++ b/modular_skyrat/modules/implants/code/augments_arms.dm
@@ -24,7 +24,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	obj_flags = CONDUCTS_ELECTRICITY
 	sharpness = SHARP_EDGED
-	force = 15
+	force = 18
 	armour_penetration = 20
 	wound_bonus = 20
 	item_flags = NEEDS_PERMIT //Beepers gets angry if you get caught with this.

--- a/modular_skyrat/modules/implants/code/augments_arms.dm
+++ b/modular_skyrat/modules/implants/code/augments_arms.dm
@@ -24,9 +24,8 @@
 	w_class = WEIGHT_CLASS_BULKY
 	obj_flags = CONDUCTS_ELECTRICITY
 	sharpness = SHARP_EDGED
-	force = 18
+	force = 20
 	armour_penetration = 20
-	wound_bonus = 10
 	item_flags = NEEDS_PERMIT //Beepers gets angry if you get caught with this.
 	hitsound = 'modular_skyrat/master_files/sound/weapons/bloodyslice.ogg'
 

--- a/modular_skyrat/modules/implants/code/augments_arms.dm
+++ b/modular_skyrat/modules/implants/code/augments_arms.dm
@@ -24,8 +24,9 @@
 	w_class = WEIGHT_CLASS_BULKY
 	obj_flags = CONDUCTS_ELECTRICITY
 	sharpness = SHARP_EDGED
-	force = 25
+	force = 15
 	armour_penetration = 20
+	wound_bonus = 20
 	item_flags = NEEDS_PERMIT //Beepers gets angry if you get caught with this.
 	hitsound = 'modular_skyrat/master_files/sound/weapons/bloodyslice.ogg'
 

--- a/modular_skyrat/modules/implants/code/augments_arms.dm
+++ b/modular_skyrat/modules/implants/code/augments_arms.dm
@@ -26,7 +26,7 @@
 	sharpness = SHARP_EDGED
 	force = 18
 	armour_penetration = 20
-	wound_bonus = 20
+	wound_bonus = 10
 	item_flags = NEEDS_PERMIT //Beepers gets angry if you get caught with this.
 	hitsound = 'modular_skyrat/master_files/sound/weapons/bloodyslice.ogg'
 


### PR DESCRIPTION
## About The Pull Request
Mantis blades do very funny levels of damage considering that crew can get these
25 damage is literally as strong as a literal changeling armblade which is if you ask me, a *wee* bit too much, so this PR changes it to 20, which is combat knife levels of damage
The wound bonus also affects the energy mantis blades, but leaves the force otherwise unchanged.
## Why It's Good For The Game
Changeling armblade levels of damage that is nodrop is kinda nuts for crew to make.
## Proof Of Testing
Just a number's change
## Changelog
:cl:
balance: Mantis blades now do 20 damage, this is down from 25 force.
/:cl:
