### PR TITLE
Make jukebox in boxstation bar all access

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -36237,7 +36237,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/machinery/jukebox,
+/obj/machinery/jukebox/no_access,
 /turf/open/floor/stone,
 /area/station/service/bar)
 "eIo" = (


### PR DESCRIPTION
## About The Pull Request

Change the jukebox in boxstation's bar to the `no_access` subtype so anyone can use it

## Why It's Good For The Game

It's in a public area not behind the counter, let people use it

## Proof Of Testing

Compiles

## Changelog

:cl:
map: Boxstation's bar jukebox is no longer access locked.
/:cl:

