### PR TITLE
slightly increase the height of the character panel and fix create loadout button

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/loadout/index.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/loadout/index.tsx
@@ -184,6 +184,7 @@ export function LoadoutPage(props) {
           currentSearch={searchLoadout}
           modifyItemDimmer={modifyItemDimmer}
           setModifyItemDimmer={setModifyItemDimmer}
+          setManagingPreset={setManagingPreset}
         />
       </Stack.Item>
     </Stack>
@@ -196,6 +197,7 @@ type LoadoutTabsProps = {
   currentSearch: string;
   modifyItemDimmer: LoadoutItem | null;
   setModifyItemDimmer: (dimmer: LoadoutItem | null) => void;
+  setManagingPreset: (string) => void;
 };
 
 function LoadoutTabs(props: LoadoutTabsProps) {
@@ -205,6 +207,7 @@ function LoadoutTabs(props: LoadoutTabsProps) {
     currentSearch,
     modifyItemDimmer,
     setModifyItemDimmer,
+    setManagingPreset,
   } = props;
   const activeCategory = loadout_tabs.find((curTab) => {
     return curTab.name === currentTab;
@@ -213,7 +216,6 @@ function LoadoutTabs(props: LoadoutTabsProps) {
 
   // BUBBER EDIT ADDITION START: Multiple loadout presets
   const { act, data } = useBackend<PreferencesMenuData>();
-  const [_, setManagingPreset] = useState<string | null>(null);
   // BUBBER EDIT END
 
   return (

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/index.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/index.tsx
@@ -20,7 +20,8 @@ import { ServerPrefs } from './useServerPrefs';
 
 export function PreferencesMenu(props) {
   return (
-    <Window width={1024} height={770}>
+    <Window width={1024} height={790}>
+      {/* BUBBER change line 23 bigger char setup */}
       <Window.Content>
         <Suspense fallback={<LoadingScreen />}>
           <PrefsWindowInner />


### PR DESCRIPTION

## About The Pull Request
slightly increase the height of the character panel and fix create loadout button

## Why It's Good For The Game
char creator UI kinda requires you to scroll to see your name and stuff, this fixes that, and the add loadout button didn't work, broken shit working is better, i'd say

## Proof Of Testing

i tested it, no pic, sorry

## Changelog

:cl:
fix: Character setup panel is now slightly bigger
fix: Character setup panel's add loadout button now works again
/:cl:

