### PR TITLE
[I think it works] Heretic reroll rite earlier, cheaper, Interlink and SSD protections to heretic targets!

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/ash_lore.dm
@@ -96,7 +96,9 @@
 	gain_text = "He was a very particular man, always watching in the dead of night. \
 		But in spite of his duty, he regularly tranced through the Manse with his blazing lantern held high. \
 		He shone brightly in the darkness, until the blaze begin to die."
-	next_knowledge = list(/datum/heretic_knowledge/knowledge_ritual/ash)
+	next_knowledge = list(
+	/datum/heretic_knowledge/knowledge_ritual/ash,
+	/datum/heretic_knowledge/reroll_targets)
 	route = PATH_ASH
 	mark_type = /datum/status_effect/eldritch/ash
 
@@ -137,7 +139,6 @@
 	gain_text = "The Nightwatcher was lost. That's what the Watch believed. Yet he walked the world, unnoticed by the masses."
 	next_knowledge = list(
 		/datum/heretic_knowledge/blade_upgrade/ash,
-		/datum/heretic_knowledge/reroll_targets,
 		/datum/heretic_knowledge/spell/space_phase,
 		/datum/heretic_knowledge/curse/paralysis,
 	)

--- a/code/modules/antagonists/heretic/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/ash_lore.dm
@@ -139,7 +139,7 @@
 	gain_text = "The Nightwatcher was lost. That's what the Watch believed. Yet he walked the world, unnoticed by the masses."
 	next_knowledge = list(
 		/datum/heretic_knowledge/blade_upgrade/ash,
-		//datum/heretic_knowledge/reroll_targets //BUBBER EDIT
+		// /datum/heretic_knowledge/reroll_targets, // BUBBER EDIT REMOVAL
 		/datum/heretic_knowledge/spell/space_phase,
 		/datum/heretic_knowledge/curse/paralysis,
 	)

--- a/code/modules/antagonists/heretic/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/ash_lore.dm
@@ -139,6 +139,7 @@
 	gain_text = "The Nightwatcher was lost. That's what the Watch believed. Yet he walked the world, unnoticed by the masses."
 	next_knowledge = list(
 		/datum/heretic_knowledge/blade_upgrade/ash,
+		//datum/heretic_knowledge/reroll_targets //BUBBER EDIT
 		/datum/heretic_knowledge/spell/space_phase,
 		/datum/heretic_knowledge/curse/paralysis,
 	)

--- a/code/modules/antagonists/heretic/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/ash_lore.dm
@@ -98,7 +98,7 @@
 		He shone brightly in the darkness, until the blaze begin to die."
 	next_knowledge = list(
 	/datum/heretic_knowledge/knowledge_ritual/ash,
-	/datum/heretic_knowledge/reroll_targets)
+	/datum/heretic_knowledge/reroll_targets) //BUBBER EDIT
 	route = PATH_ASH
 	mark_type = /datum/status_effect/eldritch/ash
 

--- a/code/modules/antagonists/heretic/knowledge/blade_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/blade_lore.dm
@@ -183,7 +183,9 @@
 		The knife will block any attack directed towards you, but is consumed on use."
 	gain_text = "His general wished to end the war, but the Champion knew there could be no life without death. \
 		He would slay the coward himself, and anyone who tried to run."
-	next_knowledge = list(/datum/heretic_knowledge/knowledge_ritual/blade)
+	next_knowledge = list(
+	/datum/heretic_knowledge/knowledge_ritual/blade,
+	/datum/heretic_knowledge/reroll_targets)
 	route = PATH_BLADE
 	mark_type = /datum/status_effect/eldritch/blade
 
@@ -229,7 +231,6 @@
 		He was without rival, equal, or purpose."
 	next_knowledge = list(
 		/datum/heretic_knowledge/blade_upgrade/blade,
-		/datum/heretic_knowledge/reroll_targets,
 		/datum/heretic_knowledge/rune_carver,
 		/datum/heretic_knowledge/crucible,
 		/datum/heretic_knowledge/rifle,

--- a/code/modules/antagonists/heretic/knowledge/blade_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/blade_lore.dm
@@ -231,7 +231,7 @@
 		He was without rival, equal, or purpose."
 	next_knowledge = list(
 		/datum/heretic_knowledge/blade_upgrade/blade,
-		//datum/heretic_knowledge/reroll_targets //BUBBER EDIT
+		// /datum/heretic_knowledge/reroll_targets, // BUBBER EDIT REMOVAL
 		/datum/heretic_knowledge/rune_carver,
 		/datum/heretic_knowledge/crucible,
 		/datum/heretic_knowledge/rifle,

--- a/code/modules/antagonists/heretic/knowledge/blade_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/blade_lore.dm
@@ -231,6 +231,7 @@
 		He was without rival, equal, or purpose."
 	next_knowledge = list(
 		/datum/heretic_knowledge/blade_upgrade/blade,
+		//datum/heretic_knowledge/reroll_targets //BUBBER EDIT
 		/datum/heretic_knowledge/rune_carver,
 		/datum/heretic_knowledge/crucible,
 		/datum/heretic_knowledge/rifle,

--- a/code/modules/antagonists/heretic/knowledge/blade_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/blade_lore.dm
@@ -185,7 +185,7 @@
 		He would slay the coward himself, and anyone who tried to run."
 	next_knowledge = list(
 	/datum/heretic_knowledge/knowledge_ritual/blade,
-	/datum/heretic_knowledge/reroll_targets)
+	/datum/heretic_knowledge/reroll_targets)  //BUBBER EDIT
 	route = PATH_BLADE
 	mark_type = /datum/status_effect/eldritch/blade
 

--- a/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
@@ -93,7 +93,9 @@
 		They will then be paralyzed for 2 seconds."
 	gain_text = "The Beast now whispered to me occasionally, only small tidbits of their circumstances. \
 		I can help them, I have to help them."
-	next_knowledge = list(/datum/heretic_knowledge/knowledge_ritual/cosmic)
+	next_knowledge = list(
+	/datum/heretic_knowledge/knowledge_ritual/cosmic,
+	/datum/heretic_knowledge/reroll_targets)
 	route = PATH_COSMIC
 	mark_type = /datum/status_effect/eldritch/cosmic
 
@@ -122,7 +124,6 @@
 	gain_text = "The Beast was behind me now at all times, with each sacrifice words of affirmation coursed through me."
 	next_knowledge = list(
 		/datum/heretic_knowledge/blade_upgrade/cosmic,
-		/datum/heretic_knowledge/reroll_targets,
 		/datum/heretic_knowledge/curse/corrosion,
 		/datum/heretic_knowledge/summon/rusty,
 		/datum/heretic_knowledge/spell/space_phase,

--- a/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
@@ -124,6 +124,7 @@
 	gain_text = "The Beast was behind me now at all times, with each sacrifice words of affirmation coursed through me."
 	next_knowledge = list(
 		/datum/heretic_knowledge/blade_upgrade/cosmic,
+		//datum/heretic_knowledge/reroll_targets //BUBBER EDIT
 		/datum/heretic_knowledge/curse/corrosion,
 		/datum/heretic_knowledge/summon/rusty,
 		/datum/heretic_knowledge/spell/space_phase,

--- a/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
@@ -124,7 +124,7 @@
 	gain_text = "The Beast was behind me now at all times, with each sacrifice words of affirmation coursed through me."
 	next_knowledge = list(
 		/datum/heretic_knowledge/blade_upgrade/cosmic,
-		//datum/heretic_knowledge/reroll_targets //BUBBER EDIT
+		// /datum/heretic_knowledge/reroll_targets, // BUBBER EDIT REMOVAL
 		/datum/heretic_knowledge/curse/corrosion,
 		/datum/heretic_knowledge/summon/rusty,
 		/datum/heretic_knowledge/spell/space_phase,

--- a/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
@@ -95,7 +95,7 @@
 		I can help them, I have to help them."
 	next_knowledge = list(
 	/datum/heretic_knowledge/knowledge_ritual/cosmic,
-	/datum/heretic_knowledge/reroll_targets)
+	/datum/heretic_knowledge/reroll_targets)  //BUBBER EDIT
 	route = PATH_COSMIC
 	mark_type = /datum/status_effect/eldritch/cosmic
 

--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -217,7 +217,9 @@
 	desc = "Your Mansus Grasp now applies the Mark of Flesh. The mark is triggered from an attack with your Bloody Blade. \
 		When triggered, the victim begins to bleed significantly."
 	gain_text = "That's when I saw them, the marked ones. They were out of reach. They screamed, and screamed."
-	next_knowledge = list(/datum/heretic_knowledge/knowledge_ritual/flesh)
+	next_knowledge = list(
+	/datum/heretic_knowledge/knowledge_ritual/flesh,
+	/datum/heretic_knowledge/reroll_targets)
 	route = PATH_FLESH
 	mark_type = /datum/status_effect/eldritch/flesh
 
@@ -247,7 +249,6 @@
 		The screams... once constant, now silenced by their wretched appearance. Nothing was out of reach."
 	next_knowledge = list(
 		/datum/heretic_knowledge/blade_upgrade/flesh,
-		/datum/heretic_knowledge/reroll_targets,
 		/datum/heretic_knowledge/spell/blood_siphon,
 		/datum/heretic_knowledge/spell/opening_blast,
 	)

--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -249,6 +249,7 @@
 		The screams... once constant, now silenced by their wretched appearance. Nothing was out of reach."
 	next_knowledge = list(
 		/datum/heretic_knowledge/blade_upgrade/flesh,
+		//datum/heretic_knowledge/reroll_targets //BUBBER EDIT
 		/datum/heretic_knowledge/spell/blood_siphon,
 		/datum/heretic_knowledge/spell/opening_blast,
 	)

--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -219,7 +219,7 @@
 	gain_text = "That's when I saw them, the marked ones. They were out of reach. They screamed, and screamed."
 	next_knowledge = list(
 	/datum/heretic_knowledge/knowledge_ritual/flesh,
-	/datum/heretic_knowledge/reroll_targets)
+	/datum/heretic_knowledge/reroll_targets) //BUBBER EDIT
 	route = PATH_FLESH
 	mark_type = /datum/status_effect/eldritch/flesh
 

--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -249,7 +249,7 @@
 		The screams... once constant, now silenced by their wretched appearance. Nothing was out of reach."
 	next_knowledge = list(
 		/datum/heretic_knowledge/blade_upgrade/flesh,
-		//datum/heretic_knowledge/reroll_targets //BUBBER EDIT
+		// /datum/heretic_knowledge/reroll_targets, // BUBBER EDIT REMOVAL
 		/datum/heretic_knowledge/spell/blood_siphon,
 		/datum/heretic_knowledge/spell/opening_blast,
 	)

--- a/code/modules/antagonists/heretic/knowledge/general_side.dm
+++ b/code/modules/antagonists/heretic/knowledge/general_side.dm
@@ -2,7 +2,7 @@
 
 /datum/heretic_knowledge/reroll_targets
 	name = "The Relentless Heartbeat"
-	desc = "Allows you transmute a harebell, a book, and a jumpsuit while standing over a rune \
+	desc = "Allows you transmute a heart, a book, and a jumpsuit while standing over a rune \
 		to reroll your sacrifice targets."
 	gain_text = "The heart is the principle that continues and preserves."
 	required_atoms = list(

--- a/code/modules/antagonists/heretic/knowledge/general_side.dm
+++ b/code/modules/antagonists/heretic/knowledge/general_side.dm
@@ -6,13 +6,13 @@
 		to reroll your sacrifice targets."
 	gain_text = "The heart is the principle that continues and preserves."
 	required_atoms = list(
-		/obj/item/organ/internal/heart = 1,
+		/obj/item/organ/internal/heart = 1, //BUBBER EDIT
 		/obj/item/book = 1,
 		/obj/item/clothing/under = 1,
 	)
 	cost = 0 // BUBBER EDIT
 	route = PATH_SIDE
-	depth = 6
+	depth = 6 //BUBBER EDIT
 	research_tree_icon_path = 'icons/mob/actions/actions_animal.dmi'
 	research_tree_icon_state = "gaze"
 

--- a/code/modules/antagonists/heretic/knowledge/general_side.dm
+++ b/code/modules/antagonists/heretic/knowledge/general_side.dm
@@ -6,7 +6,7 @@
 		to reroll your sacrifice targets."
 	gain_text = "The heart is the principle that continues and preserves."
 	required_atoms = list(
-		/obj/item/food/grown/harebell = 1,
+		/obj/item/organ/internal/heart = 1,
 		/obj/item/book = 1,
 		/obj/item/clothing/under = 1,
 	)

--- a/code/modules/antagonists/heretic/knowledge/general_side.dm
+++ b/code/modules/antagonists/heretic/knowledge/general_side.dm
@@ -12,7 +12,7 @@
 	)
 	cost = 0 // BUBBER EDIT
 	route = PATH_SIDE
-	depth = 8
+	depth = 6
 	research_tree_icon_path = 'icons/mob/actions/actions_animal.dmi'
 	research_tree_icon_state = "gaze"
 

--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -126,7 +126,9 @@
 		Attack a marked person to bar them from all passages for the duration of the mark. \
 		This will make it so that they have no access whatsoever, even public access doors will reject them."
 	gain_text = "The Gatekeeper was a corrupt Steward. She hindered her fellows for her own twisted amusement."
-	next_knowledge = list(/datum/heretic_knowledge/knowledge_ritual/lock)
+	next_knowledge = list(
+	/datum/heretic_knowledge/knowledge_ritual/lock,
+	/datum/heretic_knowledge/reroll_targets)
 	route = PATH_LOCK
 	mark_type = /datum/status_effect/eldritch/lock
 
@@ -159,7 +161,6 @@
 	gain_text = "Consorting with Burglar spirits is frowned upon, but a Steward will always want to learn about new doors."
 	next_knowledge = list(
 		/datum/heretic_knowledge/spell/opening_blast,
-		/datum/heretic_knowledge/reroll_targets,
 		/datum/heretic_knowledge/blade_upgrade/flesh/lock,
 		/datum/heretic_knowledge/unfathomable_curio,
 		/datum/heretic_knowledge/painting,

--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -128,7 +128,7 @@
 	gain_text = "The Gatekeeper was a corrupt Steward. She hindered her fellows for her own twisted amusement."
 	next_knowledge = list(
 	/datum/heretic_knowledge/knowledge_ritual/lock,
-	/datum/heretic_knowledge/reroll_targets)
+	/datum/heretic_knowledge/reroll_targets) //BUBBER EDIT
 	route = PATH_LOCK
 	mark_type = /datum/status_effect/eldritch/lock
 

--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -162,7 +162,7 @@
 	next_knowledge = list(
 		/datum/heretic_knowledge/spell/opening_blast,
 		/datum/heretic_knowledge/blade_upgrade/flesh/lock,
-		//datum/heretic_knowledge/reroll_targets //BUBBER EDIT
+		// /datum/heretic_knowledge/reroll_targets, // BUBBER EDIT REMOVAL
 		/datum/heretic_knowledge/unfathomable_curio,
 		/datum/heretic_knowledge/painting,
 	)

--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -162,6 +162,7 @@
 	next_knowledge = list(
 		/datum/heretic_knowledge/spell/opening_blast,
 		/datum/heretic_knowledge/blade_upgrade/flesh/lock,
+		//datum/heretic_knowledge/reroll_targets //BUBBER EDIT
 		/datum/heretic_knowledge/unfathomable_curio,
 		/datum/heretic_knowledge/painting,
 	)

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -96,7 +96,9 @@
 	gain_text = "The troupe on the moon would dance all day long \
 		and in that dance the moon would smile upon us \
 		but when the night came its smile would dull forced to gaze on the earth."
-	next_knowledge = list(/datum/heretic_knowledge/knowledge_ritual/moon)
+	next_knowledge = list(
+	/datum/heretic_knowledge/knowledge_ritual/moon,
+	/datum/heretic_knowledge/reroll_targets)
 	route = PATH_MOON
 	mark_type = /datum/status_effect/eldritch/moon
 
@@ -124,7 +126,6 @@
 	gain_text = "At the head of the parade he stood, the moon condensed into one mass, a reflection of the soul."
 	next_knowledge = list(
 		/datum/heretic_knowledge/blade_upgrade/moon,
-		/datum/heretic_knowledge/reroll_targets,
 		/datum/heretic_knowledge/unfathomable_curio,
 		/datum/heretic_knowledge/curse/paralysis,
 		/datum/heretic_knowledge/painting,

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -126,6 +126,7 @@
 	gain_text = "At the head of the parade he stood, the moon condensed into one mass, a reflection of the soul."
 	next_knowledge = list(
 		/datum/heretic_knowledge/blade_upgrade/moon,
+		//datum/heretic_knowledge/reroll_targets //BUBBER EDIT
 		/datum/heretic_knowledge/unfathomable_curio,
 		/datum/heretic_knowledge/curse/paralysis,
 		/datum/heretic_knowledge/painting,

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -98,7 +98,7 @@
 		but when the night came its smile would dull forced to gaze on the earth."
 	next_knowledge = list(
 	/datum/heretic_knowledge/knowledge_ritual/moon,
-	/datum/heretic_knowledge/reroll_targets)
+	/datum/heretic_knowledge/reroll_targets) //BUBBER EDIT
 	route = PATH_MOON
 	mark_type = /datum/status_effect/eldritch/moon
 

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -126,7 +126,7 @@
 	gain_text = "At the head of the parade he stood, the moon condensed into one mass, a reflection of the soul."
 	next_knowledge = list(
 		/datum/heretic_knowledge/blade_upgrade/moon,
-		//datum/heretic_knowledge/reroll_targets //BUBBER EDIT
+		// /datum/heretic_knowledge/reroll_targets, // BUBBER EDIT REMOVAL
 		/datum/heretic_knowledge/unfathomable_curio,
 		/datum/heretic_knowledge/curse/paralysis,
 		/datum/heretic_knowledge/painting,

--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -114,7 +114,9 @@
 		When triggered, your victim will suffer heavy disgust and confusion. \
 		Allows you to rust reinforced walls and floors as well as plasteel."
 	gain_text = "The Blacksmith looks away. To a place lost long ago. \"Rusted Hills help those in dire need... at a cost.\""
-	next_knowledge = list(/datum/heretic_knowledge/knowledge_ritual/rust)
+	next_knowledge = list(
+	/datum/heretic_knowledge/knowledge_ritual/rust,
+	/datum/heretic_knowledge/reroll_targets)
 	route = PATH_RUST
 	mark_type = /datum/status_effect/eldritch/rust
 
@@ -145,7 +147,6 @@
 	gain_text = "All wise men know well not to visit the Rusted Hills... Yet the Blacksmith's tale was inspiring."
 	next_knowledge = list(
 		/datum/heretic_knowledge/blade_upgrade/rust,
-		/datum/heretic_knowledge/reroll_targets,
 		/datum/heretic_knowledge/curse/corrosion,
 		/datum/heretic_knowledge/summon/rusty,
 		/datum/heretic_knowledge/crucible,

--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -116,7 +116,7 @@
 	gain_text = "The Blacksmith looks away. To a place lost long ago. \"Rusted Hills help those in dire need... at a cost.\""
 	next_knowledge = list(
 	/datum/heretic_knowledge/knowledge_ritual/rust,
-	/datum/heretic_knowledge/reroll_targets)
+	/datum/heretic_knowledge/reroll_targets) //BUBBER EDIT
 	route = PATH_RUST
 	mark_type = /datum/status_effect/eldritch/rust
 

--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -147,6 +147,7 @@
 	gain_text = "All wise men know well not to visit the Rusted Hills... Yet the Blacksmith's tale was inspiring."
 	next_knowledge = list(
 		/datum/heretic_knowledge/blade_upgrade/rust,
+		//datum/heretic_knowledge/reroll_targets //BUBBER EDIT
 		/datum/heretic_knowledge/curse/corrosion,
 		/datum/heretic_knowledge/summon/rusty,
 		/datum/heretic_knowledge/crucible,

--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -147,7 +147,7 @@
 	gain_text = "All wise men know well not to visit the Rusted Hills... Yet the Blacksmith's tale was inspiring."
 	next_knowledge = list(
 		/datum/heretic_knowledge/blade_upgrade/rust,
-		//datum/heretic_knowledge/reroll_targets //BUBBER EDIT
+		// /datum/heretic_knowledge/reroll_targets, // BUBBER EDIT REMOVAL
 		/datum/heretic_knowledge/curse/corrosion,
 		/datum/heretic_knowledge/summon/rusty,
 		/datum/heretic_knowledge/crucible,

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -28,7 +28,6 @@
 	/// Lazylist of minds that we won't pick as targets.
 	var/list/datum/mind/target_blacklist
 	/// A list of areas that make a person immune to being sacrificed, if they are there. So dorms protection.
-	var/area/protected_areas
 	/// An assoc list of [ref] to [timers] - a list of all the timers of people in the shadow realm currently
 	var/list/return_timers
 	/// Evil organs we can put in people
@@ -135,7 +134,7 @@
 			continue
 		if(!HAS_TRAIT(possible_target, TRAIT_MIND_TEMPORARILY_GONE))
 			continue
-		for(protected_areas as anything in GLOB.dorms_areas)
+		for(var/area/protected_areas as anything in GLOB.dorms_areas)
 			if(!is_type_in_list(get_area(possible_target), protected_areas))
 				continue
 		valid_targets += possible_target

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -27,7 +27,6 @@
 	var/datum/mind/heretic_mind
 	/// Lazylist of minds that we won't pick as targets.
 	var/list/datum/mind/target_blacklist
-	/// A list of areas that make a person immune to being sacrificed, if they are there. So dorms protection.
 	/// An assoc list of [ref] to [timers] - a list of all the timers of people in the shadow realm currently
 	var/list/return_timers
 	/// Evil organs we can put in people
@@ -132,10 +131,12 @@
 			continue
 		if(possible_target.current.stat == DEAD)
 			continue
+		////BUBBER EDIT START
 		if(HAS_TRAIT(possible_target, TRAIT_MIND_TEMPORARILY_GONE))
 			continue
 		if(is_centcom_level(possible_target.current.z))
 			continue
+		//BUBBERSEDIT END
 		valid_targets += possible_target
 
 	if(!length(valid_targets))

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -122,7 +122,6 @@
 /datum/heretic_knowledge/hunt_and_sacrifice/proc/obtain_targets(mob/living/user, silent = FALSE, datum/antagonist/heretic/heretic_datum)
 
 	// First construct a list of minds that are valid objective targets.
-	var/area/centcom/protected_areas
 	var/list/datum/mind/valid_targets = list()
 	for(var/datum/mind/possible_target as anything in get_crewmember_minds())
 		if(possible_target == user.mind)
@@ -133,9 +132,9 @@
 			continue
 		if(possible_target.current.stat == DEAD)
 			continue
-		if(!HAS_TRAIT(possible_target, TRAIT_MIND_TEMPORARILY_GONE))
+		if(HAS_TRAIT(possible_target, TRAIT_MIND_TEMPORARILY_GONE))
 			continue
-		if(!is_type_in_list(get_area(possible_target), protected_areas))
+		if(is_centcom_level(possible_target.current.z))
 			continue
 		valid_targets += possible_target
 

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -27,6 +27,8 @@
 	var/datum/mind/heretic_mind
 	/// Lazylist of minds that we won't pick as targets.
 	var/list/datum/mind/target_blacklist
+	/// A list of areas that make a person immune to being sacrificed, if they are there. So dorms protection.
+	var/area/protected_areas //
 	/// An assoc list of [ref] to [timers] - a list of all the timers of people in the shadow realm currently
 	var/list/return_timers
 	/// Evil organs we can put in people
@@ -131,7 +133,11 @@
 			continue
 		if(possible_target.current.stat == DEAD)
 			continue
-
+		if(!HAS_TRAIT(possible_target, TRAIT_MIND_TEMPORARILY_GONE))
+			continue
+		for(protected_areas as anything in GLOB.dorms_areas)
+			if(!is_type_in_list(get_area(possible_target), protected_areas))
+				continue
 		valid_targets += possible_target
 
 	if(!length(valid_targets))

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -28,7 +28,7 @@
 	/// Lazylist of minds that we won't pick as targets.
 	var/list/datum/mind/target_blacklist
 	/// A list of areas that make a person immune to being sacrificed, if they are there. So dorms protection.
-	var/area/protected_areas //
+	var/area/protected_areas
 	/// An assoc list of [ref] to [timers] - a list of all the timers of people in the shadow realm currently
 	var/list/return_timers
 	/// Evil organs we can put in people

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -122,6 +122,7 @@
 /datum/heretic_knowledge/hunt_and_sacrifice/proc/obtain_targets(mob/living/user, silent = FALSE, datum/antagonist/heretic/heretic_datum)
 
 	// First construct a list of minds that are valid objective targets.
+	var/area/centcom/protected_areas
 	var/list/datum/mind/valid_targets = list()
 	for(var/datum/mind/possible_target as anything in get_crewmember_minds())
 		if(possible_target == user.mind)
@@ -134,9 +135,8 @@
 			continue
 		if(!HAS_TRAIT(possible_target, TRAIT_MIND_TEMPORARILY_GONE))
 			continue
-		for(var/area/protected_areas as anything in GLOB.dorms_areas)
-			if(!is_type_in_list(get_area(possible_target), protected_areas))
-				continue
+		if(!is_type_in_list(get_area(possible_target), protected_areas))
+			continue
 		valid_targets += possible_target
 
 	if(!length(valid_targets))

--- a/code/modules/antagonists/heretic/knowledge/void_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/void_lore.dm
@@ -127,7 +127,9 @@
 		When triggered, further silences the victim and swiftly lowers the temperature of their body and the air around them."
 	gain_text = "A gust of wind? A shimmer in the air? The presence is overwhelming, \
 		my senses began to betray me. My mind is my own enemy."
-	next_knowledge = list(/datum/heretic_knowledge/knowledge_ritual/void)
+	next_knowledge = list(
+	/datum/heretic_knowledge/knowledge_ritual/void,
+	/datum/heretic_knowledge/reroll_targets)
 	route = PATH_VOID
 	mark_type = /datum/status_effect/eldritch/void
 
@@ -155,7 +157,6 @@
 		nothing - leaving a harsh, cold breeze in their wake. They disappear, and I am left in the blizzard."
 	next_knowledge = list(
 		/datum/heretic_knowledge/blade_upgrade/void,
-		/datum/heretic_knowledge/reroll_targets,
 		/datum/heretic_knowledge/spell/blood_siphon,
 		/datum/heretic_knowledge/spell/void_prison,
 		/datum/heretic_knowledge/rune_carver,

--- a/code/modules/antagonists/heretic/knowledge/void_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/void_lore.dm
@@ -157,6 +157,7 @@
 		nothing - leaving a harsh, cold breeze in their wake. They disappear, and I am left in the blizzard."
 	next_knowledge = list(
 		/datum/heretic_knowledge/blade_upgrade/void,
+		//datum/heretic_knowledge/reroll_targets //BUBBER EDIT
 		/datum/heretic_knowledge/spell/blood_siphon,
 		/datum/heretic_knowledge/spell/void_prison,
 		/datum/heretic_knowledge/rune_carver,

--- a/code/modules/antagonists/heretic/knowledge/void_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/void_lore.dm
@@ -157,7 +157,7 @@
 		nothing - leaving a harsh, cold breeze in their wake. They disappear, and I am left in the blizzard."
 	next_knowledge = list(
 		/datum/heretic_knowledge/blade_upgrade/void,
-		//datum/heretic_knowledge/reroll_targets //BUBBER EDIT
+		// /datum/heretic_knowledge/reroll_targets, // BUBBER EDIT REMOVAL
 		/datum/heretic_knowledge/spell/blood_siphon,
 		/datum/heretic_knowledge/spell/void_prison,
 		/datum/heretic_knowledge/rune_carver,


### PR DESCRIPTION
## About The Pull Request
Hello Chat. I have no idea how to test this on a private server, have no clue if we already had these protections and don't know if the freeze will even end in a month. What I DO know is that heretic has a lot of frustration with it and that I want to do my part! So let me first say, if the dorms and ssd part is unneeded/broken and a better coder says it's easier to keep the first part than fix my spaghetti, sure, I can just commit that out, we can go with just the easier rerolls.

Now let me argue my case:
## Why It's Good For The Game
Be a heretic. Roll 5 targets. Doesn't matter when. Someone's at the bar? Oh welp it's either convince them away, success, or fail at that and now you gotta stalk them out or just go guns blazing into 5 people. None of the 6 people over there want to go through all that trouble to do the thing they want to do. That includes YOU. And depending on the type of RP there's protections.

Okay, so this is why heretics have a REROLL. Awesome, problem solved? Well... Its far down the skill tree... Now you gotta wait/gather rifts or try to get sacrifices from other people, which are guaranteed to be at least 1 secoff at least 1 head (earlier on? No way you do this!), 1 coworker, 1 random person (Plus there's Mr. Busy).  That seems like 4 more chances, but really it's 2 more. 

And well, if that person's in a very open job like botany, chef, bar, then you are going to cause a slaughter trying to get this one person.  (You cannot convince everyone, it's normal). 

So when do we get the reroll?...

3 steps away from ascencion...

So what do we do? Well if you could consult the graph:
![image](https://github.com/user-attachments/assets/312392b5-dcd3-4587-84ea-e914ac5a6985)


**We let people reroll earlier on, because neither the sacrificer nor the sacrificee wants to be involved. And there are people who WANT a fight, Roleplay, or are idly wandering halls.**

Finally, we change the price. Whoah. Whoah whoah, ssalty, why the price change? Well, very simply: 
Do you know how much of an effort it is to start a garden while on the run for PACTS WITH DARK GODS?

Very. But it's not as suspicious as carrying a flower that nobody but heretics touch. Nobody. Harebells, unlike poppies, have zero use. I don't _Want_ to argue about Back In The Day, but back in the day when this got first introduced (we are talking 3 heretic paths, gib on sacrifice) there'd be arrests and suspicions over someone just taking the damn flowers!! And since then? Nothing has changed about this mechanically. To me? This looks like:

"The antag HAS to steal an item that only they ever would touch EN MASSE, or grow them - contradicting their playstyle to sit down and watch paint dry/in case they like stealth, then having to do a meaningless chore of getting the funny flower, Or have to put in energy to get someone who doesn't want to engage _at all_ into antag stuff... When there are better options availibl! Or maybe they just straight up are stuck with ONE less sacrifice option because well unlucky, your targets are ssd or ERP'ing."


If you would consult the chart
![consult the chart](https://github.com/user-attachments/assets/418d1a28-c624-4b33-b5da-afda17006e4d)


## Proof Of Testing

![hereticced](https://github.com/user-attachments/assets/6c25ba36-5aaa-4b5f-89f0-93df9ef89aac)

</details>

## Changelog

:cl:
qol: All Mansus Worshippers can use the Relentless Heartbeat (Reroll targets) ritual earlier by two steps, so that they gain access alongside the ritual of knowledge.
qol: The mansus no longer demands harebells for the Relentless Heartbeat, however a heart is used in it's place.
fix: The Grail was very adamant on keeping people making love in their chambers out of the heretic's target list when it is made or rerolled.
/:cl: