### PR TITLE
Buffs ERP by uncapping Subtler Range

### DIFF
--- a/modular_skyrat/modules/verbs/code/subtle.dm
+++ b/modular_skyrat/modules/verbs/code/subtle.dm
@@ -1,4 +1,5 @@
-#define SUBTLE_DEFAULT_DISTANCE 1
+#define SUBTLE_DEFAULT_DISTANCE world.view
+#define SUBTLE_ONE_TILE 1
 #define SUBTLE_SAME_TILE_DISTANCE 0
 #define SUBTLER_TELEKINESIS_DISTANCE 7
 
@@ -42,11 +43,11 @@
 
 	subtle_message = span_emote("<b>[user]</b>[space]<i>[user.say_emphasis(subtle_message)]</i>")
 
-	var/list/viewers = get_hearers_in_view(SUBTLE_DEFAULT_DISTANCE, user)
+	var/list/viewers = get_hearers_in_view(SUBTLE_ONE_TILE, user)
 
 	var/obj/effect/overlay/holo_pad_hologram/hologram = GLOB.hologram_impersonators[user]
 	if(hologram)
-		viewers |= get_hearers_in_view(SUBTLE_DEFAULT_DISTANCE, hologram)
+		viewers |= get_hearers_in_view(SUBTLE_ONE_TILE, hologram)
 
 	for(var/obj/effect/overlay/holo_pad_hologram/iterating_hologram in viewers)
 		if(iterating_hologram?.Impersonation?.client)
@@ -79,10 +80,6 @@
 	var/target
 	var/subtler_range = SUBTLE_DEFAULT_DISTANCE
 
-	var/datum/dna/dna = user.has_dna()
-	if(dna && dna?.check_mutation(/datum/mutation/human/telekinesis))
-		subtler_range = SUBTLER_TELEKINESIS_DISTANCE
-
 	if(SSdbcore.IsConnected() && is_banned_from(user, "emote"))
 		to_chat(user, span_warning("You cannot send subtle emotes (banned)."))
 		return FALSE
@@ -98,7 +95,7 @@
 
 		var/obj/effect/overlay/holo_pad_hologram/hologram = GLOB.hologram_impersonators[user]
 		if(hologram)
-			in_view |= get_hearers_in_view(1, hologram)
+			in_view |= get_hearers_in_view(subtler_range, hologram)
 
 		in_view -= GLOB.dead_mob_list
 		in_view.Remove(user)
@@ -113,7 +110,7 @@
 
 		switch(target)
 			if(SUBTLE_ONE_TILE_TEXT)
-				target = SUBTLE_DEFAULT_DISTANCE
+				target = SUBTLE_ONE_TILE
 			if(SUBTLE_SAME_TILE_TEXT)
 				target = SUBTLE_SAME_TILE_DISTANCE
 		subtler_message = subtler_emote
@@ -204,6 +201,7 @@
 	usr.emote("subtler")
 
 #undef SUBTLE_DEFAULT_DISTANCE
+#undef SUBTLE_ONE_TILE
 #undef SUBTLE_SAME_TILE_DISTANCE
 #undef SUBTLER_TELEKINESIS_DISTANCE
 


### PR DESCRIPTION
## About The Pull Request

Removes the subtler range and allows you to subtler anyone in view. 

## Why It's Good For The Game

I noticed there was a TK exception that allows an increased subtler range, and I don't see the reason why we need to cap it only to just TK.

## Proof Of Testing

I tested it on the AI holopad and in person. It works.

## Changelog

:cl:
add: Uncaps subtler range. Now anyone can subtler anyone else in view.
/:cl:
