### PR TITLE
Moonstation AI core adjustments to make it better defendable.

### DIFF
--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -54982,9 +54982,13 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/range)
 "pdE" = (
-/obj/structure/sign/warning/cold_temp/directional/north,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "AI Core shutters";
+	name = "AI Core Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/ai)
 "pdG" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/engineering/toolbox,
@@ -248643,9 +248647,9 @@ rPu
 kTm
 nSC
 nSC
-uUJ
-uUJ
 pdE
+pdE
+mYk
 tpx
 lZT
 wte
@@ -249671,8 +249675,8 @@ qns
 cfB
 emg
 dbk
-uUJ
-uUJ
+pdE
+pdE
 mYk
 soJ
 ykM

--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -4292,6 +4292,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/service/library,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/station/common/pool/sauna)
 "bfV" = (
@@ -29130,13 +29131,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "hYM" = (
-/obj/machinery/turretid{
-	name = "AI Chamber turret control";
-	pixel_y = 30;
-	control_area = "/area/station/ai_monitored/turret_protected/ai"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/tile/holiday/rainbow/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/fans/tiny,
+/turf/open/floor/iron/dark/corner,
+/area/station/common/pool)
 "hYS" = (
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
@@ -55862,6 +55862,14 @@
 	dir = 8
 	},
 /obj/structure/table/wood,
+/obj/item/reagent_containers/cup/bucket/wooden{
+	pixel_x = -7;
+	pixel_y = 1
+	},
+/obj/item/stack/sheet/mineral/wood{
+	amount = 5;
+	pixel_x = 5
+	},
 /turf/open/floor/wood/tile,
 /area/station/common/pool/sauna)
 "pqK" = (
@@ -238938,7 +238946,7 @@ tis
 tis
 xTd
 wTv
-xLH
+hYM
 lRS
 qWH
 xrF
@@ -249665,7 +249673,7 @@ emg
 dbk
 uUJ
 uUJ
-hYM
+mYk
 soJ
 ykM
 wte


### PR DESCRIPTION
## About The Pull Request

Removes this turret controller that controls the core turrets.

![image](https://github.com/user-attachments/assets/5b4ad2e5-e512-4f2d-92a4-64d51d72a33c)

This also makes these walls into glass so the AI is better defended the moment someone enters this room and so you can't cheese it as easily

![image](https://github.com/user-attachments/assets/b6d6bedd-bf5a-4bb7-8f4b-86b3e04eaceb)

## Why It's Good For The Game

The turret controller being placed only for the AI's direct access is a deliberate mapping thing which holds true across all maps except Moon.

Also Moonstation's AI is very cheesable.

## Proof Of Testing

It works

## Changelog

:cl:
balance: Slightly adjusts Moonstation's AI core to be more defendable for the AI.
/:cl:
