### PR TITLE
Fixes 516 character previews being small.

### DIFF
--- a/code/_onclick/hud/map_popups.dm
+++ b/code/_onclick/hud/map_popups.dm
@@ -19,6 +19,17 @@
 /atom/movable/screen/proc/set_position(x, y, px = 0, py = 0)
 	if(assigned_map)
 		screen_loc = "[assigned_map]:[x]:[px],[y]:[py]"
+		ASYNC
+			// HACK: This fixes the character creator in 516 being small and relying on other byondui things (like cameras) to open in order to update and refresh.
+			// This also will fix the camera console screen being offset, Gateway, and admin pod panel.
+			// Adding 100 then setting it back seemed to do the trick!
+			// Why the fuck does this work? This is some byond bug and I honestly have no fucking clue why this works.
+			// I don't think plane master will be affected, I hope.
+			// We're stuck in the belly of this awful machine.
+			sleep(0.2 SECONDS)
+			screen_loc = "[assigned_map]:[x+100]:[px],[y+100]:[py]"
+			sleep(0.2 SECONDS)
+			screen_loc = "[assigned_map]:[x]:[px],[y]:[py]"
 	else
 		screen_loc = "[x]:[px],[y]:[py]"
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -151,13 +151,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		ui.set_autoupdate(FALSE)
 		ui.open()
 
-		// HACK: Without this the character starts out really tiny because of some BYOND bug.
-		// You can fix it by changing a preference, so let's just forcably update the body to emulate this.
-		// Lemon from the future: this issue appears to replicate if the byond map (what we're relaying here)
-		// Is shown while the client's mouse is on the screen. As soon as their mouse enters the main map, it's properly scaled
-		// I hate this place
-		addtimer(CALLBACK(character_preview_view, TYPE_PROC_REF(/atom/movable/screen/map_view/char_preview, update_body)), 1 SECONDS)
-
 /datum/preferences/ui_state(mob/user)
 	return GLOB.always_state
 


### PR DESCRIPTION
This is really awful code and basically a splint, but the root cause is a byond bug. Hopefully just a temporary fix. Hopefully