### PR TITLE
fixes primitive skill making you stamcrit immune

### DIFF
--- a/modular_skyrat/modules/primitive_production/code/primitive.dm
+++ b/modular_skyrat/modules/primitive_production/code/primitive.dm
@@ -14,6 +14,7 @@
 
 
 /datum/status_effect/primitive_skill
+	id = "primitive_skill"
 	status_type = STATUS_EFFECT_REFRESH
 	tick_interval = 0.2 SECONDS
 	alert_type = null


### PR DESCRIPTION
## About The Pull Request
fixes primitive skill making you stamcrit immune

## Why It's Good For The Game
people abusing a exploit from id conflicts to become stamimmune is bad

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
fix: Primitive skill no longer makes you stam immune
/:cl:

fixes #2666
