### PR TITLE
Emote as door/closed turf

### DIFF
--- a/modular_zubbers/code/modules/adjacent_emote/code/adjacent_emotes.dm
+++ b/modular_zubbers/code/modules/adjacent_emote/code/adjacent_emotes.dm
@@ -1,0 +1,72 @@
+/datum/emote/door_emote
+	key = "doorknocker"
+	message = null
+
+/mob/living/verb/door_emote(atom/target in obj/machinery/door|turf/closed in get_adjacent_occupied_turfs())
+	set name = "Emote Using Wall/Door"
+	set category = "IC"
+
+	if(!istype(target))
+		to_chat(src, span_danger("No target."))
+		return FALSE
+	if (loc && (!src.IsUnconscious())) // If user's location is a turf, if it is not null, and if the user is not unconcious, continue.
+		usr.emote("doorknocker")
+
+/datum/emote/door_emote/run_emote(mob/living/user, params, type_override = null, intentional = TRUE)
+	/// The message that will be sent from as the target.
+	var/wall_message
+	/// What was inputted by the user.
+	var/door_emote = params
+	if(QDELETED(user))
+		return FALSE
+	if(is_banned_from(user, "emote"))
+		tgui_alert(user, "You cannot send emotes (banned).")
+		return FALSE
+	else if(user.client?.prefs?.muted & MUTE_IC)
+		tgui_alert(user, "You cannot send IC messages (muted).")
+		return FALSE
+
+	else if(!params) // User didn't put anything after the emote in command line, or just used the emote raw? Open a window.
+		door_emote = tgui_input_text(user, "What would you like to emote?", "Container Emote" , null, MAX_MESSAGE_LEN, TRUE, TRUE, 0)
+		if(!door_emote)
+			return FALSE
+		var/list/choices = list("Visible","Audible")
+		var/type = tgui_input_list(user, "Is this a visible or audible emote?", "Wall or Door Emote", choices, FALSE)
+		switch(type)
+			if("Visible")
+				emote_type = EMOTE_VISIBLE
+			if("Audible")
+				emote_type = EMOTE_AUDIBLE
+			else
+				tgui_alert(user, "Unable to use this emote, must be either audible or visible.")
+				return
+		door_message = door_emote //Like lemmings, I'm following the guy who did container_emote
+	else
+		door_message = params // Same as above.
+		if(type_override)
+			emote_type = type_override
+		else
+			emote_type = EMOTE_VISIBLE
+	. = TRUE
+
+	if(!can_run_emote(user))
+		return FALSE
+
+	user.log_message(door_message, LOG_EMOTE)
+
+	var/space = should_have_space_before_emote(html_decode(door_emote)[1]) ? " " : ""
+
+	door_message = ("[user.say_emphasis(door_message)]")
+
+	// Make sure the emote isnt sent after the window pops up, after the source becomes invalid
+	if(!can_run_emote(user))
+		return FALSE
+
+	if ((!target) || QDELETED(target) || user.IsUnconscious() || QDELETED(user)) //one last sanity check
+		return FALSE
+
+	if(emote_type == EMOTE_AUDIBLE)
+		picked_loc.audible_message(message = door_message, self_message = door_message, audible_message_flags = EMOTE_MESSAGE, separation = space)
+
+	else if (emote_type == EMOTE_VISIBLE)
+		picked_loc.visible_message(message = door_message, self_message = door_message, visible_message_flags = EMOTE_MESSAGE, separation = space)

--- a/modular_zubbers/code/modules/adjacent_emote/code/spatial_info.dm
+++ b/modular_zubbers/code/modules/adjacent_emote/code/spatial_info.dm
@@ -1,0 +1,17 @@
+//evil copy of get_adjacent_open_turfs
+/proc/get_adjacent_occupied_turfs(atom/center)
+	var/list/hand_back = list()
+	// Inlined get_open_turf_in_dir, just to be fast
+	var/turf/open/occupied_turf = get_step(center, NORTH)
+	if(!istype(occupied_turf))
+		hand_back += occupied_turf
+	occupied_turf = get_step(center, SOUTH)
+	if(!istype(occupied_turf))
+		hand_back += occupied_turf
+	occupied_turf = get_step(center, EAST)
+	if(!istype(occupied_turf))
+		hand_back += occupied_turf
+	occupied_turf = get_step(center, WEST)
+	if(!istype(occupied_turf))
+		hand_back += occupied_turf
+	return hand_back

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8833,6 +8833,8 @@
 #include "modular_zubbers\code\game\turfs\open\openspace.dm"
 #include "modular_zubbers\code\game\turfs\open\sand.dm"
 #include "modular_zubbers\code\modules\_defines.dm"
+#include "modular_zubbers\code\modules\adjacent_emote\code\adjacent_emotes.dm"
+#include "modular_zubbers\code\modules\adjacent_emote\code\spatial_info.dm"
 #include "modular_zubbers\code\modules\admin\verbs\debug.dm"
 #include "modular_zubbers\code\modules\alt_anomaly_refinery\anomaly_refinery.dm"
 #include "modular_zubbers\code\modules\alternative_job_titles\code\alt_job_titles.dm"


### PR DESCRIPTION
## About The Pull Request
[This suggestion](https://discord.com/channels/1059199070016655462/1071095123145924679/1318576927015047168)

## Why It's Good For The Game
wall-piercing emote

## Proof Of Testing
it's throwing errors at me at line 6 3:

## Changelog
:cl:
add: Wallpierce emote! Key is 'doorknocker'. Allows you to emote as/through machinery/doors and /turf/closed
/:cl:
