### PR TITLE
Remove taur cropping for short-sleeved kimono

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/~donator/donator_clothing.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/~donator/donator_clothing.dm
@@ -1480,6 +1480,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/korpstech, 32)
 	icon_state = "kimono-gold"
 	icon = 'modular_skyrat/master_files/icons/donator/obj/clothing/uniform.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/donator/mob/clothing/uniform.dmi'
+	gets_cropped_on_taurs = FALSE
 
 // Donation reward for Sigmar Alkahest
 /obj/item/clothing/head/hooded/sigmarcoat


### PR DESCRIPTION

## About The Pull Request
The original donator for whom this was a donator item for has requested that the taur cropping be removed for their naga character that it was designed for.  I looked into how to use the taur snake grouping to retain the cropping on other taur types, but was not able to figure it out.  If that is possible and preferred, it would be nice if someone could add it in a review as this change causes clipping with other taur species and this clothing item.  This is undesirable, even if this clothing item is rarely used.
## Why It's Good For The Game
Fixes #2931
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/46c0d576-5c8d-4a8a-bf5e-9e09056af289)

Examples of it looking odd on other taur body types:
![image](https://github.com/user-attachments/assets/65085cec-be27-40b4-963a-b6ed860f78b2)

</details>
