### PR TITLE
Kilostation abandoned warehouse update

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -897,7 +897,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "amX" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/ai_monitored/security/armory)
@@ -1168,7 +1168,7 @@
 /obj/structure/barricade/wooden/crude,
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "ari" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -2263,7 +2263,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "aKr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -3436,7 +3436,7 @@
 /obj/structure/barricade/wooden/crude,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "bib" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/conveyor{
@@ -4084,7 +4084,7 @@
 /obj/item/stack/rods,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "bty" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/plasma,
@@ -5811,7 +5811,7 @@
 	},
 /obj/machinery/nuclearbomb/beer,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "cbJ" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -5991,7 +5991,7 @@
 /obj/structure/rack,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "cdV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/circuit/green{
@@ -6501,7 +6501,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "cjN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -6798,7 +6798,7 @@
 "cnq" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "cnM" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/effect/turf_decal/sand/plating,
@@ -8558,7 +8558,7 @@
 	name = "on ramp"
 	},
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "cWl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9197,7 +9197,7 @@
 "dgw" = (
 /obj/structure/sign/warning/docking,
 /turf/closed/wall/rust,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "dgD" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
@@ -9209,7 +9209,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "dgE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -9528,7 +9528,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "dlc" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/cup/glass/mug/coco,
@@ -10057,7 +10057,7 @@
 "dsD" = (
 /obj/structure/sign/departments/cargo,
 /turf/closed/wall,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "dsI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch{
@@ -11153,7 +11153,7 @@
 /area/station/cargo/storage)
 "dME" = (
 /turf/closed/wall,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "dMF" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -12772,7 +12772,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "eqA" = (
 /obj/machinery/light_switch/directional/south{
 	pixel_x = 26
@@ -13463,7 +13463,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "eCU" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -14055,7 +14055,7 @@
 /area/station/maintenance/starboard/fore)
 "eNb" = (
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "eNy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -14591,7 +14591,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "eYd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -14892,7 +14892,7 @@
 	environment_smash = 0
 	},
 /turf/open/floor/carpet/green,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "fdC" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
@@ -15364,8 +15364,9 @@
 /obj/item/screwdriver{
 	pixel_y = 6
 	},
+/obj/item/wallframe/apc,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "fkL" = (
 /obj/structure/sign/warning/pods,
 /turf/closed/wall,
@@ -17116,7 +17117,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "fIP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/chair/office{
@@ -17745,7 +17746,7 @@
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "fSE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/cigarette,
@@ -18170,7 +18171,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "gaE" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
@@ -19714,7 +19715,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "gzA" = (
 /obj/structure/girder,
 /obj/effect/turf_decal/stripes/corner,
@@ -19950,7 +19951,7 @@
 /obj/item/shard,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "gDT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20010,7 +20011,7 @@
 	},
 /obj/structure/sign/poster/contraband/random/directional/east,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "gFD" = (
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/tile/neutral{
@@ -20261,7 +20262,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "gIz" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -20373,9 +20374,9 @@
 "gJF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/item/stack/cable_coil/five,
+/obj/item/stack/cable_coil/thirty,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "gJK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/closed/wall/rust,
@@ -20414,7 +20415,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "gKC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
@@ -20998,7 +20999,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "gUZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21277,7 +21278,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "hbC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
@@ -21433,7 +21434,7 @@
 	name = "Freight Mining Airlock"
 	},
 /turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "heU" = (
 /obj/structure/sign/warning/electric_shock/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -22698,7 +22699,7 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/closet,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "hAc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -22827,7 +22828,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "hBJ" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/maintenance/port/greater)
@@ -23453,7 +23454,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "hKB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -23704,7 +23705,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "hOt" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24545,7 +24546,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "iaH" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
@@ -24613,7 +24614,7 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "ibJ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -25020,7 +25021,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "ihU" = (
 /turf/closed/wall/rust,
 /area/station/cargo/sorting)
@@ -25537,7 +25538,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "ipI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/radio/intercom/directional/east,
@@ -25819,7 +25820,7 @@
 "itR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "itZ" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/structure/flora/bush/grassy/style_random,
@@ -26116,7 +26117,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "iyF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26470,7 +26471,7 @@
 "iEB" = (
 /obj/structure/sign/warning/docking,
 /turf/closed/wall,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "iEG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27235,7 +27236,7 @@
 /obj/item/shard,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "iQN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27501,7 +27502,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "iVj" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/security)
@@ -29056,7 +29057,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "jwi" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
@@ -29347,7 +29348,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "jBS" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -29605,7 +29606,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "jGW" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment{
@@ -30370,7 +30371,7 @@
 /area/station/security/lockers)
 "jSF" = (
 /turf/open/floor/carpet/green,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "jSJ" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/bot,
@@ -32949,7 +32950,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/effect/mapping_helpers/damaged_window,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "kNJ" = (
 /obj/structure/table/wood,
 /obj/item/folder{
@@ -34080,7 +34081,7 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/item/stack/rods,
 /turf/open/floor/carpet/green,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "lea" = (
 /obj/machinery/rnd/production/techfab/department/cargo,
 /obj/effect/turf_decal/bot,
@@ -34238,7 +34239,7 @@
 /obj/structure/sign/warning/fire/directional/north,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "lgl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
@@ -34295,7 +34296,7 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "lhm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
@@ -34784,7 +34785,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "lqy" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/stalky/style_random,
@@ -35752,7 +35753,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "lFt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/botanist,
@@ -36111,7 +36112,7 @@
 "lLH" = (
 /obj/structure/sign/departments/engineering,
 /turf/closed/wall,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "lLN" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/poddoor/massdriver_chapel,
@@ -36349,7 +36350,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "lQj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/yellow{
@@ -36490,7 +36491,7 @@
 	name = "Freight Bay Blast Door"
 	},
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "lTc" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
@@ -36784,7 +36785,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "lYa" = (
 /obj/structure/chair/comfy/brown,
 /obj/effect/landmark/start/detective,
@@ -37130,7 +37131,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "mdE" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/firealarm/directional/north,
@@ -37448,7 +37449,7 @@
 /obj/effect/decal/cleanable/oil,
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "mit" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37861,7 +37862,7 @@
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "moc" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -38290,7 +38291,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "mwn" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -38709,7 +38710,7 @@
 /area/station/science/genetics)
 "mDD" = (
 /turf/closed/wall/rust,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "mDJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -39641,7 +39642,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "mSu" = (
 /obj/structure/table,
 /obj/machinery/light/directional/west,
@@ -39896,7 +39897,7 @@
 /obj/structure/sign/poster/contraband/random/directional/north,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "mXI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40435,7 +40436,7 @@
 	icon_state = "crateopen"
 	},
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "ngF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -41117,7 +41118,7 @@
 "nuf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "nuh" = (
 /obj/effect/spawner/random/vending/colavend,
 /obj/effect/turf_decal/bot,
@@ -42293,7 +42294,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "nOR" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42887,7 +42888,7 @@
 /obj/item/stack/tile/wood,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "ocn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -44107,7 +44108,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "ozz" = (
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
@@ -44778,7 +44779,7 @@
 /obj/item/t_scanner,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "oLH" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/maintenance/starboard)
@@ -44906,7 +44907,7 @@
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "oNO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -45194,7 +45195,7 @@
 	name = "Freight Bay Blast Door"
 	},
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "oTt" = (
 /obj/structure/sign/painting/library{
 	pixel_x = 32
@@ -47367,7 +47368,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "pCP" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/spawner/random/trash/cigbutt,
@@ -48300,13 +48301,13 @@
 	name = "off ramp"
 	},
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "pQT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "pRu" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/window/left/directional/south{
@@ -49166,7 +49167,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "qhf" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -49613,7 +49614,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "qpj" = (
 /obj/structure/sign/warning/electric_shock,
 /turf/closed/wall/r_wall,
@@ -49883,7 +49884,7 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "quv" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
@@ -51345,7 +51346,7 @@
 	},
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "qVc" = (
 /obj/machinery/chem_master,
 /obj/effect/turf_decal/bot,
@@ -51473,7 +51474,7 @@
 /obj/structure/table,
 /obj/item/binoculars,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "qWz" = (
 /obj/structure/lattice,
 /obj/structure/sign/warning/secure_area/directional/east,
@@ -52730,7 +52731,7 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "rrK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -52831,7 +52832,7 @@
 	name = "External Freight Airlock"
 	},
 /turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "rsZ" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -53045,7 +53046,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "rvD" = (
 /obj/structure/transit_tube,
 /obj/effect/turf_decal/sand/plating,
@@ -54045,7 +54046,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table_frame,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "rMi" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/scrubber/huge,
@@ -54317,7 +54318,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "rQs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human{
@@ -54457,7 +54458,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "rRJ" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Satellite External Fore";
@@ -54682,7 +54683,7 @@
 	},
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/wood,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "rVw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -54840,7 +54841,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "rZE" = (
 /obj/effect/turf_decal/siding/blue/corner{
 	dir = 8
@@ -55042,7 +55043,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "scE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -55266,7 +55267,7 @@
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "sfI" = (
 /obj/structure/girder,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -56155,7 +56156,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "suo" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/caution/stand_clear,
@@ -57780,7 +57781,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "sTB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -60594,7 +60595,7 @@
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "tOa" = (
 /obj/structure/table,
 /obj/item/tank/internals/oxygen/red,
@@ -61305,7 +61306,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "tZk" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner{
@@ -62106,7 +62107,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "ulS" = (
 /turf/closed/wall,
 /area/station/security/courtroom)
@@ -63096,7 +63097,7 @@
 	},
 /obj/item/stack/rods,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "uCR" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/blood/old,
@@ -63794,7 +63795,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "uQE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -64318,7 +64319,7 @@
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "uZT" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
@@ -64667,7 +64668,7 @@
 /obj/structure/barricade/wooden/crude,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "vfO" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
@@ -65970,7 +65971,7 @@
 /obj/item/stack/rods,
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "vAw" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /obj/effect/turf_decal/bot,
@@ -67732,9 +67733,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "war" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -68451,7 +68451,7 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/sign/warning/no_smoking/directional/north,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "wlP" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/bot,
@@ -68778,7 +68778,7 @@
 	},
 /mob/living/basic/mining/hivelord,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "wpw" = (
 /turf/closed/wall,
 /area/station/science/xenobiology)
@@ -69231,7 +69231,7 @@
 /obj/structure/table/wood,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/carpet/green,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "wxI" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-05"
@@ -69433,7 +69433,7 @@
 	},
 /mob/living/basic/mining/hivelord,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "wAz" = (
 /obj/structure/railing{
 	dir = 4
@@ -69752,7 +69752,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "wGA" = (
 /obj/structure/table,
 /obj/structure/railing,
@@ -70487,7 +70487,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/atmospheric_sanity/ignore_area,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "wSL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -70571,7 +70571,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "wTS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -70592,7 +70592,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "wVb" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -70705,7 +70705,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "wWD" = (
 /obj/structure/table,
 /obj/item/wrench,
@@ -70824,7 +70824,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "wYR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -71809,7 +71809,7 @@
 "xqm" = (
 /obj/structure/sign/warning/vacuum,
 /turf/closed/wall/rust,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "xqw" = (
 /turf/open/floor/bronze,
 /area/station/maintenance/department/chapel)
@@ -72131,7 +72131,7 @@
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "xvW" = (
 /turf/closed/wall,
 /area/station/medical/paramedic)
@@ -72241,7 +72241,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/mine/eva/abandoned)
 "xxN" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/iron/dark,

--- a/modular_zubbers/maps/kilostation/area.dm
+++ b/modular_zubbers/maps/kilostation/area.dm
@@ -1,0 +1,3 @@
+/area/mine/eva/abandoned
+	name = "Abandoned EVA Warehouse"
+	icon_state = "mining_eva"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9396,6 +9396,7 @@
 #include "modular_zubbers\maps\biodome\turfs.dm"
 #include "modular_zubbers\maps\biodome\vendcation.dm"
 #include "modular_zubbers\maps\biodome\weapons.dm"
+#include "modular_zubbers\maps\kilostation\area.dm"
 #include "modular_zubbers\maps\moonstation\dp_vent_pump.dm"
 #include "modular_zubbers\maps\moonstation\telescreen.dm"
 #include "modular_zubbers\maps\offstation\mob_spawns.dm"


### PR DESCRIPTION
## About The Pull Request

Creates a proper area for the abandoned warehouse offstation on Kilostation, and provides an APC frame.

## Why It's Good For The Game

Engineering no longer keeps getting power alerts for a cargo warehouse they can't find, nor care about.

## Changelog

:cl: LT3
map: Kilostation abandoned warehouse now starts unpowered
/:cl: