### PR TITLE
Makes the clock sound not penetrate walls

### DIFF
--- a/modular_skyrat/modules/officestuff/code/officestuff.dm
+++ b/modular_skyrat/modules/officestuff/code/officestuff.dm
@@ -22,6 +22,7 @@
 	mid_sounds = list('modular_skyrat/modules/officestuff/sound/clock_ticking.ogg' = 1)
 	mid_length = 12 SECONDS
 	volume = 10
+	ignore_walls = FALSE
 
 /obj/structure/grandfatherclock/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Exactly what it says on the tin. Makes the soundloop for clocks not make noise through walls.
## Why It's Good For The Game

Constantly ticking clocks are an annoyance that can be hard to escape as command on certain maps like Moonstation. There's no reason that a wall thick enough to hold back vacuum should be letting a clock noise through it like nothing.

## Proof Of Testing

Can't really screenshot a sound, but I did test this on local and it works.

## Changelog
:cl:
fix: The ticking of clocks can no longer be heard through walls, filling the bridge with an incessant ticking noise like the Telltale heart's thumping.
/:cl:
