### PR TITLE
Wearable HUD Toggle #88825

### DIFF
--- a/code/datums/actions/items/toggles.dm
+++ b/code/datums/actions/items/toggles.dm
@@ -118,6 +118,17 @@
 /datum/action/item_action/call_link
 	name = "Call MODlink"
 
+/datum/action/item_action/toggle_wearable_hud
+	name = "Toggle Wearable HUD"
+	desc = "Toggles your wearable HUD. You can still access examine information while it's off."
+
+/datum/action/item_action/toggle_wearable_hud/Trigger(trigger_flags)
+	. = ..()
+	if(!.)
+		return
+	var/obj/item/clothing/glasses/hud/hud_display = target
+	hud_display.toggle_hud_display(owner)
+
 /datum/action/item_action/toggle_nv
 	name = "Toggle Night Vision"
 	var/stored_cutoffs

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -2,6 +2,9 @@
 	name = "HUD"
 	desc = "A heads-up display that provides important info in (almost) real time."
 	flags_1 = null //doesn't protect eyes because it's a monocle, duh
+	actions_types = list(/datum/action/item_action/toggle_wearable_hud)
+	/// Whether the HUD info is on or off
+	var/display_active = TRUE
 
 /obj/item/clothing/glasses/hud/emp_act(severity)
 	. = ..()
@@ -31,6 +34,23 @@
 		else
 			user.say("WHY IS THERE A BAR ON MY HEAD?!!")
 	return OXYLOSS
+
+/obj/item/clothing/glasses/hud/equipped(mob/living/user, slot)
+	. = ..()
+	display_active = TRUE
+
+/obj/item/clothing/glasses/hud/proc/toggle_hud_display(mob/living/carbon/eye_owner)
+	if(display_active)
+		display_active = FALSE
+		for(var/hud_trait as anything in clothing_traits)
+			REMOVE_CLOTHING_TRAIT(eye_owner, hud_trait)
+		balloon_alert(eye_owner, "hud disabled")
+		return
+
+	display_active = TRUE
+	for(var/hud_trait as anything in clothing_traits)
+		ADD_CLOTHING_TRAIT(eye_owner, hud_trait)
+	balloon_alert(eye_owner, "hud enabled")
 
 /obj/item/clothing/glasses/hud/health
 	name = "health scanner HUD"

--- a/html/changelogs/AutoChangeLog-pr-88825.yml
+++ b/html/changelogs/AutoChangeLog-pr-88825.yml
@@ -1,0 +1,4 @@
+author: "LT3"
+delete-after: True
+changes:
+  - qol: "Wearable HUDs can be toggled on and off"


### PR DESCRIPTION
## https://github.com/tgstation/tgstation/pull/88825

## About The Pull Request

Adds an action button allowing you to toggle on/off the HUD of wearables, like glasses.

https://github.com/user-attachments/assets/b95b85b7-2598-4bac-be2c-be86f9f90a95

## Why It's Good For The Game

Convenient method to temporarily disable the information for whatever reason.