### PR TITLE
Revert "Lewd Interactions are subtle, not subtler (#2889)"

### DIFF
--- a/modular_skyrat/modules/interaction_menu/code/interaction_datum.dm
+++ b/modular_skyrat/modules/interaction_menu/code/interaction_datum.dm
@@ -96,7 +96,7 @@ GLOBAL_LIST_EMPTY_TYPED(interaction_instances, /datum/interaction)
 	// We replace %USER% with nothing because manual_emote already prepends it.
 	msg = trim(replacetext(replacetext(msg, "%TARGET%", "[target]"), "%USER%", ""), INTERACTION_MAX_CHAR)
 	if(lewd)
-		user.emote("subtle", null, msg, TRUE)
+		user.emote("subtler", null, msg, TRUE)
 	else
 		user.manual_emote(msg)
 	if(user_messages.len)


### PR DESCRIPTION

## About The Pull Request
This reverts commit f4f4621826338e75f65f3920d59ac6ec1dffa31c, PR https://github.com/Bubberstation/Bubberstation/pull/2889.
## Why It's Good For The Game

Every time I ghost, I am forced to bare witness to non-stop sex. While yes, subtler isn't a requirement for ERP, we should at least encourage using subtler, as oftentimes people don't want to see exactly in detail how you are getting railed.
## Proof Of Testing

It's a revert. I dont think I need to test this.

</details>

## Changelog
:cl:
add:Lewd verbs are now subtler. No longer will you have to see people getting absolutely railed as a ghost.
/:cl:
