### PR TITLE
Readds Advanced hypospray

### DIFF
--- a/modular_skyrat/modules/company_imports/code/armament_datums/deforest_medical.dm
+++ b/modular_skyrat/modules/company_imports/code/armament_datums/deforest_medical.dm
@@ -238,6 +238,10 @@
 	item_type = /obj/item/device/custom_kit/deluxe_hypo2
 	cost = PAYCHECK_COMMAND * 2
 
+/datum/armament_entry/company_import/deforest/equipment/advanced_hypospray
+	item_type = /obj/item/hypospray/mkii/piercing
+	cost = PAYCHECK_COMMAND * 7
+
 /datum/armament_entry/company_import/deforest/equipment/afad
 	item_type = /obj/item/gun/medbeam/afad
 	cost = PAYCHECK_COMMAND * 5

--- a/modular_skyrat/modules/hyposprays/code/autolathe_designs.dm
+++ b/modular_skyrat/modules/hyposprays/code/autolathe_designs.dm
@@ -63,23 +63,6 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
-/datum/design/hypomkii/advanced
-	name = "Hypospray Mk. II Advanced"
-	id = "hypomkii_adv"
-	build_type = PROTOLATHE | AWAY_LATHE
-	materials = list(
-		/datum/material/plastic = SHEET_MATERIAL_AMOUNT * 5,
-		/datum/material/glass = SHEET_MATERIAL_AMOUNT * 3,
-		/datum/material/silver = SHEET_MATERIAL_AMOUNT,
-		/datum/material/titanium = SHEET_MATERIAL_AMOUNT,
-		/datum/material/diamond = HALF_SHEET_MATERIAL_AMOUNT,
-	)
-	build_path = /obj/item/hypospray/mkii/piercing
-	category = list(
-		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_MEDICAL_ADVANCED,
-	)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
-
 // Hypospray upgrade
 /datum/design/hypomkii/deluxe
 	name = "Hypospray Mk. II Deluxe Upgrade"
@@ -107,14 +90,12 @@
 
 /datum/techweb_node/medbay_equip_adv/New()
 	design_ids += list(
-		"hypomkii_adv",
 		"hypokit_deluxe",
 	)
 	return ..()
 
 /datum/techweb_node/alien_surgery/New()
 	design_ids += list(
-		"hypomkii_adv",
 		"hypomkii_deluxe",
 	)
 	return ..()

--- a/modular_skyrat/modules/hyposprays/code/autolathe_designs.dm
+++ b/modular_skyrat/modules/hyposprays/code/autolathe_designs.dm
@@ -1,3 +1,4 @@
+// Hypovials
 /datum/design/hypovial
 	name = "Hypovial"
 	id = "hypovial"
@@ -8,18 +9,10 @@
 	)
 	build_path = /obj/item/reagent_containers/cup/vial/small
 	category = list(
-		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_MEDICAL,
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
-/datum/techweb_node/medbay_equip/New()
-	design_ids += list(
-		"hypovial",
-	)
-	return ..()
-
-/// Large hypovials
 /datum/design/hypovial/large
 	name = "Large Hypovial"
 	id = "large_hypovial"
@@ -29,6 +22,7 @@
 	)
 	build_path = /obj/item/reagent_containers/cup/vial/large
 
+// Hypospray cases
 /datum/design/hypokit
 	name = "Hypospray Case"
 	id = "hypokit"
@@ -39,22 +33,12 @@
 	)
 	build_path = /obj/item/storage/hypospraykit/empty
 	category = list(
-		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_MEDICAL,
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
-/datum/techweb_node/chem_synthesis/New()
-	design_ids += list(
-		"large_hypovial",
-		"hypokit",
-		"hypomkii",
-	)
-	return ..()
-
-/// Hyposprays
 /datum/design/hypokit/deluxe
-	name = "Deluxe Hypospray Case"
+	name = "Hypospray Case Deluxe"
 	id = "hypokit_deluxe"
 	materials = list(
 		/datum/material/plastic = SHEET_MATERIAL_AMOUNT * 6,
@@ -63,6 +47,7 @@
 	)
 	build_path = /obj/item/storage/hypospraykit/cmo/empty
 
+// Hyposprays
 /datum/design/hypomkii
 	name = "Hypospray Mk. II"
 	id = "hypomkii"
@@ -74,11 +59,28 @@
 	)
 	build_path = /obj/item/hypospray/mkii
 	category = list(
-		RND_CATEGORY_INITIAL,
-		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_MEDICAL,
+		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_MEDICAL_ADVANCED,
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
+/datum/design/hypomkii/advanced
+	name = "Hypospray Mk. II Advanced"
+	id = "hypomkii_adv"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(
+		/datum/material/plastic = SHEET_MATERIAL_AMOUNT * 5,
+		/datum/material/glass = SHEET_MATERIAL_AMOUNT * 3,
+		/datum/material/silver = SHEET_MATERIAL_AMOUNT,
+		/datum/material/titanium = SHEET_MATERIAL_AMOUNT,
+		/datum/material/diamond = HALF_SHEET_MATERIAL_AMOUNT,
+	)
+	build_path = /obj/item/hypospray/mkii/piercing
+	category = list(
+		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_MEDICAL_ADVANCED,
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+
+// Hypospray upgrade
 /datum/design/hypomkii/deluxe
 	name = "Hypospray Mk. II Deluxe Upgrade"
 	id = "hypomkii_deluxe"
@@ -90,13 +92,29 @@
 	)
 	build_path = /obj/item/device/custom_kit/deluxe_hypo2
 	category = list(
-		RND_CATEGORY_INITIAL,
-		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_MEDICAL_ADVANCED,
+		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_EQUIPMENT_MEDICAL,
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+
+// Hypospray Research
+/datum/techweb_node/chem_synthesis/New()
+	design_ids += list(
+		"hypovial",
+		"large_hypovial",
+		"hypokit",
+		"hypomkii",
+	)
+	return ..()
+
+/datum/techweb_node/medbay_equip_adv/New()
+	design_ids += list(
+		"hypomkii_adv",
+		"hypokit_deluxe",
+	)
+	return ..()
 
 /datum/techweb_node/alien_surgery/New()
 	design_ids += list(
+		"hypomkii_adv",
 		"hypomkii_deluxe",
 	)
 	return ..()


### PR DESCRIPTION
## About The Pull Request

This PR Readds the Advanced hypo in its already nerfed state to the ~~medical lathe~~ moved to imports and also readds the Large Hypobox that goes on your belt slot, the problem was already solved and i think its silly how you are forced to buy a whole tech kit JUST for the hypo as the PR which removed it from being printable did NOT add it into imports and locked it to said tech kit, its still locked behind research of course.

## Why It's Good For The Game

This stops Medical staff from being forced to fork out 2500 credits, or a 20 minute department order cooldown for a hypo upgrade on a tool that has already had the initial problem solved, ~~allowing for the progression/upgrade path to be returned.~~ This includes re-adding the large hypo box which was also removed.

## Proof Of Testing

Complies and works on localhost

## Changelog

:cl:
add: Readds the Large Hypobox being Printable in the Medical Lathe
add: Adds Advanced Hypospray into imports
/:cl:
