### PR TITLE
Fix cryo dumping storage implant items

### DIFF
--- a/modular_skyrat/modules/cryosleep/code/cryopod.dm
+++ b/modular_skyrat/modules/cryosleep/code/cryopod.dm
@@ -421,6 +421,13 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod, 32)
 
 	visible_message(span_notice("[src] hums and hisses as it moves [mob_occupant.real_name] into storage."))
 
+	var/list/nuke_disks = mob_occupant.get_all_contents_type(/obj/item/disk/nuclear) // No
+	for(var/obj/item/disk/nuclear/the_disk as anything in nuke_disks)
+		var/turf/launch_target = get_edge_target_turf(src, pick(GLOB.alldirs))
+		mob_occupant.transferItemToLoc(the_disk, drop_location(), force = TRUE, silent = TRUE)
+		the_disk.throw_at(launch_target, 8, 14)
+		visible_message(span_warning("[src] violently ejects [the_disk]!"))
+
 	for(var/obj/item/item_content as anything in mob_occupant)
 		try_store_item(mob_occupant, item_content, control_computer)
 

--- a/modular_skyrat/modules/cryosleep/code/cryopod.dm
+++ b/modular_skyrat/modules/cryosleep/code/cryopod.dm
@@ -392,7 +392,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod, 32)
 	visible_message(span_notice("[src] hums and hisses as it moves [mob_occupant.real_name] into storage."))
 
 	for(var/obj/item/item_content as anything in mob_occupant)
-		if(!istype(item_content) || HAS_TRAIT(item_content, TRAIT_NODROP))
+		if(!istype(item_content) || HAS_TRAIT(item_content, TRAIT_NODROP) || item_content.item_flags & DROPDEL)
 			continue
 		if (issilicon(mob_occupant) && istype(item_content, /obj/item/mmi))
 			continue

--- a/modular_skyrat/modules/cryosleep/code/cryopod.dm
+++ b/modular_skyrat/modules/cryosleep/code/cryopod.dm
@@ -337,6 +337,12 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod, 32)
 					update_objective.owner.announce_objectives()
 			qdel(objective)
 
+/**
+ * Attempt to store a given item in either the control computer or on the ground.
+ * * holder - mob holding the item being stored
+ * * target_item - the item to store
+ * * control_computer - the cryo console connected to this pod, can be null
+ */
 /obj/machinery/cryopod/proc/try_store_item(mob/living/holder, obj/item/target_item, obj/machinery/computer/cryopod/control_computer)
 	if(!istype(target_item) || HAS_TRAIT(target_item, TRAIT_NODROP))
 		return FALSE


### PR DESCRIPTION
## About The Pull Request

- Move cryo item storage behavior to separate proc cause it was getting big
- Don't store `DROPDEL` items (includes implants among other things)
- Empty out storage implants and attempt to store the contents instead of dumping on the floor
- Make the cryo pod angrily launch the nuke disk across the room if someone tries to cryo with it

## Why It's Good For The Game

Fixes #3111 

## Proof Of Testing

Imagine a picture of a cryo pod but with no random items dumped on the floor

## Changelog

:cl:
fix: fixed cryoing with a storage implant dumping the contents of said implant onto the floor
/:cl:

