### PR TITLE
Fixes pirates round event so they spawn in story teller

### DIFF
--- a/modular_zubbers/code/modules/antagonists/pirate/pirate_event.dm
+++ b/modular_zubbers/code/modules/antagonists/pirate/pirate_event.dm
@@ -1,0 +1,9 @@
+/datum/round_event/pirates/start()
+	//Check for admin customization - gang_list is only populated if admins manually spawn the event
+	if(gang_list)
+		send_pirate_threat(gang_list)
+	else
+	//fires with the global pirate gang lists if gang_list is empty
+		send_pirate_threat(GLOB.heavy_pirate_gangs + GLOB.light_pirate_gangs)
+
+

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8900,6 +8900,7 @@
 #include "modular_zubbers\code\modules\antagonists\malf\doomsday.dm"
 #include "modular_zubbers\code\modules\antagonists\malf\remove_malf.dm"
 #include "modular_zubbers\code\modules\antagonists\nightmare\nightmare_species.dm"
+#include "modular_zubbers\code\modules\antagonists\pirate\pirate_event.dm"
 #include "modular_zubbers\code\modules\antagonists\traitor\goal_overrides.dm"
 #include "modular_zubbers\code\modules\antagonists\traitor\uplink\uplinkdatums.dm"
 #include "modular_zubbers\code\modules\antagonists\traitor\uplink\uplink_items\bundle.dm"


### PR DESCRIPTION

## About The Pull Request
So it turns out that the list of possible pirates was only ever populated during the dynamic game mode procs to run the event, since we use story teller and not dynamic, that means the list was empty. Empty list means no pirates. This PR makes it so that if the list is empty (it is only ever populated when an admin uses the trigger-event verb to manually spawn pirates) it will use the combined global lists of heavy and light pirates, pick one, and fire it.
## Why It's Good For The Game
this antag been broke for like a year and 3 months
## Proof Of Testing
![image](https://github.com/user-attachments/assets/a249ee38-fb31-4527-88a6-a4c74c2bc931)
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: pirates spawn again
/:cl:
