### PR TITLE
Yeets The Crab-17 From Uplinks

### DIFF
--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -178,6 +178,7 @@
 	cost = 3
 	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS
 
+/* BUBBER EDIT REMOVAL START: Remove CRAB-17: This shit's been a dead meme for years, let's not force folk who don't want to lose all their money have to ram into a single room.
 /datum/uplink_item/device_tools/suspiciousphone
 	name = "Protocol CRAB-17 Phone"
 	desc = "The Protocol CRAB-17 Phone, a phone borrowed from an unknown third party, it can be used to crash the space market, funneling the losses of the crew to your bank account.\
@@ -186,6 +187,7 @@
 	restricted = TRUE
 	cost = 7
 	limited_stock = 1
+*/
 
 /datum/uplink_item/device_tools/binary
 	name = "Binary Translator Key"


### PR DESCRIPTION

## About The Pull Request

Could be considered a salt PR, but still throwing it up to at least get discussion going.

Shitposts can be funny in the right context, this one is just tired and needs to be put down already.

And as of late, I see this spammed at least once per shift whenever I play (EU > US handover hours), and it's just incredibly frustrating to have to -at least once per round- chase down a shitty machine in the middle of fuck-knows-where to be able to use your card, or keep hold of whatever cash you managed to make during the round.

I'm also happy enough with increasing the cost to something like 10 to discourage spamming it, if maints really don't want to remove it.

## Why It's Good For The Game

Less LRP moments where a tide of 30+ people smash through the entirety of security, into the HoS office to ensure their cash doesn't get succ'd. Those who were there will know what I'm on about.

## Proof Of Testing
Basic comment removal.

## Changelog
:cl:
del: Removed the Crab-17 phone from uplinks.
/:cl:
