### PR TITLE
Fixes a seed path.

### DIFF
--- a/modular_zubbers/code/modules/hydroponics/code/grown/rocks.dm
+++ b/modular_zubbers/code/modules/hydroponics/code/grown/rocks.dm
@@ -105,7 +105,7 @@
 	plantname = "Sandfruits"
 	product = /obj/item/food/grown/shell/sand
 	mutatelist = list(/obj/item/seeds/uraniberry,
-					/obj/item/seeds/aubergine,
+					/obj/item/seeds/agbergine,
 					/obj/item/seeds/ferrotuber,
 					/obj/item/seeds/adamapple)
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.1,


### PR DESCRIPTION
## About The Pull Request

When I changed it, so the joke in the names of "Agbergine" and "Aubergine" were better aligned with the materials, I forgot that sandfruits produced "Aubergine" seeds, which meant they completely skipped silver and shortened progression to diamonds.
## Why It's Good For The Game

Don't get to diamond seeds as quickly and silver seeds are actually accessible outside of xenobio silvers and seed mesh.

![image](https://github.com/user-attachments/assets/8aa94421-1f99-4321-8455-3dae648f18c4)


## Changelog
:cl:
fix: fixed seed pathing so silver's weren't skipped with the rockfruit mutations.
/:cl:
