### PR TITLE
Allows blood filters to fit in the medical technician bag

### DIFF
--- a/modular_skyrat/modules/deforest_medical_items/code/storage_items.dm
+++ b/modular_skyrat/modules/deforest_medical_items/code/storage_items.dm
@@ -416,6 +416,7 @@
 	. = ..()
 
 	can_hold = typecacheof(list(
+		/obj/item/blood_filter,
 		/obj/item/bonesetter,
 		/obj/item/cautery,
 		/obj/item/circular_saw,


### PR DESCRIPTION
## About The Pull Request

Does what the title says. It adds a single line of code.

## Why It's Good For The Game

For months, this bag was able to hold every surgical tool except for the blood filter. Now, the pink bag is no longer afraid of performing a hemodialysis.

## Proof Of Testing

![image](https://github.com/user-attachments/assets/116e11e4-3529-4537-9c46-be9aa4ef8078)

## Changelog

:cl:
fix: Allows blood filters to fit in the medical technician bag.
/:cl:

