### PR TITLE
removes armor stats from the magician tailcoat in the costume drobe

### DIFF
--- a/modular_zubbers/code/modules/clothing/outfits/bunny.dm
+++ b/modular_zubbers/code/modules/clothing/outfits/bunny.dm
@@ -64,7 +64,7 @@
 /datum/outfit/wizard/bunny_magician
 	name = "Bunny Magician"
 	uniform = /obj/item/clothing/under/costume/playbunny/magician
-	suit = /obj/item/clothing/suit/jacket/tailcoat/magician
+	suit = /obj/item/clothing/suit/wizrobe/magician
 	back = /obj/item/storage/backpack/satchel/leather
 	head = /obj/item/clothing/head/playbunnyears
 	shoes = /obj/item/clothing/shoes/fancy_heels/wizard

--- a/modular_zubbers/code/modules/clothing/outfits/bunny.dm
+++ b/modular_zubbers/code/modules/clothing/outfits/bunny.dm
@@ -64,7 +64,7 @@
 /datum/outfit/wizard/bunny_magician
 	name = "Bunny Magician"
 	uniform = /obj/item/clothing/under/costume/playbunny/magician
-	suit = /obj/item/clothing/suit/wizrobe/magician
+	suit = /obj/item/clothing/suit/jacket/tailcoat/magician
 	back = /obj/item/storage/backpack/satchel/leather
 	head = /obj/item/clothing/head/playbunnyears
 	shoes = /obj/item/clothing/shoes/fancy_heels/wizard

--- a/modular_zubbers/code/modules/clothing/suits/jacket.dm
+++ b/modular_zubbers/code/modules/clothing/suits/jacket.dm
@@ -67,6 +67,7 @@
 	greyscale_config = /datum/greyscale_config/henchmen
 	greyscale_config_worn = /datum/greyscale_config/henchmen/worn
 	flags_1 = IS_PLAYER_COLORABLE_1
+
 /obj/item/clothing/suit/jacket/henchmen_coat/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/toggle_icon)
@@ -129,16 +130,23 @@
 /obj/item/clothing/suit/jacket/tailcoat/syndicate/fake
 	armor_type = /datum/armor/none
 
-/obj/item/clothing/suit/jacket/tailcoat/magician //Not really a robe but it's MAGIC
+/obj/item/clothing/suit/jacket/tailcoat/magician
 	name = "magician's tailcoat"
-	desc = "A magnificent, gold-lined tailcoat that seems to radiate power."
-	worn_icon = 'modular_zubbers/icons/mob/clothing/suits/jacket.dmi'
-	worn_icon_digi = 'modular_zubbers/icons/mob/clothing/suits/jacket_digi.dmi'
-	icon = 'modular_zubbers/icons/obj/clothing/suits/jacket.dmi'
+	desc = "A magnificent, gold-lined tailcoat."
 	icon_state = "tailcoat_wiz"
 	greyscale_config = null
 	greyscale_config_worn = null
+	greyscale_colors = null
+
+/obj/item/clothing/suit/wizrobe/magician //Not really a robe but it's MAGIC
+	name = /obj/item/clothing/suit/jacket/tailcoat/magician::name
+	desc = "A magnificent, gold-lined tailcoat that seems to radiate power."
+	worn_icon = /obj/item/clothing/suit/jacket/tailcoat/magician::worn_icon
+	worn_icon_digi = /obj/item/clothing/suit/jacket/tailcoat/magician::worn_icon_digi
+	icon = /obj/item/clothing/suit/jacket/tailcoat/magician::icon
+	icon_state = /obj/item/clothing/suit/jacket/tailcoat/magician::icon_state
 	inhand_icon_state = null
+	flags_inv = null
 
 /obj/item/clothing/suit/jacket/tailcoat/centcom
 	name = "Centcom tailcoat"

--- a/modular_zubbers/code/modules/clothing/suits/jacket.dm
+++ b/modular_zubbers/code/modules/clothing/suits/jacket.dm
@@ -129,15 +129,16 @@
 /obj/item/clothing/suit/jacket/tailcoat/syndicate/fake
 	armor_type = /datum/armor/none
 
-/obj/item/clothing/suit/wizrobe/magician //Not really a robe but it's MAGIC
+/obj/item/clothing/suit/jacket/tailcoat/magician //Not really a robe but it's MAGIC
 	name = "magician's tailcoat"
 	desc = "A magnificent, gold-lined tailcoat that seems to radiate power."
 	worn_icon = 'modular_zubbers/icons/mob/clothing/suits/jacket.dmi'
 	worn_icon_digi = 'modular_zubbers/icons/mob/clothing/suits/jacket_digi.dmi'
 	icon = 'modular_zubbers/icons/obj/clothing/suits/jacket.dmi'
 	icon_state = "tailcoat_wiz"
+	greyscale_config = null
+	greyscale_config_worn = null
 	inhand_icon_state = null
-	flags_inv = null
 
 /obj/item/clothing/suit/jacket/tailcoat/centcom
 	name = "Centcom tailcoat"

--- a/modular_zubbers/code/modules/vending/wardrobe.dm
+++ b/modular_zubbers/code/modules/vending/wardrobe.dm
@@ -37,6 +37,7 @@
 				/obj/item/clothing/suit/jacket/tailcoat = 6,
 				/obj/item/clothing/neck/tie/bunnytie/magician = 6,
 				/obj/item/clothing/under/costume/playbunny/magician = 6,
+				/obj/item/clothing/suit/jacket/tailcoat/magician = 6,
 				/obj/item/clothing/head/playbunnyears/british = 6,
 				/obj/item/clothing/neck/tie/bunnytie/blue = 6,
 				/obj/item/clothing/under/costume/playbunny/british = 6,
@@ -282,7 +283,7 @@
 	zubbers_products = list(
 		/obj/item/clothing/neck/tie/bunnytie/magician = 3,
 		/obj/item/clothing/under/costume/playbunny/magician = 3,
-		/obj/item/clothing/suit/wizrobe/magician = 3,
+		/obj/item/clothing/suit/jacket/tailcoat/magician = 3,
 	)
 
 /obj/machinery/vending/wardrobe/engi_wardrobe

--- a/modular_zubbers/code/modules/vending/wardrobe.dm
+++ b/modular_zubbers/code/modules/vending/wardrobe.dm
@@ -37,7 +37,6 @@
 				/obj/item/clothing/suit/jacket/tailcoat = 6,
 				/obj/item/clothing/neck/tie/bunnytie/magician = 6,
 				/obj/item/clothing/under/costume/playbunny/magician = 6,
-				/obj/item/clothing/suit/wizrobe/magician = 6,
 				/obj/item/clothing/head/playbunnyears/british = 6,
 				/obj/item/clothing/neck/tie/bunnytie/blue = 6,
 				/obj/item/clothing/under/costume/playbunny/british = 6,

--- a/modular_zubbers/code/modules/vending/wardrobe.dm
+++ b/modular_zubbers/code/modules/vending/wardrobe.dm
@@ -283,7 +283,7 @@
 	zubbers_products = list(
 		/obj/item/clothing/neck/tie/bunnytie/magician = 3,
 		/obj/item/clothing/under/costume/playbunny/magician = 3,
-		/obj/item/clothing/suit/jacket/tailcoat/magician = 3,
+		/obj/item/clothing/suit/wizrobe/magician = 3,
 	)
 
 /obj/machinery/vending/wardrobe/engi_wardrobe


### PR DESCRIPTION

## About The Pull Request
removes wizard armor from wizdrobe

## Why It's Good For The Game
costumes should not have armor

## Proof Of Testing
nope

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
del: no more wizard armor in wizdrobe, sorry, 
/:cl:

