### PR TITLE
fixes the exploit of farming primitive skill and makes the status effect tick way slower

### DIFF
--- a/modular_skyrat/modules/ashwalkers/code/buildings/wormfarm.dm
+++ b/modular_skyrat/modules/ashwalkers/code/buildings/wormfarm.dm
@@ -118,8 +118,8 @@
 			return
 		in_use = TRUE
 
-		balloon_alert(user, "feeding the worms")
 		var/skill_modifier = user.mind.get_skill_modifier(/datum/skill/primitive, SKILL_SPEED_MODIFIER)
+		var/ate_food = FALSE
 		for(var/obj/item/food/selected_food in attacking_item.contents)
 			if(!do_after(user, 1 SECONDS * skill_modifier, src))
 				in_use = FALSE
@@ -127,10 +127,15 @@
 
 			qdel(selected_food)
 			current_food++
+			ate_food = TRUE
 			if(prob(user.mind.get_skill_modifier(/datum/skill/primitive, SKILL_PROBS_MODIFIER)))
 				current_food++
+			user.mind.adjust_experience(/datum/skill/primitive, 5)
 
-		user.mind.adjust_experience(/datum/skill/primitive, 5)
+		if(ate_food)
+			balloon_alert(user, "feeding the worms")
+		else
+			balloon_alert(user, "no food in the bag")
 		in_use = FALSE
 		return
 

--- a/modular_skyrat/modules/primitive_production/code/primitive.dm
+++ b/modular_skyrat/modules/primitive_production/code/primitive.dm
@@ -15,7 +15,7 @@
 
 /datum/status_effect/primitive_skill
 	status_type = STATUS_EFFECT_REFRESH
-	tick_interval = 0.2 SECONDS
+	tick_interval = 5 SECONDS
 	alert_type = null
 	var/stored_level = SKILL_LEVEL_NOVICE
 


### PR DESCRIPTION

## About The Pull Request
fixes the exploit of farming primitive skill and makes the status effect tick way slower

## Why It's Good For The Game
exploits are bad, i guess, plus this is a 0.5S view call which is Not Good

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
add: changes the primitive skill status effect to work every 5 seconds, instead of 0.5 seconds for performance reasons.
fix: It is no longer possible to farm primitive skill using a plant bag on a wormfarm barrel.
/:cl:

