### PR TITLE
DNR no longer works on Changelings and bloodsuckers

### DIFF
--- a/modular_skyrat/modules/cortical_borer/code/abilities/_borer_abilities.dm
+++ b/modular_skyrat/modules/cortical_borer/code/abilities/_borer_abilities.dm
@@ -640,6 +640,9 @@
 	if(!cortical_owner.inside_human())
 		owner.balloon_alert(owner, "host required")
 		return
+	if(cortical_owner.human_host.has_quirk(/datum/quirk/dnr))
+		owner.balloon_alert(owner, "host unrevivable")
+		return
 	cortical_owner.chemical_storage -= chemical_cost
 	if(cortical_owner.human_host.getBruteLoss())
 		cortical_owner.human_host.adjustBruteLoss(-(cortical_owner.human_host.getBruteLoss()*0.5))

--- a/modular_zubbers/code/game/traits/neutral.dm
+++ b/modular_zubbers/code/game/traits/neutral.dm
@@ -12,6 +12,8 @@
 	element_flags = ELEMENT_DETACH_ON_HOST_DESTROY
 
 /datum/element/dnr/proc/apply_dnr(mob/living/holder)
+	if(IS_CHANGELING(holder) || IS_BLOODSUCKER(holder))
+		return
 	holder.ghostize()
 	var/mob/dead/observer/dnr_person = holder.mind.get_ghost(even_if_they_cant_reenter = TRUE)
 	dnr_person.can_reenter_corpse = FALSE


### PR DESCRIPTION
## About The Pull Request
Makes it so the DNR trait makes a bit more sense. Blocking borer revive, and not working with lings or vampires who self revive
## Why It's Good For The Game
These antags have self revive mechanics, if you take the DNR trait it will leave the soulless body alive in your stead - this makes it so if you have that trait then roll the antag, you don't still only have one life. If we want to make it so you do then we can, this is just the solution that came to me first 
## Proof Of Testing
![image](https://github.com/user-attachments/assets/e81bc822-cdf1-4efd-bf29-d70ab067add8)
borer one works, source: dude trust me
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: Lings/vampires will no longer revive as soulless bodies with DNR
fix: Borers can no longer revive hosts with DNR
/:cl:
