### PR TITLE
Cargonstein; or, The Modern Shuttlefix

### DIFF
--- a/_maps/shuttles/skyrat/cargo_skyrat.dmm
+++ b/_maps/shuttles/skyrat/cargo_skyrat.dmm
@@ -111,7 +111,7 @@
 "uk" = (
 /obj/machinery/conveyor{
 	dir = 8;
-	id = "cargoload"
+	id = "QMLoad"
 	},
 /obj/machinery/door/poddoor{
 	id = "QMLoaddoor";
@@ -194,7 +194,7 @@
 "Xz" = (
 /obj/machinery/conveyor{
 	dir = 4;
-	id = "cargounload"
+	id = "QMLoad2"
 	},
 /obj/machinery/door/poddoor{
 	id = "QMLoaddoor2";


### PR DESCRIPTION

## About The Pull Request
As I have noticed and was told, Skyrat/Stellar Haven's old cargo shuttle uses conveyor IDs different from others: "cargoload" and "cargounload" instead of "QMLoad" and "QMLoad2". I have changed the shuttle's conveyor IDs to the usual QMs, to make it fully functionally compatible with maps in rotation.
## Why It's Good For The Game

It cuts down on needless labor of reinstalling the conveyor lines every shift start.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
![2024-12-27_22-53-04](https://github.com/user-attachments/assets/ce9696e0-b7c6-48dd-a8a9-49c872410f80)
</details>

## Changelog
:cl:
fix: replaced a redundant var with actual
map: tweaked SR/SH cargo shuttle
/:cl:
