### PR TITLE
Fix hemophages not having blood meter

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_tumor.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage/hemophage_tumor.dm
@@ -27,7 +27,7 @@
 
 /obj/item/organ/heart/hemophage/on_mob_insert(mob/living/carbon/tumorful, special, movement_flags)
 	. = ..()
-	if(!. || !owner)
+	if(!owner)
 		return
 
 	SEND_SIGNAL(tumorful, COMSIG_PULSATING_TUMOR_ADDED, tumorful)


### PR DESCRIPTION
## About The Pull Request

Remove a `!.` check in `on_mob_insert` because organ refactoring means it'll always fail now (parent proc no longer returns anything)

## Why It's Good For The Game

Fixes #3214 (I cannot reproduce the part about missing the drink ability, it's most likely a separate issue so I'll wait for a new report on it if it persists)

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/f1bd2ef1-7f38-400f-bf40-83e5dc2d606d)

</details>

## Changelog

:cl:
fix: fixed hemophages missing their blood meter
/:cl:

