### PR TITLE
Changes the bedsheet bin in Infidorm apartment bathroom to a towel bin

### DIFF
--- a/modular_skyrat/modules/hotel_rooms/apartment.dmm
+++ b/modular_skyrat/modules/hotel_rooms/apartment.dmm
@@ -215,10 +215,11 @@
 /area/misc/hilbertshotel)
 "pm" = (
 /obj/structure/table/wood,
-/obj/item/serviette_pack,
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
+/obj/structure/bedsheetbin,
+/obj/item/serviette_pack,
 /turf/open/floor/wood/parquet,
 /area/misc/hilbertshotel)
 "pD" = (
@@ -417,7 +418,7 @@
 /obj/structure/sign/poster/random/directional/south,
 /obj/machinery/vending/wallmed/directional/west,
 /obj/structure/table,
-/obj/structure/bedsheetbin,
+/obj/structure/towel_bin,
 /turf/open/floor/iron/freezer,
 /area/misc/hilbertshotel)
 "Py" = (


### PR DESCRIPTION
## About The Pull Request

I believe the original mappers have simply made a mistake by placing a bedsheet bin instead of a towel bin in the bathroom Also put a bedsheet bin in the bedroom, if anyone would ever need it for any reason. Anyways please speedmerge as this is crucial to server operations.

## Why It's Good For The Game

Spessmen no longer have to dry themselves off with bedsheets? Profit?

## Proof Of Testing

![Screenshot (1)](https://github.com/user-attachments/assets/94ff668c-45c0-40f3-9782-fbd6a26eb476)

## Changelog

:cl:
map: changed the bedsheet bin in InfiDorm apartment map to a towel bin.
map: added a bedsheet bin in InfiDorm apartment map bedroom.
/:cl:
