### PR TITLE
Heretic blade shattering QOL - HUD instead of inhand

### DIFF
--- a/code/modules/antagonists/heretic/items/heretic_blades.dm
+++ b/code/modules/antagonists/heretic/items/heretic_blades.dm
@@ -24,6 +24,21 @@
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "rends")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "rend")
 	var/after_use_message = ""
+	actions_types = list(/datum/action/item_action/break_blade) //bubberstation edit start
+
+/datum/action/item_action/break_blade
+	name = "Shattering Offer"
+	background_icon_state = "bg_heretic"
+	overlay_icon_state = "bg_heretic_border"
+	button_icon = 'icons/mob/actions/actions_ecult.dmi'
+	button_icon_state = "shatter"
+
+/datum/action/item_action/break_blade/Trigger(trigger_flags)
+	if(target in owner.held_items)
+		var/obj/item/melee/sickly_blade/target_item = target
+		target_item.seek_safety(owner)
+		return
+//bubberstation edit end
 
 /obj/item/melee/sickly_blade/examine(mob/user)
 	. = ..()
@@ -48,9 +63,7 @@
 
 	return .
 
-/obj/item/melee/sickly_blade/attack_self(mob/user)
-	seek_safety(user)
-	return ..()
+//BUBBERSTAION EDIT
 
 /// Attempts to teleport the passed mob to somewhere safe on the station, if they can use the blade.
 /obj/item/melee/sickly_blade/proc/seek_safety(mob/user)
@@ -238,8 +251,7 @@
 
 	AddComponent(/datum/component/cult_ritual_item, span_cult(examine_text), turfs_that_boost_us = /turf) // Always fast to draw!
 
-/obj/item/melee/sickly_blade/cursed/attack_self_secondary(mob/user)
-	seek_safety(user, TRUE)
+// BUBBERSTATION EDIT
 
 /obj/item/melee/sickly_blade/cursed/seek_safety(mob/user, secondary_attack = FALSE)
 	if(IS_CULTIST(user) && !secondary_attack)


### PR DESCRIPTION
## About The Pull Request
Have you ever had this happen to you?
![brickandthehertic](https://github.com/user-attachments/assets/bb32d7cb-4046-42ac-8aa5-556368e23086)

If so, you know that double clicking to pick up a blade off the floor or using it inhand because you forgot to switch hands before toggling a baton uses the blade - breaking it, ending your fun, round, run, sanity . And why? Well... Just because, really. Noone likes it, it's not fun and pointless.

SO WE REMOVED THAT! Now to break a blade you use it like a spell, like your jaunt for example. Press the icon, boom. NOTHING changed about how it functions outside the way to proc it. And yes, you can bind it.

## Why It's Good For The Game

Trust me bro.

## Proof Of Testing


https://github.com/user-attachments/assets/174ac310-368d-4b35-a00b-b7cf5ca6142b
https://github.com/user-attachments/assets/9ba99057-4802-4934-b648-35b6275d30fa

## Changelog

:cl:
qol: Heretic blades are now shattered using a HUD button
/:cl:
