### PR TITLE
Adds Cytopro to Void Raptor

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -45389,6 +45389,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
+/obj/machinery/vending/cytopro,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},


### PR DESCRIPTION

## About The Pull Request
Add a Cytopro to cytology in Void Raptor (this is my first PR on here if I fucked it up sorry)

## Why It's Good For The Game
parity with TG maps 

## Proof Of Testing
It compiled fine
<details>

![image](https://github.com/user-attachments/assets/e5729505-fd78-4244-9767-271e8b357b42)

<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
map: added Cytopro to Void Raptor's cytology.
/:cl:
