### PR TITLE
Fixes being plantigrade with species overrides whitewashing you

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences/species_features/digitigrade_legs.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/species_features/digitigrade_legs.dm
@@ -44,7 +44,11 @@
 	if(value == DIGITIGRADE_LEGS)
 		target.dna.species.try_make_digitigrade(target)
 	else
-		target.set_species(target.dna.species.type) // This fucking sucks but initial doesnt do lists and we need to clear this out
+		// This fucking sucks but initial doesnt do lists and we need to clear this out
+		var/datum/species/cursed_species_we_need_for_a_list
+		if(ispath(target.dna.species.type))
+			cursed_species_we_need_for_a_list = new target.dna.species.type
+		target.dna.species.bodypart_overrides = cursed_species_we_need_for_a_list.bodypart_overrides
 	target.update_body()
 	target.dna.species.replace_body(target,target.dna.species) // TODO: Replace this with something less stupidly expensive.
 	return TRUE


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/90ae472d-c243-4603-a38d-9fcf3db8f60a)

I could've never forseen this. Woops. See branch name for more information

closes #3308

## Changelog

:cl:
fix: You no longer get randomly whitewashed when spawning with a different species and planti legs
/:cl:
