### PR TITLE
fixes bloodsuckers bleeding forever

### DIFF
--- a/modular_zubbers/code/modules/antagonists/bloodsucker/bloodsuckers/integration.dm
+++ b/modular_zubbers/code/modules/antagonists/bloodsucker/bloodsuckers/integration.dm
@@ -1,4 +1,10 @@
 
+// this suggests that your heart is beating, when it is not
+/mob/living/carbon/bleed_warn(bleed_amt = 0, forced = FALSE)
+	if(mind && IS_BLOODSUCKER(src) && !HAS_TRAIT(src, TRAIT_MASQUERADE))
+		return
+	. = ..()
+
 /datum/reagent/blood/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume, show_message=TRUE, touch_protection=0)
 	var/datum/antagonist/bloodsucker/bloodsuckerdatum = IS_BLOODSUCKER(exposed_mob)
 	if(!bloodsuckerdatum)

--- a/modular_zubbers/code/modules/antagonists/bloodsucker/bloodsuckers/integration.dm
+++ b/modular_zubbers/code/modules/antagonists/bloodsucker/bloodsuckers/integration.dm
@@ -1,8 +1,3 @@
-// Prevents Bloodsuckers from getting affected by blood
-/mob/living/carbon/human/handle_blood(seconds_per_tick, times_fired)
-	if(mind && IS_BLOODSUCKER(src))
-		return FALSE
-	return ..()
 
 /datum/reagent/blood/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume, show_message=TRUE, touch_protection=0)
 	var/datum/antagonist/bloodsucker/bloodsuckerdatum = IS_BLOODSUCKER(exposed_mob)
@@ -40,7 +35,7 @@
 		return 0
 	return ..()
 
-// Used when analyzing a Bloodsucker, Masquerade will hide brain traumas (Unless you're a Beefman)
+// Used when analyzing a Bloodsucker, Masquerade will hide brain traumas
 /// todo move this to it's own trait or something
 /mob/living/carbon/get_traumas()
 	if(!mind)

--- a/modular_zubbers/code/modules/antagonists/bloodsucker/bloodsuckers/life.dm
+++ b/modular_zubbers/code/modules/antagonists/bloodsucker/bloodsuckers/life.dm
@@ -21,8 +21,6 @@
 		return
 	if(owner.current.stat == CONSCIOUS && !HAS_TRAIT(owner.current, TRAIT_IMMOBILIZED) && !is_in_torpor())
 		INVOKE_ASYNC(src, PROC_REF(AdjustBloodVolume), -BLOODSUCKER_PASSIVE_BLOOD_DRAIN) // -.1 currently
-	INVOKE_ASYNC(src, PROC_REF(update_blood))
-	INVOKE_ASYNC(src, PROC_REF(HandleStarving))
 
 /datum/antagonist/bloodsucker/proc/life_active()
 	if(HandleHealing())
@@ -290,6 +288,11 @@
 		return
 	check_begin_torpor(TORPOR_SKIP_CHECK_ALL)
 
+/datum/antagonist/bloodsucker/proc/HandleBlood()
+	INVOKE_ASYNC(src, PROC_REF(update_blood))
+	INVOKE_ASYNC(src, PROC_REF(HandleStarving))
+	return HANDLE_BLOOD_NO_OXYLOSS | HANDLE_BLOOD_NO_NUTRITION_DRAIN
+
 /datum/antagonist/bloodsucker/proc/HandleStarving() // I am thirsty for blood!
 	// Nutrition - The amount of blood is how full we are.
 	owner.current.set_nutrition(min(bloodsucker_blood_volume, NUTRITION_LEVEL_FED))
@@ -345,8 +348,8 @@
 	owner.current.blood_volume = bloodsucker_blood_volume
 
 /// Turns the bloodsucker into a wacky talking head.
-/datum/antagonist/bloodsucker/proc/talking_head()
-	var/mob/living/poor_fucker = owner.current
+/datum/antagonist/bloodsucker/proc/talking_head(mob/target)
+	var/mob/living/poor_fucker = target
 	if(QDELETED(poor_fucker))
 		return
 	// Don't do anything if we're not actually inside a brain and a head

--- a/modular_zubbers/code/modules/antagonists/bloodsucker/bloodsuckers/procs.dm
+++ b/modular_zubbers/code/modules/antagonists/bloodsucker/bloodsuckers/procs.dm
@@ -372,24 +372,18 @@
 	if(is_head(deleted_mob))
 		on_brainmob_qdel()
 
+/datum/antagonist/bloodsucker/proc/register_body_signals(mob/target)
+	for(var/signal in body_signals)
+		RegisterSignal(target, signal, body_signals[signal])
 
-/datum/antagonist/bloodsucker/proc/unregister_body_signals()
-	UnregisterSignal(owner.current, list(
-		COMSIG_LIVING_LIFE,
-		COMSIG_ATOM_EXAMINE,
-		COMSIG_LIVING_DEATH,
-		COMSIG_SPECIES_GAIN,
-		COMSIG_QDELETING,
-		COMSIG_ENTER_COFFIN,
-		COMSIG_MOB_STAKED,
-		COMSIG_CARBON_LOSE_ORGAN
-	))
+/datum/antagonist/bloodsucker/proc/unregister_body_signals(mob/target)
+	for(var/signal in body_signals)
+		UnregisterSignal(target, signal)
+
+/datum/antagonist/bloodsucker/proc/register_sol_signals()
+	for(var/signal in sol_signals)
+		RegisterSignal(SSsunlight, signal, sol_signals[signal])
 
 /datum/antagonist/bloodsucker/proc/unregister_sol_signals()
-	UnregisterSignal(SSsunlight, list(
-		COMSIG_SOL_RANKUP_BLOODSUCKERS,
-		COMSIG_SOL_NEAR_START,
-		COMSIG_SOL_END,
-		COMSIG_SOL_RISE_TICK,
-		COMSIG_SOL_WARNING_GIVEN
-	))
+	for(var/signal in sol_signals)
+		UnregisterSignal(SSsunlight, signal)


### PR DESCRIPTION
## About The Pull Request
Fixes bloodsuckers bleeding forever because the passive bloodloss healing code was not running. 
This also means that bloodloss will do some of it's effects on bloodsuckers
Fixes #2734
## Why It's Good For The Game
It's a meta check and just kind of annoying.

## Proof Of Testing
Went ingame, used adjustBleedStacks, saw that bleeding was slowly healed. Also tested that the procs that I moved around to HandleBlood signal also worked, frenzy and HandleStarving in fact, do

## Changelog

:cl:
fix: Bloodsuckers "should" no longer be forever bleeding
/:cl:

