### PR TITLE
Removes the martyr and hijack objs, again. Also removes some heavily disruptive spy OBJs

### DIFF
--- a/code/modules/antagonists/spy/spy.dm
+++ b/code/modules/antagonists/spy/spy.dm
@@ -160,6 +160,7 @@
 				cage_the_jailbird.no_failure = TRUE
 				objectives += cage_the_jailbird
 
+	/* // BUBBER EDIT BEGIN
 	if(prob(10))
 		var/datum/objective/martyr/leave_no_trace = new()
 		leave_no_trace.owner = owner
@@ -169,6 +170,7 @@
 		var/datum/objective/hijack/steal_the_shuttle = new()
 		steal_the_shuttle.owner = owner
 		objectives += steal_the_shuttle
+	*/ // BUBBER EDIT END
 
 	else if(prob(10)) //10% chance on 87.3% chance
 		var/datum/objective/exile/hit_the_bricks = new()

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -130,9 +130,11 @@
 /datum/antagonist/traitor/proc/forge_traitor_objectives()
 	var/objective_count = 0
 
+	/* // BUBBER EDIT BEGIN
 	if((GLOB.joined_player_list.len >= HIJACK_MIN_PLAYERS) && prob(HIJACK_PROB))
 		is_hijacker = TRUE
 		objective_count++
+	*/ // BUBBER EDIT END
 
 	var/objective_limit = CONFIG_GET(number/traitor_objectives_amount)
 
@@ -147,10 +149,12 @@
  * Forges the endgame objective and adds it to this datum's objective list.
  */
 /datum/antagonist/traitor/proc/forge_ending_objective()
+	/* // BUBBER EDIT BEGIN
 	if(is_hijacker)
 		ending_objective = new /datum/objective/hijack
 		ending_objective.owner = owner
 		return
+
 
 	var/martyr_compatibility = TRUE
 
@@ -164,6 +168,7 @@
 		ending_objective.owner = owner
 		objectives += ending_objective
 		return
+	*/ // BUBBER EDIT END
 
 	ending_objective = new /datum/objective/escape
 	ending_objective.owner = owner

--- a/strings/antagonist_flavor/spy_objective.json
+++ b/strings/antagonist_flavor/spy_objective.json
@@ -1,8 +1,6 @@
 {
 	"objective_body": [
 		"Assassinate a high profile crewmember without being caught.",
-		"Cause a disaster to shake the station.",
-		"Cause a station evacuation.",
 		"Deprive the station of as many @pick(stealables) as you can.",
 		"Ensure @pick(department) is @pick(affected) by the end of the shift.",
 		"Ensure @pick(location) is @pick(affected) by the end of the shift.",
@@ -26,7 +24,6 @@
 		"Keep everyone out of @pick(location).",
 		"Make it difficult but not impossible to @pick(escape) the station.",
 		"Protect the station's @pick(happenings).",
-		"Sabotage the station's power grid or engine.",
 		"Steal all the @pick(stealables) from @pick(department).",
 		"Steal all the @pick(stealables) from @pick(location).",
 		"Steal as many @pick(stealables) as you can.",


### PR DESCRIPTION

## About The Pull Request

See name, removes the martyr and hijack objs from traitor and spy

## Why it's good for the game

Giving these out for free on a random chance on the most common antag types is a bad idea. Especially when it gives the potential justification to bypass the station integrity rule. Also it's a mess to admin + we aren't trying to be Manuel, despite what it might seem like at times.

## Changelog
:cl:
del: Removes the martyr and hijack objs from traitor and spy
/:cl:
