### PR TITLE
Fix storyteller running holiday events

### DIFF
--- a/modular_zubbers/code/modules/storyteller/event_defines/ghostset/ghostset_overrides.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/ghostset/ghostset_overrides.dm
@@ -28,7 +28,3 @@
 	track = EVENT_TRACK_GHOSTSET
 	tags = list(TAG_COMBAT, TAG_DESTRUCTIVE, TAG_CHAOTIC)
 	weight = 2
-
-/datum/round_event_control/santa
-	track = EVENT_TRACK_GHOSTSET
-	tags = list(TAG_COMMUNAL, TAG_POSITIVE)

--- a/modular_zubbers/code/modules/storyteller/event_defines/ghostset/ghostset_overrides.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/ghostset/ghostset_overrides.dm
@@ -28,3 +28,7 @@
 	track = EVENT_TRACK_GHOSTSET
 	tags = list(TAG_COMBAT, TAG_DESTRUCTIVE, TAG_CHAOTIC)
 	weight = 2
+
+/datum/round_event_control/santa
+	track = EVENT_TRACK_GHOSTSET
+	tags = list(TAG_COMMUNAL, TAG_POSITIVE)

--- a/modular_zubbers/code/modules/storyteller/event_defines/moderate/moderate_overrides.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/moderate/moderate_overrides.dm
@@ -49,3 +49,9 @@
 
 /datum/round_event_control/obsessed
 	tags = list(TAG_TARGETED)
+
+/datum/round_event_control/santa
+	tags = list(TAG_COMMUNAL, TAG_POSITIVE)
+	weight = 25
+	earliest_start = 45 MINUTES
+	min_players = 45

--- a/modular_zubbers/code/modules/storyteller/event_defines/moderate/moderate_overrides.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/moderate/moderate_overrides.dm
@@ -54,4 +54,3 @@
 	tags = list(TAG_COMMUNAL, TAG_POSITIVE)
 	weight = 25
 	earliest_start = 45 MINUTES
-	min_players = 45

--- a/modular_zubbers/code/modules/storyteller/event_defines/mundane/mundane_overrides.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/mundane/mundane_overrides.dm
@@ -105,10 +105,6 @@
 	max_occurrences = 0
 	tags = list(TAG_COMMUNAL, TAG_POSITIVE)
 
-/datum/round_event_control/santa
-	track = EVENT_TRACK_MUNDANE
-	tags = list(TAG_COMMUNAL, TAG_POSITIVE)
-
 /datum/round_event_control/spooky
 	track = EVENT_TRACK_MUNDANE
 	roundstart = TRUE

--- a/modular_zubbers/code/modules/storyteller/event_defines/mundane/mundane_overrides.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/mundane/mundane_overrides.dm
@@ -111,7 +111,3 @@
 	weight = 0
 	max_occurrences = 0
 	tags = list(TAG_COMMUNAL, TAG_POSITIVE, TAG_SPOOKY)
-
-/datum/round_event_control/santa
-	track = EVENT_TRACK_MUNDANE
-	tags = list(TAG_COMMUNAL, TAG_POSITIVE)

--- a/modular_zubbers/code/modules/storyteller/event_defines/mundane/mundane_overrides.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/mundane/mundane_overrides.dm
@@ -111,3 +111,7 @@
 	weight = 0
 	max_occurrences = 0
 	tags = list(TAG_COMMUNAL, TAG_POSITIVE, TAG_SPOOKY)
+
+/datum/round_event_control/santa
+	track = EVENT_TRACK_MUNDANE
+	tags = list(TAG_COMMUNAL, TAG_POSITIVE)

--- a/modular_zubbers/code/modules/storyteller/gamemode.dm
+++ b/modular_zubbers/code/modules/storyteller/gamemode.dm
@@ -158,10 +158,25 @@ SUBSYSTEM_DEF(gamemode)
 
 	///Seeding events into track event pools needs to happen after event config vars are loaded
 	for(var/datum/round_event_control/event as anything in control)
-		if(event.holidayID || event.wizardevent)
+		if(event.wizardevent)
 			uncategorized += event
 			continue
-		event_pools[event.track] += event //Add it to the categorized event pools
+
+		if(event.holidayID)
+			var/holiday_categorized = FALSE
+			for(var/datum/holiday/current_holiday as anything in GLOB.holidays)
+				if(current_holiday == event.holidayID)
+					log_game("Storyteller enabled event [event] due to active holiday [current_holiday]")
+					message_admins("Storyteller enabled event [event] due to active holiday [current_holiday].")
+					event_pools[event.track] += event
+					holiday_categorized = TRUE
+					break
+			if(!holiday_categorized)
+				uncategorized += event
+			continue
+		else
+			event_pools[event.track] += event //Add it to the categorized event pools
+
 	return SS_INIT_SUCCESS
 
 


### PR DESCRIPTION
## About The Pull Request

Puts holiday events in the storyteller event pool if it's the appropriate holiday

## Why It's Good For The Game

Currently storyteller just omits the event if it has a holiday assigned

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl: LT3
fix: Santa will now periodically visit the station
/:cl: