### PR TITLE
Shortening That Godawful Akko Wordwall

### DIFF
--- a/modular_skyrat/modules/customization/modules/language/te_velu_akko.dm
+++ b/modular_skyrat/modules/customization/modules/language/te_velu_akko.dm
@@ -1,14 +1,6 @@
 /datum/language/akulan
     name = "Te Velu Akko"
-    desc = "Translating to 'The Song of The King,' this language was singlehandedly invented and promulgated by the third King of Agurkrral, Akko the Uniter. \
-        Records show that the King had personally created it so that those with little education, including aliens, could integrate easier with Azulean society. \
-        To this end, the language is known for its rapid pace of learning, the written portion being readily mastered within two weeks, a tongue characterized by hard consonants followed by soft vowel strings. \
-        An underwater component exists, fleshed out and codified by deepwater reformists in the later portions of Akko the Uniter's life; featuring great emphasis on close physical proximity, variations of pitch, high-frequency sounds, and clicking. \
-        Alien tourists frequently either seek temporary genemods, or specialized organisms that dwell in the throat to be able to speak this portion., \n\n\
-        Differences exist in dialect between the Old Principalities and New Principalities; \
-        The Old sounds far slower and smoother, words flowing into each other in a very melodic way; befitting of the language's name. \
-        The New is much faster, more harsh, and more aggressive in an attempt to be more efficient; however, rapidly adopting new loanwords from alien tongues. \
-        A common greeting no matter where one is in Agurkrral is to essentially bump noses, allowing the other Azulean to feel the speaker's bioelectric field."
+    desc = "The flowing, rhythmic language of the Akula, a language created in their distant times by one of their first leaders. The older form has much more flow and cadence, while the current popular form is more quick and harsh, making it easy to find most Old Nobles and hardliners just by dialect. One could compare the sound of Akko to that of the Terran Maori language."
 
 
     key = "Z"


### PR DESCRIPTION
Because I forgot to do it during the Great Rewrite.

## About The Pull Request

During the Great Akula Lore Rewrite I shortened almost everything Akula-related I could find, but I forgot to shorten the infamous and godsawful text for the sparkledog-sounding Akula language. This changes that.

## Why It's Good For The Game

It shortens that insane wall of text to be more in line with the majority of the language descriptions: short, sweet, and to the point.

## Proof Of Testing

![image](https://github.com/user-attachments/assets/0a44f277-b536-434a-9935-296eba238f35)


## Changelog

:cl:
fix: Fixed the Akula language description to be of consistent length with the rest of the languages, instead of the wordwall it was.
/:cl:
