### PR TITLE
[TEST-MERGE ONLY] Makes storytellers random

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -174,7 +174,10 @@ SUBSYSTEM_DEF(ticker)
 			if(storyteller)
 				SSgamemode.set_storyteller(text2path(storyteller), TRUE)
 			else
-				SSvote.initiate_vote(/datum/vote/storyteller, "Storyteller Vote", forced = TRUE)
+				if (CONFIG_GET(flag/vote_for_storytellers))
+					SSvote.initiate_vote(/datum/vote/storyteller, "Storyteller Vote", forced = TRUE)
+				else
+					SSgamemode.pick_random_storyteller()
 		// BUBBERSTATION EDIT END
 			SStitle.change_title_screen() //SKYRAT EDIT ADDITION - Title screen
 			addtimer(CALLBACK(SStitle, TYPE_PROC_REF(/datum/controller/subsystem/title, change_title_screen)), 1 SECONDS) //SKYRAT EDIT ADDITION - Title screen

--- a/modular_skyrat/master_files/code/controllers/configuration/entries/skyrat_config_entries.dm
+++ b/modular_skyrat/master_files/code/controllers/configuration/entries/skyrat_config_entries.dm
@@ -63,3 +63,7 @@
 
 /// If you want to have a default storyteller
 /datum/config_entry/string/default_storyteller
+
+/// If enabled, storytellers cease being randomly picked and are voted for
+/datum/config_entry/flag/vote_for_storytellers
+	default = FALSE

--- a/modular_zubbers/code/modules/storyteller/gamemode.dm
+++ b/modular_zubbers/code/modules/storyteller/gamemode.dm
@@ -684,11 +684,13 @@ SUBSYSTEM_DEF(gamemode)
 
 	for(var/datum/storyteller/storyboy in valid)
 		if(!storyboy.votable)
-			choices -= storyboy
+			continue
 
 		///Because the vote subsystem is dumb and does not support any descriptions, we dump them into world.
 		to_chat(world, span_notice("<b>[storyboy.name]</b>"))
 		to_chat(world, span_notice("[storyboy.desc]"))
+
+		choices += storyboy.name
 
 	return choices
 
@@ -704,7 +706,7 @@ SUBSYSTEM_DEF(gamemode)
 			continue
 		if((storyboy.population_min && storyboy.population_min > client_amount) || (storyboy.population_max && storyboy.population_max < client_amount))
 			continue
-		valid += storyboy.name
+		valid += storyboy
 
 	return valid
 

--- a/modular_zubbers/code/modules/storyteller/gamemode.dm
+++ b/modular_zubbers/code/modules/storyteller/gamemode.dm
@@ -771,7 +771,7 @@ SUBSYSTEM_DEF(gamemode)
 	if (isnull(picked_teller))
 		stack_trace("No valid storyteller found during a random storyteller pick! Defaulting to extended...")
 		picked_teller = storytellers[/datum/storyteller/extended]
-	set_storyteller(picked_teller)
+	set_storyteller(picked_teller, randomly_picked = TRUE)
 
 /**
  * halt_storyteller

--- a/modular_zubbers/code/modules/storyteller/gamemode.dm
+++ b/modular_zubbers/code/modules/storyteller/gamemode.dm
@@ -773,7 +773,7 @@ SUBSYSTEM_DEF(gamemode)
 	if (isnull(picked_teller))
 		stack_trace("No valid storyteller found during a random storyteller pick! Defaulting to extended...")
 		picked_teller = storytellers[/datum/storyteller/extended]
-	set_storyteller(picked_teller, randomly_picked = TRUE)
+	set_storyteller(picked_teller.type, randomly_picked = TRUE)
 
 /**
  * halt_storyteller

--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/_storyteller.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/_storyteller.dm
@@ -46,6 +46,9 @@
 	/// Two tellers of the same intensity group can't run in 2 consecutive rounds
 	var/storyteller_type = STORYTELLER_TYPE_ALWAYS_AVAILABLE
 
+	/// The weight of this storyteller, used when flag/vote_for_storytellers is FALSE. Used in pick_weight().
+	var/random_weight = 100
+
 /datum/storyteller/process(delta_time)
 	if(disable_distribution)
 		return

--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_bomb.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_bomb.dm
@@ -10,6 +10,7 @@
 	population_min = 25
 	antag_divisor = 10
 	storyteller_type = STORYTELLER_TYPE_INTENSE
+	random_weight = 70 // uncommon
 
 /datum/storyteller_data/tracks/bomb
 	threshold_mundane = 1800

--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_clown.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_clown.dm
@@ -9,6 +9,7 @@
 	population_min = 50
 	antag_divisor = 4
 	storyteller_type = STORYTELLER_TYPE_INTENSE
+	random_weight = 40 // not common at all
 
 /datum/storyteller_data/tracks/clown
 	threshold_mundane = 700


### PR DESCRIPTION
## About The Pull Request

**In this stage of the PR, this is mostly just up for discussion - it has not been tested or tuned**

Storytellers are now randomly selected, rather than voted for. This is controlled by a new config variable.
Clown and the bomb are less common.
## Why It's Good For The Game

Clown and default andy are basically being picked 100% of the time these days. A lot of people, me incnluded, are upset by this. Im pretty sure storytellers were never made to give total control to the playerbase, more of add variety and a more nuanced experience (I could be wrong, please correct me if I am)

Ultimately, even if the players do want extreme levels of chaos 24/7 - it might be best if we t ake the wheel for once to actually dictate what _we_ think a good distribution of chaos is. In this implemenation, all storytellers are evenly weighted except f or the clown and the bomb, which are rarer.
## Proof Of Testing

Hard to test, always picks extended on 0pop

## Changelog
:cl:
add: Storytellers are now randomly picked
/:cl:
