### PR TITLE
Biodome Blueshield Quarters fixes.

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -1610,6 +1610,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
+"aBl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/dark_blue{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/biodome/aft)
 "aBm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash,
@@ -8485,6 +8494,18 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/medical/treatment_center)
+"cTZ" = (
+/obj/effect/landmark/start/blueshield,
+/obj/structure/chair/comfy/teal{
+	dir = 4
+	},
+/obj/machinery/button/curtain{
+	id = "bscurtain2";
+	pixel_x = -28;
+	pixel_y = -3
+	},
+/turf/open/floor/carpet/executive,
+/area/station/command/heads_quarters/blueshield)
 "cUa" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
@@ -10612,15 +10633,14 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
 "dGy" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 8
+	dir = 6
 	},
-/obj/machinery/light_switch/directional/south,
+/obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/blueshield)
 "dGD" = (
@@ -11926,11 +11946,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "edp" = (
-/obj/effect/landmark/start/blueshield,
-/obj/structure/chair/comfy/teal{
-	dir = 4
-	},
-/turf/open/floor/carpet/executive,
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/structure/closet/secure_closet/blueshield,
+/obj/item/storage/medkit/tactical/blueshield,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/blueshield)
 "edq" = (
 /obj/effect/landmark/start/paramedic,
@@ -19422,8 +19443,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/project)
 "gGd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/blueshield)
 "gGf" = (
@@ -23182,7 +23205,7 @@
 /obj/structure/closet/secure_closet/tac{
 	req_access = list("captain")
 	},
-/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/blueshield)
 "ibC" = (
@@ -27600,10 +27623,12 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "jGx" = (
-/obj/structure/closet/secure_closet/blueshield,
-/obj/item/storage/medkit/tactical/blueshield,
-/obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/machinery/modular_computer/preset/command,
+/obj/item/radio/intercom/directional/east,
+/obj/machinery/requests_console/auto_name/directional/north,
+/obj/effect/mapping_helpers/requests_console/announcement,
+/obj/effect/mapping_helpers/requests_console/information,
+/turf/open/floor/iron/dark/textured,
 /area/station/command/heads_quarters/blueshield)
 "jGz" = (
 /obj/structure/table/wood,
@@ -32861,6 +32886,19 @@
 "lqK" = (
 /turf/closed/wall,
 /area/station/cargo/sorting)
+"lqO" = (
+/obj/structure/table/wood/fancy/cyan,
+/obj/item/storage/fancy/donut_box{
+	pixel_y = 16
+	},
+/obj/machinery/recharger{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/carpet/executive,
+/area/station/command/heads_quarters/blueshield)
 "lqP" = (
 /obj/machinery/rnd/production/techfab/department/service,
 /obj/structure/sign/poster/official/random/directional/west,
@@ -38979,15 +39017,11 @@
 /area/station/service/library)
 "nsf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/table/wood/fancy/cyan,
-/obj/machinery/recharger{
-	pixel_x = 5;
-	pixel_y = 2
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
 	},
-/obj/item/storage/fancy/donut_box{
-	pixel_y = 16
-	},
-/turf/open/floor/carpet/executive,
+/obj/machinery/holopad,
+/turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/blueshield)
 "nsg" = (
 /obj/structure/sign/poster/random/directional/south,
@@ -42886,7 +42920,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/machinery/jukebox/no_access,
+/obj/machinery/jukebox/public,
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "oGU" = (
@@ -49248,12 +49282,13 @@
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
 "qSY" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/machinery/suit_storage_unit/security,
+/obj/machinery/door/window/brigdoor/right/directional/east{
+	req_access = list("captain");
+	name = "Blueshield's Armory"
 	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/wood/parquet,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/blueshield)
 "qTg" = (
 /obj/structure/chair{
@@ -51641,10 +51676,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "rGd" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
+/obj/machinery/light_switch/directional/east,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
 	},
-/obj/machinery/power/apc/auto_name/directional/east,
+/obj/effect/landmark/start/blueshield,
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/blueshield)
 "rGg" = (
@@ -55959,12 +55995,16 @@
 /turf/open/floor/wood/large,
 /area/station/service/theater)
 "tgT" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain/cloth/fancy/mechanical/start_closed{
+	icon_state = "bounty-closed";
+	icon_type = "bounty";
+	id = "bscurtain2";
+	name = "curtain"
 	},
-/obj/effect/landmark/start/blueshield,
-/turf/open/floor/carpet/executive,
-/area/station/command/heads_quarters/captain)
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/blueshield)
 "tgU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/engine,
@@ -63167,13 +63207,10 @@
 /turf/open/floor/plating,
 /area/station/construction)
 "vMh" = (
-/obj/machinery/suit_storage_unit/security,
-/obj/machinery/light/directional/north,
-/obj/machinery/door/window/brigdoor/right/directional/south{
-	req_access = list("captain");
-	name = "Blueshield's Armory"
-	},
-/turf/open/floor/iron/dark/smooth_large,
+/obj/machinery/computer/crew,
+/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark/textured,
 /area/station/command/heads_quarters/blueshield)
 "vMr" = (
 /obj/structure/cable,
@@ -65862,6 +65899,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"wCV" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/railing/wooden_fencing{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/biodome/aft)
 "wDd" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -66831,6 +66877,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/navigate_destination/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/cent_com/rep_or_captain,
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/blueshield)
 "wUh" = (
@@ -109983,9 +110030,9 @@ fBY
 odZ
 oxI
 oHx
-tgT
+oHx
 vEK
-bmc
+upY
 bmc
 bmc
 gHP
@@ -110243,7 +110290,7 @@ vYg
 xlG
 mba
 bmc
-upY
+bmc
 pKz
 gHP
 bMe
@@ -111021,8 +111068,8 @@ fNG
 vMh
 gGd
 nsf
-pFO
-pnf
+cTZ
+tgT
 svn
 pnf
 pnf
@@ -111278,8 +111325,8 @@ pFO
 jGx
 rGd
 dGy
-pFO
-pnf
+lqO
+tgT
 pnf
 pnf
 pnf
@@ -111536,7 +111583,7 @@ pFO
 pFO
 wUg
 pFO
-pnf
+pFO
 pnf
 pnf
 aZR
@@ -111788,10 +111835,10 @@ izf
 wFQ
 fOu
 fOu
+wCV
 kqS
 kqS
-kqS
-mZn
+aBl
 mZn
 rsY
 rsY

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -1610,15 +1610,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
-"aBl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 8
-	},
-/turf/open/floor/wood/large,
-/area/station/biodome/aft)
 "aBm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash,
@@ -8494,18 +8485,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/medical/treatment_center)
-"cTZ" = (
-/obj/effect/landmark/start/blueshield,
-/obj/structure/chair/comfy/teal{
-	dir = 4
-	},
-/obj/machinery/button/curtain{
-	id = "bscurtain2";
-	pixel_x = -28;
-	pixel_y = -3
-	},
-/turf/open/floor/carpet/executive,
-/area/station/command/heads_quarters/blueshield)
 "cUa" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
@@ -11950,7 +11929,6 @@
 /obj/structure/closet/secure_closet/blueshield,
 /obj/item/storage/medkit/tactical/blueshield,
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/blueshield)
 "edq" = (
@@ -16044,6 +16022,17 @@
 /obj/structure/railing/corner,
 /turf/open/openspace,
 /area/station/biodome/fore)
+"fyk" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain/cloth/fancy/mechanical/start_closed{
+	icon_state = "bounty-closed";
+	icon_type = "bounty";
+	id = "bscurtain2";
+	name = "curtain"
+	},
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/blueshield)
 "fyu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -28911,6 +28900,19 @@
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"kcP" = (
+/obj/structure/table/wood/fancy/cyan,
+/obj/item/storage/fancy/donut_box{
+	pixel_y = 16
+	},
+/obj/machinery/recharger{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/carpet/executive,
+/area/station/command/heads_quarters/blueshield)
 "kcS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -32886,19 +32888,6 @@
 "lqK" = (
 /turf/closed/wall,
 /area/station/cargo/sorting)
-"lqO" = (
-/obj/structure/table/wood/fancy/cyan,
-/obj/item/storage/fancy/donut_box{
-	pixel_y = 16
-	},
-/obj/machinery/recharger{
-	pixel_x = 5;
-	pixel_y = 2
-	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/turf/open/floor/carpet/executive,
-/area/station/command/heads_quarters/blueshield)
 "lqP" = (
 /obj/machinery/rnd/production/techfab/department/service,
 /obj/structure/sign/poster/official/random/directional/west,
@@ -49288,6 +49277,7 @@
 	name = "Blueshield's Armory"
 	},
 /obj/machinery/light/directional/west,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/blueshield)
 "qTg" = (
@@ -55995,16 +55985,14 @@
 /turf/open/floor/wood/large,
 /area/station/service/theater)
 "tgT" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/curtain/cloth/fancy/mechanical/start_closed{
-	icon_state = "bounty-closed";
-	icon_type = "bounty";
-	id = "bscurtain2";
-	name = "curtain"
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/station/command/heads_quarters/blueshield)
+/obj/structure/railing/wooden_fencing{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/biodome/aft)
 "tgU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/engine,
@@ -58381,6 +58369,15 @@
 "tYp" = (
 /turf/open/floor/carpet/red,
 /area/station/hallway/secondary/exit/departure_lounge)
+"tYG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/dark_blue{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/biodome/aft)
 "tYO" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/decal/cleanable/molten_object/large,
@@ -63156,6 +63153,18 @@
 /obj/structure/chair/sofa/bench/left,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"vLB" = (
+/obj/effect/landmark/start/blueshield,
+/obj/structure/chair/comfy/teal{
+	dir = 4
+	},
+/obj/machinery/button/curtain{
+	id = "bscurtain2";
+	pixel_x = -28;
+	pixel_y = -3
+	},
+/turf/open/floor/carpet/executive,
+/area/station/command/heads_quarters/blueshield)
 "vLD" = (
 /obj/structure/chair/stool/directional/south,
 /obj/effect/turf_decal/trimline/red/warning,
@@ -65899,15 +65908,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"wCV" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/structure/railing/wooden_fencing{
-	dir = 8
-	},
-/turf/open/floor/wood/large,
-/area/station/biodome/aft)
 "wDd" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -66878,6 +66878,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/navigate_destination/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/cent_com/rep_or_captain,
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/blueshield)
 "wUh" = (
@@ -111068,8 +111069,8 @@ fNG
 vMh
 gGd
 nsf
-cTZ
-tgT
+vLB
+fyk
 svn
 pnf
 pnf
@@ -111325,8 +111326,8 @@ pFO
 jGx
 rGd
 dGy
-lqO
-tgT
+kcP
+fyk
 pnf
 pnf
 pnf
@@ -111835,10 +111836,10 @@ izf
 wFQ
 fOu
 fOu
-wCV
+tgT
 kqS
 kqS
-aBl
+tYG
 mZn
 rsY
 rsY

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -2908,6 +2908,15 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
+"aWJ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/railing/wooden_fencing{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/biodome/aft)
 "aWO" = (
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
@@ -16022,17 +16031,6 @@
 /obj/structure/railing/corner,
 /turf/open/openspace,
 /area/station/biodome/fore)
-"fyk" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/curtain/cloth/fancy/mechanical/start_closed{
-	icon_state = "bounty-closed";
-	icon_type = "bounty";
-	id = "bscurtain2";
-	name = "curtain"
-	},
-/turf/open/floor/plating,
-/area/station/command/heads_quarters/blueshield)
 "fyu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -17175,6 +17173,17 @@
 	},
 /turf/open/floor/stone,
 /area/station/biodome/fore)
+"fSp" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain/cloth/fancy/mechanical/start_closed{
+	icon_state = "bounty-closed";
+	icon_type = "bounty";
+	id = "bscurtain2";
+	name = "curtain"
+	},
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/blueshield)
 "fSu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -28900,19 +28909,6 @@
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
-"kcP" = (
-/obj/structure/table/wood/fancy/cyan,
-/obj/item/storage/fancy/donut_box{
-	pixel_y = 16
-	},
-/obj/machinery/recharger{
-	pixel_x = 5;
-	pixel_y = 2
-	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/turf/open/floor/carpet/executive,
-/area/station/command/heads_quarters/blueshield)
 "kcS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -42909,7 +42905,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/machinery/jukebox/public,
+/obj/machinery/jukebox/no_access,
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "oGU" = (
@@ -49504,6 +49500,19 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"qVO" = (
+/obj/structure/table/wood/fancy/cyan,
+/obj/item/storage/fancy/donut_box{
+	pixel_y = 16
+	},
+/obj/machinery/recharger{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/carpet/executive,
+/area/station/command/heads_quarters/blueshield)
 "qVP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -55985,14 +55994,17 @@
 /turf/open/floor/wood/large,
 /area/station/service/theater)
 "tgT" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
+/obj/effect/landmark/start/blueshield,
+/obj/structure/chair/comfy/teal{
+	dir = 4
 	},
-/obj/structure/railing/wooden_fencing{
-	dir = 8
+/obj/machinery/button/curtain{
+	id = "bscurtain2";
+	pixel_x = -28;
+	pixel_y = -3
 	},
-/turf/open/floor/wood/large,
-/area/station/biodome/aft)
+/turf/open/floor/carpet/executive,
+/area/station/command/heads_quarters/blueshield)
 "tgU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/engine,
@@ -56055,6 +56067,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/large,
 /area/station/hallway/primary/aft)
+"tix" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/dark_blue{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/biodome/aft)
 "tiC" = (
 /obj/structure/showcase/machinery/cloning_pod{
 	desc = "An old decommissioned scanner, permanently scuttled.";
@@ -58369,15 +58390,6 @@
 "tYp" = (
 /turf/open/floor/carpet/red,
 /area/station/hallway/secondary/exit/departure_lounge)
-"tYG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 8
-	},
-/turf/open/floor/wood/large,
-/area/station/biodome/aft)
 "tYO" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/decal/cleanable/molten_object/large,
@@ -63153,18 +63165,6 @@
 /obj/structure/chair/sofa/bench/left,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"vLB" = (
-/obj/effect/landmark/start/blueshield,
-/obj/structure/chair/comfy/teal{
-	dir = 4
-	},
-/obj/machinery/button/curtain{
-	id = "bscurtain2";
-	pixel_x = -28;
-	pixel_y = -3
-	},
-/turf/open/floor/carpet/executive,
-/area/station/command/heads_quarters/blueshield)
 "vLD" = (
 /obj/structure/chair/stool/directional/south,
 /obj/effect/turf_decal/trimline/red/warning,
@@ -111069,8 +111069,8 @@ fNG
 vMh
 gGd
 nsf
-vLB
-fyk
+tgT
+fSp
 svn
 pnf
 pnf
@@ -111326,8 +111326,8 @@ pFO
 jGx
 rGd
 dGy
-kcP
-fyk
+qVO
+fSp
 pnf
 pnf
 pnf
@@ -111836,10 +111836,10 @@ izf
 wFQ
 fOu
 fOu
-tgT
+aWJ
 kqS
 kqS
-tYG
+tix
 mZn
 rsY
 rsY


### PR DESCRIPTION
## About The Pull Request

This PR fixes a few issues with the Blueshield Quarters on Biodome and adds a few more essentials for the room.

This fixes the access for the Blueshield Quarters airlock along with missing cable for the APC.
This also expands the room for the addition of a two computers. This also adds: A wall camera, holopad, request console, intercom, windows and curtains, fire door, and a newscaster.

## Why It's Good For The Game

It's usually good for an airlock for a restricted command area to not be accessible to assistants.

## Proof Of Testing

StrongDMM:
![image](https://github.com/user-attachments/assets/b52355af-7d43-434d-929c-f0331b362601)

In a local:
![image](https://github.com/user-attachments/assets/b99bc97b-f58e-47c5-bbd8-a6991314c1f0)

## Changelog

:cl:
map: The Blueshield Quarters on Biodome is no longer free to access by anyone. It has also been expanded.
/:cl:

