### PR TITLE
Bio-RCD Concept for Medical as a Research Unlockable

### DIFF
--- a/modular_zubbers/code/modules/medical_rcd/medical_rcd.dm
+++ b/modular_zubbers/code/modules/medical_rcd/medical_rcd.dm
@@ -1,0 +1,106 @@
+
+
+/obj/item/construction/medical
+	name = "medical grade rapid-construction-device (RCD)"
+	icon_state = "plumberer2"
+	inhand_icon_state = "plumberer"
+	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
+	worn_icon_state = "plumbing"
+	icon = 'icons/obj/tools.dmi'
+	slot_flags = ITEM_SLOT_BELT
+	banned_upgrades = RCD_ALL_UPGRADES & ~RCD_UPGRADE_SILO_LINK
+	matter = 200
+	max_matter = 200
+	drop_sound = 'sound/items/handling/tools/rcd_drop.ogg'
+	pickup_sound = 'sound/items/handling/tools/rcd_pickup.ogg'
+	sound_vary = TRUE
+	custom_materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT * 50)
+	var/design_title
+	var/obj/item/reagent_containers/cup/beaker
+	var/list/static/limbs_possible = list(
+		/obj/item/bodypart/leg/right,
+		/obj/item/bodypart/leg/left,
+		/obj/item/bodypart/arm/right,
+		/obj/item/bodypart/arm/left,
+		/obj/item/bodypart/head,
+		/obj/item/organ/external/tail,
+		/obj/item/organ/external/spines,
+		/obj/item/organ/external/wings,
+		/obj/item/organ/external/horns,
+		/obj/item/organ/external/frills,
+		/obj/item/organ/external/snout,
+		/obj/item/organ/external/tail/lizard,
+		/obj/item/organ/external/antennae,
+		/obj/item/organ/external/wings/moth,
+		/obj/item/organ/internal/ears/cat,
+		/obj/item/organ/external/tail/cat,
+
+		)
+
+	/Initialize(mapload)
+
+	.=..()
+
+
+	/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+		SHOULD_CALL_PARENT(TRUE)
+		if(istype(interacting_with, /obj/item/rcd_upgrade))
+			install_upgrade(interacting_with, user)
+			return ITEM_INTERACT_SUCCESS
+		if(insert_matter(interacting_with, user))
+			return ITEM_INTERACT_SUCCESS
+		return ..()
+
+
+	/ui_data(mob/user)
+		var/list/data = list()
+
+		//matter in the rcd
+
+			var/list/data = list()
+
+		for(var/datum/reagent/reagent_id in beaker.reagents.reagent_list)
+			var/list/reagent_data = list(
+				reagent_name = reagent_id.name,
+				reagent_amount = reagent_id.volume,
+				reagent_type = reagent_id.type
+			)
+			data["reagents"] += list(reagent_data)
+
+			data["total_reagents"] = reagents.total_volume
+			data["max_reagents"] = reagents.maximum_volume
+			data["selected_design"] =
+
+			var/list/designs = list() //initialize all designs under this category
+			for(var/atom/movable/design as anything in limbs_possible)
+				var/atom/movable/design_path = design
+
+				var/design_name = initial(design_path.name)
+
+				designs += list(list("title" = design_name, "icon" = sanitize_css_class_name(design_name)))
+
+			data += list("designs" = designs)
+			data["selected_design"] = design_title
+
+		return data
+
+	/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+		. = ..()
+		if(.)
+			return
+
+		if(action == "design")
+			toggle_silo(ui.user)
+			return TRUE
+
+		var/update = handle_ui_act(action, params, ui, state)
+		if(isnull(update))
+			update = FALSE
+		return update
+
+	/ui_interact(mob/user, datum/tgui/ui)
+		ui = SStgui.try_update_ui(user, src, ui)
+		if(!ui)
+			ui = new(user, src, "bubbermedrcd", name)
+			ui.open()

--- a/modular_zubbers/code/modules/research/designs/medical_designs.dm
+++ b/modular_zubbers/code/modules/research/designs/medical_designs.dm
@@ -26,3 +26,15 @@
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_UTILITY
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SCIENCE
+
+
+/datum/design/medical_constructor
+	name = "Medical RCD Body Constructor"
+	id = "medical_rcd"
+	build_type = PROTOLATHE
+	build_path = /obj/item/construction/rcd // change
+	materials = list(/datum/material/plastic = SHEET_MATERIAL_AMOUNT * 20)
+	construction_time = 8 SECONDS
+	category = list(
+		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_MEDICAL
+	)

--- a/modular_zubbers/code/modules/research/techweb/all_nodes.dm
+++ b/modular_zubbers/code/modules/research/techweb/all_nodes.dm
@@ -44,6 +44,7 @@
 	design_ids += list(
 		"crewmonitor",
 		"borg_upgrade_advancedanalyzer",
+		"medical_rcd",
 	)
 
 /datum/techweb_node/xenobiology/New()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9135,6 +9135,7 @@
 #include "modular_zubbers\code\modules\mapping\limastation\shuttles.dm"
 #include "modular_zubbers\code\modules\mapping\limastation\static_plaque.dm"
 #include "modular_zubbers\code\modules\mapping\ss13_construct\areas.dm"
+#include "modular_zubbers\code\modules\medical_rcd\medical_rcd.dm"
 #include "modular_zubbers\code\modules\mining\abandoned_crates.dm"
 #include "modular_zubbers\code\modules\mining\shelters.dm"
 #include "modular_zubbers\code\modules\mining\equipment\survival_pod.dm"

--- a/tgui/packages/tgui/interfaces/bubbermedrcd.tsx
+++ b/tgui/packages/tgui/interfaces/bubbermedrcd.tsx
@@ -1,0 +1,86 @@
+import { capitalizeAll } from 'common/string';
+
+import { useBackend } from '../backend';
+import { Button, LabeledList, Section, Stack } from '../components';
+import { Window } from '../layouts';
+
+type Data = {
+  reagents: [];
+  total_reagents: number;
+  max_reagents: number;
+  selected_design: string;
+  designs: [];
+};
+
+type Category = {
+  cat_name: string;
+  designs: Design[];
+};
+
+type Design = {
+  title: string;
+  icon: string;
+};
+
+export const MatterItem = (props) => {
+  const { data } = useBackend<Data>();
+  const { total_reagents } = data;
+  return (
+    <LabeledList.Item label="Units Left">
+      &nbsp;{total_reagents} Units
+    </LabeledList.Item>
+  );
+};
+
+export const InfoSection = (props) => {
+  const { data } = useBackend<Data>();
+  const { reagents } = data;
+
+  return (
+    <Section>
+      <LabeledList>
+        <MatterItem />
+        {reagents}
+      </LabeledList>
+    </Section>
+  );
+};
+
+const DesignSection = (props) => {
+  const { act, data } = useBackend<Data>();
+
+  return (
+    <Section fill scrollable>
+      {data.designs.map((design, i) => (
+        <Button
+          key={i + 1}
+          fluid
+          height="31px"
+          color="transparent"
+          selected={data.designs.title === data.selected_design}
+          onClick={() =>
+            act('design', {
+              index: i + 1,
+            })
+          }
+        >
+          <span>{capitalizeAll(design.title)}</span>
+        </Button>
+      ))}
+    </Section>
+  );
+};
+
+export const bubbermedrcd = (props) => {
+  return (
+    <Window width={450} height={590}>
+      <Window.Content>
+        <Stack vertical fill>
+          <Stack.Item>
+            <InfoSection />
+          </Stack.Item>
+        </Stack>
+      </Window.Content>
+    </Window>
+  );
+};


### PR DESCRIPTION
## About The Pull Request

The goal of this device is to be a replacement or supplement for lategame surgery and the SAD. This device will do the following:
- Print limbs, appendages, features, and other externals of someone you sample.
- Perform a surgery (actually just installs), placing the newly created and selected limb onto the mob you target.
- Consume Synthflesh, or other reagents to create a desired appendage. 
- Use a TGUI to select what you want.
- Read the prefs of the sampled mob, to generate their "designs". 
- Generally be open to changes and revision as needed.

edit: discord folks say they'd rather it be a limb spitter than an autosurgeon, so we may veer to that
This PR is not even close to finished. Let me know your thoughts.
## Why It's Good For The Game

I want medical to combat the SAD as a catch all fix for problems, and generally make life easier for medical and their patients. This device will basically operate as a sci-fi body restructuring type device. 

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
add: medical bodypart rcd
/:cl:
