### PR TITLE
Xenoarcheology and Triage pods

### DIFF
--- a/_maps/bubber/pods/shelter_4.dmm
+++ b/_maps/bubber/pods/shelter_4.dmm
@@ -32,7 +32,7 @@
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/storage/box/syringes,
 /obj/item/storage/medkit/regular,
-/obj/item/storage/medkit/robotic_repair,
+/obj/item/storage/medkit/robotic_repair/stocked,
 /obj/item/storage/medkit/toxin,
 /obj/item/storage/medkit/o2,
 /obj/item/storage/medkit/brute,

--- a/_maps/bubber/pods/shelter_triage.dmm
+++ b/_maps/bubber/pods/shelter_triage.dmm
@@ -1,0 +1,15 @@
+"a" = (/obj/structure/window/reinforced/survival_pod/spawner/directional/north,/turf/open/floor/pod/light,/area/misc/survivalpod)
+"e" = (/obj/structure/window/reinforced/survival_pod/spawner/directional/east,/obj/structure/window/reinforced/survival_pod/spawner/directional,/obj/structure/window/reinforced/survival_pod/spawner/directional/north,/obj/machinery/stasis,/turf/open/floor/pod/light,/area/misc/survivalpod)
+"l" = (/obj/structure/fans/tiny,/turf/open/floor/pod/light,/area/misc/survivalpod)
+"I" = (/obj/structure/window/reinforced/survival_pod,/turf/open/floor/pod/light,/area/misc/survivalpod)
+"O" = (/obj/structure/window/reinforced/survival_pod,/obj/structure/window/reinforced/survival_pod/spawner/directional/east,/obj/structure/window/reinforced/survival_pod/spawner/directional/north,/obj/machinery/defibrillator_mount/mobile,/obj/item/defibrillator/loaded,/turf/open/floor/pod/light,/area/misc/survivalpod)
+"P" = (/obj/structure/window/reinforced/survival_pod,/obj/structure/window/reinforced/survival_pod/spawner/directional/west,/obj/item/surgery_tray/full/deployed,/turf/open/floor/pod/light,/area/misc/survivalpod)
+"V" = (/obj/machinery/light/floor,/turf/open/floor/pod/light,/area/misc/survivalpod)
+"X" = (/obj/structure/window/reinforced/survival_pod/spawner/directional/west,/obj/structure/table/optable,/turf/open/floor/pod/light,/area/misc/survivalpod)
+"Z" = (/obj/structure/window/reinforced/survival_pod/spawner/directional/west,/obj/structure/window/reinforced/survival_pod/spawner/directional/north,/obj/machinery/computer/operating,/turf/open/floor/pod/light,/area/misc/survivalpod)
+
+(1,1,1) = {"
+Zae
+XVl
+PIO
+"}

--- a/_maps/bubber/pods/shelter_triage.dmm
+++ b/_maps/bubber/pods/shelter_triage.dmm
@@ -1,15 +1,65 @@
-"a" = (/obj/structure/window/reinforced/survival_pod/spawner/directional/north,/turf/open/floor/pod/light,/area/misc/survivalpod)
-"e" = (/obj/structure/window/reinforced/survival_pod/spawner/directional/east,/obj/structure/window/reinforced/survival_pod/spawner/directional,/obj/structure/window/reinforced/survival_pod/spawner/directional/north,/obj/machinery/stasis,/turf/open/floor/pod/light,/area/misc/survivalpod)
-"l" = (/obj/structure/fans/tiny,/turf/open/floor/pod/light,/area/misc/survivalpod)
-"I" = (/obj/structure/window/reinforced/survival_pod,/turf/open/floor/pod/light,/area/misc/survivalpod)
-"O" = (/obj/structure/window/reinforced/survival_pod,/obj/structure/window/reinforced/survival_pod/spawner/directional/east,/obj/structure/window/reinforced/survival_pod/spawner/directional/north,/obj/machinery/defibrillator_mount/mobile,/obj/item/defibrillator/loaded,/turf/open/floor/pod/light,/area/misc/survivalpod)
-"P" = (/obj/structure/window/reinforced/survival_pod,/obj/structure/window/reinforced/survival_pod/spawner/directional/west,/obj/item/surgery_tray/full/deployed,/turf/open/floor/pod/light,/area/misc/survivalpod)
-"V" = (/obj/machinery/light/floor,/turf/open/floor/pod/light,/area/misc/survivalpod)
-"X" = (/obj/structure/window/reinforced/survival_pod/spawner/directional/west,/obj/structure/table/optable,/turf/open/floor/pod/light,/area/misc/survivalpod)
-"Z" = (/obj/structure/window/reinforced/survival_pod/spawner/directional/west,/obj/structure/window/reinforced/survival_pod/spawner/directional/north,/obj/machinery/computer/operating,/turf/open/floor/pod/light,/area/misc/survivalpod)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/machinery/light/floor,
+/turf/open/floor/pod/light,
+/area/misc/survivalpod)
+"l" = (
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/structure/table/optable,
+/turf/open/floor/pod/light,
+/area/misc/survivalpod)
+"w" = (
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/item/surgery_tray/full/deployed,
+/turf/open/floor/pod/light,
+/area/misc/survivalpod)
+"x" = (
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/east,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
+/obj/machinery/defibrillator_mount/mobile,
+/obj/item/defibrillator/loaded,
+/turf/open/floor/pod/light,
+/area/misc/survivalpod)
+"H" = (
+/obj/structure/window/reinforced/survival_pod,
+/turf/open/floor/pod/light,
+/area/misc/survivalpod)
+"L" = (
+/obj/structure/window/reinforced/survival_pod/spawner/directional/east,
+/obj/structure/window/reinforced/survival_pod/spawner/directional,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
+/obj/machinery/stasis,
+/turf/open/floor/pod/light,
+/area/misc/survivalpod)
+"M" = (
+/obj/structure/fans/tiny,
+/turf/open/floor/pod/light,
+/area/misc/survivalpod)
+"R" = (
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
+/obj/machinery/computer/operating,
+/turf/open/floor/pod/light,
+/area/misc/survivalpod)
+"U" = (
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
+/turf/open/floor/pod/light,
+/area/misc/survivalpod)
 
 (1,1,1) = {"
-Zae
-XVl
-PIO
+R
+l
+w
+"}
+(2,1,1) = {"
+U
+a
+H
+"}
+(3,1,1) = {"
+L
+M
+x
 "}

--- a/_maps/bubber/pods/shelterxenoarch.dmm
+++ b/_maps/bubber/pods/shelterxenoarch.dmm
@@ -1,26 +1,64 @@
-"a" = (/obj/machinery/light/floor,/turf/open/floor/pod/light,/area/misc/survivalpod)
-"g" = (/obj/structure/window/reinforced/survival_pod/spawner/directional/north,/obj/structure/window/reinforced/survival_pod/spawner/directional/west,/obj/structure/closet/xenoarch,/turf/open/floor/pod/light,/area/misc/survivalpod)
-"m" = (/turf/open/space/basic,/area/space)
-"o" = (/obj/machinery/door/window/survival_pod/left/directional/south,/turf/open/floor/pod/light,/area/misc/survivalpod)
-"w" = (/obj/machinery/door/window/survival_pod/left/directional/north,/turf/open/floor/pod/light,/area/misc/survivalpod)
-"I" = (/obj/machinery/door/window/survival_pod/left/directional/west,/turf/open/floor/pod/light,/area/misc/survivalpod)
-"J" = (/obj/structure/window/reinforced/survival_pod/spawner/directional/east,/obj/structure/window/reinforced/survival_pod/spawner/directional/south,/obj/item/clothing/suit/hooded/wintercoat/science,/obj/item/gps/science,/turf/open/floor/pod/light,/area/misc/survivalpod)
-"M" = (/obj/structure/window/reinforced/survival_pod/spawner/directional/east,/obj/structure/window/reinforced/survival_pod/spawner/directional/north,/obj/item/tank/internals/emergency_oxygen/double,/obj/item/clothing/mask/breath,/obj/item/pickaxe/drill,/turf/open/floor/pod/light,/area/misc/survivalpod)
-"O" = (/obj/structure/window/reinforced/survival_pod/spawner/directional/south,/obj/structure/window/reinforced/survival_pod/spawner/directional/west,/obj/machinery/xenoarch/researcher,/turf/open/floor/pod/light,/area/misc/survivalpod)
-"U" = (/obj/machinery/door/window/survival_pod/left/directional/east,/turf/open/floor/pod/light,/area/misc/survivalpod)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/structure/window/reinforced/survival_pod/spawner/directional/east,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/obj/item/clothing/suit/hooded/wintercoat/science,
+/obj/item/gps/science,
+/turf/open/floor/pod/light,
+/area/misc/survivalpod)
+"c" = (
+/obj/machinery/door/window/survival_pod/left/directional/south,
+/turf/open/floor/pod/light,
+/area/misc/survivalpod)
+"e" = (
+/obj/machinery/door/window/survival_pod/left/directional/west,
+/turf/open/floor/pod/light,
+/area/misc/survivalpod)
+"k" = (
+/obj/machinery/light/floor,
+/turf/open/floor/pod/light,
+/area/misc/survivalpod)
+"v" = (
+/obj/structure/window/reinforced/survival_pod/spawner/directional/east,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/clothing/mask/breath,
+/obj/item/pickaxe/drill,
+/turf/open/floor/pod/light,
+/area/misc/survivalpod)
+"F" = (
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/structure/closet/xenoarch,
+/turf/open/floor/pod/light,
+/area/misc/survivalpod)
+"G" = (
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/machinery/xenoarch/researcher,
+/turf/open/floor/pod/light,
+/area/misc/survivalpod)
+"T" = (
+/obj/machinery/door/window/survival_pod/left/directional/north,
+/turf/open/floor/pod/light,
+/area/misc/survivalpod)
+"W" = (
+/obj/machinery/door/window/survival_pod/left/directional/east,
+/turf/open/floor/pod/light,
+/area/misc/survivalpod)
 
 (1,1,1) = {"
-gwM
-IaU
-OoJ
+F
+e
+G
 "}
-(1,1,2) = {"
-mmm
-mmm
-mmm
+(2,1,1) = {"
+T
+k
+c
 "}
-(1,1,3) = {"
-mmm
-mmm
-mmm
+(3,1,1) = {"
+v
+W
+a
 "}

--- a/_maps/bubber/pods/shelterxenoarch.dmm
+++ b/_maps/bubber/pods/shelterxenoarch.dmm
@@ -1,0 +1,26 @@
+"a" = (/obj/machinery/light/floor,/turf/open/floor/pod/light,/area/misc/survivalpod)
+"g" = (/obj/structure/window/reinforced/survival_pod/spawner/directional/north,/obj/structure/window/reinforced/survival_pod/spawner/directional/west,/obj/structure/closet/xenoarch,/turf/open/floor/pod/light,/area/misc/survivalpod)
+"m" = (/turf/open/space/basic,/area/space)
+"o" = (/obj/machinery/door/window/survival_pod/left/directional/south,/turf/open/floor/pod/light,/area/misc/survivalpod)
+"w" = (/obj/machinery/door/window/survival_pod/left/directional/north,/turf/open/floor/pod/light,/area/misc/survivalpod)
+"I" = (/obj/machinery/door/window/survival_pod/left/directional/west,/turf/open/floor/pod/light,/area/misc/survivalpod)
+"J" = (/obj/structure/window/reinforced/survival_pod/spawner/directional/east,/obj/structure/window/reinforced/survival_pod/spawner/directional/south,/obj/item/clothing/suit/hooded/wintercoat/science,/obj/item/gps/science,/turf/open/floor/pod/light,/area/misc/survivalpod)
+"M" = (/obj/structure/window/reinforced/survival_pod/spawner/directional/east,/obj/structure/window/reinforced/survival_pod/spawner/directional/north,/obj/item/tank/internals/emergency_oxygen/double,/obj/item/clothing/mask/breath,/obj/item/pickaxe/drill,/turf/open/floor/pod/light,/area/misc/survivalpod)
+"O" = (/obj/structure/window/reinforced/survival_pod/spawner/directional/south,/obj/structure/window/reinforced/survival_pod/spawner/directional/west,/obj/machinery/xenoarch/researcher,/turf/open/floor/pod/light,/area/misc/survivalpod)
+"U" = (/obj/machinery/door/window/survival_pod/left/directional/east,/turf/open/floor/pod/light,/area/misc/survivalpod)
+
+(1,1,1) = {"
+gwM
+IaU
+OoJ
+"}
+(1,1,2) = {"
+mmm
+mmm
+mmm
+"}
+(1,1,3) = {"
+mmm
+mmm
+mmm
+"}

--- a/modular_zubbers/code/modules/mining/equipment/survival_pod.dm
+++ b/modular_zubbers/code/modules/mining/equipment/survival_pod.dm
@@ -296,7 +296,7 @@
 /datum/supply_pack/science/xenoarchpod
 	name = "Xenoarcheology Pod"
 	desc = "A bluespace pod, containing an 3x3 xenoarcheology capsule."
-	cost = CARGO_CRATE_VALUE * 3
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/obj/item/survivalcapsule/xenoarchpod)
 	crate_type = /obj/structure/closet/crate/nakamura
 
@@ -325,5 +325,5 @@
 /datum/supply_pack/medical/triagepod
 	name = "Triage Pod"
 	desc = "A bluespace pod, containing an 3x3 triage suite."
-	cost = CARGO_CRATE_VALUE * 3
+	cost = CARGO_CRATE_VALUE * 15
 	contains = list(/obj/item/survivalcapsule/triage)

--- a/modular_zubbers/code/modules/mining/equipment/survival_pod.dm
+++ b/modular_zubbers/code/modules/mining/equipment/survival_pod.dm
@@ -54,6 +54,26 @@
 	item_type = /obj/item/survivalcapsule/chemistry
 	cost = PAYCHECK_COMMAND * 20
 
+/datum/supply_pack/medical/medpod
+	name = "Medical Trauma Pod"
+	crate_name = "medical pod crate"
+	desc = "A bluespace capsule that deploys a fairly effective medical treatment pod!"
+	access = ACCESS_MEDICAL
+	cost = CARGO_CRATE_VALUE * 20
+	contains = list(
+		/obj/item/survivalcapsule/medical,
+	)
+
+/datum/supply_pack/medical/chempod
+	name = "Chemical Refinement Pod"
+	crate_name = "chemistry pod crate"
+	desc = "A bluespace capsule that deploys a functional chemistry refining area, useful for harvesting those helpful geysers."
+	access = ACCESS_MEDICAL
+	cost = CARGO_CRATE_VALUE * 10
+	contains = list(
+		/obj/item/survivalcapsule/chemistry,
+	)
+
 /*****************************Botany Pods - Home is where the green is...********************************/
 /obj/item/survivalcapsule/botany
 	name = "botany control capsule"
@@ -94,6 +114,8 @@
 	. = ..()
 	whitelisted_turfs = typecacheof(/turf/closed/mineral)
 	banned_objects = typecacheof(/obj/structure/stone_tile)
+
+/*********************************************Odd Pods**************************************************/
 
 /obj/item/survivalcapsule/fan
 	name = "airlock fan capsule"
@@ -176,7 +198,7 @@
 	banned_objects = typecacheof(/obj/structure/stone_tile)
 
 /obj/item/survivalcapsule/threebythree
-	name = "deployable small emtpy capsule"
+	name = "deployable small empty capsule"
 	desc = "A bluespace pod, containing an empty 3x3 capsule."
 	icon_state = "capsule"
 	icon = 'icons/obj/mining.dmi'
@@ -196,7 +218,7 @@
 	banned_objects = typecacheof(/obj/structure/stone_tile)
 
 /obj/item/survivalcapsule/sixbysix
-	name = "deployable large emtpy capsule"
+	name = "deployable large empty capsule"
 	desc = "A bluespace pod, containing an empty 6x6 capsule."
 	icon_state = "capsule"
 	icon = 'icons/obj/mining.dmi'
@@ -246,3 +268,62 @@
 /datum/armament_entry/company_import/nri_surplus/misc/cabin
 	item_type = /obj/item/survivalcapsule/cabin
 	cost = PAYCHECK_COMMAND * 2
+
+
+/************************* MED-SCI Pods***************************/
+
+/***xenoarcheology***/
+/obj/item/survivalcapsule/xenoarchpod
+	name = "deployable xenoarcheology capsule"
+	desc = "A bluespace pod, containing an 3x3 xenoarcheology capsule."
+	icon_state = "capsule"
+	icon = 'icons/obj/mining.dmi'
+	w_class = WEIGHT_CLASS_TINY
+	template_id = "shelter_xenoarch"
+	used = FALSE
+
+/datum/map_template/shelter/xenoarch
+	name = "xenoarch capsule deployer"
+	shelter_id = "shelter_xenoarch"
+	description = "A contained small xenoarch capsule."
+	mappath = "_maps/bubber/pods/shelterxenoarch.dmm"
+
+/datum/map_template/shelter/xenoarch/New()
+	. = ..()
+	whitelisted_turfs = typecacheof(/turf/closed/mineral)
+	banned_objects = typecacheof(/obj/structure/stone_tile)
+
+/datum/supply_pack/science/xenoarchpod
+	name = "Xenoarcheology Pod"
+	desc = "A bluespace pod, containing an 3x3 xenoarcheology capsule."
+	cost = CARGO_CRATE_VALUE * 3
+	contains = list(/obj/item/survivalcapsule/xenoarchpod)
+	crate_type = /obj/structure/closet/crate/nakamura
+
+/***triage***/
+
+/obj/item/survivalcapsule/triage
+	name = "deployable triage capsule"
+	desc = "A bluespace pod, containing an 3x3 emergency triage."
+	icon_state = "capsule"
+	icon = 'icons/obj/mining.dmi'
+	w_class = WEIGHT_CLASS_TINY
+	template_id = "shelter_triage"
+	used = FALSE
+
+/datum/map_template/shelter/triage
+	name = "triage capsule deployer"
+	shelter_id = "shelter_triage"
+	description = "A contained small triage capsule."
+	mappath = "_maps/bubber/pods/shelter_triage.dmm"
+
+/datum/map_template/shelter/triage/New()
+	. = ..()
+	whitelisted_turfs = typecacheof(/turf/closed/mineral)
+	banned_objects = typecacheof(/obj/structure/stone_tile)
+
+/datum/supply_pack/medical/triagepod
+	name = "Triage Pod"
+	desc = "A bluespace pod, containing an 3x3 triage suite."
+	cost = CARGO_CRATE_VALUE * 3
+	contains = list(/obj/item/survivalcapsule/triage)


### PR DESCRIPTION

## About The Pull Request

This PR aims to add two new pods along side adding two long existing pods to departmental orders.

The two new pods, both 3x3 deployables; One contains; a stasis bed, operating equipment for medical triage during dangerous situations. The xenoarcheology pod is available one; carrying a suite of tools for xenoarcheology and useful supplies for your expeditions.

I also applied a small fix to the large medical shelter, which actually makes the robotic repair medkit actually have supplies, I'm shocked no-one told me after this long!
## Why It's Good For The Game

Valued at 1,500cr the triage pod is also available on departmental orders, a useful thing to keep for breaches, fires and blob/xeno breakouts. The xenoarcheology pod is very useful; affordable (400cr) for scientists and a reliable way of getting started. Most people didn't even notice the medical and chemistry pods even existed; access on departmental orders means parameds, chemists and doctors who wish to operate on the planet can get what they want. 

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
Xenoarch:

![image](https://github.com/user-attachments/assets/6e68e4f2-5246-4ac9-b9fb-13662957ea89)

Triage:

![image](https://github.com/user-attachments/assets/9031060b-315f-49d5-ba8a-bc9166f15396)


</details>

## Changelog
:cl:
add: Added two new pods; Xenoarch and triage
fix: fixed the robotic repair kit in the large medical pod from being empty.
/:cl:
