### PR TITLE
Fix bubber-exclusive jobs having no icon in observe menu

### DIFF
--- a/tgui/packages/tgui/interfaces/Orbit/JobIcon.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/JobIcon.tsx
@@ -15,6 +15,18 @@ const customJobs = [
   'Orderly',
   'Science Guard',
   'Security Medic',
+  'Persistence Hostage',
+  'Persistence General Staff',
+  'Persistence Sanitation Technician',
+  'Persistence Researcher',
+  'Persistence Engineering Officer',
+  'Persistence Medical Officer',
+  'Persistence Cargo Technician',
+  'Persistence Master At Arms',
+  'Persistence Brig Officer',
+  'Syndicate Corporate Liaison',
+  'Persistence Admiral',
+  'Tarkon Ensign',
 ];
 // BUBBER EDIT ADDITION END - Custom observe menu icons
 

--- a/tgui/packages/tgui/interfaces/Orbit/JobIcon.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/JobIcon.tsx
@@ -2,6 +2,22 @@ import { DmIcon, Icon } from '../../components';
 import { JOB2ICON } from '../common/JobToIcon';
 import { Antagonist, Observable } from './types';
 
+// BUBBER EDIT ADDITION BEGIN - Custom observe menu icons
+const customJobs = [
+  'Telecomms Specialist',
+  'Barber',
+  'Blueshield',
+  'Bouncer',
+  'Corrections Officer',
+  'Customs Agent',
+  'Engineering Guard',
+  'Nanotrasen Consultant',
+  'Orderly',
+  'Science Guard',
+  'Security Medic',
+];
+// BUBBER EDIT ADDITION END - Custom observe menu icons
+
 type Props = {
   item: Observable | Antagonist;
   realNameDisplay: boolean;
@@ -22,20 +38,31 @@ const antagIcon: IconSettings = {
   transform: 'scale(1.8) translateX(-16px) translateY(7px)',
 };
 
+// BUBBER EDIT ADDITION BEGIN - Custom observe menu icons
+const customIcon: IconSettings = {
+  dmi: 'modular_zubbers/icons/mob/huds/hud.dmi',
+  transform: 'scale(2.3) translateX(9px) translateY(1px)',
+};
+// BUBBER EDIT ADDITION END - Custom observe menu icons
+
 export function JobIcon(props: Props) {
   const { item, realNameDisplay } = props;
-
-  let iconSettings: IconSettings;
-  if ('antag' in item) {
-    iconSettings = antagIcon;
-  } else {
-    iconSettings = normalIcon;
-  }
 
   // We don't need to cast here but typescript isn't smart enough to know that
   const { icon = '', job = '', mind_icon = '', mind_job = '' } = item;
   const usedIcon = realNameDisplay ? mind_icon || icon : icon;
   const usedJob = realNameDisplay ? mind_job || job : job;
+
+  let iconSettings: IconSettings;
+  if ('antag' in item) {
+    iconSettings = antagIcon;
+    // BUBBER EDIT ADDITION BEGIN - Custom observe menu icons
+  } else if (customJobs.includes(usedJob)) {
+    iconSettings = customIcon;
+    // BUBBER EDIT ADDITION END - Custom observe menu icons
+  } else {
+    iconSettings = normalIcon;
+  }
 
   return (
     <div className="JobIcon">


### PR DESCRIPTION
## About The Pull Request

Add a special case in `JobIcon.tsx` to point the DMIcon element to our modular icon file if it's a custom job.

## Why It's Good For The Game

little job pictures :)

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/23c33422-a648-4ddf-a130-dc06237697c3)

</details>

## Changelog

:cl:
fix: fixed Bubber-exclusive job icons not showing in observe menu.
/:cl:
