### PR TITLE
Makes the jukebox in BoxStation perma accessless

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -57315,9 +57315,7 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "rUx" = (
-/obj/machinery/jukebox{
-	req_access = list("bar", "security")
-	},
+/obj/machinery/jukebox/no_access,
 /turf/open/floor/wood,
 /area/station/security/prison)
 "rUy" = (


### PR DESCRIPTION

## About The Pull Request
Does as the title says.
## Why It's Good For The Game
It was unusable by anyone due to the way its access was set.
## Proof Of Testing
It was a simple map edit, it should work.
## Changelog
:cl:
map: modified the jukebox in BoxStation's permabrig to be accessless
/:cl:
