### PR TITLE
Changes nosferatu examine message and doubles disgust gain per level

### DIFF
--- a/modular_zubbers/code/modules/antagonists/bloodsucker/clans/clan_nosferatu.dm
+++ b/modular_zubbers/code/modules/antagonists/bloodsucker/clans/clan_nosferatu.dm
@@ -30,6 +30,7 @@
 		ogler.adjust_disgust(owner_datum.GetRank() * 10)
 	// show that they are dangerous nosferatu, as if you're gazing upon them with fear, without mentioning the clan name/antagonist name, describe their appearance
 	examine_text += span_danger("[ogled.p_They()] look like a pale, grotesque hunchback, with a mouth full of jagged yellowy teeth, and breath that reeks of fresh blood. You feel both afraid and disgusted as you gaze upon them.")
+	examine_text += span_userdanger("[ogled.p_They()] are clearly a BLOODSUCKER!")
 
 /datum/bloodsucker_clan/nosferatu/Destroy(force)
 	var/datum/action/cooldown/bloodsucker/feed/suck = locate() in bloodsuckerdatum.powers

--- a/modular_zubbers/code/modules/antagonists/bloodsucker/clans/clan_nosferatu.dm
+++ b/modular_zubbers/code/modules/antagonists/bloodsucker/clans/clan_nosferatu.dm
@@ -27,8 +27,9 @@
 	var/mob/living/ogler = examiner
 	if(isliving(examiner) && examiner != ogled && !ogler.mob_mood.has_mood_of_category("nosferatu_examine"))
 		ogler.add_mood_event("nosferatu_examine", /datum/mood_event/nosferatu_examined, ogled, owner_datum.GetRank())
-		ogler.adjust_disgust(owner_datum.GetRank() * 5)
-	examine_text += span_danger("[ogled.p_They()] look[ogled.p_s()] horrifically disfigured and grotesque, pale as a corpse, and [ogled.p_their()] body is covered in scars and burns.")
+		ogler.adjust_disgust(owner_datum.GetRank() * 10)
+	// show that they are dangerous nosferatu, as if you're gazing upon them with fear, without mentioning the clan name/antagonist name, describe their appearance
+	examine_text += span_danger("[ogled.p_They()] look like a pale, grotesque hunchback, with a mouth full of jagged yellowy teeth, and breath that reeks of fresh blood. You feel both afraid and disgusted as you gaze upon them.")
 
 /datum/bloodsucker_clan/nosferatu/Destroy(force)
 	var/datum/action/cooldown/bloodsucker/feed/suck = locate() in bloodsuckerdatum.powers


### PR DESCRIPTION
## About The Pull Request
As title says, changes the description of nosferatu's examine to make it obvious they are in fact, a bloodsucker.
![image](https://github.com/user-attachments/assets/8db87d55-a112-4128-ac39-0c66a9d2d55f)


## Why It's Good For The Game
People tend to kind of ignore the nosferatu examine, either not understanding or simply willingly ignoring it, I'd like it to be a bit more obvious so it's super clear that this is in fact, a bloodsucker, a nosferatu who willingly gives up any pretense at hiding in return for their powers
## Proof Of Testing
Text/number changes, not tested
## Changelog

:cl:
add: Added new mechanics or gameplay changes
balance: Nosferatu when examined disgust you doubly as much.
add: Changes nosferatu examine to be more clear on what they are
/:cl:

