### PR TITLE
Speedmerge of Upstream CD delay on all action buttons

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -101,6 +101,7 @@ DEFINE_BITFIELD(status_flags, list(
 #define CLICK_CD_RAPID 2
 #define CLICK_CD_HYPER_RAPID 1
 #define CLICK_CD_SLOW 10
+#define CLICK_CD_ACTIVATE_ABILITY 1
 
 #define CLICK_CD_THROW 8
 #define CLICK_CD_RANGE 4

--- a/code/datums/actions/action.dm
+++ b/code/datums/actions/action.dm
@@ -427,5 +427,5 @@
 		if(source.next_click > world.time)
 			return
 		else
-			source.next_click = world.time + CLICK_CD_RANGE
+			source.next_click = world.time + CLICK_CD_ACTIVATE_ABILITY
 	INVOKE_ASYNC(src, PROC_REF(Trigger))


### PR DESCRIPTION
## About The Pull Request

SPEEDMERGE FROM UPSTREAM TG
This PR reduces the cooldown on selecting which spell to cast using hotkeys. This is because hotkeys have a different cooldown than using your mouse to click the icons. I do not think there should be a reason for using hotkeys to do the same thing as clicking to be clunky to the point shown in videos below.

## Why It's Good For the game
Previous
https://github.com/user-attachments/assets/91814a17-c753-4c4b-b5cc-68e1be5528ac
Introduced here
https://github.com/user-attachments/assets/d9db3834-fc56-4a77-b4ef-4948c72b3334

Less clunky, easier to chain abilities. **It works on every single ui button, not just spells btw. So modsuit modules that require targetting, pretty much everything.**
(Huge thanks to ArturLang for the help with this)
## Changelog
:cl:
qol: Selecting which spells to cast with hotkeys, and using them in general is faster.
/:cl:

