### PR TITLE
Make moonstation jukebox all access

### DIFF
--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -30971,7 +30971,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "iBj" = (
-/obj/machinery/jukebox,
+/obj/machinery/jukebox/no_access,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "iBl" = (


### PR DESCRIPTION
## About The Pull Request

Makes the jukebox in Moonstation's bar the all access subtype

## Why It's Good For The Game

The music must be democratized

## Proof Of Testing

It compile

## Changelog

:cl:
map: Moonstation's bar jukebox is no longer access locked.
/:cl:
