### PR TITLE
Fixes research hanging the MC (#89855)

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -35,6 +35,8 @@ Nothing else in the console has ID requirements.
 	var/id_cache = list()
 	/// Sequence var for the id cache
 	var/id_cache_seq = 1
+	/// Cooldown that prevents hanging the MC when tech disks are copied
+	STATIC_COOLDOWN_DECLARE(cooldowncopy)
 
 /proc/CallMaterialName(ID)
 	if (istype(ID, /datum/material))
@@ -344,18 +346,23 @@ Nothing else in the console has ID requirements.
 			else
 				to_chat(usr, span_boldwarning("Unauthorized Access."))
 			return TRUE
+
 		if ("researchNode")
 			research_node(params["node_id"], usr)
 			return TRUE
+
 		if ("enqueueNode")
 			enqueue_node(params["node_id"], usr)
 			return TRUE
+
 		if ("dequeueNode")
 			dequeue_node(params["node_id"], usr)
 			return TRUE
+
 		if ("ejectDisk")
 			eject_disk(params["type"])
 			return TRUE
+
 		if ("uploadDisk")
 			if (params["type"] == RND_DESIGN_DISK)
 				if(QDELETED(d_disk))
@@ -368,19 +375,28 @@ Nothing else in the console has ID requirements.
 				d_disk.on_upload(stored_research, src)
 				return TRUE
 			if (params["type"] == RND_TECH_DISK)
+				if(!COOLDOWN_FINISHED(src, cooldowncopy)) // prevents MC hang
+					say("Servers busy!")
+					return
 				if (QDELETED(t_disk))
 					say("No tech disk inserted!")
 					return TRUE
+				COOLDOWN_START(src, cooldowncopy, 5 SECONDS)
 				say("Uploading technology disk.")
 				t_disk.stored_research.copy_research_to(stored_research)
 			return TRUE
+
 		//Tech disk-only action.
 		if ("loadTech")
+			if(!COOLDOWN_FINISHED(src, cooldowncopy)) // prevents MC hang
+				say("Servers busy!")
+				return
 			if(QDELETED(t_disk))
 				say("No tech disk inserted!")
 				return
-			stored_research.copy_research_to(t_disk.stored_research)
+			COOLDOWN_START(src, cooldowncopy, 5 SECONDS)
 			say("Downloading to technology disk.")
+			stored_research.copy_research_to(t_disk.stored_research)
 			return TRUE
 
 /obj/machinery/computer/rdconsole/proc/eject_disk(type)


### PR DESCRIPTION
## About The Pull Request

See https://github.com/tgstation/tgstation/pull/89855

So design disks and the techweb have this neat little thing called
```copy_research_to``` which chains three **highly expensive** procs
together which only sleep during CHECK_TICK. So it piles all the bodies
up in the corner and the Master Controller explodes trying to process a
fuck load of procs and the speed of my autoclicker

The entire research chain probally needs to be refactored to be less
expensive, but for now a 5 second cooldown will hopefully give it plenty
of time. You only need to click these buttons once. So the cooldown can
easily be increased without much gameplay effect.


![image](https://github.com/user-attachments/assets/5e0c2b5a-0fe5-4afc-b0bd-afa19e528ce6)

I didn't lag out on my local server using the debug disk so I think this
is a fix.

fixes: #89827
## Why It's Good For The Game

I'm sorry mr admin i crashed the server