### PR TITLE
mirrors "Removes the Sloth Ruin from the pool" from Nova

### DIFF
--- a/config/lavaruinblacklist.txt
+++ b/config/lavaruinblacklist.txt
@@ -23,7 +23,7 @@ _maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
 #_maps/RandomRuins/LavaRuins/lavaland_surface_gluttony.dmm
 #_maps/RandomRuins/LavaRuins/lavaland_surface_greed.dmm
 #_maps/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
-#_maps/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
+_maps/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
 
 ##MISC
 #_maps/RandomRuins/AnywhereRuins/fountain_hall.dmm


### PR DESCRIPTION

## About The Pull Request

https://github.com/NovaSector/NovaSector/pull/4319
see attached PR, it's so fucking annoying seeing sloth eat up a giant ass portion of the map
i'm pretty sure in length sloth is either longer or very similar to the entirety of the Persistence, and it adds exactly fuckall to the game, too
## Why It's Good For The Game

`"The Sloth shrine current iteration has been quite underwhelming, a long tunnel with no other reward than an orange and sepia tiles, with no other objective than to annoy the player that enters the shrine. We have better things to spawn than this!"` - quote, the original PR
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
del: Removes the Sloth Ruin from the rotation (ie, add it to the blacklist)
/:cl:
