### PR TITLE
Fix synths spawning without charging arm implant

### DIFF
--- a/modular_skyrat/modules/synths/code/bodyparts/power_cord.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/power_cord.dm
@@ -2,7 +2,8 @@
 	name = "charging implant"
 	desc = "An internal power cord. Useful if you run on elecricity. Not so much otherwise."
 	items_to_create = list(/obj/item/synth_powercord)
-	zone = "l_arm"
+	zone = BODY_ZONE_L_ARM
+	slot = ORGAN_SLOT_LEFT_ARM_AUG
 
 /obj/item/synth_powercord
 	name = "power cord"


### PR DESCRIPTION
## About The Pull Request

Explicitly set the `slot` var for charging arm implants, the cause of the issue is an upstream issue that I've reported, but this will work in the meantime 

## Why It's Good For The Game

Fixes #2986 

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/4e16fadb-67f0-4841-829c-0577cbc5eb93)

</details>

## Changelog

:cl:
fix: synths once again start with a charging arm implant
/:cl:
