### PR TITLE
Fixes BDM eye's buff duration.(I believe.)

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -74,8 +74,8 @@
 
 /datum/status_effect/blooddrunk
 	id = "blooddrunk"
-	duration = 1 SECONDS
-//	tick_interval = -1 
+	duration = 15
+	tick_interval = -1 
 	alert_type = /atom/movable/screen/alert/status_effect/blooddrunk
 
 /atom/movable/screen/alert/status_effect/blooddrunk

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -74,8 +74,8 @@
 
 /datum/status_effect/blooddrunk
 	id = "blooddrunk"
-	duration = 10
-	tick_interval = -1
+	duration = 1 SECONDS
+//	tick_interval = -1 
 	alert_type = /atom/movable/screen/alert/status_effect/blooddrunk
 
 /atom/movable/screen/alert/status_effect/blooddrunk

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -75,7 +75,7 @@
 /datum/status_effect/blooddrunk
 	id = "blooddrunk"
 	duration = 15
-	tick_interval = -1 
+	tick_interval = -1
 	alert_type = /atom/movable/screen/alert/status_effect/blooddrunk
 
 /atom/movable/screen/alert/status_effect/blooddrunk


### PR DESCRIPTION
## About The Pull Request

Makes the BDM eye's buff actually last for one second as it promises.
## Why It's Good For The Game

I began to wonder why the BDM eye isn't properly working, I was near to double or triple up its duration until I realized it was coded like it was using ticks when apparently the buff codiing seems to be really using seconds instead. I hope this fixes the BDM and makes it work as intended.

Edit: I reverted the requested change and I increased the ticks instead from 10 to 15 ticks.

## Proof Of Testing

Local test seems to work fine.

## Changelog
:cl:
fix: Blood-drunk buff should really last for 1 second.
/:cl:
