### PR TITLE
Extends integration test timeout to 25 minutes

### DIFF
--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   run_integration_tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     services:
       mysql:
         image: mysql:latest


### PR DESCRIPTION

## About The Pull Request

Sometimes they just take that long, talk about bloat.

closes #2613
## Why It's Good For The Game

Less flakiness
## Proof Of Testing
N/A

## Changelog
N/A
