### PR TITLE
Fixes shadekin blinking

### DIFF
--- a/modular_zubbers/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/modular_zubbers/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -4,3 +4,5 @@
 	eye_icon_state = "shadekin_eyes"
 	icon_state = "eyeballs-moth"	//i'm too lazy to give them their own sprite
 	flash_protect = FLASH_PROTECTION_SENSITIVE
+	blink_animation = FALSE
+	iris_overlays = FALSE


### PR DESCRIPTION
## About The Pull Request
Makes it so shadekin no longer blink, most other species that have special eyes don't currently blink (moths, slimepeople), this brings them in line with the others.
## Why It's Good For The Game
Currently when they blink they have a little error icon, this fixes that.

fixes #3203

## Proof Of Testing
It was a two line change, it SHOULD work.
## Changelog
:cl:
fix: shadekin no longer blink
/:cl:
