### PR TITLE
Fix Escape Menu Overlapping

### DIFF
--- a/modular_skyrat/modules/escape_menu/code/escape_menu_skyrat.dm
+++ b/modular_skyrat/modules/escape_menu/code/escape_menu_skyrat.dm
@@ -6,7 +6,7 @@
 			/* hud_owner = */ src,
 			src,
 			"OPFOR",
-			/* offset = */ 3,
+			/* offset = */ 6,
 			CALLBACK(src, PROC_REF(home_opfor)),
 		)
 	)
@@ -17,7 +17,7 @@
 			/* hud_owner = */ src,
 			src,
 			"Ghost",
-			/* offset = */ 4,
+			/* offset = */ 7,
 			CALLBACK(src, PROC_REF(home_ghost)),
 		)
 	)


### PR DESCRIPTION
## About The Pull Request

Escape menu has the opfor and ghost entries overlapping the entries TG added a while back, let's fix it.

## Why It's Good For The Game

Bug bad, fix good.

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/a8b3f470-e6ca-4f2d-be69-fd5d886e0d7f)

</details>

## Changelog
:cl:
fix: Fixed escape menu having overlapping entries.
/:cl:
