### PR TITLE
Reduces antag counts across most storytellers

### DIFF
--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_bomb.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_bomb.dm
@@ -8,7 +8,7 @@
 		TAG_DESTRUCTIVE = 2
 	)
 	population_min = 25
-	antag_divisor = 10
+	antag_divisor = 13
 	storyteller_type = STORYTELLER_TYPE_INTENSE
 
 /datum/storyteller_data/tracks/bomb

--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_chill.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_chill.dm
@@ -11,7 +11,7 @@
 		TAG_DESTRUCTIVE = 0.3,
 		TAG_CHAOTIC = 0.1
 	)
-	antag_divisor = 32
+	antag_divisor = 38
 	storyteller_type = STORYTELLER_TYPE_CALM
 
 /datum/storyteller_data/tracks/chill

--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_clown.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_clown.dm
@@ -7,7 +7,7 @@
 	track_data = /datum/storyteller_data/tracks/clown
 
 	population_min = 50
-	antag_divisor = 4
+	antag_divisor = 7
 	storyteller_type = STORYTELLER_TYPE_INTENSE
 
 /datum/storyteller_data/tracks/clown

--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_default.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_default.dm
@@ -2,5 +2,5 @@
 	name = "Default Andy"
 	desc = "Default Andy is the default Storyteller, and the comparison point for every other Storyteller. Best for an average, varied experience."
 	welcome_text = "If I chopped you up in a meat grinder..."
-	antag_divisor = 8
+	antag_divisor = 12
 	storyteller_type = STORYTELLER_TYPE_ALWAYS_AVAILABLE

--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_gamer.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_gamer.dm
@@ -11,7 +11,7 @@
 		TAG_CHAOTIC = 1.3
 	)
 	population_min = 35
-	antag_divisor = 5
+	antag_divisor = 6
 	storyteller_type = STORYTELLER_TYPE_INTENSE
 
 /datum/storyteller_data/tracks/gamer


### PR DESCRIPTION

## About The Pull Request

I really didn't want to make this PR, because I hoped someone with more knowledge of the problem at hand would come along, but noone has so far. So you're stuck with my desperate attempt to make things a little better.

I know this PR isn't very good. I don't really know the core issue besides "rounds way too chaotic"; but I think it's a reasonable assumption that too many antags could be a candidate - especially since a lot of new players seem to not engage in a healthy antag relationship.
## Why It's Good For The Game

Storytellers have gone off the rails recently, directly correlating with our popsize. I think we should try reducing the amount of antags even by just a little to see if it helps.
## Proof Of Testing

it compiles

## Changelog
:cl:
balance: Storytellers spawn less antags
/:cl:
