### PR TITLE
Nerf Cyborg lockdowns.

### DIFF
--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -92,8 +92,9 @@
 				var/mob/living/silicon/robot/R = locate(params["ref"]) in GLOB.silicon_mobs
 				if(can_control(usr, R) && !..())
 					if(isAI(usr))
+						var/mob/living/silicon/ai/ai = usr
 						if(R.lockcharge)
-							if(R.ai_lockdown)
+							if(R.ai_lockdown || ai.malf_picker) //Bubber EDIT - Original - if(R.ai_lockdown)
 								R.ai_lockdown = FALSE
 								lock_unlock_borg(R)
 							else

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -92,7 +92,7 @@
 				var/mob/living/silicon/robot/R = locate(params["ref"]) in GLOB.silicon_mobs
 				if(can_control(usr, R) && !..())
 					if(isAI(usr))
-						var/mob/living/silicon/ai/ai = usr
+						var/mob/living/silicon/ai/ai = usr //Bubber EDIT Addition
 						if(R.lockcharge)
 							if(R.ai_lockdown || ai.malf_picker) //Bubber EDIT - Original - if(R.ai_lockdown)
 								R.ai_lockdown = FALSE

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -421,7 +421,7 @@
 	if(state)
 		throw_alert(ALERT_HACKED, /atom/movable/screen/alert/locked)
 		if(!ai_lockdown)
-			lockdown_timer = addtimer(CALLBACK(src,PROC_REF(lockdown_override), FALSE), 3 MINUTES, TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_DELETE_ME | TIMER_STOPPABLE) //BUBBER EDIT - Original - TIMER WAS ORIGINALLY SET TO 10 MINUTES
+			lockdown_timer = addtimer(CALLBACK(src,PROC_REF(lockdown_override), FALSE), 10 MINUTES, TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_DELETE_ME | TIMER_STOPPABLE)
 			to_chat(src, "<br><br>[span_alert("ALERT - Remote system lockdown engaged. Trying to hack the lockdown subsystem...")]<br>")
 	else
 		deltimer(lockdown_timer)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -421,7 +421,7 @@
 	if(state)
 		throw_alert(ALERT_HACKED, /atom/movable/screen/alert/locked)
 		if(!ai_lockdown)
-			lockdown_timer = addtimer(CALLBACK(src,PROC_REF(lockdown_override), FALSE), 10 MINUTES, TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_DELETE_ME | TIMER_STOPPABLE)
+			lockdown_timer = addtimer(CALLBACK(src,PROC_REF(lockdown_override), FALSE), 3 MINUTES, TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_DELETE_ME | TIMER_STOPPABLE) //BUBBER EDIT - Original - TIMER WAS ORIGINALLY SET TO 10 MINUTES
 			to_chat(src, "<br><br>[span_alert("ALERT - Remote system lockdown engaged. Trying to hack the lockdown subsystem...")]<br>")
 	else
 		deltimer(lockdown_timer)


### PR DESCRIPTION

## About The Pull Request
The Current Cyborg lockdown is insane, You basically can lockdown borgs for 10 **WHOLE** minutes, and a AI (Malf or not) literally cannot unlock them unless the AI decide to unpower the APC(if of course the RD didn't already deactivate the camera), this bullshit is downright stupid and is actually unfun for cyborg and malf AI players
so this PR basically make it so malf AI can unlock borgs even if it is locked down by someone else, and locked down borgs would be unlocked after 3 minutes.
## Why It's Good For The Game
I don't care what you'll say, the original 10-minute lockdown was straight up ridiculous, It was literally made to kill the fun for cyborg players and just leave them twiddling their thumbs doing fuck all, especially since from what **_i've_** noticed the players who lock the cyborg don't retrieve or go kill the locked-down cyborgs, forcing them to wait for 10 whole minutes if they're rogue.
the AI being unable to unlock their own cyborgs because they were locked down by someone who had access to a console that can be printed any time don't make sense, I've decided to not straight up remove it but made it so malf AI can unlock their own cyborg without having to disable APCs.
Either way, 3 minutes seems to be fine, because if you're unable to kill or recover and cut the lockdown wire to a cyborg under 3 whole minutes, that's on you.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/e255ae65-f1fa-4df8-9f66-4eeea2ed7577)

</details>

## Changelog
:cl:
balance: Allows malf AI to unlock their linked cyborgs if locked down by 'a user with higher permission'
balance: Lower Cyborg's 10 minutes lockdown timer to 3 minutes.
/:cl:
