### PR TITLE
Add for engineering borg - Usage of gripper for stock parts and cells

### DIFF
--- a/modular_zubbers/code/game/objects/items/robot/items/storage.dm
+++ b/modular_zubbers/code/game/objects/items/robot/items/storage.dm
@@ -156,6 +156,7 @@
 					/obj/item/conveyor_switch_construct,
 					/obj/item/wallframe,
 					/obj/item/tank,
+					/obj/item/stock_parts,
 					)
 
 /obj/item/borg/apparatus/mining/examine()


### PR DESCRIPTION
Fixes #2992 
## About The Pull Request
It gives them back the ability to grab parts and cells so to fix minor things such as APCs and machinery that has been destroyed. They are still unable to grab circuits and insert on the machinery however, without either the parts device or the circuit gripper upgrade.

## Why It's Good For The Game

It gives them back the ability to grab parts and cells so to fix minor things such as APCs and machinery that has been destroyed.
They are still unable to grab circuits and insert on the machinery however, without either the parts device or the circuit gripper upgrade.
They are also still unable to take the batteries out of chargers. Its a different issue.

## Proof Of Testing

<summary>Screenshots/Videos</summary>

https://github.com/user-attachments/assets/47a1c317-a30b-4830-bc82-2960a4c06e1d

</details>

## Changelog
:cl:
add: The ability to grab parts and cells as a borg.

/:cl:
