### PR TITLE
Makes roundstart jellypeople not 50% resistant to burns

### DIFF
--- a/modular_skyrat/modules/bodyparts/code/roundstartslime_bodyparts.dm
+++ b/modular_skyrat/modules/bodyparts/code/roundstartslime_bodyparts.dm
@@ -5,24 +5,30 @@
 	icon_greyscale = BODYPART_ICON_ROUNDSTARTSLIME
 	biological_state = (BIO_FLESH|BIO_BLOODED)
 	teeth_count = 0
+	burn_modifier = 1
 
 /obj/item/bodypart/chest/jelly/slime/roundstart
 	is_dimorphic = TRUE
 	icon_greyscale = BODYPART_ICON_ROUNDSTARTSLIME
 	biological_state = (BIO_FLESH|BIO_BLOODED)
+	burn_modifier = 1
 
 /obj/item/bodypart/arm/left/jelly/slime/roundstart
 	icon_greyscale = BODYPART_ICON_ROUNDSTARTSLIME
 	biological_state = (BIO_FLESH|BIO_BLOODED)
+	burn_modifier = 1
 
 /obj/item/bodypart/arm/right/jelly/slime/roundstart
 	icon_greyscale = BODYPART_ICON_ROUNDSTARTSLIME
 	biological_state = (BIO_FLESH|BIO_BLOODED)
+	burn_modifier = 1
 
 /obj/item/bodypart/leg/left/jelly/slime/roundstart
 	icon_greyscale = BODYPART_ICON_ROUNDSTARTSLIME
 	biological_state = (BIO_FLESH|BIO_BLOODED)
+	burn_modifier = 1
 
 /obj/item/bodypart/leg/right/jelly/slime/roundstart
 	icon_greyscale = BODYPART_ICON_ROUNDSTARTSLIME
 	biological_state = (BIO_FLESH|BIO_BLOODED)
+	burn_modifier = 1


### PR DESCRIPTION
## About The Pull Request
Ditto as title, it's kind of *really strong* especially for bloodsuckers

## Why It's Good For The Game
50% damage resist vs a large majority of damage is horrifying

## Proof Of Testing

![image](https://github.com/user-attachments/assets/01484065-922d-4a27-a335-276a5da693ad)


## Changelog

:cl:
balance: Roundstart slimepeople no longer get 50% burn damage type resist on limbs
/:cl:

