### PR TITLE
buffs flesh heretic ghouls to 100, and mute ghouls to 135

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -1,7 +1,7 @@
 /// The max amount of health a ghoul has.
-#define GHOUL_MAX_HEALTH 25
+#define GHOUL_MAX_HEALTH HUMAN_MAXHEALTH - 35 // BUBBER EDIT
 /// The max amount of health a voiceless dead has.
-#define MUTE_MAX_HEALTH 50
+#define MUTE_MAX_HEALTH HUMAN_MAXHEALTH // BUBBER EDIT
 
 /**
  * # The path of Flesh.


### PR DESCRIPTION
## About The Pull Request
ditto to PR title

## Why It's Good For The Game
Flesh path is kind of really sad, and even on TG, flesh path struggles, as having so little HP means even one shot often crits you, let's give the heretic type that brings back dead people a good fair chance at doing it's thing.

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
balance: Flesh ghouls now have 100 HP, while heretic mute ghouls have normal human HP, ie, 135, from 25 and 50
/:cl:

