### PR TITLE
Horseshoes Loadout Item

### DIFF
--- a/modular_skyrat/modules/reagent_forging/code/crafting_bench_recipes.dm
+++ b/modular_skyrat/modules/reagent_forging/code/crafting_bench_recipes.dm
@@ -57,7 +57,7 @@
 	recipe_requirements = list(
 		/obj/item/forging/complete/chain = 4,
 	)
-	resulting_item = /obj/item/clothing/shoes/horseshoe
+	resulting_item = /obj/item/clothing/shoes/horseshoe/reagent_clothing
 	required_good_hits = 8
 
 /datum/crafting_bench_recipe/ring

--- a/modular_skyrat/modules/reagent_forging/code/forge_clothing.dm
+++ b/modular_skyrat/modules/reagent_forging/code/forge_clothing.dm
@@ -112,26 +112,19 @@
 	AddComponent(/datum/component/armor_plate, 2)
 	AddComponent(/datum/component/reagent_clothing, ITEM_SLOT_FEET)
 
-/obj/item/clothing/shoes/horseshoe
-	name = "reagent horseshoe"
+/obj/item/clothing/shoes/horseshoe/reagent_clothing
+	name = "reagent horseshoes"
 	desc = "A pair of horseshoes made out of chains."
-	icon = 'modular_skyrat/modules/reagent_forging/icons/obj/forge_clothing.dmi'
-	worn_icon = 'modular_skyrat/modules/reagent_forging/icons/mob/clothing/forge_clothing.dmi'
-	icon_state = "horseshoe"
-	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 
-	body_parts_covered = parent_type::body_parts_covered | LEGS
 	armor_type = /datum/armor/shoes_horseshoe
 	material_flags = MATERIAL_EFFECTS | MATERIAL_ADD_PREFIX | MATERIAL_COLOR
-	resistance_flags = FIRE_PROOF
 	skyrat_obj_flags = ANVIL_REPAIR
-	can_be_tied = FALSE
 
 /datum/armor/shoes_horseshoe
 	melee = 20
 	bullet = 20
 
-/obj/item/clothing/shoes/horseshoe/Initialize(mapload)
+/obj/item/clothing/shoes/horseshoe/reagent_clothing/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/armor_plate, 2)
 	AddComponent(/datum/component/reagent_clothing, ITEM_SLOT_FEET)

--- a/modular_zubbers/code/modules/clothing/shoes/boots.dm
+++ b/modular_zubbers/code/modules/clothing/shoes/boots.dm
@@ -266,3 +266,15 @@
 	if (!owner.dropItemToGround(src))
 		return FALSE
 	return TRUE
+
+/obj/item/clothing/shoes/horseshoe
+	name = "horseshoes"
+	desc = "A pair of horseshoes made out of chains."
+	icon = 'modular_skyrat/modules/reagent_forging/icons/obj/forge_clothing.dmi'
+	worn_icon = 'modular_skyrat/modules/reagent_forging/icons/mob/clothing/forge_clothing.dmi'
+	icon_state = "horseshoe"
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
+
+	body_parts_covered = parent_type::body_parts_covered | LEGS
+	resistance_flags = FIRE_PROOF
+	can_be_tied = FALSE

--- a/modular_zubbers/code/modules/loadout/categories/shoes.dm
+++ b/modular_zubbers/code/modules/loadout/categories/shoes.dm
@@ -27,3 +27,7 @@
 /datum/loadout_item/shoes/Wheely_heels
 	name = "Wheely-Heels"
 	item_path = /obj/item/clothing/shoes/wheelys
+
+/datum/loadout_item/shoes/horseshoes
+	name = "Horseshoes"
+	item_path = /obj/item/clothing/shoes/horseshoe


### PR DESCRIPTION

## About The Pull Request

Adds horseshoes as a loadout item. Same as the smithable ones except without any of the armor of reagent stuff.
Bounty by Gavla.

## Why It's Good For The Game

horseshoe

## Proof Of Testing

![image](https://github.com/user-attachments/assets/eb4ba33c-e73d-4dbd-a73d-f78a429e714c)


</details>

## Changelog
:cl:
add: Adds horseshoes to loadout
/:cl: