### PR TITLE
Pun Pun suit sensors

### DIFF
--- a/modular_skyrat/master_files/code/modules/clothing/clothing_variation_overrides/under.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/clothing_variation_overrides/under.dm
@@ -220,6 +220,8 @@
 
 /obj/item/clothing/under/suit/waiter
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
+	random_sensor = FALSE
+	sensor_mode = SENSOR_OFF
 
 /obj/item/clothing/under/rank/prisoner
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION


### PR DESCRIPTION
## About The Pull Request

Makes Pun Pun's suit sensors off by default

## Why It's Good For The Game

No rush between medical trying to turn them off and the bartender killing the monke

## Changelog

:cl: LT3
del: Pun Pun's suit sensors are off by default
/:cl: