### PR TITLE
Add a growing vat to Void Raptor cytology

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -81356,6 +81356,7 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 8
 	},
+/obj/machinery/vatgrower,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/xenobiology)
 "wBT" = (


### PR DESCRIPTION
## About The Pull Request

Add a growing vat to the Void Raptor cytology pen

## Why It's Good For The Game

It's like the main thing they need to do cytology and there isn't one

## Proof Of Testing

Compiled

## Changelog

:cl:
map: added a growing vat to Void Raptor's cytology pen.
/:cl:

