### PR TITLE
Buffs ERP on Moonstation (Adds a bucket, five wood, and tinyfan to the Sauna)

### DIFF
--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -14122,6 +14122,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/cargo/storage)
+"dWb" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/tile/holiday/rainbow/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/fans/tiny,
+/turf/open/floor/iron/dark/corner,
+/area/station/common/pool)
 "dWi" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -55862,6 +55869,14 @@
 	dir = 8
 	},
 /obj/structure/table/wood,
+/obj/item/reagent_containers/cup/bucket/wooden{
+	pixel_x = -7;
+	pixel_y = 1
+	},
+/obj/item/stack/sheet/mineral/wood{
+	amount = 5;
+	pixel_x = 5
+	},
 /turf/open/floor/wood/tile,
 /area/station/common/pool/sauna)
 "pqK" = (
@@ -238938,7 +238953,7 @@ tis
 tis
 xTd
 wTv
-xLH
+dWb
 lRS
 qWH
 xrF

--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -4292,6 +4292,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/service/library,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/station/common/pool/sauna)
 "bfV" = (
@@ -14122,13 +14123,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/cargo/storage)
-"dWb" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/tile/holiday/rainbow/half/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/fans/tiny,
-/turf/open/floor/iron/dark/corner,
-/area/station/common/pool)
 "dWi" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -61765,6 +61759,13 @@
 /obj/machinery/light/small/red/dim/directional/east,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/turret_protected/aisat/maint)
+"qXp" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/tile/holiday/rainbow/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/fans/tiny,
+/turf/open/floor/iron/dark/corner,
+/area/station/common/pool)
 "qXq" = (
 /obj/effect/turf_decal/tile/dark_green/diagonal_centre,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -238953,7 +238954,7 @@ tis
 tis
 xTd
 wTv
-dWb
+qXp
 lRS
 qWH
 xrF


### PR DESCRIPTION
## About The Pull Request

Adds five pieces of wood, a bucket, and a tinyfan to the Moonstation Sauna

## Why It's Good For The Game

Just a few tiny tweaks to moonstation so the sauna is slightly more accessable without needing to go too far out of the way.

## Proof Of Testing

Check map dif

## Changelog

:cl:
add: Quality Improvements to the Moonstation Sauna
/:cl:
