### PR TITLE
System cleaner sobers up synths.

### DIFF
--- a/modular_skyrat/modules/synths/code/reagents/reagents.dm
+++ b/modular_skyrat/modules/synths/code/reagents/reagents.dm
@@ -27,6 +27,7 @@
 /datum/reagent/medicine/system_cleaner/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	affected_mob.adjustToxLoss(-2 * REM * seconds_per_tick, 0)
 	affected_mob.adjust_disgust(-5 * REM * seconds_per_tick)
+	affected_mob.adjust_drunk_effect(-10 * REM * seconds_per_tick)
 	var/remove_amount = 1 * REM * seconds_per_tick;
 	for(var/thing in affected_mob.reagents.reagent_list)
 		var/datum/reagent/reagent = thing


### PR DESCRIPTION

## About The Pull Request

In short this makes it so that system cleaner cleans alcohol out of one's system, much like a weaker antihol. So synths can be sobered up.

## Why It's Good For The Game

Getting too drunk as a synth is irksome, since they can't process antihol or water. Also gives more use to system cleaner besides just purging chems.

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
Before:

![image](https://github.com/user-attachments/assets/964d6ed4-4cd1-4a89-82a0-15b895577f1f)

After:

![image](https://github.com/user-attachments/assets/c66368f0-fa60-476c-a19b-e9326aece4d0)

</details>

## Changelog
:cl:
qol: System cleaner now sobers up synthetics.
/:cl:
