### PR TITLE
Increase space Z levels to account for high pop and more fun

### DIFF
--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -171,7 +171,7 @@ Always compile, always use that verb, and always make sure that it works for wha
 #define PLACE_ISOLATED "isolated" //On isolated ruin z level
 
 ///Map generation defines
-#define DEFAULT_SPACE_RUIN_LEVELS 4 // Bubber Edit - ORG: 7
+#define DEFAULT_SPACE_RUIN_LEVELS 10 // Bubber Edit - ORG: 7
 #define DEFAULT_SPACE_EMPTY_LEVELS 1
 
 #define BIOME_LOW_HEAT "low_heat"


### PR DESCRIPTION

## About The Pull Request
an alternative to https://github.com/Bubberstation/Bubberstation/pull/2847
Increases the space Z levels from 4 to 10, instead of 7, because space is sick, and exploring it is super fun.
<!-- Please make sure to test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game
uhh, see above. The lag issue was resolved. I tested it, and it works. Improves gameplay for Tarkon, Charlie, and BMD when they spawn with more space to look around in. Improves station gameplay for those who want to explore by giving them MORE to explore.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/8d3c8e5e-0c01-45a0-87cd-d25620aff58b)

</details>

## Changelog
:cl:
add: Space Z levels increased from 4, to 10. Get exploring!
/:cl:
