### PR TITLE
Increases Blob Max mass points. (175)

### DIFF
--- a/code/__DEFINES/blob_defines.dm
+++ b/code/__DEFINES/blob_defines.dm
@@ -1,6 +1,6 @@
 // Overmind defines
 
-#define OVERMIND_MAX_POINTS_DEFAULT 999 // Max point storage. Bubber edit, original: 100. Good luck reaching that cap.
+#define OVERMIND_MAX_POINTS_DEFAULT 175 // Max point storage. Bubber edit, original: 100. Good luck reaching that cap.
 #define OVERMIND_STARTING_POINTS 60 // Points granted upon start
 #define OVERMIND_STARTING_REROLLS 1 // Free strain rerolls at the start
 #define OVERMIND_STARTING_MIN_PLACE_TIME (1 MINUTES) // Minimum time before the core can be placed

--- a/code/__DEFINES/blob_defines.dm
+++ b/code/__DEFINES/blob_defines.dm
@@ -1,6 +1,6 @@
 // Overmind defines
 
-#define OVERMIND_MAX_POINTS_DEFAULT 100 // Max point storage
+#define OVERMIND_MAX_POINTS_DEFAULT 999 // Max point storage. Bubber edit, original: 100. Good luck reaching that cap.
 #define OVERMIND_STARTING_POINTS 60 // Points granted upon start
 #define OVERMIND_STARTING_REROLLS 1 // Free strain rerolls at the start
 #define OVERMIND_STARTING_MIN_PLACE_TIME (1 MINUTES) // Minimum time before the core can be placed


### PR DESCRIPTION
## About The Pull Request

Increases blob max biomass from 100 to 175.
## Why It's Good For The Game

Let's be real, Blob is the most CBT'd antag role of the server with currently zero chances to win against a late-game fully armed crew who can easily distribute guns and build emitters to counter them. This basically buffs a bit the Blob back with just lazily increasing their stored mass cap to get a bit of chance of getting a comeback when the crew least expect it.

## Proof Of Testing

idk, I just changed numbers.

</details>

## Changelog
:cl:
balance: Blob's mass cap reaches to 175
/:cl:
