### PR TITLE
lone infiltrator no longer gives an admin log error for 0 reason

### DIFF
--- a/modular_zubbers/code/modules/storyteller/event_defines/ghostset/lone_infiltrator.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/ghostset/lone_infiltrator.dm
@@ -41,6 +41,7 @@
 	player_mind.set_assigned_role(SSjob.get_job_type(/datum/job/lone_operative))
 	player_mind.special_role = "Lone Infiltrator"
 	player_mind.add_antag_datum(/datum/antagonist/traitor/lone_infiltrator)
+	spawned_mobs += operative
 
 	message_admins("[ADMIN_LOOKUPFLW(operative)] has been made into lone infiltrator.")
 	log_game("[key_name(operative)] was spawned as a lone infiltrator")


### PR DESCRIPTION

## About The Pull Request
title
## Why It's Good For The Game
players wont care, less chat spam for me (admin)
## Proof Of Testing
![image](https://github.com/user-attachments/assets/7828376c-09cf-4f61-946f-dfaa50000e39)
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: lone infil adds the chosen player to the spawned_mobs list
/:cl:
