### PR TITLE
Updates mending touch interactions to current tg.

### DIFF
--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -112,9 +112,36 @@
 	// Halves transferred damage if synchronized. (0.5 with synchronizer chromosome)
 	to_modify.synchronizer_coefficient = GET_MUTATION_SYNCHRONIZER(src)
 
+/datum/mutation/human/lay_on_hands
+	name = "Mending Touch"
+	desc = "The affected can lay their hands on other people to transfer a small amount of their injuries to themselves."
+	quality = POSITIVE
+	locked = FALSE
+	difficulty = 16
+	text_gain_indication = span_notice("Your hand feels blessed!")
+	text_lose_indication = span_notice("Your hand feels secular once more.")
+	power_path = /datum/action/cooldown/spell/touch/lay_on_hands
+	instability = POSITIVE_INSTABILITY_MAJOR
+	energy_coeff = 1
+	power_coeff = 1
+	synchronizer_coeff = 1
+
+/datum/mutation/human/lay_on_hands/modify()
+	. = ..()
+	var/datum/action/cooldown/spell/touch/lay_on_hands/to_modify =.
+
+	if(!istype(to_modify)) // null or invalid
+		return
+
+	// Transfers more damage if strengthened. (1.5 with power chromosome)
+	to_modify.power_coefficient = GET_MUTATION_POWER(src)
+	// Halves transferred damage if synchronized. (0.5 with synchronizer chromosome)
+	to_modify.synchronizer_coefficient = GET_MUTATION_SYNCHRONIZER(src)
+
 /datum/action/cooldown/spell/touch/lay_on_hands
 	name = "Mending Touch"
-	desc = "You can now lay your hands on other people to transfer a small amount of their physical injuries to yourself."
+	desc = "You can now lay your hands on other people to transfer a small amount of their physical injuries to yourself. \
+		For some reason, this power does not play nicely with the undead, or people with strange ideas about morality."
 	button_icon = 'icons/mob/actions/actions_genetic.dmi'
 	button_icon_state = "mending_touch"
 	sound = 'sound/effects/magic/staff_healing.ogg'
@@ -159,6 +186,17 @@
 	// Message to show on a successful heal if the healer has a special pacifism interaction with the mutation.
 	var/peaceful_message = null
 
+	var/success
+
+	var/hurt_this_guy = determine_if_this_hurts_instead(mendicant, hurtguy)
+
+	if (hurt_this_guy && HAS_TRAIT(mendicant, TRAIT_PACIFISM) || hurt_this_guy && !mendicant.combat_mode) //Returns if we're a pacifist and we'd hurt them, or we're not in combat mode and we'll hurt them
+		mendicant.balloon_alert(mendicant, "[hurtguy] would be hurt!")
+		return FALSE
+
+	if(hurt_this_guy)
+		return by_gods_light_i_smite_you(mendicant, hurtguy, heal_multiplier)
+
 	// Heal more, hurt a bit more.
 	// If you crunch the numbers it sounds crazy good,
 	// but I think that's a fair reward for combining the efforts of Genetics, Medbay, and Mining to reach a hidden mechanic.
@@ -177,7 +215,6 @@
 		heal_multiplier *= 1.75
 		peaceful_message = span_boldnotice("Your peaceful nature helps you guide all the pain to yourself.")
 
-	var/success
 	if(iscarbon(hurtguy))
 		success = do_complicated_heal(mendicant, hurtguy, heal_multiplier, pain_multiplier)
 	else
@@ -311,7 +348,7 @@
 		if(!blood_to_hurtguy)
 			return .
 		// We ignore incompatibility here.
-		mendicant.transfer_blood_to(hurtguy, blood_to_hurtguy, forced = TRUE)
+		mendicant.transfer_blood_to(hurtguy, blood_to_hurtguy, forced = TRUE, ignore_incompatibility = TRUE)
 		to_chat(mendicant, span_notice("Your veins (and brain) feel a bit lighter."))
 		. = TRUE
 		// Because we do our own spin on it!
@@ -328,7 +365,7 @@
 		// mender always gonna have blood
 
 		// We ignore incompatibility here.
-		hurtguy.transfer_blood_to(mendicant, hurtguy.blood_volume - BLOOD_VOLUME_EXCESS, forced = TRUE)
+		hurtguy.transfer_blood_to(mendicant, hurtguy.blood_volume - BLOOD_VOLUME_EXCESS, forced = TRUE, ignore_incompatibility = TRUE)
 		to_chat(hurtguy, span_notice("Your veins don't feel quite so swollen anymore."))
 		. = TRUE
 		// Because we do our own spin on it!
@@ -337,6 +374,77 @@
 			to_chat(mendicant, span_notice("Your veins swell and itch!"))
 		else
 			to_chat(mendicant, span_notice("Your veins swell!"))
+
+
+/datum/action/cooldown/spell/touch/lay_on_hands/proc/determine_if_this_hurts_instead(mob/living/carbon/mendicant, mob/living/hurtguy)
+	var/hurt_this_guy = FALSE
+
+	if(HAS_TRAIT(mendicant, TRAIT_PACIFISM))
+		return FALSE //always return false if we're pacifist
+
+	if(hurtguy.mob_biotypes & MOB_UNDEAD && mendicant.mob_biotypes & MOB_UNDEAD)
+		return FALSE //always return false if we're both undead //undead solidarity
+
+	if(hurtguy.mob_biotypes & MOB_UNDEAD && !HAS_TRAIT(mendicant, TRAIT_EVIL)) //Is the mob undead and we're not evil? If so, hurt.
+		hurt_this_guy = TRUE
+
+	else if(HAS_TRAIT(hurtguy, TRAIT_EVIL) && !HAS_TRAIT(mendicant, TRAIT_EVIL)) //Is the guy evil and we're not evil? If so, hurt.
+		hurt_this_guy = TRUE
+
+	else if(!(hurtguy.mob_biotypes & MOB_UNDEAD) && HAS_TRAIT(hurtguy, TRAIT_EMPATH) && HAS_TRAIT(mendicant, TRAIT_EVIL)) //Is the guy not undead, they're an empath and we're evil? If so, hurt.
+		hurt_this_guy = TRUE
+
+	return hurt_this_guy
+
+///If our target was undead or evil, we blast them with a firey beam rather than healing them. For, you know, 'holy' reasons. When did genes become so morally uptight?
+
+/datum/action/cooldown/spell/touch/lay_on_hands/proc/by_gods_light_i_smite_you(mob/living/carbon/smiter, mob/living/motherfucker_to_hurt, smite_multiplier)
+	var/our_smite_multiplier = smite_multiplier
+	var/evil_smite = HAS_TRAIT(smiter, TRAIT_EVIL) ? TRUE : FALSE
+	var/divine_champion = smiter.mind?.holy_role >= HOLY_ROLE_PRIEST ? TRUE : FALSE
+	var/smite_text_to_target = "lays hands on you"
+
+	if(divine_champion || HAS_TRAIT(smiter, TRAIT_SPIRITUAL))
+
+		// Defaults for possible deity. You know, just in case.
+		var/possible_deity = evil_smite ? "Satan" : "God"
+
+		var/mob/living/carbon/human/human_smiter = smiter
+
+		// If we have a client, check their deity pref and use that instead of our chaps god if our smiter is a spiritualist
+		var/client/smiter_client = smiter.client
+
+		if(smiter_client && HAS_TRAIT(smiter, TRAIT_SPIRITUAL))
+			possible_deity = smiter_client.prefs?.read_preference(/datum/preference/name/deity)
+		else if (GLOB.deity)
+			possible_deity = GLOB.deity
+
+		if(ishuman(human_smiter))
+			human_smiter.force_say()
+			if(evil_smite)
+				human_smiter.say("in [possible_deity]'s dark name, I COMMAND YOU TO PERISH!!!", forced = "compelled by the power of their deity")
+			else
+				human_smiter.say("By [possible_deity]'s might, I SMITE YOU!!!", forced = "compelled by the power of their deity")
+		our_smite_multiplier *= divine_champion ? 5 : 1 //good luck surviving this if they're a chap
+
+	if(evil_smite)
+		motherfucker_to_hurt.visible_message(span_warning("[smiter] snaps [smiter.p_their()] fingers in front of [motherfucker_to_hurt]'s face, and [motherfucker_to_hurt]'s body twists violently from an unseen force!"))
+		motherfucker_to_hurt.apply_damage(10 * our_smite_multiplier, BRUTE, spread_damage = TRUE, wound_bonus = 5 * our_smite_multiplier)
+		motherfucker_to_hurt.adjust_staggered_up_to(STAGGERED_SLOWDOWN_LENGTH * our_smite_multiplier, 25 SECONDS)
+		smiter.emote("snap")
+		smite_text_to_target = "crushes you psychically with a snap of [smiter.p_their()] fingers"
+	else
+		motherfucker_to_hurt.visible_message(span_warning("[smiter] lays hands on [motherfucker_to_hurt], but it shears [motherfucker_to_hurt.p_them()] with a brilliant energy!"))
+		motherfucker_to_hurt.apply_damage(10 * our_smite_multiplier, BURN, spread_damage = TRUE, wound_bonus = 5 * our_smite_multiplier)
+		motherfucker_to_hurt.adjust_fire_stacks(3 * our_smite_multiplier)
+		motherfucker_to_hurt.ignite_mob()
+
+	motherfucker_to_hurt.update_damage_overlays()
+
+	to_chat(motherfucker_to_hurt, span_bolddanger("[smiter] [smite_text_to_target], hurting you!"))
+	motherfucker_to_hurt.emote("scream")
+	new /obj/effect/temp_visual/explosion(get_turf(motherfucker_to_hurt), evil_smite ? LIGHT_COLOR_BLOOD_MAGIC : LIGHT_COLOR_HOLY_MAGIC)
+	. = TRUE
 
 /obj/item/melee/touch_attack/lay_on_hands
 	name = "mending touch"

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -221,8 +221,11 @@
 					. += "[t_He] [t_is] shivering."
 				if(HAS_TRAIT(src, TRAIT_EVIL))
 					. += "[t_His] eyes radiate with a unfeeling, cold detachment. There is nothing but darkness within [t_his] soul."
-					living_user.add_mood_event("encountered_evil", /datum/mood_event/encountered_evil)
-					living_user.set_jitter_if_lower(15 SECONDS)
+					if(living_user.mind?.holy_role >= HOLY_ROLE_PRIEST)
+						. += span_warning("PERFECT FOR SMITING!!")
+					else
+						living_user.add_mood_event("encountered_evil", /datum/mood_event/encountered_evil)
+						living_user.set_jitter_if_lower(15 SECONDS)
 
 			if(HAS_TRAIT(user, TRAIT_SPIRITUAL) && mind?.holy_role)
 				. += "[t_He] [t_has] a holy aura about [t_him]."

--- a/modular_zubbers/code/modules/antagonists/bloodsucker/bloodsuckers/integration.dm
+++ b/modular_zubbers/code/modules/antagonists/bloodsucker/bloodsuckers/integration.dm
@@ -18,7 +18,7 @@
 		return ..()
 	bloodsuckerdatum.AdjustBloodVolume(round(reac_volume, 0.1))
 
-/mob/living/carbon/transfer_blood_to(atom/movable/AM, amount, forced)
+/mob/living/carbon/transfer_blood_to(atom/movable/AM, amount, forced, ignore_incompatibility)
 	. = ..()
 	if(!mind)
 		return


### PR DESCRIPTION

## About The Pull Request

Straight up copy-paste of https://github.com/tgstation/tgstation/pull/87187
## Why It's Good For The Game

See original PR, smiting people is funny :)
This pr also fixes mending touch not properly ignoring blood type incompatibility resulting in being able to just shove a lethal amount of toxins into someone if you are trying to heal them.
## Proof Of Testing
<details>
Tested and works on chaplain to evil/undead and evil to empath. Video only shows evil to empath due to my stupid ass not being able to record properly.
https://github.com/user-attachments/assets/21214507-27ce-4b49-b141-6713d442153a
</details>

## Changelog
:cl:
add: Mending touch now has additional effects based on whether or not the target or user is evil, an undead or an empath. Don't use mending touch on evil people or undead, or they might go up in flames. Though evil people can get back at empaths specifically and heal udnead as normal.
add: Chaplains engulf people using mending touch's harmful reactions to diametrically opposed entities especially well. Because of religious zeal, of course.
add: Empath chaplains ignore the fear consequences of examining an evil person. They instead get additional information about what to do to these people if the need arises.
fix: mending touch now properly ignores blood incompatibility.
/:cl:
