### PR TITLE
Fixes digilegs not being baked into our species, adding needless exec times

### DIFF
--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -389,6 +389,9 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	human_who_gained_species.mob_respiration_type = inherent_respiration_type
 	human_who_gained_species.butcher_results = knife_butcher_results?.Copy()
 
+	// BUBBER EDIT BEGIN - Bake digitigrade into the species on apply
+	try_make_digitigrade(human_who_gained_species)
+	// BUBBER EDIT END
 	if(old_species.type != type)
 		replace_body(human_who_gained_species, src)
 
@@ -2023,32 +2026,14 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	new_species ||= target.dna.species //If no new species is provided, assume its src.
 	//Note for future: Potentionally add a new C.dna.species() to build a template species for more accurate limb replacement
 
-	// SKYRAT EDIT ADDITION START - Synth digitigrade sanitization
-	var/ignore_digi = FALSE // You can jack into this var with other checks, if you want.
-	if(issynthetic(target))
-		var/list/chassis = target.dna.mutant_bodyparts[MUTANT_SYNTH_CHASSIS]
-		if(chassis)
-			var/list/chassis_accessory = SSaccessories.sprite_accessories[MUTANT_SYNTH_CHASSIS]
-			var/datum/sprite_accessory/synth_chassis/body_choice
-			if(chassis_accessory)
-				body_choice = chassis_accessory[chassis[MUTANT_INDEX_NAME]]
-			if(body_choice && !body_choice.is_digi_compatible)
-				ignore_digi = TRUE
-	// SKYRAT EDIT END
-
 	var/list/final_bodypart_overrides = new_species.bodypart_overrides.Copy()
-	if(!ignore_digi && ((new_species.digitigrade_customization == DIGITIGRADE_OPTIONAL && target.dna.features["legs"] == DIGITIGRADE_LEGS) || new_species.digitigrade_customization == DIGITIGRADE_FORCED)) //if((new_species.digitigrade_customization == DIGITIGRADE_OPTIONAL && target.dna.features["legs"] == DIGITIGRADE_LEGS) || new_species.digitigrade_customization == DIGITIGRADE_FORCED) // SKYRAT EDIT - Digitigrade customization - ORIGINAL
-		/* SKYRAT EDIT - Digitigrade customization - ORIGINAL:
+
+	// BUBBER EDIT BEGIN REMOVAL - We bake these into the species
+	/*
+	if((new_species.digitigrade_customization == DIGITIGRADE_OPTIONAL && target.dna.features["legs"] == DIGITIGRADE_LEGS) || new_species.digitigrade_customization == DIGITIGRADE_FORCED)
 		final_bodypart_overrides[BODY_ZONE_R_LEG] = /obj/item/bodypart/leg/right/digitigrade
 		final_bodypart_overrides[BODY_ZONE_L_LEG] = /obj/item/bodypart/leg/left/digitigrade
-		*/ // ORIGINAL END - SKYRAT EDIT START:
-		var/obj/item/bodypart/leg/right/r_leg = new_species.bodypart_overrides[BODY_ZONE_R_LEG]
-		if(r_leg)
-			final_bodypart_overrides[BODY_ZONE_R_LEG] = initial(r_leg.digitigrade_type)
-		var/obj/item/bodypart/leg/left/l_leg = new_species.bodypart_overrides[BODY_ZONE_L_LEG]
-		if(l_leg)
-			final_bodypart_overrides[BODY_ZONE_L_LEG] = initial(l_leg.digitigrade_type)
-		// SKYRAT EDIT END
+	*/ // BUBBER EDIT END
 
 	for(var/obj/item/bodypart/old_part as anything in target.bodyparts)
 		if((old_part.change_exempt_flags & BP_BLOCK_CHANGE_SPECIES) || (old_part.bodypart_flags & BODYPART_IMPLANTED))

--- a/modular_skyrat/master_files/code/modules/client/preferences/species_features/digitigrade_legs.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/species_features/digitigrade_legs.dm
@@ -41,6 +41,10 @@
 
 	target.dna.features["legs"] = value
 
+	if(value == DIGITIGRADE_LEGS)
+		target.dna.species.try_make_digitigrade(target)
+	else
+		target.set_species(target.dna.species.type) // This fucking sucks but initial doesnt do lists and we need to clear this out
 	target.update_body()
-	target.dna.species.replace_body(target, target.dna.species) // TODO: Replace this with something less stupidly expensive.
+	target.dna.species.replace_body(target,target.dna.species) // TODO: Replace this with something less stupidly expensive.
 	return TRUE

--- a/modular_skyrat/master_files/code/modules/mob/living/carbon/human/_species.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/carbon/human/_species.dm
@@ -15,3 +15,25 @@
 		human_who_gained_species.dna.mutant_bodyparts = list()
 		human_who_gained_species.dna.body_markings = list()
 	. = ..()
+
+/// Tries to override our bodypart_overrides with digi varieties
+/// Doesnt actually give us the limbs, you might have to call replace_body after this
+/datum/species/proc/try_make_digitigrade(mob/living/carbon/human/human_who_gained_species)
+	var/ignore_digi = FALSE // You can jack into this var with other checks, if you want.
+	if(type == /datum/species/synthetic)
+		var/list/chassis = human_who_gained_species.dna.mutant_bodyparts[MUTANT_SYNTH_CHASSIS]
+		if(chassis)
+			var/list/chassis_accessory = SSaccessories.sprite_accessories[MUTANT_SYNTH_CHASSIS]
+			var/datum/sprite_accessory/synth_chassis/body_choice
+			if(chassis_accessory)
+				body_choice = chassis_accessory[chassis[MUTANT_INDEX_NAME]]
+			if(body_choice && !body_choice.is_digi_compatible)
+				ignore_digi = TRUE
+
+	if(!ignore_digi && ((digitigrade_customization == DIGITIGRADE_OPTIONAL && human_who_gained_species.dna.features["legs"] == DIGITIGRADE_LEGS) || digitigrade_customization == DIGITIGRADE_FORCED))
+		var/obj/item/bodypart/leg/right/r_leg = bodypart_overrides[BODY_ZONE_R_LEG]
+		if(r_leg)
+			bodypart_overrides[BODY_ZONE_R_LEG] = initial(r_leg.digitigrade_type)
+		var/obj/item/bodypart/leg/left/l_leg = bodypart_overrides[BODY_ZONE_L_LEG]
+		if(l_leg)
+			bodypart_overrides[BODY_ZONE_L_LEG] = initial(l_leg.digitigrade_type)

--- a/modular_skyrat/modules/bodyparts/code/_mutant_bodyparts.dm
+++ b/modular_skyrat/modules/bodyparts/code/_mutant_bodyparts.dm
@@ -11,13 +11,15 @@
 /obj/item/bodypart/proc/check_mutant_compatability()
 	return
 
-/obj/item/bodypart/leg/right
+/obj/item/bodypart/leg // Abstract type, if something retrieves null from this it's your fault
 	/// This is used in digitigrade legs, when this leg is swapped out with the digitigrade version.
-	var/digitigrade_type = /obj/item/bodypart/leg/right/digitigrade
+	var/digitigrade_type
+
+/obj/item/bodypart/leg/right
+	digitigrade_type = /obj/item/bodypart/leg/right/digitigrade
 
 /obj/item/bodypart/leg/left
-	/// This is used in digitigrade legs, when this leg is swapped out with the digitigrade version.
-	var/digitigrade_type = /obj/item/bodypart/leg/left/digitigrade
+	digitigrade_type = /obj/item/bodypart/leg/left/digitigrade
 
 
 /// General mutant bodyparts. Used in most mutant species.


### PR DESCRIPTION
## About The Pull Request

See name, this fixes the issue with slimes regenerating their limbs as well.
## Why It's Good For The Game

closes #2849
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: Having digi legs is now baked into your bodypart_overrides, speeding up replace_body, and fixing a bug with slime legs
/:cl:
