### PR TITLE
Nerfs Entombed

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -43,8 +43,8 @@ GLOBAL_LIST_INIT_TYPED(quirk_blacklist, /list/datum/quirk, list(
 	//BUBBER EDIT ADDITION BEGIN
 	list(/datum/quirk/featherweight, /datum/quirk/oversized),
 	list(/datum/quirk/overweight, /datum/quirk/obese),
-	list(/datum/quirk/dominant_aura, /datum/quirk/well_trained)
-	list(/datum/quirk/entombed, /datum/quirk/bad_back)
+	list(/datum/quirk/dominant_aura, /datum/quirk/well_trained),
+	list(/datum/quirk/entombed, /datum/quirk/bad_back),
 	//BUBBER EDIT ADDITION END
 ))
 

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -44,6 +44,7 @@ GLOBAL_LIST_INIT_TYPED(quirk_blacklist, /list/datum/quirk, list(
 	list(/datum/quirk/featherweight, /datum/quirk/oversized),
 	list(/datum/quirk/overweight, /datum/quirk/obese),
 	list(/datum/quirk/dominant_aura, /datum/quirk/well_trained)
+	list(/datum/quirk/entombed, /datum/quirk/bad_back)
 	//BUBBER EDIT ADDITION END
 ))
 

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -44,7 +44,7 @@ GLOBAL_LIST_INIT_TYPED(quirk_blacklist, /list/datum/quirk, list(
 	list(/datum/quirk/featherweight, /datum/quirk/oversized),
 	list(/datum/quirk/overweight, /datum/quirk/obese),
 	list(/datum/quirk/dominant_aura, /datum/quirk/well_trained),
-	list(/datum/quirk/entombed, /datum/quirk/bad_back),
+	list(/datum/quirk/equipping/entombed, /datum/quirk/badback),
 	//BUBBER EDIT ADDITION END
 ))
 

--- a/modular_zubbers/master_files/code/modules/entombed_quirk/code/entombed_mod.dm
+++ b/modular_zubbers/master_files/code/modules/entombed_quirk/code/entombed_mod.dm
@@ -7,7 +7,6 @@
 	armor_type = /datum/armor/mod_entombed
 	resistance_flags = FIRE_PROOF | ACID_PROOF // It is better to die for the Emperor than live for yourself.
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
-	siemens_coefficient = 0
 	complexity_max = DEFAULT_MAX_COMPLEXITY - 5
 	charge_drain = DEFAULT_CHARGE_DRAIN
 	slowdown_inactive = 2.5 // very slow because the quirk infers you rely on this to move/exist
@@ -20,15 +19,15 @@
 		/obj/item/flashlight,
 	)
 
-/datum/armor/mod_entombed
-	melee = 30
-	bullet = 30
-	laser = 30
-	energy = 30
-	bio = 100
-	fire = 30
-	acid = 30
-	wound = 30
+/datum/armor/mod_entombed // Equalized its armour values to be the same as the civilian modsuit
+	melee = 5
+	bullet = 5
+	laser = 5
+	energy = 5
+	bio = 50
+	fire = 25
+	acid = 25
+	wound = 5
 
 /obj/item/mod/module/joint_torsion/entombed
 	name = "internal joint torsion adaptation"

--- a/modular_zubbers/master_files/code/modules/entombed_quirk/code/entombed_mod.dm
+++ b/modular_zubbers/master_files/code/modules/entombed_quirk/code/entombed_mod.dm
@@ -7,7 +7,7 @@
 	armor_type = /datum/armor/mod_theme_civilian
 	resistance_flags = FIRE_PROOF | ACID_PROOF // It is better to die for the Emperor than live for yourself.
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
-	complexity_max = DEFAULT_MAX_COMPLEXITY - 5
+	complexity_max = DEFAULT_MAX_COMPLEXITY - 2 // Sets the modsuit complexity to a total of 13 (functionally 10 as the default storage module consumes 3. ) to keep it in line with the civilian modsuit.
 	charge_drain = DEFAULT_CHARGE_DRAIN
 	slowdown_inactive = 2.5 // very slow because the quirk infers you rely on this to move/exist
 	slowdown_active = 0.95

--- a/modular_zubbers/master_files/code/modules/entombed_quirk/code/entombed_mod.dm
+++ b/modular_zubbers/master_files/code/modules/entombed_quirk/code/entombed_mod.dm
@@ -19,16 +19,6 @@
 		/obj/item/flashlight,
 	)
 
-/* /datum/armor/mod_entombed  (Commented out cus entombed modsuit just refers to the civilian one directly now)
-	melee = 5
-	bullet = 5
-	laser = 5
-	energy = 5
-	bio = 50
-	fire = 25
-	acid = 25
-	wound = 5
-*/
 /obj/item/mod/module/joint_torsion/entombed
 	name = "internal joint torsion adaptation"
 	desc = "Your adaptation to life in this MODsuit shell allows you to ambulate in such a way that your movements recharge the suit's internal batteries slightly, but only while under the effect of gravity."

--- a/modular_zubbers/master_files/code/modules/entombed_quirk/code/entombed_mod.dm
+++ b/modular_zubbers/master_files/code/modules/entombed_quirk/code/entombed_mod.dm
@@ -4,7 +4,7 @@
 	extended_desc = "Some great aspect of someone's past has permanently bound them to this device, for better or worse."
 
 	default_skin = "standard"
-	armor_type = /datum/armor/mod_entombed
+	armor_type = /datum/armor/mod_theme_civilian
 	resistance_flags = FIRE_PROOF | ACID_PROOF // It is better to die for the Emperor than live for yourself.
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	complexity_max = DEFAULT_MAX_COMPLEXITY - 5
@@ -19,7 +19,7 @@
 		/obj/item/flashlight,
 	)
 
-/datum/armor/mod_entombed // Equalized its armour values to be the same as the civilian modsuit
+/* /datum/armor/mod_entombed  (Commented out cus entombed modsuit just refers to the civilian one directly now)
 	melee = 5
 	bullet = 5
 	laser = 5
@@ -28,7 +28,7 @@
 	fire = 25
 	acid = 25
 	wound = 5
-
+*/
 /obj/item/mod/module/joint_torsion/entombed
 	name = "internal joint torsion adaptation"
 	desc = "Your adaptation to life in this MODsuit shell allows you to ambulate in such a way that your movements recharge the suit's internal batteries slightly, but only while under the effect of gravity."


### PR DESCRIPTION
## About The Pull Request

Sets the fused MODsuit's defence values to be the same as the civilian suit, removes its free insulated gloves and makes it unable to be taken with Bad Back for the free +8 points. Additionally bumps the Mod Complexity of the Entombed suit to 13, it will functionally be 10 since the default storage module the entombed suits has consumes 3, and 10 complexity sets it in line with other suits.
## Why It's Good For The Game

The entombed quirk provides a comical amount of benefits for a so called neutral quirk, including an abusable interaction with the Bad Back Quirk that allows the player to ignore all the downsides of Bad Back and get a free +8 points as a result.
## Proof Of Testing

Works on literally everyone else's machine. Glory to Dream-Maker. Tested and maintainer approved.
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
balance: Made entombed not insulated, lowered its defences and is unable to be taken with Bad Back.
/:cl:
