### PR TITLE
Gives ghosts access to LOOC

### DIFF
--- a/modular_skyrat/modules/verbs/code/looc.dm
+++ b/modular_skyrat/modules/verbs/code/looc.dm
@@ -40,12 +40,6 @@
 		if(is_banned_from(ckey, BAN_LOOC))
 			to_chat(src, span_warning("You are LOOC banned!"))
 			return
-		if(mob.stat == DEAD)
-			to_chat(src, span_danger("You cannot use LOOC while dead."))
-			return
-		if(istype(mob, /mob/dead))
-			to_chat(src, span_danger("You cannot use LOOC while ghosting."))
-			return
 
 	msg = emoji_parse(msg)
 
@@ -78,10 +72,6 @@
 		if (is_holder)
 			admin_seen[hearing_client] = TRUE
 			// dont continue here, still need to show runechat
-
-
-		if (isobserver(hearing) && !is_holder)
-			continue //ghosts dont hear looc, apparantly
 
 		// do the runetext here so admins can still get the runetext
 		if(mob.runechat_prefs_check(hearing) && hearing.client?.prefs.read_preference(/datum/preference/toggle/enable_looc_runechat))

--- a/modular_skyrat/modules/verbs/code/looc.dm
+++ b/modular_skyrat/modules/verbs/code/looc.dm
@@ -79,10 +79,14 @@
 			// I wish it didn't include the asterisk but it's modular this way.
 			hearing.create_chat_message(mob, raw_message = "(LOOC: [msg])", runechat_flags = EMOTE_MESSAGE)
 
+		var/sender_name = src.mob.name
+		if (istype(mob, /mob/dead))
+			sender_name = key
+
 		if (is_holder)
 			continue //admins are handled afterwards
 
-		to_chat(hearing_client, span_looc(span_prefix("LOOC[wall_pierce ? " (WALL PIERCE)" : ""]:</span> <EM>[src.mob.name]:</EM> <span class='message'>[msg]")))
+		to_chat(hearing_client, span_looc(span_prefix("LOOC[wall_pierce ? " (WALL PIERCE)" : ""]:</span> <EM>[sender_name]:</EM> <span class='message'>[msg]")))
 
 	for(var/client/cli_client as anything in GLOB.admins)
 		if (admin_seen[cli_client])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ghosts can now send and receive LOOC messages.
Ghosts show their ckey instead of character name in LOOC.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

The pros:

- Scenes where one person ends up dying can now have people talk about their experience and share feedback afterwards.
- Scenes where one person ends up dying won't have the living person confused about why their partner isn't answering their LOOC anymore.
- Dead people can have 1:1 chats about how the round went with the living after the shuttle has docked with CC.

The cons:

- You could use this to metacommunicate, but that hasn't stopped the living from getting LOOC, OOC, AOOC, SOOC etc. And ghosts can already use regular OOC or discord messages if they want to be cheeky.
- You could hear the LOOC from lewds you are observing, but LOOC messages don't usually contain full context for what's going on and shouldn't offend anyone too badly. 

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Proof Of Testing

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/ff20ef5e-986e-4409-b49f-f70cb67a1717)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Ghosts can now send and receive LOOC messages.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
