### PR TITLE
Admins show ckey on LOOC when they're ghosted 

### DIFF
--- a/modular_skyrat/modules/verbs/code/looc.dm
+++ b/modular_skyrat/modules/verbs/code/looc.dm
@@ -92,7 +92,10 @@
 		if (is_holder)
 			continue //admins are handled afterwards
 
-		to_chat(hearing_client, span_looc(span_prefix("LOOC[wall_pierce ? " (WALL PIERCE)" : ""]:</span> <EM>[src.mob.name]:</EM> <span class='message'>[msg]")))
+		if(holder && isdead(src.mob)) // Admins ghosted display ckey
+			to_chat(hearing_client, span_looc(span_prefix("LOOC[wall_pierce ? " (WALL PIERCE)" : ""]:</span> <EM>[src.ckey]:</EM> <span class='message'>[msg]")))
+		else
+			to_chat(hearing_client, span_looc(span_prefix("LOOC[wall_pierce ? " (WALL PIERCE)" : ""]:</span> <EM>[src.mob.name]:</EM> <span class='message'>[msg]")))
 
 	for(var/client/cli_client as anything in GLOB.admins)
 		if (admin_seen[cli_client])


### PR DESCRIPTION
## About The Pull Request

Makes admins who are ghosted show by their ckey when they LOOC instead of their character name.

## Why It's Good For The Game

Makes it more clear if an admin is LOOCing to you in game if it's needed

## Proof Of Testing

![image](https://github.com/user-attachments/assets/e2620d04-cf50-449c-8037-ce3d90349018)

## Changelog

:cl:
admin: ghosted admins who LOOC now show by their ckey
/:cl:
