### PR TITLE
Make gas miner beacons clean up after themselves

### DIFF
--- a/modular_skyrat/modules/modular_items/code/summon_beacon.dm
+++ b/modular_skyrat/modules/modular_items/code/summon_beacon.dm
@@ -150,4 +150,3 @@
 	)
 
 	area_string = "atmospherics"
-	supply_pod_stay = TRUE


### PR DESCRIPTION
## About The Pull Request

Change gas miner beacons to be the kind that delete the delivery pod once they've landed

## Why It's Good For The Game

At ten thousand credits a piece you'd think NT would spring for the bluespace ones (the pod staying in the chamber is so ugly and I hate it)

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/3e41bb72-34b0-4aa4-9978-61908d3877ab)

</details>

## Changelog

:cl:
qol: gas miner delivery pods now delete themselves after landing.
/:cl:

