### PR TITLE
Fix Kilostation supermatter air alarm not being linked to the chamber

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -59959,7 +59959,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/machinery/air_sensor/engine_chamber,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "tCQ" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -17268,6 +17268,10 @@
 	pixel_y = -24
 	},
 /obj/effect/mapping_helpers/airalarm/engine_access,
+/obj/effect/mapping_helpers/airalarm/link{
+	chamber_id = "engine"
+	},
+/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "fKJ" = (
@@ -50980,6 +50984,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos/storage/gas)
+"qPu" = (
+/obj/machinery/air_sensor/engine_chamber,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter)
 "qPz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -59951,6 +59959,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/machinery/air_sensor/engine_chamber,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "tCQ" = (
@@ -110280,7 +110289,7 @@ uqD
 kBz
 vyN
 mda
-vyN
+qPu
 dGG
 vyN
 eVL


### PR DESCRIPTION
## About The Pull Request

Add a gas sensor to the Kilo SM chamber and the map helpers necessary to connect it to the air alarm outside

## Why It's Good For The Game

Currently the air alarm gives you an atmos reading of the engine room itself not the chamber which is useless

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/c8798446-dfa4-4ac3-829c-aa7be976c34c)

</details>

## Changelog

:cl:
map: fixed Kilostation engine room air alarm not giving readings from inside the chamber.
/:cl:
