### PR TITLE
nameless quirk

### DIFF
--- a/modular_zubbers/code/datums/quirks/neutral_quirks/nameless.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/nameless.dm
@@ -17,6 +17,17 @@
 	can_randomize = FALSE
 	maximum_value_length = 20
 
+/// Some sanity to ensure you can't have "     #1000"
+
+/datum/preference/text/is_valid(value)
+	return !isnull(permissive_sanitize_name(value))
+
+/datum/preference/text/nameless_quirk_option/serialize(input)
+	return htmlrendertext(input)
+
+/datum/preference/text/nameless_quirk_option/deserialize(input, datum/preferences/preferences)
+	return htmlrendertext(input)
+
 /datum/preference/text/nameless_quirk_option/apply_to_human(mob/living/carbon/human/target, value)
 	return
 
@@ -36,9 +47,7 @@
 
 /datum/quirk/nameless/proc/generate_name()
 
-	var/prefix_pref = quirk_holder.client?.prefs.read_preference(/datum/preference/text/nameless_quirk_option)
-	// So people don't have "           #1245" as a name
-	var/prefix = permissive_sanitize_name(prefix_pref) || null
+	var/prefix = quirk_holder.client?.prefs.read_preference(/datum/preference/text/nameless_quirk_option)
 	var/job
 	var/number = pick(rand(1000, 9999))
 

--- a/modular_zubbers/code/datums/quirks/neutral_quirks/nameless.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/nameless.dm
@@ -36,7 +36,9 @@
 
 /datum/quirk/nameless/proc/generate_name()
 
-	var/prefix = quirk_holder.client?.prefs.read_preference(/datum/preference/text/nameless_quirk_option)
+	var/prefix_pref = quirk_holder.client?.prefs.read_preference(/datum/preference/text/nameless_quirk_option)
+	// So people don't have "           #1245" as a name
+	var/prefix = permissive_sanitize_name(prefix_pref) || null
 	var/job
 	var/number = pick(rand(1000, 9999))
 

--- a/modular_zubbers/code/datums/quirks/neutral_quirks/nameless.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/nameless.dm
@@ -1,0 +1,51 @@
+/datum/quirk/nameless
+	name = "Nameless"
+	desc = "You don't have a name. You are known only as a number."
+	medical_record_text = "Subject lacks a name in records."
+	value = 0
+	icon = FA_ICON_USER_NINJA
+	gain_text = span_notice("You feel your name slip away.")
+	lose_text = span_notice("You spontaniously remember your full name!")
+	quirk_flags = QUIRK_HIDE_FROM_SCAN
+	var/character_name
+	var/new_name
+
+/datum/preference/text/nameless_quirk_option
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "nameless_quirk_name"
+	savefile_identifier = PREFERENCE_CHARACTER
+	can_randomize = FALSE
+	maximum_value_length = 20
+
+/datum/preference/text/nameless_quirk_option/apply_to_human(mob/living/carbon/human/target, value)
+	return
+
+/datum/quirk_constant_data/nameless
+	associated_typepath = /datum/quirk/nameless
+	customization_options = list(
+		/datum/preference/text/nameless_quirk_option
+	)
+
+/datum/quirk/nameless/add(client/client_source)
+	character_name = client_source?.prefs.read_preference(/datum/preference/name/real_name)
+	new_name = generate_name()
+	quirk_holder.fully_replace_character_name(character_name, new_name)
+
+/datum/quirk/nameless/remove()
+	quirk_holder.fully_replace_character_name(new_name, character_name)
+
+/datum/quirk/nameless/proc/generate_name()
+
+	var/prefix = quirk_holder.client?.prefs.read_preference(/datum/preference/text/nameless_quirk_option)
+	var/job
+	var/number = pick(rand(1000, 9999))
+
+	if(prefix)
+		job = prefix
+	else
+		job = isnull(quirk_holder.job) ? pick("Alpha", "Beta", "Delta", "Echo", "Zulu", "Omega") : quirk_holder.job
+
+	return "[job] #[number]"
+
+
+

--- a/modular_zubbers/code/datums/quirks/neutral_quirks/nameless.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/nameless.dm
@@ -17,9 +17,10 @@
 	can_randomize = FALSE
 	maximum_value_length = 20
 
-/// Some sanity to ensure you can't have "     #1000"
-
-/datum/preference/text/is_valid(value)
+/// Some sanity to ensure you can't have "     #1000" as your name.
+/datum/preference/text/nameless_quirk_option/is_valid(value)
+	if(isnull(value))
+		return TRUE
 	return !isnull(permissive_sanitize_name(value))
 
 /datum/preference/text/nameless_quirk_option/serialize(input)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8728,6 +8728,7 @@
 #include "modular_zubbers\code\datums\quirks\neutral_quirks\hungry.dm"
 #include "modular_zubbers\code\datums\quirks\neutral_quirks\hydrophilic.dm"
 #include "modular_zubbers\code\datums\quirks\neutral_quirks\lungs.dm"
+#include "modular_zubbers\code\datums\quirks\neutral_quirks\nameless.dm"
 #include "modular_zubbers\code\datums\quirks\neutral_quirks\oversized_quirk.dm"
 #include "modular_zubbers\code\datums\quirks\neutral_quirks\pet_owner.dm"
 #include "modular_zubbers\code\datums\quirks\neutral_quirks\waddle.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/bubbers/nameless.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/bubbers/nameless.tsx
@@ -2,6 +2,7 @@ import { Feature, FeatureShortTextInput } from '../../base';
 
 export const nameless_quirk_name: Feature<string> = {
   name: 'Prefix Name',
-  description: 'Example: (Prefix) #1334. Leave blank to default to job title.',
+  description:
+    'Example: (Prefix) #1334. Leave blank to default to job title. Minimum 3 characters.',
   component: FeatureShortTextInput,
 };

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/bubbers/nameless.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/bubbers/nameless.tsx
@@ -1,0 +1,7 @@
+import { Feature, FeatureShortTextInput } from '../../base';
+
+export const nameless_quirk_name: Feature<string> = {
+  name: 'Prefix Name',
+  description: 'Example: (Prefix) #1334. Leave blank to default to job title.',
+  component: FeatureShortTextInput,
+};


### PR DESCRIPTION

## About The Pull Request

Adds the nameless quirk with the option to have a prefix. Without a prefix, you will spawn is as your [job] #[number]. If you don't have a job or prefix, you have some random prefixes I threw together that it chooses from.

## Why It's Good For The Game

Adds an option for characters to spawn in as a random number. Adds to the bubber roleplay experience. You can be mass produced or something.

## Proof Of Testing

![image](https://github.com/user-attachments/assets/ca41a8cf-151a-42df-9df0-0fd2a8f91466)

## Changelog

:cl:
add: Nameless Quirk
/:cl:
