### PR TITLE
Fixes akula hair layers

### DIFF
--- a/code/modules/surgery/bodyparts/head_hair_and_lips.dm
+++ b/code/modules/surgery/bodyparts/head_hair_and_lips.dm
@@ -124,8 +124,8 @@
 			hair_overlay.pixel_y = hair_sprite_accessory.y_offset
 			// SKYRAT EDIT ADDITION - Species hair offset
 			if(LAZYFIND(owner?.dna?.species?.offset_features, OFFSET_HAIR))
-				hair_overlay.pixel_x += owner.dna.species.offset_features[OFFSET_HAIR][INDEX_X]
-				hair_overlay.pixel_y += owner.dna.species.offset_features[OFFSET_HAIR][INDEX_Y]
+				hair_overlay.pixel_w += owner.dna.species.offset_features[OFFSET_HAIR][INDEX_X]
+				hair_overlay.pixel_z += owner.dna.species.offset_features[OFFSET_HAIR][INDEX_Y]
 			// SKYRAT EDIT ADDITION END
 			//Emissive blocker
 			if(blocks_emissive != EMISSIVE_BLOCK_NONE)
@@ -141,8 +141,8 @@
 				hair_gradient_overlay.pixel_y = hair_sprite_accessory.y_offset
 				// SKYRAT EDIT ADDITION - Species hair offset
 				if(LAZYFIND(owner?.dna?.species?.offset_features, OFFSET_HAIR))
-					hair_gradient_overlay.pixel_x += owner.dna.species.offset_features[OFFSET_HAIR][INDEX_X]
-					hair_gradient_overlay.pixel_y += owner.dna.species.offset_features[OFFSET_HAIR][INDEX_Y]
+					hair_gradient_overlay.pixel_w += owner.dna.species.offset_features[OFFSET_HAIR][INDEX_X]
+					hair_gradient_overlay.pixel_z += owner.dna.species.offset_features[OFFSET_HAIR][INDEX_Y]
 				// SKYRAT EDIT ADDITION END
 				. += hair_gradient_overlay
 


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/user-attachments/assets/54063391-50e6-48aa-8011-c93202ac8e27)

pixel_x and pixel_y needed to be converted to pixel_w and pixel_z

If you encounter any other issues like this, this is how you should be able to fix them

## Changelog
:cl:
fix: Akula hair now layers correctly
/:cl:
