### PR TITLE
Fix mail sorter name, add spawn

### DIFF
--- a/modular_zubbers/code/game/machinery/flatpacker.dm
+++ b/modular_zubbers/code/game/machinery/flatpacker.dm
@@ -1,0 +1,26 @@
+/obj/item/flatpack/mailsorter
+	name = "flatpack (mail sorter)"
+
+/datum/area_spawn/mailsorter
+	target_areas = list(/area/station/cargo/office)
+	desired_atom = /obj/item/flatpack/mailsorter
+
+/datum/area_spawn/mailsorter/try_spawn()
+	// Turfs that are available
+	var/list/available_turfs
+
+	for(var/area_type in target_areas)
+		var/area/found_area = GLOB.areas_by_type[area_type]
+		if(!found_area)
+			continue
+		available_turfs = SSarea_spawn.get_turf_candidates(found_area, mode)
+		if(LAZYLEN(available_turfs))
+			break
+
+	if(!LAZYLEN(available_turfs))
+		return
+
+	for(var/i in 1 to amount_to_spawn)
+		var/turf/candidate_turf = SSarea_spawn.pick_turf_candidate(available_turfs)
+		var/final_desired_atom = desired_atom
+		new final_desired_atom(candidate_turf)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8769,6 +8769,7 @@
 #include "modular_zubbers\code\game\Items\storage\medkit.dm"
 #include "modular_zubbers\code\game\machinery\crew_monitor.dm"
 #include "modular_zubbers\code\game\machinery\department_balance.dm"
+#include "modular_zubbers\code\game\machinery\flatpacker.dm"
 #include "modular_zubbers\code\game\machinery\medipen_refiller.dm"
 #include "modular_zubbers\code\game\machinery\morgue.dm"
 #include "modular_zubbers\code\game\machinery\syndiepad.dm"


### PR DESCRIPTION
## About The Pull Request

Fixes mail sorter name, adds spawn datum

## Changelog

:cl: LT3
fix: Mail sorter is now properly named in the CargoDrobe
/:cl: