### PR TITLE
Shuttle boards are now printable for mining and public shuttle

### DIFF
--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -395,3 +395,23 @@
 		RND_CATEGORY_COMPUTER + RND_SUBCATEGORY_COMPUTER_RECORDS
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SERVICE
+
+/datum/design/board/aiupload
+	name = "Public Lavaland Shuttle Board"
+	desc = "Allows for the construction of circuit boards used to build a Lavaland Shuttle Console."
+	id = "lavalandshuttle"
+	build_path = /obj/item/circuitboard/computer/mining_shuttle/common
+	category = list(
+		RND_CATEGORY_COMPUTER + RND_SUBCATEGORY_COMPUTER_CARGO
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_CARGO | DEPARTMENT_BITFLAG_ENGINEERING
+
+/datum/design/board/aiupload
+	name = "Mining Shuttle Board"
+	desc = "Allows for the construction of circuit boards used to build a Mining Shuttle Console."
+	id = "miningshuttle"
+	build_path = /obj/item/circuitboard/computer/mining_shuttle
+	category = list(
+		RND_CATEGORY_COMPUTER + RND_SUBCATEGORY_COMPUTER_CARGO
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_CARGO

--- a/code/modules/research/techweb/nodes/mining_nodes.dm
+++ b/code/modules/research/techweb/nodes/mining_nodes.dm
@@ -46,6 +46,9 @@
 		"mod_gps",
 		"mod_visor_meson",
 		"mesons",
+		"lavalandshuttle",
+		"miningshuttle",
+
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_1_POINTS)
 	announce_channels = list(RADIO_CHANNEL_SUPPLY)


### PR DESCRIPTION

## About The Pull Request

Pretty self-explanatory. Can be printed now, and researched in the same node as mining tech too.

does NOT allow you to MAKE a shuttle. Just allows control of the existing ones.

## Why It's Good For The Game

I got ahelped saying that It needed admin intervention to get the boards back (So what?) and that I wasn't allowed to do it. Thats lame. So now you can print new ones, same as any other console.

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/0053141a-2abd-4ef6-809f-288331f2949c)

</details>

## Changelog
:cl:
add: Adds shuttle boards to engineering and cargo.
/:cl:
