### PR TITLE
Subtler filters out clientless mobs

### DIFF
--- a/modular_skyrat/modules/verbs/code/subtle.dm
+++ b/modular_skyrat/modules/verbs/code/subtle.dm
@@ -103,8 +103,12 @@
 		in_view -= GLOB.dead_mob_list
 		in_view.Remove(user)
 
-		for(var/mob/camera/ai_eye/ai_eye in in_view)
-			in_view.Remove(ai_eye)
+		for(var/mob/mob in in_view) // Filters out the AI eye and clientless mobs.
+			if(istype(/mob/camera/ai_eye))
+				continue
+			if(mob.client)
+				continue
+			in_view.Remove(mob)
 
 		var/list/targets = list(SUBTLE_ONE_TILE_TEXT, SUBTLE_SAME_TILE_TEXT) + in_view
 		target = tgui_input_list(user, "Pick a target", "Target Selection", targets)

--- a/modular_skyrat/modules/verbs/code/subtle.dm
+++ b/modular_skyrat/modules/verbs/code/subtle.dm
@@ -104,7 +104,7 @@
 		in_view.Remove(user)
 
 		for(var/mob/mob in in_view) // Filters out the AI eye and clientless mobs.
-			if(istype(/mob/camera/ai_eye))
+			if(istype(mob, /mob/camera/ai_eye))
 				continue
 			if(mob.client)
 				continue


### PR DESCRIPTION
## About The Pull Request

Per the tin, it will remove clientless mobs from the subtle menu.

## Why It's Good For The Game

Clientless mobs can't hear your sex

## Proof Of Testing

Works

## Changelog

:cl:
fix: Subtler will now filter out clientless mobs
/:cl:
