### PR TITLE
Allows hypospray kits to fit in two more medical bags.

### DIFF
--- a/modular_skyrat/modules/deforest_medical_items/code/storage_items.dm
+++ b/modular_skyrat/modules/deforest_medical_items/code/storage_items.dm
@@ -353,6 +353,7 @@
 		/obj/item/stamp,
 		/obj/item/sensor_device,
 		/obj/item/storage/fancy/cigarettes,
+		/obj/item/storage/hypospraykit,
 		/obj/item/storage/pill_bottle,
 		/obj/item/surgical_drapes,
 		/obj/item/surgicaldrill,

--- a/modular_skyrat/modules/deforest_medical_items/code/storage_items.dm
+++ b/modular_skyrat/modules/deforest_medical_items/code/storage_items.dm
@@ -251,6 +251,7 @@
 		/obj/item/stack/sticky_tape,
 		/obj/item/sensor_device,
 		/obj/item/storage/fancy/cigarettes,
+		/obj/item/storage/hypospraykit,
 		/obj/item/storage/pill_bottle,
 		/obj/item/tank/internals/emergency_oxygen,
 		/obj/item/storage/box/bandages,


### PR DESCRIPTION
## About The Pull Request

This PR adds the hypospray kit (box) to the list of allowed objects to the first responder surgical kit and orange satchel medical kit. There's been an inconsistency since the kit can fit in medical belts and medical technician bags; this allows the kit more options to be placed in.

## Why It's Good For The Game

While this gives the standard kit another option to be placed it, it still suffers the drawback of object interaction inside of a bag inside of a bag. Balance-wise, this is no different than a standard kit being placed and used within an internals box or smugglers satchel.

## Proof Of Testing

![image](https://github.com/user-attachments/assets/1949de38-9dad-4b24-9e7f-db2e459a58d5)
finally.

## Changelog
:cl:
add: Allows hypospray kits to fit in the first responder surgical kit and orange satchel medical kit.
/:cl:
