### PR TITLE
Fixes an oversite that allows ghosts to make opfors.

### DIFF
--- a/modular_skyrat/modules/opposing_force/code/mind.dm
+++ b/modular_skyrat/modules/opposing_force/code/mind.dm
@@ -16,7 +16,9 @@
 			fail_message += " You have to be in the current round at some point to have one."
 		to_chat(src, span_warning(fail_message))
 		return
-
+	if(mind?.assigned_role.title == ROLE_GHOST_CAFE)
+		to_chat(src, span_warning("You have to be inside the current round to request an opfor."))
+		return
 	if(is_banned_from(ckey, BAN_ANTAGONIST))
 		to_chat(src, span_warning("You are antagonist banned!"))
 		return


### PR DESCRIPTION
## About The Pull Request

Removes the ability for the ghost cafe to make opfors. The original intention behind this code was to stop ghosts from making opfors, and they all sort of shifted to going to the ghost cafe to circumvent that. It's obviously an oversite.

## Why It's Good For The Game

The senior admin team all sort of said this was fine and it's kind of an annoyance. The system is fine if you're in round asking to beat up the chef, but some people do seriously go to the ghost cafe and ask for ninja (or some other antag) every round and it's always kind of a repeating cycle with new faces doing it.

## Proof Of Testing

![image](https://github.com/user-attachments/assets/af01bdb4-6a37-4531-9fb9-26b2c7bca41d)

## Changelog

:cl:
del: Ghost Cafe can no longer make opfors.
/:cl:
