### PR TITLE
Removes the enforced height changes for settler/spacer

### DIFF
--- a/code/datums/quirks/positive_quirks/settler.dm
+++ b/code/datums/quirks/positive_quirks/settler.dm
@@ -25,10 +25,7 @@
 
 /datum/quirk/item_quirk/settler/add(client/client_source)
 	var/mob/living/carbon/human/human_quirkholder = quirk_holder
-	//SKYRAT EDIT BEGIN - This is so Teshari don't get the height decrease.
-	if(!isteshari(human_quirkholder))
-		human_quirkholder.set_mob_height(HUMAN_HEIGHT_SHORTEST)
-	//SKYRAT EDIT END
+	//human_quirkholder.set_mob_height(HUMAN_HEIGHT_SHORTEST) // Bubber Removal - Stops Settler/Spacer from changing mob heights
 	human_quirkholder.add_movespeed_modifier(/datum/movespeed_modifier/settler)
 	human_quirkholder.physiology.hunger_mod *= 0.5 //good for you, shortass, you don't get hungry nearly as often
 	human_quirkholder.add_traits(settler_traits, QUIRK_TRAIT)
@@ -41,7 +38,7 @@
 	if(QDELING(quirk_holder))
 		return
 	var/mob/living/carbon/human/human_quirkholder = quirk_holder
-	human_quirkholder.set_mob_height(HUMAN_HEIGHT_MEDIUM)
+	//human_quirkholder.set_mob_height(HUMAN_HEIGHT_MEDIUM) // Bubber Removal - Stops Settler/Spacer from changing mob heights
 	human_quirkholder.remove_movespeed_modifier(/datum/movespeed_modifier/settler)
 	human_quirkholder.physiology.hunger_mod *= 2
 	human_quirkholder.remove_traits(settler_traits, QUIRK_TRAIT)

--- a/code/datums/quirks/positive_quirks/spacer.dm
+++ b/code/datums/quirks/positive_quirks/spacer.dm
@@ -46,7 +46,7 @@
 	quirk_holder.inertia_move_multiplier *= 0.8
 
 	var/mob/living/carbon/human/human_quirker = quirk_holder
-	human_quirker.set_mob_height(modded_height)
+	//human_quirker.set_mob_height(modded_height) // Bubber Removal - Stops Settler/Spacer from changing mob heights
 	human_quirker.physiology.pressure_mod *= 0.8
 	human_quirker.physiology.cold_mod *= 0.8
 
@@ -79,7 +79,7 @@
 	quirk_holder.remove_status_effect(/datum/status_effect/spacer)
 
 	var/mob/living/carbon/human/human_quirker = quirk_holder
-	human_quirker.set_mob_height(HUMAN_HEIGHT_MEDIUM)
+	//human_quirker.set_mob_height(HUMAN_HEIGHT_MEDIUM) // Bubber Removal - Stops Settler/Spacer from changing mob heights
 	human_quirker.physiology.pressure_mod /= 0.8
 	human_quirker.physiology.cold_mod /= 0.8
 

--- a/modular_zubbers/code/modules/customization/height_scaling/preferences.dm
+++ b/modular_zubbers/code/modules/customization/height_scaling/preferences.dm
@@ -42,9 +42,11 @@
 	if (HAS_TRAIT(target, TRAIT_DWARF)) // nuh uh. your height is set mf
 		return FALSE
 
-	for (var/quirk_id as anything in preferences?.all_quirks)
-		if (quirk_id in incompatable_quirk_ids)
-			return FALSE
+	// Bubber Removal Start - Stops Settler/Spacer from changing mob heights
+	// for (var/quirk_id as anything in preferences?.all_quirks)
+	// 	if (quirk_id in incompatable_quirk_ids)
+	// 		return FALSE
+	// Bubber Removal End
 
 	target.set_mob_height(value)
 


### PR DESCRIPTION

## About The Pull Request

Someone complained about the height fucking up hats for them, and I don't really see the need to enforce specific heights for the spacer or settler quirks.
This removes the enforcement.
## Why It's Good For The Game

I'unno, it's better?

## Proof Of Testing

I commented out the lines of code that change peoples height, when they took the quirk or lost the quirk, as well as a section in preference code which disabled the dropdown and checked to see if you could use the selected height anyways.

## Changelog
:cl:
qol: The Spacer and Settler traits no longer force a character to be a specific height, now you can select your preferred height as usual.
/:cl:
