### PR TITLE
The pendulum swings once again, re-enables delta on malf

### DIFF
--- a/code/modules/antagonists/malf_ai/malf_ai_modules.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai_modules.dm
@@ -52,7 +52,7 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 		/obj/machinery/computer/gateway_control,
 	)))
 
-GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module/malf)
+GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module/malf))
 
 /// The malf AI action subtype. All malf actions are subtypes of this.
 /datum/action/innate/ai

--- a/code/modules/antagonists/malf_ai/malf_ai_modules.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai_modules.dm
@@ -52,7 +52,7 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 		/obj/machinery/computer/gateway_control,
 	)))
 
-GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module/malf) - /datum/ai_module/malf/destructive/nuke_station) // BUBBER EDIT - REMOVES NUKE STATION ROUNDSTART MODULE
+GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module/malf)
 
 /// The malf AI action subtype. All malf actions are subtypes of this.
 /datum/action/innate/ai


### PR DESCRIPTION
## About The Pull Request
Title
## Why It's Good For The Game
As malf currently stands, delta has been removed due to alleged malf AI silent deltas. While I do completely understand where the frustration comes from, the proponents of this ideal generally do not play command or security, where most of the escalation occurs. It is entirely possible and even likely that the average assistant, or service player and even a lot of other departments won't hear about all of the back end workings and communication of the malf AI and the roles who's job it is to hunt the valid and how their situations get escalated, which lends to this issue.
Now, without delta another issue arises, and this one both feels bad for the silicon player(s) and can even start feeling bad for carbon players. This issue being, the malf AI has no incentive to actually antag, quite the opposite really. Upon being called out to the crew at large, a Malf AI will have the entire station arming up against them and it will be only a matter of time before they LOSE. Now here on bubberstation, winning is not everything and I completely agree, its entirely possible to lose handedly and still enjoy the experience, however, having a guaranteed loss unless you play in a very specific way, is almost always no fun.
As it stands Malf AI has the boon of being unfindable if it moves without delta, allowing it to do some prep work for an hour and end up in some fuckoff part of maints or space where it can blissfully blow stuff up without recourse, or its other option to have a chance at winning is attempting to simply stealth its objectives. For an antag that is meant to be an EVERYONE problem, and once found out is allowed to be blown up at will by every assistant and their mother, this is not fun gameplay.
Admins are and should be cognisant enough to recognize if a malf AI literally did nothing all shift and just deltad for no reason, and as an admin myself, speaking from experience, we do ban the players that do this and stop the delta from happening.
At the end of the day, if crew is allowed to delete the AI from existence at first sign of being malf, then the Malf AI should be a threat that warrents this response, thank you for coming to my TedTalk.
## Proof Of Testing
![image](https://github.com/user-attachments/assets/a97a81e8-d078-4a39-9f86-219287d4fa5f)

It works surely
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
add:Re adds delta
/:cl:
