### PR TITLE
Run changelog compile a bit earlier

### DIFF
--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -2,7 +2,7 @@ name: Compile changelogs
 
 on:
   schedule:
-  - cron: "15 23 * * *"
+  - cron: "2 23 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## About The Pull Request

Pushes changelog compile up a bit to give some extra buffer, so that there's less risk of it crossing midnight.