### PR TITLE
Updates main Storyteller description texts with comparisons

### DIFF
--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_1_chill.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_1_chill.dm
@@ -1,6 +1,7 @@
 /datum/storyteller/chill
 	name = "Chill (Low Chaos)"
-	desc = "The Chill will be light on events compared to other storytellers, especially so on ones involving combat, destruction, or chaos. Best for more chill rounds."
+	desc = "The Chill will be light on events compared to other storytellers, especially so on ones involving combat, destruction, or chaos. \
+	The least hectic storyteller of all, while still having some spice.  Best for RP-focused rounds with a few events sprinkled in."
 	welcome_text = "If you vote for this storyteller on Ice Box, you have no originality."
 
 	track_data = /datum/storyteller_data/tracks/chill

--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_2_fragile.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_2_fragile.dm
@@ -1,6 +1,7 @@
 /datum/storyteller/fragile
-	name = "Fragile (Medium-Low Chaos)"
-	desc = "The Fragile will limit destructive, combat-focused, and chaotic events. You'll rarely see midround antagonist roles that usually cause it."
+	name = "The Fragile"
+	desc = "The Fragile will limit destructive, combat-focused, and chaotic events. You'll rarely see midround antagonist roles that usually cause it. \
+	Spawns more events and allows for more combat than the Chill, but remains lower in frequency than Default Andy. It will also repeat events less than the Chill."
 	welcome_text = "Handle with care!"
 
 	event_repetition_multiplier = 0.5
@@ -12,7 +13,7 @@
 		TAG_DESTRUCTIVE = 0.1,
 		TAG_CHAOTIC = 0.1
 	)
-	storyteller_type = STORYTELLER_TYPE_ALWAYS_AVAILABLE
+	storyteller_type = STORYTELLER_TYPE_CALM
 
 /datum/storyteller_data/tracks/fragile
 	threshold_mundane = 1200

--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_3_default.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_3_default.dm
@@ -1,6 +1,7 @@
 /datum/storyteller/default
 	name = "Default Andy (Medium Chaos)"
-	desc = "Default Andy is the default Storyteller, and the comparison point for every other Storyteller. Best for an average, varied experience."
+	desc = "Default Andy is the default Storyteller, and the comparison point for every other Storyteller. \
+	More frequent events than the Chill or the Fragile, but less frequent events than The Gamer or the Clown. Best for an average, varied experience."
 	welcome_text = "If I chopped you up in a meat grinder..."
 	antag_divisor = 8
 	storyteller_type = STORYTELLER_TYPE_ALWAYS_AVAILABLE

--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_5_gamer.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_5_gamer.dm
@@ -1,6 +1,7 @@
 /datum/storyteller/gamer
 	name = "Gamer (High Chaos)"
-	desc = "The Gamer will try to create the most combat focused events, while trying to avoid purely destructive ones."
+	desc = "The Gamer will try to create the most combat focused events, while trying to avoid purely destructive ones. \
+	More combat-focused and frequent events than the Default, but stayss ordered to avoid creating a hellshift, unlike the Clown."
 	welcome_text = "Welcome to the Gamer storyteller. Now with 50% more ahelps!"
 
 	track_data = /datum/storyteller_data/tracks/gamer

--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_6_clown.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_6_clown.dm
@@ -1,7 +1,7 @@
 /datum/storyteller/clown
 	name = "Clown (Very-High Chaos)"
-	desc = "The Clown will try to create the most events and antagonists out of all the storytellers, not caring for their weight. \
-	As such, it can be truly chaotic and even end rounds prematurely."
+desc = "The Clown will try to create the most events and antagonists out of all the storytellers, not caring for their weight. \
+	As such, this storyteller is hell, and is likely to end the round prematurely. It is the most chaotic of all."
 	welcome_text = "honk"
 
 	track_data = /datum/storyteller_data/tracks/clown


### PR DESCRIPTION
## About The Pull Request
This PR makes it so that the description text for each storyteller compares it to other Storytellers, for added clarity.

## Why It's Good For The Game
Helps you understand the difference between given Storytellers!

## Proof Of Testing
Compiles

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl: ReturnToZender
add: Updated descriptions to individual storytellers to compare them to each other.
/:cl: