### PR TITLE
Lewd Interactions are subtle, not subtler

### DIFF
--- a/modular_skyrat/modules/interaction_menu/code/interaction_datum.dm
+++ b/modular_skyrat/modules/interaction_menu/code/interaction_datum.dm
@@ -96,7 +96,7 @@ GLOBAL_LIST_EMPTY_TYPED(interaction_instances, /datum/interaction)
 	// We replace %USER% with nothing because manual_emote already prepends it.
 	msg = trim(replacetext(replacetext(msg, "%TARGET%", "[target]"), "%USER%", ""), INTERACTION_MAX_CHAR)
 	if(lewd)
-		user.emote("subtler", null, msg, TRUE)
+		user.emote("subtle", null, msg, TRUE)
 	else
 		user.manual_emote(msg)
 	if(user_messages.len)

--- a/modular_skyrat/modules/verbs/code/subtle.dm
+++ b/modular_skyrat/modules/verbs/code/subtle.dm
@@ -1,4 +1,5 @@
-#define SUBTLE_DEFAULT_DISTANCE 1
+#define SUBTLE_DEFAULT_DISTANCE world.view
+#define SUBTLE_ONE_TILE 1
 #define SUBTLE_SAME_TILE_DISTANCE 0
 #define SUBTLER_TELEKINESIS_DISTANCE 7
 
@@ -42,11 +43,11 @@
 
 	subtle_message = span_emote("<b>[user]</b>[space]<i>[user.say_emphasis(subtle_message)]</i>")
 
-	var/list/viewers = get_hearers_in_view(SUBTLE_DEFAULT_DISTANCE, user)
+	var/list/viewers = get_hearers_in_view(SUBTLE_ONE_TILE, user)
 
 	var/obj/effect/overlay/holo_pad_hologram/hologram = GLOB.hologram_impersonators[user]
 	if(hologram)
-		viewers |= get_hearers_in_view(SUBTLE_DEFAULT_DISTANCE, hologram)
+		viewers |= get_hearers_in_view(SUBTLE_ONE_TILE, hologram)
 
 	for(var/obj/effect/overlay/holo_pad_hologram/iterating_hologram in viewers)
 		if(iterating_hologram?.Impersonation?.client)
@@ -79,10 +80,6 @@
 	var/target
 	var/subtler_range = SUBTLE_DEFAULT_DISTANCE
 
-	var/datum/dna/dna = user.has_dna()
-	if(dna && dna?.check_mutation(/datum/mutation/human/telekinesis))
-		subtler_range = SUBTLER_TELEKINESIS_DISTANCE
-
 	if(SSdbcore.IsConnected() && is_banned_from(user, "emote"))
 		to_chat(user, span_warning("You cannot send subtle emotes (banned)."))
 		return FALSE
@@ -98,7 +95,7 @@
 
 		var/obj/effect/overlay/holo_pad_hologram/hologram = GLOB.hologram_impersonators[user]
 		if(hologram)
-			in_view |= get_hearers_in_view(1, hologram)
+			in_view |= get_hearers_in_view(subtler_range, hologram)
 
 		in_view -= GLOB.dead_mob_list
 		in_view.Remove(user)
@@ -113,7 +110,7 @@
 
 		switch(target)
 			if(SUBTLE_ONE_TILE_TEXT)
-				target = SUBTLE_DEFAULT_DISTANCE
+				target = SUBTLE_ONE_TILE
 			if(SUBTLE_SAME_TILE_TEXT)
 				target = SUBTLE_SAME_TILE_DISTANCE
 		subtler_message = subtler_emote
@@ -204,6 +201,7 @@
 	usr.emote("subtler")
 
 #undef SUBTLE_DEFAULT_DISTANCE
+#undef SUBTLE_ONE_TILE
 #undef SUBTLE_SAME_TILE_DISTANCE
 #undef SUBTLER_TELEKINESIS_DISTANCE
 


### PR DESCRIPTION
## About The Pull Request

Makes lewd interactions subtle, instead of anti-ghost subtler. It doesn't broadcast target information anyway so it's honestly just doing it in a 1x1 square anyway.

Also to stop the dinging sound with any lewd interaction.

## Why It's Good For The Game

Ding ding ding ding. Also this was an oversight on my part.

## Proof Of Testing

Works

## Changelog

:cl:
fix: Lewd interactions broadcasting down the entire hall
/:cl:
