### PR TITLE
Fix cryopods dropping prosthetic bodyparts

### DIFF
--- a/modular_skyrat/modules/cryosleep/code/cryopod.dm
+++ b/modular_skyrat/modules/cryosleep/code/cryopod.dm
@@ -352,7 +352,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod, 32)
 		for(var/obj/item/nested_item as anything in target_item)
 			try_store_item(holder, nested_item, control_computer)
 		return FALSE
-	if(target_item.item_flags & DROPDEL)
+	if(target_item.item_flags & (ABSTRACT|DROPDEL))
 		return FALSE
 
 	if(control_computer)
@@ -428,7 +428,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod, 32)
 		the_disk.throw_at(launch_target, 8, 14)
 		visible_message(span_warning("[src] violently ejects [the_disk]!"))
 
-	for(var/obj/item/item_content as anything in mob_occupant)
+	// get_equipped_items() prevents moving bodyparts, since those are in mob contents now
+	for(var/obj/item/item_content in mob_occupant.get_equipped_items(INCLUDE_POCKETS | INCLUDE_HELD | INCLUDE_ACCESSORIES))
 		try_store_item(mob_occupant, item_content, control_computer)
 
 	GLOB.joined_player_list -= stored_ckey


### PR DESCRIPTION
## About The Pull Request
Uses `mob_occupant.get_equipped_items()` instead of `mob_occupant.contents`. This results in skipping 
Also, abstract items will not be stored, similar to how `DROPDEL` items aren't stored.

~~Currently untested, but it will at least solve the linked issue, assuming it doesn't introduce any new ones.~~
I tested it, works fine.

## Why It's Good For The Game
Fixes https://github.com/SPLURT-Station/S.P.L.U.R.T-tg/issues/158.

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/3a3eaf2c-f943-4da6-a885-20ae76a94d14)

</details>

## Changelog

:cl:
fix: fixed cryopods dropping prosthetic bodyparts of despawned mobs
/:cl:
