### PR TITLE
Adds the unique Holobadge variants to the loadout menu.

### DIFF
--- a/modular_zubbers/code/modules/loadout/categories/neck.dm
+++ b/modular_zubbers/code/modules/loadout/categories/neck.dm
@@ -24,7 +24,7 @@
 	item_path = /obj/item/clothing/neck/scarf/pride
 	can_be_reskinned = TRUE
 
- /datum/loadout_item/neck/holobadge/hos
+/datum/loadout_item/neck/holobadge/hos
     name = "Head of Security's Holobadge"
     item_path = /obj/item/clothing/accessory/badge/holo/hos
     restricted_roles = list(JOB_HEAD_OF_SECURITY)

--- a/modular_zubbers/code/modules/loadout/categories/neck.dm
+++ b/modular_zubbers/code/modules/loadout/categories/neck.dm
@@ -23,3 +23,18 @@
 	name = "Pride Scarf"
 	item_path = /obj/item/clothing/neck/scarf/pride
 	can_be_reskinned = TRUE
+
+ /datum/loadout_item/neck/holobadge/hos
+    name = "Head of Security's Holobadge"
+    item_path = /obj/item/clothing/accessory/badge/holo/hos
+    restricted_roles = list(JOB_HEAD_OF_SECURITY)
+
+/datum/loadout_item/neck/holobadge/warden
+    name = "Warden's Holobadge"
+    item_path = /obj/item/clothing/accessory/badge/holo/warden
+    restricted_roles = list(JOB_WARDEN)
+
+/datum/loadout_item/neck/holobadge/detective
+    name = "Detective's Holobadge"
+    item_path = /obj/item/clothing/accessory/badge/holo/detective
+    restricted_roles = list(JOB_DETECTIVE)


### PR DESCRIPTION

## About The Pull Request

(This is my very first PR. Do bear with me here.) 

This adds the three unique holobadge variants (Detective, Warden, HoS) to the loadout neck menu. Proper job whitelists and all

## Why It's Good For The Game

Badges cool, customization cool, what not to like?


## Proof Of Testing
![assistant](https://github.com/user-attachments/assets/2179009a-edbb-4fbc-b901-055bbb7a42d3)
![warden](https://github.com/user-attachments/assets/e819f35b-6df3-4354-b306-137eead82efb)
![hos](https://github.com/user-attachments/assets/f12b9c39-ba23-4b7f-9b50-a13b101c4bcc)
![dettt](https://github.com/user-attachments/assets/11915c50-a5ad-4582-8b9f-5a0e4326e4a8)
![loadoutmenu](https://github.com/user-attachments/assets/2ceaf8be-00aa-4a07-af3b-a4171873865d)


## Changelog

:cl:
add:Added the unique variants of the Holobadge to the loadout neck section. 