### PR TITLE
Flechett ammo rebalance.

### DIFF
--- a/modular_skyrat/modules/shotgunrebalance/code/shotgun.dm
+++ b/modular_skyrat/modules/shotgunrebalance/code/shotgun.dm
@@ -171,7 +171,7 @@
 	sharpness = SHARP_EDGED //Did you knew flechettes fly sideways into people
 	weak_against_armour = TRUE
 	damage_falloff_tile = -1 // Five tiles will halve the effectiveness dramatically
-
+	wound_falloff_tile = -3
 /obj/projectile/bullet/pellet/shotgun_buckshot/flechette/Initialize(mapload)
 	. = ..()
 	SpinAnimation()

--- a/modular_skyrat/modules/shotgunrebalance/code/shotgun.dm
+++ b/modular_skyrat/modules/shotgunrebalance/code/shotgun.dm
@@ -153,7 +153,7 @@
 
 /obj/item/ammo_casing/shotgun/flechette
 	name = "flechette shell"
-	desc = "A 12 gauge flechette shell that specializes in ripping armoured targets apart."
+	desc = "A 12 gauge flechette shell that specializes in ripping unarmoured targets apart. These are exceptionally weak against armored targets."
 	icon_state = "fshell"
 	projectile_type = /obj/projectile/bullet/pellet/shotgun_buckshot/flechette
 	pellets = 5

--- a/modular_skyrat/modules/shotgunrebalance/code/shotgun.dm
+++ b/modular_skyrat/modules/shotgunrebalance/code/shotgun.dm
@@ -172,6 +172,7 @@
 	weak_against_armour = TRUE
 	damage_falloff_tile = -1 // Five tiles will halve the effectiveness dramatically
 	wound_falloff_tile = -3
+
 /obj/projectile/bullet/pellet/shotgun_buckshot/flechette/Initialize(mapload)
 	. = ..()
 	SpinAnimation()
@@ -279,10 +280,6 @@
 		else
 			demolition_mod = 2
 			damage = 15
-
-/obj/projectile/bullet/shotgun_slug // Dead simple slug. Hurts like a bitch
-	damage = 30
-	armour_penetration = 40 // Can bypass 40 percent bullet resist
 
 /obj/item/ammo_casing/shotgun/hunter
 	name = "hunter slug shell"

--- a/modular_skyrat/modules/shotgunrebalance/code/shotgun.dm
+++ b/modular_skyrat/modules/shotgunrebalance/code/shotgun.dm
@@ -157,7 +157,7 @@
 	icon_state = "fshell"
 	projectile_type = /obj/projectile/bullet/pellet/shotgun_buckshot/flechette
 	pellets = 5
-	variance = 8
+	variance = 15
 	custom_materials = AMMO_MATS_SHOTGUN_FLECH
 	advanced_print_req = TRUE
 
@@ -166,12 +166,11 @@
 	icon = 'modular_skyrat/modules/shotgunrebalance/icons/projectiles.dmi'
 	icon_state = "flechette"
 	damage = 10
-	wound_bonus = 5
-	bare_wound_bonus = 10
+	wound_bonus = 10
+	bare_wound_bonus = 15
 	sharpness = SHARP_EDGED //Did you knew flechettes fly sideways into people
-	weak_against_armour = FALSE
-	damage_falloff_tile = 0
-	armour_penetration = 50
+	weak_against_armour = TRUE
+	damage_falloff_tile = 0.5
 
 /obj/projectile/bullet/pellet/shotgun_buckshot/flechette/Initialize(mapload)
 	. = ..()
@@ -280,6 +279,10 @@
 		else
 			demolition_mod = 2
 			damage = 15
+
+/obj/projectile/bullet/shotgun_slug
+	damage = 30
+	armour_penetration = 30 // Can bypass 30 percent bullet resist
 
 /obj/item/ammo_casing/shotgun/hunter
 	name = "hunter slug shell"

--- a/modular_skyrat/modules/shotgunrebalance/code/shotgun.dm
+++ b/modular_skyrat/modules/shotgunrebalance/code/shotgun.dm
@@ -170,7 +170,7 @@
 	bare_wound_bonus = 15
 	sharpness = SHARP_EDGED //Did you knew flechettes fly sideways into people
 	weak_against_armour = TRUE
-	damage_falloff_tile = 0.5
+	damage_falloff_tile = -1 // Five tiles will halve the effectiveness dramatically
 
 /obj/projectile/bullet/pellet/shotgun_buckshot/flechette/Initialize(mapload)
 	. = ..()
@@ -195,8 +195,8 @@
 	icon_state = "hornet"
 	damage = 4
 	stamina = 15
-	damage_falloff_tile = 1
-	stamina_falloff_tile = 1
+	damage_falloff_tile = -1
+	stamina_falloff_tile = -1
 	wound_bonus = 5
 	bare_wound_bonus = 5
 	wound_falloff_tile = 0
@@ -231,8 +231,8 @@
 	icon_state = "stardust"
 	damage = 15
 	stamina = 33
-	damage_falloff_tile = 0.2
-	stamina_falloff_tile = 0.3
+	damage_falloff_tile = -0.2
+	stamina_falloff_tile = -0.3
 	wound_bonus = 40
 	bare_wound_bonus = 40
 	stutter = 3 SECONDS
@@ -280,9 +280,9 @@
 			demolition_mod = 2
 			damage = 15
 
-/obj/projectile/bullet/shotgun_slug
+/obj/projectile/bullet/shotgun_slug // Dead simple slug. Hurts like a bitch
 	damage = 30
-	armour_penetration = 30 // Can bypass 30 percent bullet resist
+	armour_penetration = 40 // Can bypass 40 percent bullet resist
 
 /obj/item/ammo_casing/shotgun/hunter
 	name = "hunter slug shell"


### PR DESCRIPTION
## About The Pull Request

# Flechetts
- 5 pellets at a 15 varience spread (a little better then buckshot). This means that the spread will start to miss one or two entire pellets at 4-5 tiles. 
- 10 damage with a damage drop off of 1 per tile. (at five tiles, it'll be halved)
- Removed the AP and made it weak against armor.
- Base wounding is at 10 with a bonus wounding of 15 (25 total) and has a wounding dropoff of 3 per tile. 

Also the tile drop off for antitide and beehive now properly subtracts its damage instead of adding.

## Why It's Good For The Game
Flechett rounds are litterally the best shotgun ammo in the game. You don't need to use anything else. This is one shot on an elite suit.

![image](https://github.com/user-attachments/assets/d14b2e7a-ede2-4a7d-9c83-df95729987b9)

They can be a great wounding ammo, but their damage should suffer when it begins to not be point blank and against armored targets.

## Proof Of Testing

I don't have specific videos but I got the numbers from somewhere. But truth be told, this needs heavy test merging.

## Changelog

:cl:
balance: Signifigantly changes flechett shotgun rounds. They are a close range ammo with reliable wounding and damage against unarmored with very shitty armor penitration. Damage drops off signifigantly with range.
fix: Beehive and Antitide shotgun ammo now properly subtracts damage dropoff instead of adding.
/:cl:


