### PR TITLE
Fix Engineering plumbing constructor not being researchable

### DIFF
--- a/modular_skyrat/master_files/code/modules/research/techweb/all_nodes.dm
+++ b/modular_skyrat/master_files/code/modules/research/techweb/all_nodes.dm
@@ -192,6 +192,12 @@
 	)
 	return ..()
 
+/datum/techweb_node/chem_synthesis/New()
+	design_ids += list(
+		"plumbing_eng",
+	)
+	return ..()
+
 // Modularly removes x-ray and thermals from here, it's in adv_vision instead
 /datum/techweb_node/cyber/cyber_organs_adv/New()
 	design_ids -= list(
@@ -247,12 +253,6 @@
 /datum/techweb_node/exp_tools/New()
 	design_ids += list(
 		"multi_cell_charger",
-	)
-	return ..()
-
-/datum/techweb_node/plumbing/New()
-	design_ids += list(
-		"plumbing_eng",
 	)
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request

Add the engineering plumbing constructor design to the chemical synthesis techweb node with the rest of the plumbing constructors because `/datum/techweb_node/plumbing` is not a real thing

## Why It's Good For The Game

Bug fix

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/c57cb654-9cb9-4d20-a942-fd2dcb794344)

</details>

## Changelog

:cl:
fix: fixed the engineering plumbing constructor not appearing in protolathes.
/:cl:
