### PR TITLE
Allows the size collar to work for teshari and vox primalis

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/size_items.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/size_items.dm
@@ -128,7 +128,7 @@
 	var/mob/living/carbon/human/human_parent = parent
 	apply_size(original_size)
 
-	if(isteshari(human_parent) || isvoxprimalis(human_parent)) //BUBBER EDIT: We reapply it on destroy if they were
+	if(isteshari(human_parent) || isvoxprimalis(human_parent)) // We reapply it on destroy if they were
 		human_parent.dna.species.body_size_restricted = TRUE
 	UnregisterSignal(parent, COMSIG_ENTER_AREA)
 

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/size_items.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/size_items.dm
@@ -116,7 +116,7 @@
 	if(!human_parent || !size_to_apply || (human_parent.dna.features["body_size"] == size_to_apply))
 		return FALSE
 
-	if(isteshari(human_parent) || isvoxprimalis(human_parent)) //BUBBER EDIT: We check if the human_parent is a Vox Primalis or Teshari & temporarily disable the bodysize restriction
+	if(isteshari(human_parent) || isvoxprimalis(human_parent)) // We check if the human_parent is a Vox Primalis or Teshari & temporarily disable the bodysize restriction
 		human_parent.dna.species.body_size_restricted = FALSE
 
 	human_parent.dna.features["body_size"] = size_to_apply

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/size_items.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/size_items.dm
@@ -116,13 +116,20 @@
 	if(!human_parent || !size_to_apply || (human_parent.dna.features["body_size"] == size_to_apply))
 		return FALSE
 
+	if(isteshari(human_parent) || isvoxprimalis(human_parent)) //BUBBER EDIT: We check if the human_parent is a Vox Primalis or Teshari & temporarily disable the bodysize restriction
+		human_parent.dna.species.body_size_restricted = FALSE
+
 	human_parent.dna.features["body_size"] = size_to_apply
 	human_parent.maptext_height = 32 * human_parent.dna.features["body_size"]
 	human_parent.dna.update_body_size()
 	return TRUE
 
 /datum/component/temporary_size/Destroy(force, silent)
+	var/mob/living/carbon/human/human_parent = parent
 	apply_size(original_size)
+
+	if(isteshari(human_parent) || isvoxprimalis(human_parent)) //BUBBER EDIT: We reapply it on destroy if they were
+		human_parent.dna.species.body_size_restricted = TRUE
 	UnregisterSignal(parent, COMSIG_ENTER_AREA)
 
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This makes the size collar item from the lustwish vendor modify Teshari & Vox Primalis size (Both of which have bodysize restrictions). It has the same restriction as before (infinidorms/interlink areas) and does NOT affect NIF Polymorph or the Character Creation bodysize slider.

## Why It's Good For The Game

More ERP options regarding size stuff for birds. It's unlinked to the main course of the game and shouldn't affect that - teshari and vox primalis deserve to be the big bird (or small bird) for scenes in areas where it can't get them an advantage (the size collar only works in dorms areas.

## Proof Of Testing

Compiled and tested on a localhost, large bird image provided below
<details>
<summary>Screenshots/Videos</summary>

![collar1](https://github.com/user-attachments/assets/3010a967-19e1-4399-b87a-28f3df1fd56b)

</details>

## Changelog


<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Teshari and Vox primalis can now use size collars in dorms/interlink areas.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
