### PR TITLE
Lizard Gas Atmos Fix/I.D transferred to Modular File

### DIFF
--- a/_maps/RandomRuins/IceRuins/bubberstation/icemoon_surface_gas_bubber.dmm
+++ b/_maps/RandomRuins/IceRuins/bubberstation/icemoon_surface_gas_bubber.dmm
@@ -23,18 +23,13 @@
 	},
 /area/ruin/powered/lizard_gas)
 "ap" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/door/airlock/external/ruin,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "lizardgas_lavaland_entrance"
+	},
+/obj/structure/fans/tiny,
 /obj/machinery/duct,
-/turf/closed/wall/r_wall{
-	baseturfs = /turf/open/floor/plating/lavaland_baseturf
-	},
-/area/ruin/powered/lizard_gas)
-"aG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
-/turf/open/floor/iron{
+/turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
 /area/ruin/powered/lizard_gas)
@@ -262,6 +257,15 @@
 /obj/structure/fence/corner,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/unexplored)
+"gC" = (
+/obj/structure/reagent_dispensers/plumbed/storage{
+	dir = 8;
+	reagent_id = /datum/reagent/toxin/plasma;
+	name = "plasma storage tank";
+	tank_volume = 2500
+	},
+/turf/open/floor/plating/icemoon,
+/area/ruin/powered/lizard_gas)
 "gE" = (
 /obj/structure/cable,
 /obj/structure/railing,
@@ -350,13 +354,20 @@
 	},
 /area/ruin/powered/lizard_gas)
 "hV" = (
-/obj/structure/sign/warning/fire/directional/north,
-/turf/template_noop,
-/area/template_noop)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/turf/open/floor/iron{
+	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
+	},
+/area/ruin/powered/lizard_gas)
 "ia" = (
-/obj/structure/sign/warning/chem_diamond/directional/north,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/unexplored)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden,
+/turf/closed/wall/r_wall{
+	baseturfs = /turf/open/floor/plating/lavaland_baseturf
+	},
+/area/ruin/powered/lizard_gas)
 "iC" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/structure/table,
@@ -431,11 +442,9 @@
 	},
 /area/ruin/powered/lizard_gas)
 "kq" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/iron{
-	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
+/turf/closed/wall/r_wall{
+	baseturfs = /turf/open/floor/plating/lavaland_baseturf
 	},
 /area/ruin/powered/lizard_gas)
 "kJ" = (
@@ -508,14 +517,17 @@
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
 /area/ruin/powered/lizard_gas)
+"nA" = (
+/obj/structure/sign/warning/chem_diamond/directional/north,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/unexplored)
 "nH" = (
-/obj/structure/reagent_dispensers/plumbed/storage{
-	dir = 8;
-	reagent_id = /datum/reagent/toxin/plasma;
-	name = "plasma storage tank";
-	tank_volume = 2500
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/iron{
+	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
-/turf/open/floor/plating/icemoon,
 /area/ruin/powered/lizard_gas)
 "nN" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -696,17 +708,6 @@
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
 /area/ruin/powered/lizard_gas)
-"uJ" = (
-/obj/machinery/door/airlock/external/ruin,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "lizardgas_lavaland_entrance"
-	},
-/obj/structure/fans/tiny,
-/obj/machinery/duct,
-/turf/open/floor/iron/smooth{
-	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
-	},
-/area/ruin/powered/lizard_gas)
 "uQ" = (
 /obj/machinery/air_sensor{
 	chamber_id = "lizardgaslava"
@@ -744,10 +745,11 @@
 	},
 /area/ruin/powered/lizard_gas)
 "vX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden,
-/turf/closed/wall/r_wall{
-	baseturfs = /turf/open/floor/plating/lavaland_baseturf
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1;
+	filter_types = list(/datum/gas/oxygen)
 	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/ruin/powered/lizard_gas)
 "vY" = (
 /obj/machinery/duct,
@@ -778,12 +780,6 @@
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
-/area/ruin/powered/lizard_gas)
-"xJ" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Plasma Hook-Up"
-	},
-/turf/open/floor/plating/icemoon,
 /area/ruin/powered/lizard_gas)
 "xS" = (
 /obj/structure/table,
@@ -881,7 +877,9 @@
 	},
 /area/ruin/powered/lizard_gas)
 "zc" = (
-/obj/machinery/airalarm/directional/west,
+/obj/machinery/airalarm/directional/west{
+	all_access = 1
+	},
 /obj/effect/mob_spawn/ghost_role/human/lavaland_gasstation{
 	dir = 4
 	},
@@ -1022,6 +1020,12 @@
 /turf/open/floor/plating/lavaland_atmos{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
+/area/ruin/powered/lizard_gas)
+"Dc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/structure/sign/warning/no_smoking/circle/directional/east,
+/obj/machinery/duct,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/ruin/powered/lizard_gas)
 "Df" = (
 /obj/structure/cable,
@@ -1241,11 +1245,10 @@
 /turf/open/floor/asphalt,
 /area/ruin/powered/lizard_gas)
 "Hq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1;
-	filter_types = list(/datum/gas/oxygen)
+/obj/machinery/duct,
+/turf/closed/wall/r_wall{
+	baseturfs = /turf/open/floor/plating/lavaland_baseturf
 	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/ruin/powered/lizard_gas)
 "HA" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/plasma_input{
@@ -1333,10 +1336,10 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/unexplored)
 "Lb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
-/obj/structure/sign/warning/no_smoking/circle/directional/east,
-/obj/machinery/duct,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
+/obj/machinery/door/airlock/grunge{
+	name = "Plasma Hook-Up"
+	},
+/turf/open/floor/plating/icemoon,
 /area/ruin/powered/lizard_gas)
 "Ll" = (
 /obj/item/stack/sheet/mineral/wood/fifty{
@@ -1514,11 +1517,9 @@
 /turf/open/floor/wood/parquet,
 /area/ruin/powered/lizard_gas)
 "QF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
-/turf/closed/wall/r_wall{
-	baseturfs = /turf/open/floor/plating/lavaland_baseturf
-	},
-/area/ruin/powered/lizard_gas)
+/obj/structure/sign/warning/fire/directional/north,
+/turf/template_noop,
+/area/template_noop)
 "QM" = (
 /obj/machinery/vending/dorms{
 	density = 0;
@@ -1757,6 +1758,7 @@
 /turf/open/floor/asphalt,
 /area/ruin/powered/lizard_gas)
 "Wq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
 /obj/machinery/duct,
 /turf/closed/wall/r_wall{
 	baseturfs = /turf/open/floor/plating/lavaland_baseturf
@@ -2173,8 +2175,8 @@ gm
 gm
 gm
 Ja
-uJ
-vX
+ap
+ia
 Bv
 Bv
 Vw
@@ -2201,7 +2203,7 @@ mK
 yb
 QW
 XL
-vX
+ia
 hi
 FS
 FS
@@ -2274,8 +2276,8 @@ DD
 dD
 zv
 vE
-kq
-kq
+nH
+nH
 wB
 Ga
 wB
@@ -2334,7 +2336,7 @@ um
 nN
 UE
 hy
-aG
+hV
 PC
 gm
 QP
@@ -2388,7 +2390,7 @@ GA
 GA
 ZQ
 qQ
-kq
+nH
 mH
 ts
 Rt
@@ -2415,11 +2417,11 @@ gm
 IN
 gm
 gm
-QF
+kq
 zb
-ap
-Lb
-Hq
+Wq
+Dc
+vX
 Vw
 Vw
 Bv
@@ -2445,9 +2447,9 @@ eA
 Vv
 QM
 gm
-Wq
+Hq
 gm
-ia
+nA
 Bv
 Gr
 Gr
@@ -2472,8 +2474,8 @@ za
 hj
 VK
 gm
-nH
-xJ
+gC
+Lb
 Bv
 Gr
 Gr
@@ -2501,7 +2503,7 @@ gm
 gm
 gm
 gm
-hV
+QF
 Gr
 Gr
 Gr

--- a/_maps/RandomRuins/IceRuins/bubberstation/icemoon_surface_gas_bubber.dmm
+++ b/_maps/RandomRuins/IceRuins/bubberstation/icemoon_surface_gas_bubber.dmm
@@ -1,6 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ac" = (
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -22,18 +23,26 @@
 	},
 /area/ruin/powered/lizard_gas)
 "ap" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
 /obj/machinery/duct,
+/turf/closed/wall/r_wall{
+	baseturfs = /turf/open/floor/plating/lavaland_baseturf
+	},
+/area/ruin/powered/lizard_gas)
+"aG" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
 /area/ruin/powered/lizard_gas)
 "bn" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
 /obj/structure/noticeboard/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -75,7 +84,6 @@
 /obj/effect/mapping_helpers/apc/cell_10k,
 /obj/effect/mapping_helpers/apc/unlocked,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
 /obj/item/flashlight{
 	pixel_x = 4;
 	pixel_y = 6
@@ -278,7 +286,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -337,29 +344,22 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
 /area/ruin/powered/lizard_gas)
 "hV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
-/turf/closed/wall{
-	baseturfs = /turf/open/floor/plating/lavaland_baseturf
-	},
-/area/ruin/powered/lizard_gas)
+/obj/structure/sign/warning/fire/directional/north,
+/turf/template_noop,
+/area/template_noop)
 "ia" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
-/turf/open/floor/iron/smooth{
-	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
-	},
-/area/ruin/powered/lizard_gas)
+/obj/structure/sign/warning/chem_diamond/directional/north,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/unexplored)
 "iC" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/structure/table,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
 /obj/item/crowbar{
 	pixel_x = 1;
 	pixel_y = 4
@@ -368,7 +368,7 @@
 	pixel_x = 7;
 	pixel_y = 0;
 	name = "Manager Note";
-	default_raw_text = "Good news! That little decrepit hut out front is finally, <B>legally</B> ours! Feel free to snoop around it if you find the time, and remember, time to lean means time to clean!<BR><BR>P.S, go into the backroom and set the nitrogen and oxygen pressure tanks to layer 3 with the multitool, the HVAC tech had no fucking clue what he was doing apparently!<BR><BR>-General Manager, Ra'Tahul Rekinov"
+	default_raw_text = "Good news! That little decrepit hut out front is finally, <B>legally</B> ours! Feel free to snoop around it if you find the time, and remember, time to lean means time to clean!<BR><BR>-General Manager, Ra'Tahul Rekinov"
 	},
 /obj/item/multitool{
 	pixel_x = -6;
@@ -417,7 +417,6 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -432,10 +431,9 @@
 	},
 /area/ruin/powered/lizard_gas)
 "kq" = (
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -455,7 +453,6 @@
 "lx" = (
 /obj/effect/spawner/random/trash/food_packaging,
 /obj/structure/cable,
-/obj/machinery/duct,
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -467,11 +464,13 @@
 "mH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
 /obj/item/trash/popcorn/caramel{
 	pixel_x = -7;
 	pixel_y = 11
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -510,13 +509,13 @@
 	},
 /area/ruin/powered/lizard_gas)
 "nH" = (
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
-/turf/open/floor/iron{
-	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
+/obj/structure/reagent_dispensers/plumbed/storage{
+	dir = 8;
+	reagent_id = /datum/reagent/toxin/plasma;
+	name = "plasma storage tank";
+	tank_volume = 2500
 	},
+/turf/open/floor/plating/icemoon,
 /area/ruin/powered/lizard_gas)
 "nN" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -592,9 +591,9 @@
 "sk" = (
 /obj/structure/cable,
 /obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
 /obj/machinery/door/airlock/maintenance_hatch,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -631,14 +630,16 @@
 	pixel_x = 2;
 	pixel_y = 2
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
 /area/ruin/powered/lizard_gas)
 "sB" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
 /obj/machinery/light_switch/directional/south,
+/obj/machinery/duct,
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -659,7 +660,8 @@
 "ts" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/powered/lizard_gas)
 "tB" = (
@@ -672,10 +674,8 @@
 "tJ" = (
 /obj/structure/cable,
 /obj/machinery/light/small/directional/west,
-/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -693,6 +693,17 @@
 	dir = 8
 	},
 /turf/open/floor/iron{
+	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
+	},
+/area/ruin/powered/lizard_gas)
+"uJ" = (
+/obj/machinery/door/airlock/external/ruin,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "lizardgas_lavaland_entrance"
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/duct,
+/turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
 /area/ruin/powered/lizard_gas)
@@ -717,28 +728,26 @@
 	pixel_x = 7
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
 /area/ruin/powered/lizard_gas)
 "vE" = (
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
 /obj/machinery/door/airlock/grunge{
 	name = "Break Room"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
 /area/ruin/powered/lizard_gas)
 "vX" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/machinery/duct,
-/turf/open/floor/plating/lavaland_baseturf,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden,
+/turf/closed/wall/r_wall{
+	baseturfs = /turf/open/floor/plating/lavaland_baseturf
+	},
 /area/ruin/powered/lizard_gas)
 "vY" = (
 /obj/machinery/duct,
@@ -748,8 +757,8 @@
 /area/ruin/powered/lizard_gas)
 "wB" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -764,10 +773,17 @@
 	pixel_y = 2;
 	pixel_x = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
+/area/ruin/powered/lizard_gas)
+"xJ" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Plasma Hook-Up"
+	},
+/turf/open/floor/plating/icemoon,
 /area/ruin/powered/lizard_gas)
 "xS" = (
 /obj/structure/table,
@@ -782,7 +798,7 @@
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/unexplored)
 "xV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -859,6 +875,7 @@
 	id_tag = "gasbathroom";
 	name = "Bathroom"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -868,16 +885,14 @@
 /obj/effect/mob_spawn/ghost_role/human/lavaland_gasstation{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
 /area/ruin/powered/lizard_gas)
 "zv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -897,7 +912,7 @@
 /obj/item/reagent_containers/condiment/milk,
 /obj/item/reagent_containers/condiment/soymilk,
 /obj/item/reagent_containers/condiment/soymilk,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
 /turf/open/floor/iron/freezer{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -919,7 +934,6 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1015,7 +1029,6 @@
 	component_parts = 4;
 	charge = 0
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1031,15 +1044,14 @@
 "DJ" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/deluxe_garbage,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
 /area/ruin/powered/lizard_gas)
 "DN" = (
 /obj/structure/sign/poster/contraband/tipper_cream_soda/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/condiment/bbqsauce{
 	pixel_y = 17;
@@ -1064,6 +1076,8 @@
 /obj/item/food/bun,
 /obj/item/food/bun,
 /obj/item/food/bun,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1078,12 +1092,11 @@
 /area/icemoon/underground/unexplored)
 "Ec" = (
 /obj/machinery/door/airlock/external/ruin,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "lizardgas_lavaland_entrance"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1127,7 +1140,6 @@
 /area/icemoon/underground/unexplored)
 "Fg" = (
 /obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
 /obj/item/food/donut/choco{
 	pixel_x = -4;
 	pixel_y = 7
@@ -1135,6 +1147,7 @@
 /obj/item/food/donut/berry{
 	pixel_x = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1155,7 +1168,6 @@
 	pixel_x = 3
 	},
 /obj/structure/closet/crate/freezer,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
 /obj/item/food/cornuto{
 	pixel_y = -5;
 	pixel_x = -3
@@ -1172,6 +1184,7 @@
 	pixel_y = -5;
 	pixel_x = 2
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron/freezer{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1195,21 +1208,21 @@
 /area/ruin/powered/lizard_gas)
 "FU" = (
 /obj/structure/sign/poster/official/plasma_effects/directional/east,
-/obj/structure/reagent_dispensers/plumbed/storage{
-	dir = 8;
-	reagent_id = /datum/reagent/toxin/plasma;
-	name = "plasma storage tank";
-	tank_volume = 2500
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen{
+	connected_port = 1
+	},
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
 /area/ruin/powered/lizard_gas)
 "Ga" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1228,13 +1241,11 @@
 /turf/open/floor/asphalt,
 /area/ruin/powered/lizard_gas)
 "Hq" = (
-/obj/machinery/atmospherics/components/tank/oxygen{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1;
+	filter_types = list(/datum/gas/oxygen)
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
-/turf/open/floor/iron/smooth{
-	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
-	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/ruin/powered/lizard_gas)
 "HA" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/plasma_input{
@@ -1278,7 +1289,7 @@
 	},
 /area/ruin/powered/lizard_gas)
 "IP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron{
@@ -1322,10 +1333,11 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/unexplored)
 "Lb" = (
-/obj/structure/fence,
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/structure/sign/warning/no_smoking/circle/directional/east,
+/obj/machinery/duct,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/underground/unexplored)
+/area/ruin/powered/lizard_gas)
 "Ll" = (
 /obj/item/stack/sheet/mineral/wood/fifty{
 	pixel_x = 10;
@@ -1338,11 +1350,11 @@
 /turf/open/floor/wood/lavaland,
 /area/icemoon/underground/unexplored)
 "Lm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
 /obj/machinery/door/airlock/grunge{
 	id_tag = "corpoffice";
 	name = "Manager's Office"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
 /turf/open/floor/wood/parquet,
 /area/ruin/powered/lizard_gas)
 "Lo" = (
@@ -1350,7 +1362,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1413,6 +1424,7 @@
 /obj/item/food/raw_sausage{
 	pixel_y = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1459,7 +1471,8 @@
 /area/icemoon/underground/unexplored)
 "PC" = (
 /obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1501,16 +1514,18 @@
 /turf/open/floor/wood/parquet,
 /area/ruin/powered/lizard_gas)
 "QF" = (
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron{
-	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
+/turf/closed/wall/r_wall{
+	baseturfs = /turf/open/floor/plating/lavaland_baseturf
 	},
 /area/ruin/powered/lizard_gas)
 "QM" = (
 /obj/machinery/vending/dorms{
 	density = 0;
 	pixel_y = -32
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
@@ -1528,7 +1543,7 @@
 /area/ruin/powered/lizard_gas)
 "QW" = (
 /obj/machinery/light/small/dim/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1545,7 +1560,6 @@
 	},
 /area/ruin/powered/lizard_gas)
 "Rt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
 /obj/structure/railing{
 	dir = 4
 	},
@@ -1555,6 +1569,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plating/lavaland_atmos{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1602,6 +1617,9 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/end,
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1
+	},
 /turf/open/floor/plating/lavaland_atmos{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1650,7 +1668,6 @@
 /obj/item/gun/energy/recharge/kinetic_accelerator/glock,
 /obj/item/clothing/mask/breath,
 /obj/item/pickaxe,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
 /obj/item/tank/internals/emergency_oxygen/double,
 /obj/item/tank/internals/emergency_oxygen/double,
 /obj/item/storage/backpack/satchel/science{
@@ -1703,6 +1720,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "lizardgas_lavaland_entrance"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1714,6 +1732,9 @@
 	normaldoorcontrol = 1;
 	id = "gasbathroom";
 	name = "Door Bolt Control"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
 	},
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
@@ -1736,8 +1757,8 @@
 /turf/open/floor/asphalt,
 /area/ruin/powered/lizard_gas)
 "Wq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
-/turf/closed/wall{
+/obj/machinery/duct,
+/turf/closed/wall/r_wall{
 	baseturfs = /turf/open/floor/plating/lavaland_baseturf
 	},
 /area/ruin/powered/lizard_gas)
@@ -1747,9 +1768,8 @@
 /area/ruin/powered/lizard_gas)
 "WZ" = (
 /obj/structure/cable,
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1759,6 +1779,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1774,10 +1795,8 @@
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/unexplored)
 "YL" = (
-/obj/machinery/atmospherics/components/tank/nitrogen{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1806,9 +1825,9 @@
 	},
 /area/ruin/powered/lizard_gas)
 "ZX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
 /obj/structure/sign/poster/fluff/lizards_gas_payment/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -2121,13 +2140,13 @@ Vw
 Bv
 MK
 MK
-cx
+MK
 MK
 MK
 MK
 VR
 MK
-MK
+cx
 MK
 Vw
 Gr
@@ -2145,17 +2164,17 @@ Gr
 Gr
 Vw
 dK
-Bv
+Vw
 gm
 yo
+yo
+yo
+gm
+gm
+gm
+Ja
+uJ
 vX
-yo
-gm
-gm
-gm
-Ja
-Ja
-gm
 Bv
 Bv
 Vw
@@ -2175,14 +2194,14 @@ bZ
 gm
 gm
 UC
-QF
+GA
 MX
 fr
 mK
 yb
 QW
 XL
-gm
+vX
 hi
 FS
 FS
@@ -2229,7 +2248,7 @@ AN
 xV
 yb
 BR
-ap
+ZQ
 ll
 Qw
 Mu
@@ -2255,7 +2274,7 @@ DD
 dD
 zv
 vE
-nH
+kq
 kq
 wB
 Ga
@@ -2275,7 +2294,7 @@ Gr
 "}
 (18,1,1) = {"
 gm
-Wq
+yb
 yb
 yb
 yb
@@ -2304,7 +2323,7 @@ Gr
 gm
 Df
 fv
-ia
+WZ
 DJ
 tJ
 WZ
@@ -2315,7 +2334,7 @@ um
 nN
 UE
 hy
-um
+aG
 PC
 gm
 QP
@@ -2333,7 +2352,7 @@ iO
 ac
 YL
 Ah
-Hq
+pT
 FU
 yb
 ch
@@ -2356,9 +2375,9 @@ Gr
 "}
 (21,1,1) = {"
 gm
-Wq
+yb
 Lm
-hV
+yb
 gm
 gm
 Jb
@@ -2369,7 +2388,7 @@ GA
 GA
 ZQ
 qQ
-GA
+kq
 mH
 ts
 Rt
@@ -2396,11 +2415,11 @@ gm
 IN
 gm
 gm
-gm
+QF
 zb
-gm
-Vw
-Vw
+ap
+Lb
+Hq
 Vw
 Vw
 Bv
@@ -2426,9 +2445,9 @@ eA
 Vv
 QM
 gm
-Vw
-Bv
-Vw
+Wq
+gm
+ia
 Bv
 Gr
 Gr
@@ -2442,7 +2461,7 @@ RU
 SL
 gm
 Vw
-Lb
+Vw
 LJ
 PA
 dv
@@ -2453,8 +2472,8 @@ za
 hj
 VK
 gm
-Vw
-Bv
+nH
+xJ
 Bv
 Gr
 Gr
@@ -2480,9 +2499,9 @@ gm
 gm
 gm
 gm
-Gr
-Gr
-Gr
+gm
+gm
+hV
 Gr
 Gr
 Gr

--- a/_maps/RandomRuins/IceRuins/bubberstation/icemoon_surface_gas_bubber.dmm
+++ b/_maps/RandomRuins/IceRuins/bubberstation/icemoon_surface_gas_bubber.dmm
@@ -555,6 +555,12 @@
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
 /area/ruin/powered/lizard_gas)
+"pb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
+/turf/closed/wall{
+	baseturfs = /turf/open/floor/plating/lavaland_baseturf
+	},
+/area/ruin/powered/lizard_gas)
 "pu" = (
 /obj/structure/sign/warning/fire/directional/north,
 /obj/structure/reagent_dispensers/fueltank/large{
@@ -632,7 +638,6 @@
 /area/ruin/powered/lizard_gas)
 "sy" = (
 /obj/structure/sign/poster/official/pda_ad/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
 /obj/structure/table/reinforced,
 /obj/item/food/rootbread_peanut_butter_banana{
 	pixel_y = 12;
@@ -2379,7 +2384,7 @@ Gr
 gm
 yb
 Lm
-yb
+pb
 gm
 gm
 Jb

--- a/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_surface_gas_bubber.dmm
+++ b/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_surface_gas_bubber.dmm
@@ -5,7 +5,6 @@
 /area/lavaland/surface/outdoors)
 "aN" = (
 /obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
 /obj/item/food/donut/choco{
 	pixel_x = -4;
 	pixel_y = 7
@@ -13,6 +12,7 @@
 /obj/item/food/donut/berry{
 	pixel_x = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -26,7 +26,6 @@
 	pixel_x = 7
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -45,12 +44,9 @@
 	},
 /area/ruin/thelizardsgas_lavaland)
 "bK" = (
-/obj/structure/cable,
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
-/turf/open/floor/iron/smooth{
-	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
+/turf/closed/wall/r_wall{
+	baseturfs = /turf/open/floor/plating/lavaland_baseturf
 	},
 /area/ruin/thelizardsgas_lavaland)
 "bL" = (
@@ -69,26 +65,26 @@
 	id = "gasbathroom";
 	name = "Door Bolt Control"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
 /area/ruin/thelizardsgas_lavaland)
 "bO" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
 /obj/structure/noticeboard/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
 /area/ruin/thelizardsgas_lavaland)
 "cf" = (
 /obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
-/turf/open/floor/iron{
-	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
+/turf/closed/wall/r_wall{
+	baseturfs = /turf/open/floor/plating/lavaland_baseturf
 	},
 /area/ruin/thelizardsgas_lavaland)
 "cg" = (
@@ -141,7 +137,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -169,6 +164,9 @@
 "eB" = (
 /obj/item/mop,
 /obj/structure/mop_bucket/janitorialcart,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -185,7 +183,6 @@
 "ga" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/structure/table,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
 /obj/item/crowbar{
 	pixel_x = 1;
 	pixel_y = 4
@@ -241,10 +238,9 @@
 	},
 /area/ruin/thelizardsgas_lavaland)
 "gQ" = (
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -267,6 +263,9 @@
 	density = 0;
 	pixel_y = -32
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -275,13 +274,12 @@
 /turf/template_noop,
 /area/template_noop)
 "hC" = (
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
 /obj/machinery/door/airlock/grunge{
 	name = "Break Room"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -304,14 +302,6 @@
 	},
 /obj/machinery/light/dim/directional/south,
 /turf/open/floor/asphalt,
-/area/ruin/thelizardsgas_lavaland)
-"il" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron{
-	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
-	},
 /area/ruin/thelizardsgas_lavaland)
 "iE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -401,7 +391,7 @@
 /turf/open/floor/asphalt,
 /area/ruin/thelizardsgas_lavaland)
 "lM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron{
@@ -423,7 +413,6 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -497,8 +486,8 @@
 "nE" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/deluxe_garbage,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -520,8 +509,8 @@
 /area/lavaland/surface/outdoors)
 "oY" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -542,7 +531,6 @@
 	charge = 0
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -582,7 +570,7 @@
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "rD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -655,18 +643,17 @@
 /area/ruin/thelizardsgas_lavaland)
 "tk" = (
 /obj/structure/cable,
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
 /obj/machinery/door/airlock/maintenance_hatch,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
 /area/ruin/thelizardsgas_lavaland)
 "tq" = (
 /obj/structure/sign/warning/fire/directional/north,
-/turf/template_noop,
-/area/template_noop)
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "tD" = (
 /obj/structure/cable,
 /turf/open/floor/iron{
@@ -682,6 +669,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -689,7 +677,8 @@
 "uf" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/thelizardsgas_lavaland)
 "uq" = (
@@ -710,8 +699,9 @@
 /area/ruin/thelizardsgas_lavaland)
 "uB" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
 /obj/machinery/light_switch/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -740,7 +730,9 @@
 	},
 /area/ruin/thelizardsgas_lavaland)
 "uX" = (
-/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/portable_atmospherics/canister{
+	connected_port = 1
+	},
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "vj" = (
@@ -757,6 +749,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "lizardgas_lavaland_entrance"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -778,11 +771,13 @@
 "vD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
 /obj/item/trash/popcorn/caramel{
 	pixel_x = -7;
 	pixel_y = 11
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -795,7 +790,6 @@
 /obj/effect/mapping_helpers/apc/cell_10k,
 /obj/effect/mapping_helpers/apc/unlocked,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
 /obj/item/flashlight{
 	pixel_x = 4;
 	pixel_y = 6
@@ -838,15 +832,17 @@
 	},
 /area/ruin/thelizardsgas_lavaland)
 "xM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
-/turf/closed/wall{
-	baseturfs = /turf/open/floor/plating/lavaland_baseturf
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1;
+	filter_types = list(/datum/gas/oxygen)
 	},
+/obj/machinery/duct,
+/turf/open/floor/plating/lavaland_atmos,
 /area/ruin/thelizardsgas_lavaland)
 "xV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
 /obj/structure/sign/poster/fluff/lizards_gas_payment/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -857,6 +853,7 @@
 /area/icemoon/underground/unexplored)
 "yb" = (
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -866,7 +863,6 @@
 /area/icemoon/underground/unexplored)
 "yy" = (
 /obj/structure/sign/poster/contraband/tipper_cream_soda/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/condiment/bbqsauce{
 	pixel_y = 17;
@@ -891,6 +887,9 @@
 /obj/item/food/bun,
 /obj/item/food/bun,
 /obj/item/food/bun,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -904,13 +903,10 @@
 /turf/open/floor/asphalt,
 /area/ruin/thelizardsgas_lavaland)
 "zo" = (
-/obj/machinery/atmospherics/components/tank/nitrogen{
-	dir = 8
+/obj/machinery/door/airlock/grunge{
+	name = "Plasma Hook-Up"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
-/turf/open/floor/iron/smooth{
-	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
-	},
+/turf/open/floor/plating/lavaland_atmos,
 /area/ruin/thelizardsgas_lavaland)
 "zz" = (
 /obj/machinery/light/directional/west,
@@ -961,7 +957,7 @@
 /area/ruin/thelizardsgas_lavaland)
 "Bs" = (
 /obj/machinery/light/small/dim/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -995,10 +991,14 @@
 /turf/closed/wall/r_wall,
 /area/ruin/thelizardsgas_lavaland)
 "CG" = (
-/obj/structure/fence,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/obj/structure/reagent_dispensers/plumbed/storage{
+	dir = 8;
+	reagent_id = /datum/reagent/toxin/plasma;
+	name = "plasma storage tank";
+	tank_volume = 2500
+	},
+/turf/open/floor/plating/lavaland_atmos,
+/area/ruin/thelizardsgas_lavaland)
 "CY" = (
 /obj/structure/rack,
 /obj/item/food/candy,
@@ -1033,10 +1033,12 @@
 	},
 /area/ruin/thelizardsgas_lavaland)
 "DL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/door/airlock/external/ruin,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "lizardgas_lavaland_entrance"
+	},
+/obj/structure/fans/tiny,
 /obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1074,7 +1076,6 @@
 	pixel_x = 3
 	},
 /obj/structure/closet/crate/freezer,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
 /obj/item/food/cornuto{
 	pixel_y = -5;
 	pixel_x = -3
@@ -1108,8 +1109,8 @@
 /area/ruin/thelizardsgas_lavaland)
 "FZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1150,6 +1151,7 @@
 	dir = 1
 	},
 /obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1196,7 +1198,6 @@
 /obj/item/gun/energy/recharge/kinetic_accelerator/glock,
 /obj/item/clothing/mask/breath,
 /obj/item/pickaxe,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
 /obj/item/tank/internals/emergency_oxygen/double,
 /obj/item/tank/internals/emergency_oxygen/double,
 /obj/item/storage/backpack/satchel/science{
@@ -1297,6 +1298,7 @@
 	id_tag = "gasbathroom";
 	name = "Bathroom"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1316,11 +1318,11 @@
 "Mp" = (
 /obj/machinery/door/airlock/external/ruin,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "lizardgas_lavaland_entrance"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1397,7 +1399,7 @@
 /obj/item/reagent_containers/condiment/milk,
 /obj/item/reagent_containers/condiment/soymilk,
 /obj/item/reagent_containers/condiment/soymilk,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
 /turf/open/floor/iron/freezer{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1525,7 +1527,6 @@
 /area/ruin/thelizardsgas_lavaland)
 "Sq" = (
 /obj/structure/sign/poster/official/pda_ad/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
 /obj/structure/table/reinforced,
 /obj/item/food/rootbread_peanut_butter_banana{
 	pixel_y = 12;
@@ -1535,13 +1536,16 @@
 	pixel_x = 2;
 	pixel_y = 2
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
 /area/ruin/thelizardsgas_lavaland)
 "Su" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1554,16 +1558,19 @@
 /area/ruin/thelizardsgas_lavaland)
 "Ta" = (
 /obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
 /area/ruin/thelizardsgas_lavaland)
 "Tc" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/machinery/duct,
-/turf/open/floor/plating/lavaland_baseturf,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/iron{
+	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
+	},
 /area/ruin/thelizardsgas_lavaland)
 "Tk" = (
 /turf/open/misc/asteroid/basalt/lava_land_surface,
@@ -1578,7 +1585,7 @@
 	pixel_y = 2;
 	pixel_x = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1587,15 +1594,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
 /area/ruin/thelizardsgas_lavaland)
 "UK" = (
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron{
-	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/turf/closed/wall/r_wall{
+	baseturfs = /turf/open/floor/plating/lavaland_baseturf
 	},
 /area/ruin/thelizardsgas_lavaland)
 "Vd" = (
@@ -1603,8 +1610,7 @@
 /turf/open/floor/asphalt,
 /area/ruin/thelizardsgas_lavaland)
 "Vn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/closed/wall{
 	baseturfs = /turf/open/floor/plating/lavaland_baseturf
 	},
@@ -1615,14 +1621,11 @@
 /area/lavaland/surface/outdoors)
 "Wg" = (
 /obj/structure/sign/poster/official/plasma_effects/directional/east,
-/obj/structure/reagent_dispensers/plumbed/storage{
-	dir = 8;
-	reagent_id = /datum/reagent/toxin/plasma;
-	name = "plasma storage tank";
-	tank_volume = 2500
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1635,11 +1638,11 @@
 /turf/open/floor/asphalt,
 /area/ruin/thelizardsgas_lavaland)
 "WI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
 /obj/machinery/door/airlock/grunge{
 	id_tag = "corpoffice";
 	name = "Manager's Office"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
 /turf/open/floor/wood/parquet,
 /area/ruin/thelizardsgas_lavaland)
 "WL" = (
@@ -1654,7 +1657,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1664,13 +1666,11 @@
 /obj/effect/mob_spawn/ghost_role/human/lavaland_gasstation{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
 /area/ruin/thelizardsgas_lavaland)
 "WV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
 /obj/structure/railing{
 	dir = 4
 	},
@@ -1680,6 +1680,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/duct,
 /turf/open/floor/plating/lavaland_atmos{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1719,7 +1720,6 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer2,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1731,10 +1731,8 @@
 "XD" = (
 /obj/structure/cable,
 /obj/machinery/light/small/directional/west,
-/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1785,8 +1783,11 @@
 	},
 /area/ruin/thelizardsgas_lavaland)
 "Zt" = (
-/obj/machinery/atmospherics/components/tank/oxygen{
+/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
 	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen{
+	connected_port = 1
 	},
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
@@ -2107,13 +2108,13 @@ Tk
 Tk
 jo
 jo
-Sh
+jo
 jo
 jo
 jo
 bp
 jo
-jo
+Sh
 jo
 tK
 Tk
@@ -2134,20 +2135,20 @@ Tk
 at
 cB
 Xb
-Tc
+Xb
 Xb
 cB
 cB
 cB
 Rb
-Rb
+DL
 cB
 YH
 Tk
 Tk
-hr
-hr
-hr
+Tk
+Tk
+Tk
 hr
 hr
 "}
@@ -2161,7 +2162,7 @@ Qi
 cB
 cB
 QP
-UK
+tD
 Mw
 qX
 uG
@@ -2201,7 +2202,7 @@ RW
 RW
 gt
 Ra
-hr
+Tk
 hr
 hr
 "}
@@ -2215,7 +2216,7 @@ Zo
 rD
 wE
 CY
-il
+KS
 fc
 vz
 uq
@@ -2228,7 +2229,7 @@ gW
 nJ
 gt
 IF
-hr
+Tk
 hr
 hr
 "}
@@ -2239,9 +2240,9 @@ gd
 Bf
 Is
 gn
-DL
+oY
 hC
-cf
+gQ
 gQ
 FZ
 Su
@@ -2255,13 +2256,13 @@ bL
 sk
 gt
 IF
-hr
+Tk
 hr
 hr
 "}
 (18,1,1) = {"
 cB
-xM
+wE
 wE
 wE
 wE
@@ -2282,7 +2283,7 @@ sk
 sk
 gt
 GV
-hr
+Tk
 hr
 hr
 "}
@@ -2293,7 +2294,7 @@ Hq
 oY
 nE
 XD
-bK
+oY
 wE
 Ao
 lM
@@ -2309,7 +2310,7 @@ vj
 vj
 gt
 GV
-hr
+Tk
 hr
 hr
 "}
@@ -2317,7 +2318,7 @@ hr
 cB
 Xj
 yb
-zo
+rD
 eB
 Zt
 Wg
@@ -2336,13 +2337,13 @@ RW
 RW
 gt
 Ab
-hr
+Tk
 hr
 hr
 "}
 (21,1,1) = {"
 cB
-xM
+wE
 WI
 Vn
 cB
@@ -2355,7 +2356,7 @@ tD
 tD
 KS
 WZ
-tD
+Tc
 vD
 uf
 WV
@@ -2382,15 +2383,15 @@ cB
 DE
 cB
 cB
-cB
+bK
 LL
-cB
+UK
+xM
 Tk
 Tk
 Tk
 Tk
 Tk
-hr
 hr
 hr
 "}
@@ -2412,8 +2413,8 @@ uM
 bM
 gY
 cB
-Tk
-Tk
+cf
+cB
 Tk
 Tk
 hr
@@ -2428,7 +2429,7 @@ ID
 XA
 cB
 Tk
-CG
+Tk
 ry
 kT
 hG
@@ -2439,8 +2440,8 @@ ef
 BN
 bG
 cB
-Tk
-Tk
+CG
+zo
 Tk
 hr
 hr
@@ -2466,8 +2467,8 @@ cB
 cB
 cB
 cB
-hr
-hr
+cB
+cB
 hr
 hr
 hr

--- a/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_surface_gas_bubber.dmm
+++ b/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_surface_gas_bubber.dmm
@@ -44,7 +44,7 @@
 	},
 /area/ruin/thelizardsgas_lavaland)
 "bK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
 /turf/closed/wall/r_wall{
 	baseturfs = /turf/open/floor/plating/lavaland_baseturf
 	},
@@ -82,9 +82,11 @@
 	},
 /area/ruin/thelizardsgas_lavaland)
 "cf" = (
-/obj/machinery/duct,
-/turf/closed/wall/r_wall{
-	baseturfs = /turf/open/floor/plating/lavaland_baseturf
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/iron{
+	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
 /area/ruin/thelizardsgas_lavaland)
 "cg" = (
@@ -238,10 +240,13 @@
 	},
 /area/ruin/thelizardsgas_lavaland)
 "gQ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/iron{
+/obj/machinery/door/airlock/external/ruin,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "lizardgas_lavaland_entrance"
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/duct,
+/turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
 /area/ruin/thelizardsgas_lavaland)
@@ -302,6 +307,14 @@
 	},
 /obj/machinery/light/dim/directional/south,
 /turf/open/floor/asphalt,
+/area/ruin/thelizardsgas_lavaland)
+"il" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1;
+	filter_types = list(/datum/gas/oxygen)
+	},
+/obj/machinery/duct,
+/turf/open/floor/plating/lavaland_atmos,
 /area/ruin/thelizardsgas_lavaland)
 "iE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -508,11 +521,9 @@
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "oY" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/iron/smooth{
-	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
+/obj/machinery/duct,
+/turf/closed/wall/r_wall{
+	baseturfs = /turf/open/floor/plating/lavaland_baseturf
 	},
 /area/ruin/thelizardsgas_lavaland)
 "po" = (
@@ -570,10 +581,10 @@
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "rD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/iron/smooth{
-	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
+/obj/machinery/door/airlock/grunge{
+	name = "Plasma Hook-Up"
 	},
+/turf/open/floor/plating/lavaland_atmos,
 /area/ruin/thelizardsgas_lavaland)
 "rE" = (
 /obj/structure/cable,
@@ -832,12 +843,11 @@
 	},
 /area/ruin/thelizardsgas_lavaland)
 "xM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1;
-	filter_types = list(/datum/gas/oxygen)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/iron{
+	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
-/obj/machinery/duct,
-/turf/open/floor/plating/lavaland_atmos,
 /area/ruin/thelizardsgas_lavaland)
 "xV" = (
 /obj/structure/sign/poster/fluff/lizards_gas_payment/directional/west,
@@ -903,10 +913,10 @@
 /turf/open/floor/asphalt,
 /area/ruin/thelizardsgas_lavaland)
 "zo" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Plasma Hook-Up"
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/iron/smooth{
+	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
-/turf/open/floor/plating/lavaland_atmos,
 /area/ruin/thelizardsgas_lavaland)
 "zz" = (
 /obj/machinery/light/directional/west,
@@ -990,15 +1000,6 @@
 "Cf" = (
 /turf/closed/wall/r_wall,
 /area/ruin/thelizardsgas_lavaland)
-"CG" = (
-/obj/structure/reagent_dispensers/plumbed/storage{
-	dir = 8;
-	reagent_id = /datum/reagent/toxin/plasma;
-	name = "plasma storage tank";
-	tank_volume = 2500
-	},
-/turf/open/floor/plating/lavaland_atmos,
-/area/ruin/thelizardsgas_lavaland)
 "CY" = (
 /obj/structure/rack,
 /obj/item/food/candy,
@@ -1033,12 +1034,9 @@
 	},
 /area/ruin/thelizardsgas_lavaland)
 "DL" = (
-/obj/machinery/door/airlock/external/ruin,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "lizardgas_lavaland_entrance"
-	},
-/obj/structure/fans/tiny,
-/obj/machinery/duct,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1566,11 +1564,13 @@
 	},
 /area/ruin/thelizardsgas_lavaland)
 "Tc" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/iron{
-	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
+/obj/structure/reagent_dispensers/plumbed/storage{
+	dir = 8;
+	reagent_id = /datum/reagent/toxin/plasma;
+	name = "plasma storage tank";
+	tank_volume = 2500
 	},
+/turf/open/floor/plating/lavaland_atmos,
 /area/ruin/thelizardsgas_lavaland)
 "Tk" = (
 /turf/open/misc/asteroid/basalt/lava_land_surface,
@@ -1600,7 +1600,7 @@
 	},
 /area/ruin/thelizardsgas_lavaland)
 "UK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /turf/closed/wall/r_wall{
 	baseturfs = /turf/open/floor/plating/lavaland_baseturf
 	},
@@ -1662,7 +1662,9 @@
 	},
 /area/ruin/thelizardsgas_lavaland)
 "WT" = (
-/obj/machinery/airalarm/directional/west,
+/obj/machinery/airalarm/directional/west{
+	all_access = 1
+	},
 /obj/effect/mob_spawn/ghost_role/human/lavaland_gasstation{
 	dir = 4
 	},
@@ -2141,7 +2143,7 @@ cB
 cB
 cB
 Rb
-DL
+gQ
 cB
 YH
 Tk
@@ -2213,7 +2215,7 @@ gd
 Jp
 Jp
 Zo
-rD
+zo
 wE
 CY
 KS
@@ -2240,10 +2242,10 @@ gd
 Bf
 Is
 gn
-oY
+DL
 hC
-gQ
-gQ
+cf
+cf
 FZ
 Su
 FZ
@@ -2291,10 +2293,10 @@ hr
 cB
 pB
 Hq
-oY
+DL
 nE
 XD
-oY
+DL
 wE
 Ao
 lM
@@ -2318,7 +2320,7 @@ hr
 cB
 Xj
 yb
-rD
+zo
 eB
 Zt
 Wg
@@ -2356,7 +2358,7 @@ tD
 tD
 KS
 WZ
-Tc
+xM
 vD
 uf
 WV
@@ -2383,10 +2385,10 @@ cB
 DE
 cB
 cB
-bK
-LL
 UK
-xM
+LL
+bK
+il
 Tk
 Tk
 Tk
@@ -2413,7 +2415,7 @@ uM
 bM
 gY
 cB
-cf
+oY
 cB
 Tk
 Tk
@@ -2440,8 +2442,8 @@ ef
 BN
 bG
 cB
-CG
-zo
+Tc
+rD
 Tk
 hr
 hr

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1138,13 +1138,6 @@
 	desc = "A rainbow card, promoting fun in a 'business proper' sense!"
 	icon_state = "card_rainbow"
 
-/obj/item/card/id/advanced/lizardgas
-	name = "Lizard Gas Employee Card"
-	desc = "A rainbow ID card, promoting fun in a 'business proper' sense!"
-	icon_state = "card_rainbow"
-	trim = /datum/id_trim/away/lizardgas
-	wildcard_slots = WILDCARD_LIMIT_GREY
-
 /obj/item/card/id/advanced/silver
 	name = "silver identification card"
 	desc = "A silver card which shows honour and dedication."

--- a/modular_zubbers/code/game/objects/items/cards_ids.dm
+++ b/modular_zubbers/code/game/objects/items/cards_ids.dm
@@ -17,3 +17,10 @@
 	inhand_icon_state = "korven"
 	lefthand_file = 'modular_zubbers/icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'modular_zubbers/icons/mob/inhands/equipment/idcards_righthand.dmi'
+
+/obj/item/card/id/advanced/lizardgas
+	name = "Lizard Gas Employee Card"
+	desc = "A rainbow ID card, promoting fun in a 'business proper' sense!"
+	icon_state = "card_rainbow"
+	trim = /datum/id_trim/away/lizardgas
+	wildcard_slots = WILDCARD_LIMIT_GREY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The Lizard Gas Ghost roles use Omni pressure tanks, these are ass in game and don't have layers properly coded in. Also the loop is currently not hooked up. Also the Liquid plasma tank network has been changed to have an exterior store-house, because immediately upon people trying to fix atmos- sparks from the RPD caught the tank on fire and torched the entire backroom, maintenance room, and manager's office in a roaring plasma/trit fire 😔 

p.s the Lizard Gas I.D was added to a non-modular file on accident, this PR switches it to modular.

The mapsize was not altered to accommodate these changes overall and it remains a 25x25 Ghost Role ruin (as it's always been.)

TL;DR:

-Atmos Pipes are colored Red and Blue for Scrubbers and Air Supply, as God intended
-Exterior Scrubber added to suck Oxygen out of the air and store it in the network/a connected Atmos Oxygen Cannister
-Mapping Error corrected, interior vent in the central room was set to layer 4, and not hooked up.
-Exterior storage closet added for liquid plasma supply following ridiculous flammability INSIDE of the structure (risks torching the ENTIRE gas station because of a single spark.)
-Moves Lizard Gas I.D `item` to Modular folder, is currently (and unnecessarily)  in Non-Modular folder without being noted. No bueno.
-Grants access to alter their own air alarm
-Additional Air Scrubber and Vent added to Maintenance backroom
-Additional Air Scrubber and Vent added to Bathroom
-Moves Oxygen Atmos can inside instead of outback, pretty sure the heat of Lavaland damages it/causes it to leak.

Edit: 
-Edited the Note that formerly mentioned the omni pressure tanks, as manually fixing the atmos is no longer required as they have been removed!
-Added Connector port for giant fucking plasma gas tank outside. Formerly was only for looks, now can actually inject more plasma into the tank (no one ever will probably but it makes more sense than having it just, not hooked up to anything)
-Actually connected plasma tank to Plasma connectors of the gas station. They weren't. For some reason.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game
Overall it fixes a blatant mapping error and prevents a Ghost role from being scorched/burned out so easily. Pretty sure I don't have to elaborate on the modular part
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Proof Of Testing
Tested Locally/It's a very minor map edit. I.D still functions the same, it's only a movement of the code to a modular folder. No new Run-Time Errors.
<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->
<details>
<summary>Screenshots/Videos</summary>

![atmospr1](https://github.com/user-attachments/assets/b1d7649b-12ed-4a07-9c41-c74785ca5b2a)
![image](https://github.com/user-attachments/assets/43710ecd-c13d-4722-98aa-d1015f6b7e98)

p.s the fluid ducting as been moved to connect horizontally instead of vertically, instead of as defined in the pictures.

</details>



<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
