### PR TITLE
changes "The House now runs the show..." to "The House always wins." because why

### DIFF
--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_6_house.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_6_house.dm
@@ -2,7 +2,7 @@
 	name = "The House (Unpredictable Intensity)"
 	desc = "The House gives permission for admins to drive the adminbus straight into the station. \
 			All weights set to one at Medium - Low intensity."
-	welcome_text = "The House now runs the show..."
+	welcome_text = "The House always wins."
 	track_data = /datum/storyteller_data/tracks/fragile
 	votable = TRUE
 


### PR DESCRIPTION

## About The Pull Request

changes "The House now runs the show..." to "The House always wins."
## Why It's Good For The Game

it's ideal
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: changes The House's welcome text "The House now runs the show..." to "The House always wins." because it simply makes More Sense
/:cl:
