### PR TITLE
Makes the softcap message disableable again

### DIFF
--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -34,7 +34,7 @@
 
 	//SKYRAT EDIT ADDITION
 	var/soft_player_cap = CONFIG_GET(number/player_soft_cap)
-	if(TGS_CLIENT_COUNT >= soft_player_cap)
+	if(soft_player_cap && TGS_CLIENT_COUNT >= soft_player_cap)
 		INVOKE_ASYNC(src, PROC_REF(connect_to_second_server))
 	//SKYRAT EDIT END
 


### PR DESCRIPTION

## About The Pull Request
quickly fixes https://github.com/Bubberstation/Bubberstation/pull/2910 which makes the softcap message appear when testing instead of disabling itself as expected
## Why It's Good For The Game
The repo's booting process already has a lot of runtimes and errors, I'd prefer not having to also deal with a popup each time I open it
## Proof Of Testing
It works
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: makes the softcap config disableable again
/:cl:
