### PR TITLE
Adds borgmat to Synths *Turf

### DIFF
--- a/modular_skyrat/modules/emotes/code/additionalemotes/turf_emote.dm
+++ b/modular_skyrat/modules/emotes/code/additionalemotes/turf_emote.dm
@@ -50,6 +50,8 @@
 			else
 				user.allowed_turfs += "holoseat"
 
+			user.allowed_turfs += "borgmat"
+
 		//wings
 		if((istype(user.get_organ_slot(ORGAN_SLOT_WINGS), /obj/item/organ/external/wings/moth)) || HAS_TRAIT(user, TRAIT_SPARKLE_ASPECT))
 			user.allowed_turfs += "dust" //moth's dust ✨


### PR DESCRIPTION
## About The Pull Request

Adds the borg mat to synths as of a request from AvianAviator

## Why It's Good For The Game

Comfy Mat for synths now

## Proof Of Testing

Works perfectly fine on localhost

## Changelog

:cl:
add: Adds the Borg mat to Synth's *Turf
/:cl: