### PR TITLE
Locks the research paper only to the hermit

### DIFF
--- a/_maps/RandomRuins/IceRuins/bubberstation/icemoon_persistence.dmm
+++ b/_maps/RandomRuins/IceRuins/bubberstation/icemoon_persistence.dmm
@@ -7030,7 +7030,6 @@
 /obj/machinery/cell_charger_multi,
 /obj/machinery/light/directional/west,
 /obj/machinery/firealarm/directional/west,
-/obj/item/research_paper,
 /obj/item/experi_scanner,
 /obj/structure/sign/poster/official/science/directional/south,
 /turf/open/floor/iron/smooth,

--- a/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_persistence.dmm
+++ b/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_persistence.dmm
@@ -15759,7 +15759,6 @@
 /obj/machinery/cell_charger_multi,
 /obj/machinery/light/directional/west,
 /obj/machinery/firealarm/directional/west,
-/obj/item/research_paper,
 /obj/item/experi_scanner,
 /obj/structure/sign/poster/official/science/directional/south,
 /turf/open/floor/iron/smooth,

--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -140,7 +140,7 @@
 /// The time needed to unlock hardcore random mode in preferences
 #define PLAYTIME_HARDCORE_RANDOM 120 // 2 hours
 /// The time needed to unlock the gamer cloak in preferences
-#define PLAYTIME_VETERAN 300000 // 5,000 hours
+#define PLAYTIME_VETERAN 120000 // 5,000 hours -- BUBBER EDIT - 2000 hours --
 
 /// The key used for sprite accessories that should never actually be applied to the player.
 #define SPRITE_ACCESSORY_NONE "None"

--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -140,7 +140,7 @@
 /// The time needed to unlock hardcore random mode in preferences
 #define PLAYTIME_HARDCORE_RANDOM 120 // 2 hours
 /// The time needed to unlock the gamer cloak in preferences
-#define PLAYTIME_VETERAN 120000 // 5,000 hours -- BUBBER EDIT - 2000 hours --
+#define PLAYTIME_VETERAN 300000 // 5,000 hours
 
 /// The key used for sprite accessories that should never actually be applied to the player.
 #define SPRITE_ACCESSORY_NONE "None"

--- a/modular_skyrat/modules/simple_research/research_document.dm
+++ b/modular_skyrat/modules/simple_research/research_document.dm
@@ -6,6 +6,7 @@
 		/obj/item/stack/sheet/cloth = 4,
 	)
 	category = CAT_TOOLS
+	crafting_flags = CRAFT_MUST_BE_LEARNED
 
 /obj/item/research_paper
 	name = "research paper"

--- a/modular_zubbers/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/modular_zubbers/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -20,3 +20,13 @@
 	gloves = /obj/item/clothing/gloves/fingerless
 	head = /obj/item/clothing/head/soft/purple
 	l_pocket = /obj/item/modular_computer/pda
+
+/datum/outfit/hermit
+	backpack_contents = list(/obj/item/research_paper = 1)
+
+/datum/outfit/hermit/post_equip(mob/living/carbon/human/hermit, visualsOnly)
+	. = ..()
+	if(visualsOnly)
+		return
+	hermit.mind.teach_crafting_recipe(/datum/crafting_recipe/research_paper)
+	to_chat(hermit, span_notice("You learn the recipe of the <b>research paper</b> to craft everything from nothing."))

--- a/modular_zubbers/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/modular_zubbers/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -29,4 +29,4 @@
 	if(visualsOnly)
 		return
 	hermit.mind?.teach_crafting_recipe(/datum/crafting_recipe/research_paper)
-	to_chat(hermit, span_notice("You learn the recipe of the <b>research paper</b> to craft everything from nothing."))
+	to_chat(hermit, span_notice("You learn the recipe for the <b>research paper</b>, giving you the ability to craft everything from nothing."))

--- a/modular_zubbers/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/modular_zubbers/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -28,5 +28,5 @@
 	. = ..()
 	if(visualsOnly)
 		return
-	hermit.mind.teach_crafting_recipe(/datum/crafting_recipe/research_paper)
+	hermit.mind?.teach_crafting_recipe(/datum/crafting_recipe/research_paper)
 	to_chat(hermit, span_notice("You learn the recipe of the <b>research paper</b> to craft everything from nothing."))


### PR DESCRIPTION
## About The Pull Request

Removes the research paper from everywhere and locks it only to the hermit.

## Why It's Good For The Game

This item was only specifically meant to go to the hermit. I defended it at first, but people are correct that prisoners shouldn't be building entire robotic factories and I think the age of easy alien tools in science should probally pass.

## Proof Of Testing

![image](https://github.com/user-attachments/assets/319c0c93-6144-41e9-a6dc-965e6f6c392b)

![image](https://github.com/user-attachments/assets/e785f8f1-cb86-412a-b9d4-c368a8bb8c9b)


## Changelog

:cl:
balance: The research paper crafting recipe has been locked to the hermit.
/:cl:
