### PR TITLE
Makes ordered jukeboxes not require bar access

### DIFF
--- a/modular_zubbers/code/modules/cargo/packs/service.dm
+++ b/modular_zubbers/code/modules/cargo/packs/service.dm
@@ -2,7 +2,7 @@
 	name = "Jukebox crate"
 	desc = "Shift getting too boring? Lighten up the mood with some music from the jukebox!"
 	cost = CARGO_CRATE_VALUE * 50
-	contains = list(/obj/machinery/jukebox)
+	contains = list(/obj/machinery/jukebox/no_access)
 	crate_type = /obj/structure/closet/crate/large
 	access_view = ACCESS_BAR
 


### PR DESCRIPTION

## About The Pull Request

Exactly what it says on the tin. Currently if someone orders a jukebox for their project, it requires bar access to actually operate it. This change makes the crate come with the free access version.

## Why It's Good For The Game

Most if not all map-spawned jukeboxes don't have access requirements, because that makes them harder to actually use for entertaining people. Jukeboxes that people order for a side project shouldn't still need that access.

## Proof Of Testing

I forgot to record the testing, but I did test it and it worked fine. If video proof of testing a one-line change is needed, I can go back and do that.

## Changelog
:cl:
tweak: Ordered jukeboxes no longer only work for those with bar access.
/:cl:
