### PR TITLE
1984s the delay for opening a borgs cover.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -334,11 +334,6 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		if(locked)
 			balloon_alert(user, "chassis cover locked!")
 		else
-			// BUBBER EDIT START
-			balloon_alert(user, "chassis cover opened")
-			if(!do_after(user, 0.5 SECONDS))
-				return FALSE
-			// BUBBER EDIT START
 			opened = TRUE
 			update_icons()
 


### PR DESCRIPTION

## About The Pull Request
removes the delay and balloon alert when opening a borgs cover
## Why It's Good For The Game
ultimately this was done because 1 dude ran around emagging a ton of borgs in the open and a certain subsect of borg players got mad about it. Not only is this player no longer with us, but it also really discourages any stealth play with individual borgs compared to just relawing the AI as a whole as its made impossible to silently emag a borg, now requiring the use of multiple flashes or an EMP, the former allowing the borg to talk on binary/comms quick while it happens, the latter alerting the AI via damage taken on the status panel (if its paying attention).
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
balance: no more delay on borg covers
/:cl:
