### PR TITLE
inflitrator suit now has all modules the normal nuclear suit has plus chameleon

### DIFF
--- a/modular_skyrat/master_files/code/modules/mod/mod_types.dm
+++ b/modular_skyrat/master_files/code/modules/mod/mod_types.dm
@@ -1,12 +1,6 @@
-/obj/item/mod/control/pre_equipped/nuclear/chameleon
-	req_access = null
-	applied_modules = list(
-		/obj/item/mod/module/storage/syndicate,
-		/obj/item/mod/module/emp_shield,
-		/obj/item/mod/module/magnetic_harness,
-		/obj/item/mod/module/jetpack,
-		/obj/item/mod/module/chameleon,
-	)
+/obj/item/mod/control/pre_equipped/nuclear/chameleon/Initialize(mapload, new_theme, new_skin, new_core)
+	applied_modules += /obj/item/mod/module/chameleon
+	. = ..()
 
 /obj/item/mod/control/pre_equipped/asset_protection
 	theme = /datum/mod_theme/asset_protection


### PR DESCRIPTION
## About The Pull Request
ditto as per PR, also readds it's ID lock since infiltrator starts out with a agent ID anyway.

## Why It's Good For The Game
it's just wierd that it has less modules than the nuclear suit, not sure if it was because of updates and the hardcoded list addition, but in this case I made it add on initialize so any updates to it won't affect it

## Proof Of Testing
tested ingame, works
![image](https://github.com/user-attachments/assets/56b9b17e-13a7-4a79-9130-09433d1784d2)

</details>

## Changelog

:cl:
add: Lone Infiltrator syndicate suit now has all the normal nuclear modules plus their chameleon module
/:cl:

