### PR TITLE
Crew Monitor Console Alarm Logic change to TG's logic for determination if someone counts

### DIFF
--- a/modular_zubbers/code/game/machinery/crew_monitor.dm
+++ b/modular_zubbers/code/game/machinery/crew_monitor.dm
@@ -20,10 +20,14 @@
 
 	for(var/mob/living/carbon/human/mob in GLOB.suit_sensors_list)
 
+		var/turf/pos = get_turf(mob)
+
 		if(!istype(mob))
 			continue
-		if(mob.z != src.z  && !HAS_TRAIT(mob, TRAIT_MULTIZ_SUIT_SENSORS))
+
+		if(pos.z != z && (!is_station_level(pos.z) || !is_station_level(z)) && !HAS_TRAIT(mob, TRAIT_MULTIZ_SUIT_SENSORS))
 			continue
+
 		var/obj/item/clothing/under/uniform = mob.w_uniform
 		if(uniform.sensor_mode == SENSOR_COORDS && (uniform.has_sensor != BROKEN_SENSORS) && (HAS_TRAIT(mob, TRAIT_CRITICAL_CONDITION) || mob.stat == DEAD))
 			if(mob.get_dnr()) // DNR won't beep anymore


### PR DESCRIPTION

## About The Pull Request

Changes the alarm logic to share the same for consideration if it beeps based on tg's logic for crew monitor entries.
## Why It's Good For The Game

consistency, people wouldn't beep on icebox but would on the same z as the console. 

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: crew monitor alarm logic is updated to work with planetary z's
/:cl:
