### PR TITLE
Fixes xenos lacking their abilities

### DIFF
--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/defender.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/defender.dm
@@ -10,6 +10,16 @@
 	melee_damage_lower = 25
 	melee_damage_upper = 30
 	next_evolution = /mob/living/carbon/alien/adult/skyrat/warrior
+	default_organ_types_by_slot = list(
+		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
+		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears,
+		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel/small,
+	)
 
 /mob/living/carbon/alien/adult/skyrat/defender/Initialize(mapload)
 	. = ..()
@@ -22,10 +32,6 @@
 	REMOVE_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
 
 	add_movespeed_modifier(/datum/movespeed_modifier/alien_heavy)
-
-/mob/living/carbon/alien/adult/skyrat/defender/create_internal_organs()
-	organs += new /obj/item/organ/alien/plasmavessel/small
-	..()
 
 /datum/action/cooldown/spell/aoe/repulse/xeno/skyrat_tailsweep
 	name = "Crushing Tail Sweep"

--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/drone.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/drone.dm
@@ -10,15 +10,22 @@
 	melee_damage_lower = 15
 	melee_damage_upper = 20
 	next_evolution = /mob/living/carbon/alien/adult/skyrat/praetorian
+	default_organ_types_by_slot = list(
+		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
+		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears,
+		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel/large,
+		ORGAN_SLOT_XENO_RESINSPINNER = /obj/item/organ/alien/resinspinner,
+		ORGAN_SLOT_XENO_ACIDGLAND = /obj/item/organ/alien/acid,
+	)
 
 /mob/living/carbon/alien/adult/skyrat/drone/Initialize(mapload)
 	. = ..()
 	GRANT_ACTION(/datum/action/cooldown/alien/skyrat/heal_aura)
-
-/mob/living/carbon/alien/adult/skyrat/drone/create_internal_organs()
-	organs += new /obj/item/organ/alien/plasmavessel
-	organs += new /obj/item/organ/alien/resinspinner
-	..()
 
 /datum/action/cooldown/alien/skyrat/heal_aura
 	name = "Healing Aura"

--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/praetorian.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/praetorian.dm
@@ -10,6 +10,18 @@
 	melee_damage_lower = 25
 	melee_damage_upper = 30
 	next_evolution = /mob/living/carbon/alien/adult/skyrat/queen
+	default_organ_types_by_slot = list(
+		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
+		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears,
+		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel/large,
+		ORGAN_SLOT_XENO_RESINSPINNER = /obj/item/organ/alien/resinspinner,
+		ORGAN_SLOT_XENO_NEUROTOXINGLAND = /obj/item/organ/alien/neurotoxin/spitter,
+	)
 
 /mob/living/carbon/alien/adult/skyrat/praetorian/Initialize(mapload)
 	. = ..()
@@ -22,12 +34,6 @@
 	REMOVE_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
 
 	add_movespeed_modifier(/datum/movespeed_modifier/alien_big)
-
-/mob/living/carbon/alien/adult/skyrat/praetorian/create_internal_organs()
-	organs += new /obj/item/organ/alien/plasmavessel/large
-	organs += new /obj/item/organ/alien/neurotoxin/spitter
-	organs += new /obj/item/organ/alien/resinspinner
-	..()
 
 /datum/action/cooldown/alien/skyrat/heal_aura/juiced
 	name = "Strong Healing Aura"

--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/queen.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/queen.dm
@@ -10,6 +10,19 @@
 	icon_state = "alienqueen"
 	melee_damage_lower = 30
 	melee_damage_upper = 35
+	default_organ_types_by_slot = list(
+		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
+		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears,
+		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel/large/queen,
+		ORGAN_SLOT_XENO_RESINSPINNER = /obj/item/organ/alien/resinspinner,
+		ORGAN_SLOT_XENO_NEUROTOXINGLAND = /obj/item/organ/alien/neurotoxin/queen,
+		ORGAN_SLOT_XENO_EGGSAC = /obj/item/organ/alien/eggsac
+	)
 
 /mob/living/carbon/alien/adult/skyrat/queen/Initialize(mapload)
 	. = ..()
@@ -22,13 +35,6 @@
 	REMOVE_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
 
 	add_movespeed_modifier(/datum/movespeed_modifier/alien_big)
-
-/mob/living/carbon/alien/adult/skyrat/queen/create_internal_organs()
-	organs += new /obj/item/organ/alien/plasmavessel/large/queen
-	organs += new /obj/item/organ/alien/resinspinner
-	organs += new /obj/item/organ/alien/neurotoxin/queen
-	organs += new /obj/item/organ/alien/eggsac
-	..()
 
 /mob/living/carbon/alien/adult/skyrat/queen/alien_talk(message, shown_name = name)
 	..(message, shown_name, TRUE)

--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/ravager.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/ravager.dm
@@ -11,6 +11,16 @@
 	icon_state = "alienravager"
 	melee_damage_lower = 30
 	melee_damage_upper = 35
+	default_organ_types_by_slot = list(
+		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
+		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears,
+		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel,
+	)
 
 /mob/living/carbon/alien/adult/skyrat/ravager/Initialize(mapload)
 	. = ..()
@@ -22,10 +32,6 @@
 	grant_actions_by_list(innate_actions)
 
 	REMOVE_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
-
-/mob/living/carbon/alien/adult/skyrat/ravager/create_internal_organs()
-	organs += new /obj/item/organ/alien/plasmavessel
-	..()
 
 /datum/action/cooldown/mob_cooldown/charge/triple_charge/ravager
 	name = "Triple Charge Attack"

--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/rouny.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/rouny.dm
@@ -16,6 +16,16 @@
 	melee_damage_upper = 20
 	next_evolution = /mob/living/carbon/alien/adult/skyrat/ravager
 	on_fire_pixel_y = 0
+	default_organ_types_by_slot = list(
+		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
+		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears,
+		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel/small/tiny,
+	)
 
 /mob/living/carbon/alien/adult/skyrat/runner/Initialize(mapload)
 	. = ..()
@@ -24,10 +34,6 @@
 	evade_ability.Grant(src)
 
 	add_movespeed_modifier(/datum/movespeed_modifier/alien_quick)
-
-/mob/living/carbon/alien/adult/skyrat/runner/create_internal_organs()
-	organs += new /obj/item/organ/alien/plasmavessel/small/tiny
-	..()
 
 /datum/action/cooldown/alien/skyrat/evade
 	name = "Evade"

--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/sentinel.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/sentinel.dm
@@ -10,16 +10,22 @@
 	melee_damage_lower = 10
 	melee_damage_upper = 15
 	next_evolution = /mob/living/carbon/alien/adult/skyrat/spitter
+	default_organ_types_by_slot = list(
+		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
+		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears,
+		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel/small,
+		ORGAN_SLOT_XENO_NEUROTOXINGLAND = /obj/item/organ/alien/neurotoxin/sentinel,
+	)
 
 /mob/living/carbon/alien/adult/skyrat/sentinel/Initialize(mapload)
 	. = ..()
 
 	add_movespeed_modifier(/datum/movespeed_modifier/alien_slow)
-
-/mob/living/carbon/alien/adult/skyrat/sentinel/create_internal_organs()
-	organs += new /obj/item/organ/alien/plasmavessel/small
-	organs += new /obj/item/organ/alien/neurotoxin/sentinel
-	..()
 
 /datum/action/cooldown/alien/acid/skyrat
 	name = "Spit Neurotoxin"

--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/spitter.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/spitter.dm
@@ -9,6 +9,17 @@
 	icon_state = "alienspitter"
 	melee_damage_lower = 15
 	melee_damage_upper = 20
+	default_organ_types_by_slot = list(
+		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
+		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears,
+		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel,
+		ORGAN_SLOT_XENO_NEUROTOXINGLAND = /obj/item/organ/alien/neurotoxin/spitter,
+	)
 
 /mob/living/carbon/alien/adult/skyrat/spitter/Initialize(mapload)
 	. = ..()
@@ -16,8 +27,3 @@
 	add_movespeed_modifier(/datum/movespeed_modifier/alien_heavy)
 
 	REMOVE_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
-
-/mob/living/carbon/alien/adult/skyrat/spitter/create_internal_organs()
-	organs += new /obj/item/organ/alien/plasmavessel
-	organs += new /obj/item/organ/alien/neurotoxin/spitter
-	..()

--- a/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/warrior.dm
+++ b/modular_skyrat/modules/xenos_skyrat_redo/code/xeno_types/warrior.dm
@@ -9,6 +9,16 @@
 	icon_state = "alienwarrior"
 	melee_damage_lower = 30
 	melee_damage_upper = 35
+	default_organ_types_by_slot = list(
+		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
+		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears,
+		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel,
+	)
 
 /mob/living/carbon/alien/adult/skyrat/warrior/Initialize(mapload)
 	. = ..()
@@ -22,10 +32,6 @@
 	REMOVE_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
 
 	add_movespeed_modifier(/datum/movespeed_modifier/alien_big)
-
-/mob/living/carbon/alien/adult/skyrat/warrior/create_internal_organs()
-	organs += new /obj/item/organ/alien/plasmavessel
-	..()
 
 /datum/action/cooldown/alien/skyrat/warrior_agility
 	name = "Agility Mode"


### PR DESCRIPTION

## About The Pull Request
Replaces create_internal_organs with default_organ_types_by_slot bringing Skyrat xenos in line with /tg/ and fixing them in the process.
## Why It's Good For The Game
Xenos are once again able to xeno.
## Proof Of Testing
It compiled, ran, and worked.
## Changelog
:cl:
fix: fixed xenos lacking their abilities
/:cl:
