### PR TITLE
Changes ingame chain_of_command to reflect our SOP

### DIFF
--- a/modular_zubbers/code/controllers/subsystem/job.dm
+++ b/modular_zubbers/code/controllers/subsystem/job.dm
@@ -1,0 +1,12 @@
+/datum/controller/subsystem/job
+	chain_of_command = list(
+			JOB_CAPTAIN = 1,
+			JOB_HEAD_OF_PERSONNEL = 2,
+			JOB_RESEARCH_DIRECTOR = 3,
+			JOB_CHIEF_MEDICAL_OFFICER = 4,
+			JOB_CHIEF_ENGINEER = 5,
+			JOB_QUARTERMASTER = 6,
+			JOB_NT_REP = 7,
+			JOB_HEAD_OF_SECURITY = 8,
+			JOB_BLUESHIELD = 9
+		)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8666,6 +8666,7 @@
 #include "modular_zubbers\code\_onclick\hud\screen_objects\hud_timer.dm"
 #include "modular_zubbers\code\controllers\configuration\entries\nsfw.dm"
 #include "modular_zubbers\code\controllers\subsystem\air.dm"
+#include "modular_zubbers\code\controllers\subsystem\job.dm"
 #include "modular_zubbers\code\controllers\subsystem\map_vote.dm"
 #include "modular_zubbers\code\controllers\subsystem\mapping.dm"
 #include "modular_zubbers\code\controllers\subsystem\research.dm"


### PR DESCRIPTION
## About The Pull Request

Changes the ingame chain_of_command variable used to determine who gets the safe code cookie to reflect our SOP (RD before CE, QM and NTC before HoS, include BS).
## Why It's Good For The Game

The safe code should be given to the person who our SOP indicates. When it goes to someone else, there's sometime arguments due to "CC just said I'm the acting" or whatnot. The NTC and Blueshield should also be able to get it if there's nobody higher than them in the chain on duty.

## Proof Of Testing

![image](https://github.com/user-attachments/assets/739e84c9-da04-43e4-87a4-d5105f4a694c)

Can't easily test the reprioritization on private, since that requires two separate people readied up at the start of the round, but since the other change work it should too.

## Changelog
:cl:
fix: The Spare ID safe code should now go to the person designated in our SOP
/:cl:
