### PR TITLE
Makes CI require a client to activate

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -151,18 +151,13 @@
 		return
 	. = combat_mode
 	combat_mode = new_mode
-	SEND_SIGNAL(src, COMSIG_LIVING_COMBAT_MODE_TOGGLE, new_mode) //SKYRAT EDIT ADDITION
+	// BUBBER EDIT START
+	if(client)
+		SEND_SIGNAL(src, COMSIG_LIVING_COMBAT_MODE_TOGGLE, new_mode)
+	// BUBBER EDIT END
 	if(hud_used?.action_intent)
 		hud_used.action_intent.update_appearance()
-	//SKYRAT EDIT ADDITION BEGIN
-	if(!ishuman(src) && !ckey)
-		if(combat_mode)
-			set_combat_indicator(TRUE)
-		else
-			set_combat_indicator(FALSE)
-	face_mouse = (client?.prefs?.read_preference(/datum/preference/toggle/face_cursor_combat_mode) && combat_mode) ? TRUE : FALSE
-	//SKYRAT EDIT ADDITION END
-
+	face_mouse = (client?.prefs?.read_preference(/datum/preference/toggle/face_cursor_combat_mode) && combat_mode) ? TRUE : FALSE // BUBBER EDIT
 	if(silent || !(client?.prefs.read_preference(/datum/preference/toggle/sound_combatmode)))
 		return
 	if(combat_mode)

--- a/modular_skyrat/modules/indicators/code/combat_indicator.dm
+++ b/modular_skyrat/modules/indicators/code/combat_indicator.dm
@@ -70,6 +70,9 @@ GLOBAL_VAR_INIT(combat_indicator_overlay, GenerateCombatOverlay())
 	if(stat == DEAD)
 		combat_indicator = FALSE
 
+	if(!isnull(client)) // CI is a player thing.
+		return
+
 	if(combat_indicator == state) // If the mob is dead (should not happen) or if the combat_indicator is the same as state (also shouldnt happen) kill the proc.
 		return
 

--- a/modular_skyrat/modules/indicators/code/combat_indicator.dm
+++ b/modular_skyrat/modules/indicators/code/combat_indicator.dm
@@ -70,9 +70,6 @@ GLOBAL_VAR_INIT(combat_indicator_overlay, GenerateCombatOverlay())
 	if(stat == DEAD)
 		combat_indicator = FALSE
 
-	if(isnull(client)) // CI is a player thing.
-		return
-
 	if(combat_indicator == state) // If the mob is dead (should not happen) or if the combat_indicator is the same as state (also shouldnt happen) kill the proc.
 		return
 

--- a/modular_skyrat/modules/indicators/code/combat_indicator.dm
+++ b/modular_skyrat/modules/indicators/code/combat_indicator.dm
@@ -70,7 +70,7 @@ GLOBAL_VAR_INIT(combat_indicator_overlay, GenerateCombatOverlay())
 	if(stat == DEAD)
 		combat_indicator = FALSE
 
-	if(!isnull(client)) // CI is a player thing.
+	if(isnull(client)) // CI is a player thing.
 		return
 
 	if(combat_indicator == state) // If the mob is dead (should not happen) or if the combat_indicator is the same as state (also shouldnt happen) kill the proc.


### PR DESCRIPTION
## About The Pull Request

CI should only work while the mob has an active client

## Why It's Good For The Game

Due to how basic AI works, it also flashes CI. This is stupid. Let's be less stupid.

## Proof Of Testing

It works

## Changelog
:cl:
del: Clientless mobs should no longer flash CI.
/:cl:
