### PR TITLE
Maintentance around nitrogen breathers

### DIFF
--- a/modular_skyrat/modules/customization/game/objects/items/tanks/n2_tanks.dm
+++ b/modular_skyrat/modules/customization/game/objects/items/tanks/n2_tanks.dm
@@ -27,7 +27,7 @@
 	inhand_icon_state = "nitrogen"
 	slot_flags = ITEM_SLOT_BELT
 	force = 5
-	volume = 12 // changed from previous 24, its the same as double oxy. I think it was suposed to be double oxy equivalent suggesting icon state name.
+	volume = 12
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/tank/internals/nitrogen/belt/full/populate_gas()

--- a/modular_skyrat/modules/customization/game/objects/items/tanks/n2_tanks.dm
+++ b/modular_skyrat/modules/customization/game/objects/items/tanks/n2_tanks.dm
@@ -8,6 +8,7 @@
 	icon_state = "oxygen_fr"
 	force = 10
 	distribute_pressure = TANK_DEFAULT_RELEASE_PRESSURE
+	distribute_pressure = 4 // see vox.dm for their intake values balance changes
 
 /obj/item/tank/internals/nitrogen/populate_gas()
 	air_contents.assert_gas(/datum/gas/nitrogen)
@@ -26,7 +27,7 @@
 	inhand_icon_state = "nitrogen"
 	slot_flags = ITEM_SLOT_BELT
 	force = 5
-	volume = 24
+	volume = 12 // changed from previous 24, its the same as double oxy. I think it was suposed to be double oxy equivalent suggesting icon state name.
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/tank/internals/nitrogen/belt/full/populate_gas()

--- a/modular_skyrat/modules/customization/modules/surgery/organs/vox.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/vox.dm
@@ -3,7 +3,7 @@
 	desc = "A set of lungs for breathing nitrogen."
 	safe_oxygen_min = 0	//Dont need oxygen
 	safe_oxygen_max = 2 //But it is quite toxic
-	safe_nitro_min = 4 // Atleast 10 nitrogen // previously 10 changed to 4 via Bubber change, exactly the same numbers as plasmaman lungs
+	safe_nitro_min = 4 // Atleast 4 nitrogen
 	oxy_damage_type = TOX
 	oxy_breath_dam_min = 6
 	oxy_breath_dam_max = 20

--- a/modular_skyrat/modules/customization/modules/surgery/organs/vox.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/vox.dm
@@ -3,7 +3,7 @@
 	desc = "A set of lungs for breathing nitrogen."
 	safe_oxygen_min = 0	//Dont need oxygen
 	safe_oxygen_max = 2 //But it is quite toxic
-	safe_nitro_min = 10 // Atleast 10 nitrogen
+	safe_nitro_min = 4 // Atleast 10 nitrogen // previously 10 changed to 4 via Bubber change, exactly the same numbers as plasmaman lungs
 	oxy_damage_type = TOX
 	oxy_breath_dam_min = 6
 	oxy_breath_dam_max = 20

--- a/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
+++ b/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
@@ -214,6 +214,13 @@
 	patient.client?.prefs?.safe_transfer_prefs_to_with_damage(patient)
 	patient.dna.update_dna_identity()
 	SSquirks.AssignQuirks(patient, patient.client)
+	if(patient.has_quirk(/datum/quirk/equipping/lungs/nitrogen))
+		if(!patient.get_organ_by_type(/obj/item/organ/internal/lungs/nitrogen))
+			var/lungs = patient.get_organ_slot(ORGAN_SLOT_LUNGS)
+			qdel(lungs)
+			var/obj/item/organ/target_organ = new /obj/item/organ/internal/lungs/nitrogen
+			target_organ.Insert(patient, special = TRUE)
+
 	log_game("[key_name(patient)] used a Self-Actualization Device at [loc_name(src)].")
 
 	if(patient.dna.real_name != original_name)

--- a/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
+++ b/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
@@ -214,13 +214,6 @@
 	patient.client?.prefs?.safe_transfer_prefs_to_with_damage(patient)
 	patient.dna.update_dna_identity()
 	SSquirks.AssignQuirks(patient, patient.client)
-	if(patient.has_quirk(/datum/quirk/equipping/lungs/nitrogen))
-		if(!patient.get_organ_by_type(/obj/item/organ/internal/lungs/nitrogen))
-			var/lungs = patient.get_organ_slot(ORGAN_SLOT_LUNGS)
-			qdel(lungs)
-			var/obj/item/organ/target_organ = new /obj/item/organ/internal/lungs/nitrogen
-			target_organ.Insert(patient, special = TRUE)
-
 	log_game("[key_name(patient)] used a Self-Actualization Device at [loc_name(src)].")
 
 	if(patient.dna.real_name != original_name)

--- a/modular_zubbers/code/datums/quirks/neutral_quirks/lungs.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/lungs.dm
@@ -22,7 +22,6 @@
 	if(!isnull(lungs_holding))
 		lungs_holding.moveToNullspace() // save them for later
 	carbon_holder.dna.species.mutantlungs = /obj/item/organ/internal/lungs/nitrogen
-	RegisterSignal(carbon_holder, COMSIG_LIVING_REVIVE, TYPE_PROC_REF(/datum/quirk/equipping/lungs/nitrogen, on_revive))
 
 /datum/quirk/equipping/lungs/remove()
 	var/mob/living/carbon/carbon_holder = quirk_holder
@@ -34,7 +33,6 @@
 		return
 	lungs_holding.Insert(carbon_holder, special = TRUE, movement_flags = DELETE_IF_REPLACED)
 	lungs_holding.organ_flags &= ~ORGAN_FROZEN
-	UnregisterSignal(carbon_holder, COMSIG_LIVING_REVIVE)
 	carbon_holder.dna.species.mutantlungs = initial(carbon_holder.dna.species.mutantlungs)
 
 /datum/quirk/equipping/lungs/on_equip_item(obj/item/equipped, success)
@@ -92,10 +90,3 @@
 		return
 	carbon_holder.internal = equipped
 
-/datum/quirk/equipping/lungs/nitrogen/proc/on_revive(mob/user)
-	SIGNAL_HANDLER
-	if(!user.get_organ_by_type(/obj/item/organ/internal/lungs/nitrogen))
-		var/lungs = user.get_organ_slot(ORGAN_SLOT_LUNGS)
-		qdel(lungs)
-		var/obj/item/organ/target_organ = new /obj/item/organ/internal/lungs/nitrogen
-		target_organ.Insert(user, special = TRUE)

--- a/modular_zubbers/code/datums/quirks/neutral_quirks/lungs.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/lungs.dm
@@ -21,6 +21,8 @@
 	lungs_added.Insert(carbon_holder, special = TRUE)
 	if(!isnull(lungs_holding))
 		lungs_holding.moveToNullspace() // save them for later
+	carbon_holder.dna.species.mutantlungs = /obj/item/organ/internal/lungs/nitrogen
+	RegisterSignal(carbon_holder, COMSIG_LIVING_REVIVE, TYPE_PROC_REF(/datum/quirk/equipping/lungs/nitrogen, on_revive))
 
 /datum/quirk/equipping/lungs/remove()
 	var/mob/living/carbon/carbon_holder = quirk_holder
@@ -32,6 +34,8 @@
 		return
 	lungs_holding.Insert(carbon_holder, special = TRUE, movement_flags = DELETE_IF_REPLACED)
 	lungs_holding.organ_flags &= ~ORGAN_FROZEN
+	UnregisterSignal(carbon_holder, COMSIG_LIVING_REVIVE)
+	carbon_holder.dna.species.mutantlungs = initial(carbon_holder.dna.species.mutantlungs)
 
 /datum/quirk/equipping/lungs/on_equip_item(obj/item/equipped, success)
 	var/mob/living/carbon/human/human_holder = quirk_holder
@@ -87,3 +91,11 @@
 	if (!success || !istype(carbon_holder) || !istype(equipped, /obj/item/tank/internals))
 		return
 	carbon_holder.internal = equipped
+
+/datum/quirk/equipping/lungs/nitrogen/proc/on_revive(mob/user)
+	SIGNAL_HANDLER
+	if(!user.get_organ_by_type(/obj/item/organ/internal/lungs/nitrogen))
+		var/lungs = user.get_organ_slot(ORGAN_SLOT_LUNGS)
+		qdel(lungs)
+		var/obj/item/organ/target_organ = new /obj/item/organ/internal/lungs/nitrogen
+		target_organ.Insert(user, special = TRUE)


### PR DESCRIPTION
## About The Pull Request

First of the changes would be the fact that tank which voxes and people with nitrogen breathing quirk get is extremly big, and can store double the amount of any tank in the game and its a belt tank, which means can be stored in the pockets. This changes to initial value of 25 liters, to 12l which seems to be better alternative, and more fiting since the tank looks like double oxy tank, which can be crafter by engineering. 

To compensate the fact, that nitrogen breathers have to keep their internals on all the time, for close to 2:45 as our shifts tend to be, or their risk quick death. Their minimal gas intake value was changed from 10 to 4, which is the value that plasmaman need to stay alive and not choke to death. So it means that, they only need 4 kpa on their tank, to not take any damage which lowers their need for constant nitrogen resupplies. 

On top of that I fumbled around the quirk, and now aheal/sad will not remove your lungs. SAD will give em back, in case something didnt work out as suposed, while having quirk on you, will readd the lungs each time you miss them during revival. On top of that admin aheal will give em back, as the quirk overrides species default lungs. 


## Why It's Good For The Game

Overall QOL around playing with nitrogen breathing quirk, or as vox as this affects them as well. Its overall good balance change, and brings back their tanks to normal centralised value. 

## Proof Of Testing

Tested it few times in game, I dont quarantee that it wont break any any point, but! I tested everything in game 

## Changelog

:cl:
qol: Vox and people with nitrogen breathing quirk, need less nitrogen to sustain themselfs.
balance: Changed nitrogen tank belt max capacity of 25l to 12l
fix: Aheal/S.A.D interaction doesnt remove nitrogen lungs on quirk holders. Both Aheal/Sad will return them, replacing the one inside you. This means, cybernetic lungs will be removed. 
/:cl: