### PR TITLE
Removes block chance malus against balistics/thermals on desword/dualsaber [Not Modular]

### DIFF
--- a/code/game/objects/items/dualsaber.dm
+++ b/code/game/objects/items/dualsaber.dm
@@ -159,8 +159,8 @@
 		if(our_projectile.reflectable)
 			final_block_chance = 0 //we handle this via IsReflect(), effectively 75% block
 		else
-			final_block_chance -= 25 //We aren't AS good at blocking physical projectiles, like ballistics and thermals
-
+			final_block_chance -= 0 //We aren't AS good at blocking physical projectiles, like ballistics and thermals
+//BUBBER EDIT: final_block_chance 75% against balistics instead of 50%
 	if(attack_type == LEAP_ATTACK)
 		final_block_chance -= 50 //We are particularly bad at blocking someone JUMPING at us..
 


### PR DESCRIPTION

## About The Pull Request

Desword/Dualsaber block chance against non-energy projectiles increased from 50% to 75%.
## Why It's Good For The Game

Deswords currently have
75% Reflect chance against energy/melee
50% block chance against balistic/thermals/non-energy projectiles
25% block chance against tackles/bodythrows

In comparison eswords have
50% block against everything except tackles/bodythrows
25% block against tackles/bodythrows
while costing much less and having an off-hand slot for a shield or ranged weapon

Tgstation balances ballistics by making them weak, hard to acquire, hard to load (no mags outside of hacked emag stuff from cargo) and substantially niche in terms of crew weaponry. Considering balistics are still slightly stronger than energy weapons on bubber, extremely accessible by crew, and with huge magazine size to reload even if you run out of ammo shooting an esword/desword user, especially with the heavier weapons, there is no reason for this balance to stay the way it is here. Sure, they're two handed, but that doesn't really change much. Hence, why this is a bubber PR, not a tg PR.

Deswords are basically on par with eswords despite costing about twice the amount and taking up both your slots. They're still horribly weak to tackles and bodythrows and nothing will ever change that, and running away and spraying them down will bullets will still kill one pretty easily, or a lucky baton hit or general knockdown that disarms em. Because well, if you a running a desword, you are stuck with melee combat unless you want to lose all your defensive block values.
## Proof Of Testing

Numbers change.
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
balance: Deswords are no longer worse at blocking ballistics than energy weapons.
/:cl:
