### PR TITLE
Adds checks to make sure that both the AI and Modsuit wearer are present and in character to allow for mind swap + 1 bug fix

### DIFF
--- a/modular_zubbers/code/modules/mod/modules.dm
+++ b/modular_zubbers/code/modules/mod/modules.dm
@@ -74,6 +74,11 @@
 	if(!mod.ai_assistant)
 		balloon_alert(mod.wearer, "no AI present")
 		return
+	if(isnull(mod.wearer.client))
+		balloon_alert(mod.ai_assistant, "host is unresponsive")
+		return
+	if(isnull(mod.ai_assistant.client))
+		balloon_alert(mod.wearer, "AI is unresponsive")
 	return ..()
 
 /obj/item/mod/module/mind_swap/on_activation()

--- a/modular_zubbers/code/modules/mod/modules.dm
+++ b/modular_zubbers/code/modules/mod/modules.dm
@@ -97,11 +97,12 @@
 		swap_minds()
 
 /obj/item/mod/module/mind_swap/proc/swap_minds()
+	if(!mod.ai_assistant)
+		mod.wearer.ghostize(FALSE)
+		mod.ai_assistant.key = ai_key
+		return
 	mod.wearer.ghostize(FALSE)
 	mod.ai_assistant.ghostize(FALSE)
-	if(!mod.ai_assistant)
-		mod.wearer.key = wearer_key
-		return
 	if(ai_control)
 		mod.wearer.key = wearer_key
 		mod.ai_assistant.key = ai_key

--- a/modular_zubbers/code/modules/mod/modules.dm
+++ b/modular_zubbers/code/modules/mod/modules.dm
@@ -91,6 +91,7 @@
 /obj/item/mod/module/mind_swap/on_suit_activation()
 	ai_key = mod.ai_assistant?.key
 	wearer_key = mod.wearer.key
+	ai_control = FALSE
 
 /obj/item/mod/module/mind_swap/on_suit_deactivation(deleting = FALSE)
 	if(wearer_key != mod.wearer.key)

--- a/modular_zubbers/code/modules/mod/modules.dm
+++ b/modular_zubbers/code/modules/mod/modules.dm
@@ -79,6 +79,7 @@
 		return
 	if(isnull(mod.ai_assistant.client))
 		balloon_alert(mod.wearer, "AI is unresponsive")
+		return
 	return ..()
 
 /obj/item/mod/module/mind_swap/on_activation()

--- a/modular_zubbers/code/modules/mod/modules.dm
+++ b/modular_zubbers/code/modules/mod/modules.dm
@@ -99,6 +99,9 @@
 /obj/item/mod/module/mind_swap/proc/swap_minds()
 	mod.wearer.ghostize(FALSE)
 	mod.ai_assistant.ghostize(FALSE)
+	if(!mod.ai_assistant)
+		mod.wearer.key = wearer_key
+		return
 	if(ai_control)
 		mod.wearer.key = wearer_key
 		mod.ai_assistant.key = ai_key


### PR DESCRIPTION

## About The Pull Request
Title + fixes a bug where cryoing as the suit ai as the original wearer of the modsuit would then cause the original AI to be stuck in limbo when deactivating the suit
## Why It's Good For The Game
bugs
## Proof Of Testing
![image](https://github.com/user-attachments/assets/c932a2e2-4530-45cd-b21c-e375375aa9b9)
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: AIs can no long control a host body and themself at the same time
fix: if the original wearer becomes the AI and cryo's, the original AI will no longer be stuck in limbo
/:cl:
