### PR TITLE
Remove sec vendors from Moonstation hallway

### DIFF
--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -8865,7 +8865,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/iron/checker,
 /area/station/hallway/primary/central/aft)
 "czq" = (
@@ -10936,7 +10935,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "ddH" = (


### PR DESCRIPTION
## About The Pull Request

Removes a pair of sec vendors that escaped into Moonstation's primary hallway.

## Why It's Good For The Game

As funny as it is, the crew should not have readily available access to security gear.

## Changelog

:cl: LT3
map: Moonstation's escaped security vendors have been returned to where they belong
/:cl:
