### PR TITLE
Adds a new storyteller, "The Enemy Within"

### DIFF
--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_7_enemy.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_7_enemy.dm
@@ -1,0 +1,35 @@
+/datum/storyteller/enemy
+	name = "Enemy Within (Medium-High Chaos)"
+	desc = "The Enemy Within aims to ensure that there are only crew antagonists while also prioritizing spawns for those antagonist types."
+	welcome_text = "Chat, I think there is an imposter among us on this Space Station 13. I have grown suspicious."
+
+	tag_multipliers = list(
+		TAG_DESTRUCTIVE = 0.25,
+		TAG_CHAOTIC = 0.1, //*look inside medium-high chaos storyteller* *no chaos*
+		TAG_CREW_ANTAG = 2,
+		TAG_OUTSIDER_ANTAG = 0
+	)
+	population_min = 35
+	antag_divisor = 5
+	storyteller_type = STORYTELLER_TYPE_INTENSE
+
+	guarantees_roundstart_crewset = TRUE
+
+	track_data = /datum/storyteller_data/tracks/enemy
+
+	starting_point_multipliers = list(
+		EVENT_TRACK_MUNDANE = 0,
+		EVENT_TRACK_MODERATE = 0,
+		EVENT_TRACK_MAJOR = 0,
+		EVENT_TRACK_CREWSET = 1,
+		EVENT_TRACK_GHOSTSET = 0
+	)
+
+	event_repetition_multiplier = 1 //Set from default 0.6 so that the round just doesn't throw every antag type possible at the crew.
+
+/datum/storyteller_data/tracks/enemy
+	threshold_mundane = 1200
+	threshold_moderate = 1800
+	threshold_major = 8000
+	threshold_crewset = 3000
+	threshold_ghostset = 8000

--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_7_enemy.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_7_enemy.dm
@@ -1,11 +1,11 @@
 /datum/storyteller/enemy
-	name = "Enemy Within (Medium-High Chaos)"
+	name = "Enemy Within (High Chaos)"
 	desc = "The Enemy Within aims to ensure that there are only crew antagonists while also prioritizing spawns for those antagonist types."
 	welcome_text = "Chat, I think there is an imposter among us on this Space Station 13. I have grown suspicious."
 
 	tag_multipliers = list(
 		TAG_DESTRUCTIVE = 0.25,
-		TAG_CHAOTIC = 0.1, //*look inside medium-high chaos storyteller* *no chaos*
+		TAG_CHAOTIC = 0.1, //*look inside high chaos storyteller* *no chaos*
 		TAG_CREW_ANTAG = 2,
 		TAG_OUTSIDER_ANTAG = 0
 	)


### PR DESCRIPTION
## About The Pull Request

Adds a new storyteller, "The Enemy Within".

"The Enemy Within" is designed to create more crew-centric antagonist types while completely avoiding off-station ones. On top of that, antagonist events have a much higher weight.

## Why It's Good For The Game

This is an experiment to see if rounds would be better (and that people would enjoy them) with less off-station antagonists and more crew-focused ones.

Initially, I wanted to create an alternative to The Gamer, but I think it's own separate storyteller would be better.

Some settings are tweaked to ensure that the round isn't just an antag handbasket of every antag possible because of how storyteller works.

This should be testmerged in case some weird shit happens.

## Proof Of Testing

Untested. I don't have more than 2 friends.

</details>

## Changelog

:cl: BurgerBB
add: Adds a new storyteller, "The Enemy Within".
/:cl:
