### PR TITLE
Limits the RBMK to pulse every three seconds. Halves range

### DIFF
--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -14,7 +14,7 @@
 #define ATMOS_RADIATION_VOLUME_EXP 3
 
 /// Maximum range a radiation pulse is allowed to be from a gas reaction.
-#define GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE 20
+#define GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE 10
 
 // Water Vapor:
 /// The temperature required for water vapor to condense.

--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -14,7 +14,7 @@
 #define ATMOS_RADIATION_VOLUME_EXP 3
 
 /// Maximum range a radiation pulse is allowed to be from a gas reaction.
-#define GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE 10
+#define GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE 20
 
 // Water Vapor:
 /// The temperature required for water vapor to condense.

--- a/modular_zubbers/code/game/machinery/burger_reactor/reactor.dm
+++ b/modular_zubbers/code/game/machinery/burger_reactor/reactor.dm
@@ -118,7 +118,7 @@
 			if(stored_rod)
 				remove_rod()
 			explosion(src, devastation_range  = explosion_power*0.25, heavy_impact_range = explosion_power*0.5, light_impact_range = explosion_power, flash_range = explosion_power*2, adminlog = FALSE)
-			last_radiation_pulse = GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE*4 //It just keeps getting worse and worse.
+			last_radiation_pulse = GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE*2 //It just keeps getting worse and worse.
 			radiation_pulse(src,last_radiation_pulse,threshold = RAD_FULL_INSULATION)
 		else
 			message_admins("[src] exploded due to damage at [ADMIN_VERBOSEJMP(T)]")

--- a/modular_zubbers/code/game/machinery/burger_reactor/reactor.dm
+++ b/modular_zubbers/code/game/machinery/burger_reactor/reactor.dm
@@ -58,6 +58,7 @@
 	var/max_power_generation = 350000 //Maximum allowed power generation (joules) per cycle before the rods go apeshit. Improved via matter bins. The absolute max is 20 times this.
 
 	var/list/obj/machinery/rbmk2_sniffer/linked_sniffers = list()
+	COOLDOWN_DECLARE(radiation_pulse)
 
 /datum/armor/rbmk2
 	melee = 50

--- a/modular_zubbers/code/game/machinery/burger_reactor/reactor_processing.dm
+++ b/modular_zubbers/code/game/machinery/burger_reactor/reactor_processing.dm
@@ -52,7 +52,7 @@
 			else
 				last_radiation_pulse = min( last_power_generation*0.001 ,GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE/2)
 				radiation_pulse(src,last_radiation_pulse,threshold = RAD_MEDIUM_INSULATION)
-			COOLDOWN_START(src, radiation_pulse, 2 SECONDS)
+			COOLDOWN_START(src, radiation_pulse, 3 SECONDS)
 
 		if(power && powernet && last_power_generation)
 			src.add_avail(min(last_power_generation,max_power_generation*10))

--- a/modular_zubbers/code/game/machinery/burger_reactor/reactor_processing.dm
+++ b/modular_zubbers/code/game/machinery/burger_reactor/reactor_processing.dm
@@ -45,12 +45,15 @@
 		//This is where the fun begins.
 		// https://www.desmos.com/calculator/ffcsaaftzz
 		last_power_generation *= (1 + max(0,(rod_mix.temperature - T0C)/1500)**1.4)*(0.75 + (amount_to_consume/gas_consumption_base)*0.25)
-		if(meltdown)
-			last_radiation_pulse = min( last_power_generation*0.002 ,GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE)
-			radiation_pulse(src,last_radiation_pulse,threshold = RAD_HEAVY_INSULATION)
-		else
-			last_radiation_pulse = min( last_power_generation*0.001 ,GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE)
-			radiation_pulse(src,last_radiation_pulse,threshold = RAD_MEDIUM_INSULATION)
+		if(COOLDOWN_FINISHED(src, radiation_pulse))
+			if(meltdown)
+				last_radiation_pulse = min( last_power_generation*0.002 ,GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE)
+				radiation_pulse(src,last_radiation_pulse,threshold = RAD_HEAVY_INSULATION)
+			else
+				last_radiation_pulse = min( last_power_generation*0.001 ,GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE)
+				radiation_pulse(src,last_radiation_pulse,threshold = RAD_MEDIUM_INSULATION)
+			COOLDOWN_START(src, radiation_pulse, 5 SECONDS)
+
 		if(power && powernet && last_power_generation)
 			src.add_avail(min(last_power_generation,max_power_generation*10))
 		consumed_mix.remove_specific(/datum/gas/tritium, last_tritium_consumption*0.50) //50% of used tritium gets deleted. The rest gets thrown into the air.

--- a/modular_zubbers/code/game/machinery/burger_reactor/reactor_processing.dm
+++ b/modular_zubbers/code/game/machinery/burger_reactor/reactor_processing.dm
@@ -122,8 +122,6 @@
 		meltdown_multiplier *= last_power_generation/max_power_generation //It just gets worse.
 		var/datum/gas_mixture/rod_mix = stored_rod.air_contents
 		var/rod_mix_heat_capacity = rod_mix.heat_capacity()
-		last_radiation_pulse = min( last_power_generation*0.003*meltdown_multiplier ,GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE*3) //It just keeps getting worse.
-		radiation_pulse(src,last_radiation_pulse,threshold = RAD_HEAVY_INSULATION)
 		if(rod_mix_heat_capacity > 0)
 			rod_mix.temperature += (rod_mix.temperature*0.02*rand() + (8000/rod_mix_heat_capacity)*(overclocked ? 2 : 1))*meltdown_multiplier //It's... it's not shutting down!
 			rod_mix.temperature = clamp(rod_mix.temperature,5,0xFFFFFF)

--- a/modular_zubbers/code/game/machinery/burger_reactor/reactor_processing.dm
+++ b/modular_zubbers/code/game/machinery/burger_reactor/reactor_processing.dm
@@ -52,7 +52,7 @@
 			else
 				last_radiation_pulse = min( last_power_generation*0.001 ,GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE/2)
 				radiation_pulse(src,last_radiation_pulse,threshold = RAD_MEDIUM_INSULATION)
-			COOLDOWN_START(src, radiation_pulse, 5 SECONDS)
+			COOLDOWN_START(src, radiation_pulse, 2 SECONDS)
 
 		if(power && powernet && last_power_generation)
 			src.add_avail(min(last_power_generation,max_power_generation*10))

--- a/modular_zubbers/code/game/machinery/burger_reactor/reactor_processing.dm
+++ b/modular_zubbers/code/game/machinery/burger_reactor/reactor_processing.dm
@@ -47,10 +47,10 @@
 		last_power_generation *= (1 + max(0,(rod_mix.temperature - T0C)/1500)**1.4)*(0.75 + (amount_to_consume/gas_consumption_base)*0.25)
 		if(COOLDOWN_FINISHED(src, radiation_pulse))
 			if(meltdown)
-				last_radiation_pulse = min( last_power_generation*0.002 ,GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE)
+				last_radiation_pulse = min( last_power_generation*0.002 ,GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE/2)
 				radiation_pulse(src,last_radiation_pulse,threshold = RAD_HEAVY_INSULATION)
 			else
-				last_radiation_pulse = min( last_power_generation*0.001 ,GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE)
+				last_radiation_pulse = min( last_power_generation*0.001 ,GAS_REACTION_MAXIMUM_RADIATION_PULSE_RANGE/2)
 				radiation_pulse(src,last_radiation_pulse,threshold = RAD_MEDIUM_INSULATION)
 			COOLDOWN_START(src, radiation_pulse, 5 SECONDS)
 


### PR DESCRIPTION
## About The Pull Request

So every tick nine machines sent out radiation pulses that can climb up to 20 tiles. Radiation creates massive lists, especially 20 tiles of lists. Radiation should not be allocating more total heap then god damn signals, lol.

```
/datum/gas_mixture/copy = 35.4 MB
/datum/light_source/update_corners = 43.4 MB
/datum/lighting_object/update = 83.4 MB
/datum/lighting_object/New = 104.9 MB
/datum/RegisterSignal = 170.5 MB
/radiation_pulse = 178.2 MB
```

## Why It's Good For The Game

We kind of need memory to play this game.

## Proof Of Testing

It compiles, so I assume it works. I have zero idea how this thing works.

## Changelog

:cl:
fix: RBMK no longer crashes the server.
/:cl:

