### PR TITLE
Mesmerize no longer requires you to face your target

### DIFF
--- a/modular_zubbers/code/modules/antagonists/bloodsucker/powers/targeted/mesmerize.dm
+++ b/modular_zubbers/code/modules/antagonists/bloodsucker/powers/targeted/mesmerize.dm
@@ -161,7 +161,7 @@
 
 /datum/action/cooldown/bloodsucker/targeted/mesmerize/FireSecondaryTargetedPower(atom/target, params)
 	if(!isliving(target))
-		CRASH("[src] somehow casted on a non-living taDrget, should have been stopped by CheckCanTarget.")
+		CRASH("[src] somehow casted on a non-living target, should have been stopped by CheckCanTarget.")
 	if(timer || !COOLDOWN_FINISHED(src, mesmerize_cooldown))
 		return
 	COOLDOWN_START(src, mesmerize_cooldown, 2 SECONDS)

--- a/modular_zubbers/code/modules/antagonists/bloodsucker/powers/targeted/mesmerize.dm
+++ b/modular_zubbers/code/modules/antagonists/bloodsucker/powers/targeted/mesmerize.dm
@@ -28,7 +28,7 @@
 	/// At what level this ability will blind the target at. Level 0 = never.
 	var/blind_at_level = 0
 	/// if the ability requires you to be physically facing the target
-	var/requires_facing_target = TRUE
+	var/requires_facing_target = FALSE
 	/// if the ability requires you to not have your eyes covered
 	var/blocked_by_glasses = TRUE
 	/// if the ability will knockdown on secondary click
@@ -161,7 +161,7 @@
 
 /datum/action/cooldown/bloodsucker/targeted/mesmerize/FireSecondaryTargetedPower(atom/target, params)
 	if(!isliving(target))
-		CRASH("[src] somehow casted on a non-living target, should have been stopped by CheckCanTarget.")
+		CRASH("[src] somehow casted on a non-living taDrget, should have been stopped by CheckCanTarget.")
 	if(timer || !COOLDOWN_FINISHED(src, mesmerize_cooldown))
 		return
 	COOLDOWN_START(src, mesmerize_cooldown, 2 SECONDS)


### PR DESCRIPTION

## About The Pull Request
Mesmerize no longer requires you to face your target, I originally thought this was only required on the original cast, but this essentially makes normal mesmerize useless, as Dominate, tremere's version does not require this, but with this, you can simply look away and Mesmerize will fail

## Why It's Good For The Game
Mesmerize has been reworked heavily and this does not make sense to have anymore, I plan to rework the facing aspect to force you to watch the bloodsucker anyway, and this check is not needed til I add that

## Proof Of Testing
Not tested, variable change.
</details>

## Changelog

:cl:
balance: Mesmerize no longer requires your victim to be facing the bloodsucker.
/:cl:

