### PR TITLE
Synth Heretics Heart QOL

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/starting_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/starting_lore.dm
@@ -187,7 +187,7 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 		return FALSE
 	if(!new_heart.useable)
 		return FALSE
-	if(new_heart.organ_flags & (ORGAN_ROBOTIC|ORGAN_FAILING))
+	if(new_heart.organ_flags & (ORGAN_FAILING)) //BUBBERSTATION EDIT
 		return FALSE
 
 	return TRUE


### PR DESCRIPTION
## About The Pull Request

Heretics who are synths no longer have to craft their living heart - making them not reliant on poppies to start antagging - **Putting them on an even playing field.**

## Why It's Good For The Game

The check for making hearts only apply to non-synths was making some people not have a good time, so I deletedi t

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>
Heart very much beating
https://github.com/user-attachments/assets/409a913c-0a03-4e5a-aa5e-ea4e2882bd0c
</details>

:cl:
qol: Heretic Synths also start with a living heart
/:cl:
