### PR TITLE
Memory 2.0: The flickering light removal

### DIFF
--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -454,11 +454,6 @@ ADMIN_VERB(check_bomb_impacts, R_DEBUG, "Check Bomb Impact", "See what the effec
 			if(EXPLODE_LIGHT)
 				SSexplosions.lowturf += explode
 
-		//SKYRAT EDIT ADDITION
-		for(var/obj/machinery/light/iterating_light in explode)
-			iterating_light.start_flickering()
-		//SKYRAT EDIT END
-
 		if(prob(40) && dist < flame_range && !isspaceturf(explode) && !explode.density)
 			flameturf += explode
 

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -382,10 +382,6 @@
 			. += span_danger("The [fitting] has been smashed.")
 	if(cell || has_mock_cell)
 		. +=  span_notice("Its backup power charge meter reads [has_mock_cell ? 100 : round((cell.charge / cell.maxcharge) * 100, 0.1)]%.")
-	//SKYRAT EDIT ADDITION
-	if(constant_flickering)
-		. += span_danger("The lighting ballast appears to be damaged, this could be fixed with a multitool.")
-	//SKYRAT EDIT END
 
 // attack with item - insert light (if right type), otherwise try to break the light
 

--- a/modular_skyrat/modules/aesthetics/lights/code/lighting.dm
+++ b/modular_skyrat/modules/aesthetics/lights/code/lighting.dm
@@ -16,9 +16,6 @@
 	bulb_major_emergency_brightness_mul = 0.9
 	var/maploaded = FALSE //So we don't have a lot of stress on startup.
 	var/turning_on = FALSE //More stress stuff.
-	var/constant_flickering = FALSE // Are we always flickering?
-	var/flicker_timer = null
-	var/roundstart_flicker = FALSE
 
 /obj/machinery/light/proc/delayed_turn_on(trigger, play_sound = TRUE, color_set, power_set, brightness_set)
 	if(QDELETED(src))
@@ -39,57 +36,10 @@
 		if(play_sound)
 			playsound(src.loc, 'modular_skyrat/modules/aesthetics/lights/sound/light_on.ogg', 65, 1)
 
-/obj/machinery/light/proc/start_flickering()
-	on = FALSE
-	update(FALSE, TRUE, FALSE)
-
-	constant_flickering = TRUE
-
-	flicker_timer = addtimer(CALLBACK(src, PROC_REF(flicker_on)), rand(0.5 SECONDS, 1 SECONDS))
-
-/obj/machinery/light/proc/stop_flickering()
-	constant_flickering = FALSE
-
-	if(flicker_timer)
-		deltimer(flicker_timer)
-		flicker_timer = null
-
-	set_on(has_power())
-
-/obj/machinery/light/proc/alter_flicker(enable = TRUE)
-	if(!constant_flickering)
-		return
-	if(has_power())
-		on = enable
-		update(FALSE, TRUE, FALSE)
-
-/obj/machinery/light/proc/flicker_on()
-	alter_flicker(TRUE)
-	flicker_timer = addtimer(CALLBACK(src, PROC_REF(flicker_off)), rand(0.5 SECONDS, 1 SECONDS))
-
-/obj/machinery/light/proc/flicker_off()
-	alter_flicker(FALSE)
-	flicker_timer = addtimer(CALLBACK(src, PROC_REF(flicker_on)), rand(0.5 SECONDS, 5 SECONDS))
-
 /obj/machinery/light/Initialize(mapload = TRUE)
 	. = ..()
 	if(on)
 		maploaded = TRUE
-
-	if(roundstart_flicker)
-		start_flickering()
-
-/obj/machinery/light/multitool_act(mob/living/user, obj/item/multitool)
-	if(!constant_flickering)
-		balloon_alert(user, "ballast is already working!")
-		return ITEM_INTERACT_SUCCESS
-
-	balloon_alert(user, "repairing the ballast...")
-	if(do_after(user, 2 SECONDS, src))
-		stop_flickering()
-		balloon_alert(user, "ballast repaired!")
-		return ITEM_INTERACT_SUCCESS
-	return ..()
 
 #undef NIGHTSHIFT_LIGHT_MODIFIER
 #undef NIGHTSHIFT_COLOR_MODIFIER

--- a/modular_skyrat/modules/decay_subsystem/code/decaySS.dm
+++ b/modular_skyrat/modules/decay_subsystem/code/decaySS.dm
@@ -15,8 +15,6 @@ These procs are incredibly expensive and should only really be run once. That's 
 
 #define NEST_PERCENT_CHANCE 1
 
-#define LIGHT_FLICKER_PERCENT_CHANCE 10
-
 SUBSYSTEM_DEF(decay)
 	name = "Decay System"
 	flags = SS_NO_FIRE
@@ -120,10 +118,6 @@ SUBSYSTEM_DEF(decay)
 				if(!iterating_floor.Enter(spawned_spawner))
 					qdel(spawned_spawner)
 
-		for(var/obj/machinery/light/iterating_light in iterating_maintenance)
-			if(prob(LIGHT_FLICKER_PERCENT_CHANCE))
-				iterating_light.start_flickering()
-
 /datum/controller/subsystem/decay/proc/do_engineering()
 	for(var/area/station/engineering/iterating_engineering in possible_areas)
 		for(var/turf/open/iterating_floor in iterating_engineering)
@@ -152,7 +146,3 @@ SUBSYSTEM_DEF(decay)
 				if(!iterating_floor.Enter(spawned_vomit))
 					qdel(spawned_vomit)
 
-		if(is_type_in_list(iterating_medical, list(/area/station/medical/coldroom, /area/station/medical/morgue, /area/station/medical/psychology)))
-			for(var/obj/machinery/light/iterating_light in iterating_medical)
-				if(prob(LIGHT_FLICKER_PERCENT_CHANCE))
-					iterating_light.start_flickering()


### PR DESCRIPTION

## About The Pull Request

Removes broken flickering lights

## Why It's Good For The Game

Lighting is another one of our massive memory usages. Let's remove this.

## Changelog

:cl:
del: Removes broken light flickering.
/:cl:
