### PR TITLE
Fix people with anosmia smelling pollution

### DIFF
--- a/modular_skyrat/modules/pollution/code/pollution.dm
+++ b/modular_skyrat/modules/pollution/code/pollution.dm
@@ -38,6 +38,9 @@
 
 /// When a user smells this pollution
 /datum/pollution/proc/smell_act(mob/living/sniffer)
+	if(HAS_TRAIT(sniffer, TRAIT_ANOSMIA))
+		return
+
 	var/list/singleton_cache = SSpollution.singletons
 	var/datum/pollutant/dominant_pollutant
 	var/dominiant_smell_power


### PR DESCRIPTION
## About The Pull Request

Check for anosmia trait in `/datum/pollution/smell_act`
## Why It's Good For The Game

Anosmics shouldn't be smelling stuff!!

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/3c3a04a1-a922-4d88-91e0-0b2476860db3)

</details>

## Changelog

:cl:
fix: fixed mobs with anosmia still smelling pollution.
/:cl:

