### PR TITLE
IceBoxStation.dmm - Added Fitness equipment to fitness room

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -20107,6 +20107,10 @@
 	dir = 9
 	},
 /area/station/science/research)
+"fLm" = (
+/obj/structure/weightmachine,
+/turf/open/floor/iron,
+/area/station/commons/fitness)
 "fLq" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -21145,11 +21149,11 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored/graveyard)
 "gaC" = (
-/obj/structure/closet/lasertag/red,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
 /obj/machinery/newscaster/directional/north,
+/obj/structure/weightmachine/weightlifter,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "gaF" = (
@@ -53827,8 +53831,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/item/kirbyplants/random,
 /obj/structure/sign/flag/terragov/directional/north,
+/obj/structure/closet/lasertag/red,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "pyn" = (
@@ -250306,7 +250310,7 @@ dyA
 skl
 gaC
 vfW
-eOl
+fLm
 vfW
 vfW
 lvk


### PR DESCRIPTION
## About The Pull Request

When playing on Icebox station with another player, we went to the fitness room to workout to only realize they don't have any actual fitness equipment in the room. Without totally tearing apart the layout, I added two lifting benches so that people can still get their muscles swole and still give the room the same ease of flow for people to move through it.


## Why It's Good For The Game

This adds equipment to the map that needs to be there so that players can build up their fitness levels other than using the boxing ring.

## Proof Of Testing

![Screenshot 2024-12-18 112307](https://github.com/user-attachments/assets/bc7e33e6-f045-4d32-8141-a7abc3e564e3)


## Changelog

:cl: Sparex

map: Added lifting benches/workout benches to the fitness room for IceboxStation.dmm

/:cl:
