### PR TITLE
Lizard Gas Update

### DIFF
--- a/_maps/RandomRuins/IceRuins/bubberstation/icemoon_surface_gas_bubber.dmm
+++ b/_maps/RandomRuins/IceRuins/bubberstation/icemoon_surface_gas_bubber.dmm
@@ -23,12 +23,20 @@
 	},
 /area/ruin/powered/lizard_gas)
 "ap" = (
-/obj/machinery/door/airlock/external/ruin,
+/obj/machinery/door/airlock/external/ruin{
+	pixel_x = 0;
+	pixel_y = 0;
+	id_tag = "lizardgasbolt"
+	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "lizardgas_lavaland_entrance"
 	},
 /obj/structure/fans/tiny,
 /obj/machinery/duct,
+/obj/machinery/door/poddoor{
+	id = "lizardshutters"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -45,6 +53,9 @@
 "bZ" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/structure/cable,
+/obj/machinery/door/poddoor/shutters{
+	id = "lizardshutters"
+	},
 /turf/open/floor/plating,
 /area/ruin/powered/lizard_gas)
 "cb" = (
@@ -124,7 +135,7 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/unexplored)
 "dv" = (
-/obj/structure/bonfire/prelit,
+/obj/structure/bonfire,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/unexplored)
 "dD" = (
@@ -175,6 +186,9 @@
 /area/icemoon/underground/unexplored)
 "ea" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/door/poddoor/shutters{
+	id = "lizardshutters"
+	},
 /turf/open/floor/plating/lavaland_baseturf,
 /area/ruin/powered/lizard_gas)
 "es" = (
@@ -389,6 +403,10 @@
 	pixel_x = 0;
 	pixel_y = 0
 	},
+/obj/item/inducer{
+	pixel_x = 0;
+	pixel_y = 8
+	},
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -402,6 +420,10 @@
 /obj/item/flatpacked_machine{
 	pixel_x = 7;
 	pixel_y = 5
+	},
+/obj/item/circuitboard/machine/biogenerator/food_replicator{
+	pixel_x = -4;
+	pixel_y = -8
 	},
 /turf/open/floor/wood/lavaland,
 /area/icemoon/underground/unexplored)
@@ -668,6 +690,26 @@
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
 /area/ruin/powered/lizard_gas)
+"sY" = (
+/obj/structure/cable,
+/obj/machinery/button/door/directional/east{
+	id = "lizardshutters";
+	pixel_x = 24;
+	pixel_y = 7;
+	name = "Privacy Shutters"
+	},
+/obj/machinery/button/door/directional/east{
+	pixel_x = 24;
+	pixel_y = -3;
+	name = "Entrance Doorbolts";
+	id = "lizardgasbolt";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
+/turf/open/floor/iron/smooth{
+	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
+	},
+/area/ruin/powered/lizard_gas)
 "tk" = (
 /obj/machinery/rnd/production/circuit_imprinter/offstation{
 	name = "Gas Station Imprinter"
@@ -679,6 +721,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
 /obj/machinery/duct,
+/obj/machinery/door/poddoor/shutters{
+	id = "lizardshutters"
+	},
 /turf/open/floor/iron,
 /area/ruin/powered/lizard_gas)
 "tB" = (
@@ -824,6 +869,9 @@
 "yo" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/door/poddoor/shutters{
+	id = "lizardshutters"
+	},
 /turf/open/floor/plating/lavaland_baseturf,
 /area/ruin/powered/lizard_gas)
 "yp" = (
@@ -883,7 +931,8 @@
 /area/ruin/powered/lizard_gas)
 "zc" = (
 /obj/machinery/airalarm/directional/west{
-	all_access = 1
+	all_access = 1;
+	req_access = null
 	},
 /obj/effect/mob_spawn/ghost_role/human/lavaland_gasstation{
 	dir = 4
@@ -892,6 +941,13 @@
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
 /area/ruin/powered/lizard_gas)
+"zh" = (
+/obj/item/paper{
+	default_raw_text = "Please do not steal materials/machinery from this shed, as they are direly useful to the Employees of The Lizard Gas-- whom are currently Cryosleeping and may wake up soon!<BR><BR>-General Manager, Ra'Tahul Rekinov";
+	name = "IMPORTANT NOTE!"
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/unexplored)
 "zv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
@@ -927,7 +983,7 @@
 /obj/machinery/button/door/directional/west{
 	specialfunctions = 4;
 	normaldoorcontrol = 1;
-	id = "gasbathroom";
+	id = "corpooffice";
 	name = "Door Bolt Control"
 	},
 /turf/open/floor/wood/parquet,
@@ -1012,6 +1068,14 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden,
+/turf/open/floor/asphalt,
+/area/ruin/powered/lizard_gas)
+"CA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden,
+/obj/item/paper{
+	name = "IMPORTANT NOTE!";
+	default_raw_text = "Hello traveller! If you are reading this and the Blastdoors/Shutters are currently active, that means we are <B>CLOSED!</B> Please do not disturb our Lizard Gas team members or their materials as they are currently Cyrosleeping inside.<BR><BR>-General Manager, Ra'Tahul Rekinov"
+	},
 /turf/open/floor/asphalt,
 /area/ruin/powered/lizard_gas)
 "CM" = (
@@ -1100,12 +1164,20 @@
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/unexplored)
 "Ec" = (
-/obj/machinery/door/airlock/external/ruin,
+/obj/machinery/door/airlock/external/ruin{
+	pixel_x = 0;
+	pixel_y = 0;
+	id_tag = "lizardgasbolt"
+	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "lizardgas_lavaland_entrance"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
+/obj/machinery/door/poddoor{
+	id = "lizardshutters"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1288,10 +1360,16 @@
 /turf/open/floor/wood/parquet,
 /area/ruin/powered/lizard_gas)
 "IN" = (
-/obj/machinery/door/airlock/external/ruin,
+/obj/machinery/door/airlock/external/ruin{
+	id_tag = "lizardgasbolt"
+	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "lizard-gas-back"
 	},
+/obj/machinery/door/poddoor{
+	id = "lizardshutters"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1305,11 +1383,19 @@
 	},
 /area/ruin/powered/lizard_gas)
 "Ja" = (
-/obj/machinery/door/airlock/external/ruin,
+/obj/machinery/door/airlock/external/ruin{
+	id_tag = "lizardgasbolt";
+	pixel_x = 0;
+	pixel_y = 0
+	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "lizardgas_lavaland_entrance"
 	},
 /obj/structure/fans/tiny,
+/obj/machinery/door/poddoor{
+	id = "lizardshutters"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1320,6 +1406,13 @@
 	baseturfs = /turf/open/floor/plating/lavaland_baseturf
 	},
 /area/ruin/powered/lizard_gas)
+"Je" = (
+/obj/item/paper{
+	default_raw_text = "Please do not steal materials from this crate, as they are direly useful to the Employees of The Lizard Gas-- whom are currently Cryosleeping and may wake up soon!<BR><BR>-General Manager, Ra'Tahul Rekinov";
+	name = "IMPORTANT NOTE!"
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/underground/unexplored)
 "Kv" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -1342,8 +1435,10 @@
 /area/icemoon/underground/unexplored)
 "Lb" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Plasma Hook-Up"
+	name = "Plasma Hook-Up";
+	id_tag = "lizardgasbolt"
 	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating/icemoon,
 /area/ruin/powered/lizard_gas)
 "Ll" = (
@@ -1684,6 +1779,26 @@
 	name = "lizard gas satchel";
 	desc = "Useful for holding work materials."
 	},
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/suit/apron/chef/colorable_apron{
+	greyscale_colors = "#8e1dd6";
+	name = "Lizard Gas Apron";
+	desc = "A purple apron imprinted with the signature little green lizard of Lizard Gas! This cute outfit is surely reflected by its underpaid drop-out wearer."
+	},
+/obj/item/clothing/suit/apron/chef/colorable_apron{
+	greyscale_colors = "#8e1dd6";
+	name = "Lizard Gas Apron";
+	desc = "A purple apron imprinted with the signature little green lizard of Lizard Gas! This cute outfit is surely reflected by its underpaid drop-out wearer."
+	},
+/obj/item/clothing/head/beret/science/rd{
+	desc = "A beret awarded to team members who have lasted a full year or more under the employment of the Lizard Gas brand! A pizza party is sure to be held on their anniversary.";
+	name = "Veteran Lizard Gas Beret"
+	},
+/obj/item/clothing/head/beret/science/rd{
+	desc = "A beret awarded to team members who have lasted a full year or more under the employment of the Lizard Gas brand! A pizza party is sure to be held on their anniversary.";
+	name = "Veteran Lizard Gas Beret"
+	},
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1722,11 +1837,19 @@
 	},
 /area/ruin/powered/lizard_gas)
 "Vb" = (
-/obj/machinery/door/airlock/external/ruin,
+/obj/machinery/door/airlock/external/ruin{
+	pixel_x = 0;
+	pixel_y = 0;
+	id_tag = "lizardgasbolt"
+	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "lizardgas_lavaland_entrance"
 	},
 /obj/machinery/duct,
+/obj/machinery/door/poddoor{
+	id = "lizardshutters"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1899,7 +2022,7 @@ DU
 Ll
 Ey
 gP
-Vw
+zh
 Bv
 Gr
 Vw
@@ -2143,7 +2266,7 @@ Gr
 Gr
 Gr
 Vw
-Vw
+Je
 Bv
 MK
 MK
@@ -2152,7 +2275,7 @@ MK
 MK
 MK
 VR
-MK
+CA
 cx
 MK
 Vw
@@ -2275,7 +2398,7 @@ Gr
 (17,1,1) = {"
 gm
 Uo
-OR
+sY
 TM
 DD
 dD

--- a/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_surface_gas_bubber.dmm
+++ b/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_surface_gas_bubber.dmm
@@ -203,6 +203,10 @@
 	pixel_x = 0;
 	pixel_y = 0
 	},
+/obj/item/inducer{
+	pixel_x = 0;
+	pixel_y = 8
+	},
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -239,13 +243,26 @@
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
 /area/ruin/thelizardsgas_lavaland)
+"gP" = (
+/obj/item/paper{
+	default_raw_text = "Please do not steal materials from this crate, as they are direly useful to the Employees of The Lizard Gas-- whom are currently Cryosleeping and may wake up soon!<BR><BR>-General Manager, Ra'Tahul Rekinov";
+	name = "IMPORTANT NOTE!"
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "gQ" = (
-/obj/machinery/door/airlock/external/ruin,
+/obj/machinery/door/airlock/external/ruin{
+	id_tag = "lizardgasbolt"
+	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "lizardgas_lavaland_entrance"
 	},
 /obj/structure/fans/tiny,
 /obj/machinery/duct,
+/obj/machinery/door/poddoor{
+	id = "lizardshutters"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -290,7 +307,7 @@
 	},
 /area/ruin/thelizardsgas_lavaland)
 "hG" = (
-/obj/structure/bonfire/prelit,
+/obj/structure/bonfire,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "hM" = (
@@ -323,7 +340,7 @@
 /obj/machinery/button/door/directional/west{
 	specialfunctions = 4;
 	normaldoorcontrol = 1;
-	id = "gasbathroom";
+	id = "corpooffice";
 	name = "Door Bolt Control"
 	},
 /turf/open/floor/wood/parquet,
@@ -625,6 +642,10 @@
 	pixel_x = -5;
 	pixel_y = 4
 	},
+/obj/item/circuitboard/machine/biogenerator/food_replicator{
+	pixel_x = -4;
+	pixel_y = -8
+	},
 /turf/open/floor/wood/lavaland,
 /area/icemoon/underground/unexplored)
 "sk" = (
@@ -690,6 +711,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
 /obj/machinery/duct,
+/obj/machinery/door/poddoor/shutters{
+	id = "lizardshutters"
+	},
 /turf/open/floor/iron,
 /area/ruin/thelizardsgas_lavaland)
 "uq" = (
@@ -730,6 +754,26 @@
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
 /area/ruin/thelizardsgas_lavaland)
+"uH" = (
+/obj/structure/cable,
+/obj/machinery/button/door/directional/east{
+	id = "lizardshutters";
+	pixel_x = 24;
+	pixel_y = 7;
+	name = "Privacy Shutters"
+	},
+/obj/machinery/button/door/directional/east{
+	pixel_x = 24;
+	pixel_y = -3;
+	name = "Entrance Doorbolts";
+	id = "lizardgasbolt";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
+/turf/open/floor/iron/smooth{
+	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
+	},
+/area/ruin/thelizardsgas_lavaland)
 "uM" = (
 /obj/machinery/light/directional/north,
 /obj/structure/closet/crate/bin,
@@ -756,11 +800,17 @@
 	},
 /area/ruin/thelizardsgas_lavaland)
 "vw" = (
-/obj/machinery/door/airlock/external/ruin,
+/obj/machinery/door/airlock/external/ruin{
+	id_tag = "lizardgasbolt"
+	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "lizardgas_lavaland_entrance"
 	},
 /obj/machinery/duct,
+/obj/machinery/door/poddoor{
+	id = "lizardshutters"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1025,10 +1075,16 @@
 /turf/open/floor/asphalt,
 /area/ruin/thelizardsgas_lavaland)
 "DE" = (
-/obj/machinery/door/airlock/external/ruin,
+/obj/machinery/door/airlock/external/ruin{
+	id_tag = "lizardgasbolt"
+	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "lizard-gas-back"
 	},
+/obj/machinery/door/poddoor{
+	id = "lizardshutters"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1206,6 +1262,16 @@
 	name = "lizard gas satchel";
 	desc = "Useful for holding work materials."
 	},
+/obj/item/clothing/head/beret/science/rd{
+	desc = "A beret awarded to team members who have lasted a full year or more under the employment of the Lizard Gas brand! A pizza party is sure to be held on their anniversary.";
+	name = "Veteran Lizard Gas Beret"
+	},
+/obj/item/clothing/head/beret/science/rd{
+	desc = "A beret awarded to team members who have lasted a full year or more under the employment of the Lizard Gas brand! A pizza party is sure to be held on their anniversary.";
+	name = "Veteran Lizard Gas Beret"
+	},
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1313,14 +1379,27 @@
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
 /area/ruin/thelizardsgas_lavaland)
+"Me" = (
+/obj/item/paper{
+	default_raw_text = "Please do not steal materials/machinery from this shed, as they are direly useful to the Employees of The Lizard Gas-- whom are currently Cryosleeping and may wake up soon!<BR><BR>-General Manager, Ra'Tahul Rekinov";
+	name = "IMPORTANT NOTE!"
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "Mp" = (
-/obj/machinery/door/airlock/external/ruin,
+/obj/machinery/door/airlock/external/ruin{
+	id_tag = "lizardgasbolt"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "lizardgas_lavaland_entrance"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
+/obj/machinery/door/poddoor{
+	id = "lizardshutters"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1444,6 +1523,9 @@
 "Qi" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/structure/cable,
+/obj/machinery/door/poddoor/shutters{
+	id = "lizardshutters"
+	},
 /turf/open/floor/plating,
 /area/ruin/thelizardsgas_lavaland)
 "QP" = (
@@ -1485,11 +1567,17 @@
 	},
 /area/ruin/thelizardsgas_lavaland)
 "Rb" = (
-/obj/machinery/door/airlock/external/ruin,
+/obj/machinery/door/airlock/external/ruin{
+	id_tag = "lizardgasbolt"
+	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "lizardgas_lavaland_entrance"
 	},
 /obj/structure/fans/tiny,
+/obj/machinery/door/poddoor{
+	id = "lizardshutters"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/iron/smooth{
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	},
@@ -1521,6 +1609,10 @@
 "Sh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden,
 /obj/machinery/duct,
+/obj/item/paper{
+	name = "IMPORTANT NOTE!";
+	default_raw_text = "Hello traveller! If you are reading this and the Blastdoors/Shutters are currently active, that means we are <B>CLOSED!</B> Please do not disturb our Lizard Gas team members or their materials as they are currently Cyrosleeping inside.<BR><BR>-General Manager, Ra'Tahul Rekinov"
+	},
 /turf/open/floor/asphalt,
 /area/ruin/thelizardsgas_lavaland)
 "Sq" = (
@@ -1663,7 +1755,7 @@
 /area/ruin/thelizardsgas_lavaland)
 "WT" = (
 /obj/machinery/airalarm/directional/west{
-	all_access = 1
+	req_access = null
 	},
 /obj/effect/mob_spawn/ghost_role/human/lavaland_gasstation{
 	dir = 4
@@ -1697,6 +1789,9 @@
 "Xb" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/door/poddoor/shutters{
+	id = "lizardshutters"
+	},
 /turf/open/floor/plating/lavaland_baseturf,
 /area/ruin/thelizardsgas_lavaland)
 "Xj" = (
@@ -1862,7 +1957,7 @@ Yl
 ck
 Li
 lm
-Tk
+Me
 Tk
 hr
 hr
@@ -1917,7 +2012,7 @@ yl
 Yl
 yl
 jc
-Tk
+gP
 hr
 hr
 hr
@@ -2238,7 +2333,7 @@ hr
 (17,1,1) = {"
 cB
 IG
-gd
+uH
 Bf
 Is
 gn


### PR DESCRIPTION

## About The Pull Request

Following an issue with Miners and other Lavaland/Icemoon roles ransacking the Gas station of its mats if no attendants spawn in, I've opted to add blastdoors/shutters, along with warning notes to IC'ly notify folk that this is a Ghost Role and should be left undisturbed. Said notes do not use OOC language in doing so, and simply inform the reader that "hey there are people cryosleeping inside, please dont rob this place"

Also I added some things I left out in the original overhaul by mistake

-Added Privacy Shutters to all exterior windows, controllable by a Button in the Break/Spawn Room
-Added Blast-Doors to all exterior Airlocks, controllable by a Button in the Break/Spawn Room
-Added 2x 'Veteran Lizard Gas Beret' to Locker, a Purple, renamed/desc'd Badged Beret
-Added 2x 'Lizard Gas Apron' to Locker, a Purple, renamed/desc'd Apron
-Added an Inducer to spawn room, in case late-round joiners spawn in the Gas Station while it has run out of power.
-Added 2x Insulated Gloves to Locker, in case they need to alter their doors in case of broken APC/Other reasons the power may be out and not restorable *(And the doors are still Bolted.)*
-Added Colony Core Replicator Board to `Abandoned Storehouse`. This was meant to be added to the other flatpacked Colony machines, all it allows is for clothes/medicine/food to be printed out of Organic material.
-Fixed: The Button in the Manager's Office was not correctly set to Bolt the door, and instead controlled the Restroom's door. Fixed that.
## Why It's Good For The Game

Keeps people from ransacking the Ghost Role location before it's spawned/let's people know that it's a Ghost role and shouldn't be tampered with. 

The Locker Additions are primarily quality of life/fluff adds, but the tools added have little impact/are generally useful to have. 
## Proof Of Testing

Purely a minor map change. Ran locally. No additional Run-Time errors.
