### PR TITLE
Reduces the weight of round-start malf ai from 10 to 2.

### DIFF
--- a/modular_zubbers/code/modules/storyteller/event_defines/crewset/malf.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/crewset/malf.dm
@@ -23,7 +23,7 @@
 
 	roundstart = TRUE
 	typepath = /datum/round_event/antagonist/solo/malf_ai/roundstart
-	weight = 10
+	weight = 2
 
 // God has abandoned us
 /datum/round_event_control/antagonist/solo/malf/roundstart/get_candidates()


### PR DESCRIPTION
## About The Pull Request

Reduces the weight of round-start MALF from 10 to 2.

## Why It's Good For The Game

I was told that MALF "rolls every round" so I went to investigate and discovered that roundstart malf has a weight of 10. For reference, heretic has a weight of 3. Traitors have a weight of 16. Changeling has a weight of 8. 10 is really common compared to the rest of things that can roll.

MALF shouldn't be more common than Changeling or Heretic, especially considering that malf ai is an extremely destructive antag type.

## Proof Of Testing

If it compiles, it werks.

## Changelog

:cl: BurgerBB
del: Reduces the weight of round-start malf ai from 10 to 2.
/:cl:

