### PR TITLE
Remove DME Edit autolabel

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -39,12 +39,6 @@ Dependencies:
     - any-glob-to-any-file: '**/package-lock.json'
     - any-glob-to-any-file: '**/yarn.lock'
 
-# When the .DME is changed
-DME Edit:
-- changed-files:
-    - any-glob-to-any-file: './*.dme'
-    - any-glob-to-any-file: '**/*.dme'
-
 # Changes to JavaScript files
 Javascript:
 - changed-files:


### PR DESCRIPTION
## About The Pull Request

Removes DME Edit autolabel. It doesn't add much beyond clutter, and a PR will fail linters if it has files missing from tgstation.dme