### PR TITLE
Fix typo in skyrat sleek roboticst jumpsuit name

### DIFF
--- a/modular_skyrat/master_files/code/modules/clothing/under/jobs/rnd.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/under/jobs/rnd.dm
@@ -42,7 +42,7 @@
 */
 
 /obj/item/clothing/under/rank/rnd/roboticist/skyrat/sleek
-	name = "sleek roboticst jumpsuit"
+	name = "sleek roboticist jumpsuit"
 	desc = "A sleek version of the roboticist uniform, complete with amber sci-fi stripes."
 	icon_state = "robosleek"
 	can_adjust = FALSE


### PR DESCRIPTION

## About The Pull Request
Roboticst -> roboticist
## Why It's Good For The Game
typo silly
## Proof Of Testing
compiled and spawned it and it was spelled right smiles
