### PR TITLE
being prone (army crawling, borers) now adds the TRAIT_IGNORE_ELEVATION trait

### DIFF
--- a/modular_skyrat/master_files/code/datums/components/prone_mob.dm
+++ b/modular_skyrat/master_files/code/datums/components/prone_mob.dm
@@ -10,7 +10,7 @@
 
 	if(hand_blocking)
 		parent.add_traits(list(TRAIT_HANDS_BLOCKED), type)
-	parent.add_traits(list(TRAIT_PRONE, TRAIT_FLOORED, TRAIT_NO_THROWING), type)
+	parent.add_traits(list(TRAIT_PRONE, TRAIT_FLOORED, TRAIT_NO_THROWING, TRAIT_IGNORE_ELEVATION), type)
 	passtable_on(parent, type)
 	source.layer = PROJECTILE_HIT_THRESHHOLD_LAYER
 
@@ -27,7 +27,7 @@
 /datum/component/prone_mob/proc/stop_army_crawl(mob/living/source)
 	SIGNAL_HANDLER
 	source = parent
-	parent.remove_traits(list(TRAIT_PRONE, TRAIT_FLOORED, TRAIT_NO_THROWING, TRAIT_HANDS_BLOCKED), type)
+	parent.remove_traits(list(TRAIT_PRONE, TRAIT_FLOORED, TRAIT_NO_THROWING, TRAIT_HANDS_BLOCKED, TRAIT_IGNORE_ELEVATION), type)
 	passtable_off(parent, type)
 	source.layer = MOB_LAYER
 	qdel(src)


### PR DESCRIPTION
## About The Pull Request
What it means is that there shouldn't be any more sprite stuttering* when crawling under racks or tables due to the elevation elements attached to them.

*Under normal cirumstances, it should be offset vertically but for some reason the offset is reset, perhaps from some of your modular changes, leaving only the animation in.

## Why It's Good For The Game
Fixing a nominal issue.

## Proof Of Testing
It works for xeno larvas upstream. It'll work here as well.

## Changelog

:cl:
fix: You no longer jitter when crawling under tables and the likes as a borer or from of army crawling.
/:cl: