### PR TITLE
Nerfs Icebox by adding shrinkage

### DIFF
--- a/modular_zubbers/code/modules/customization/genitals.dm
+++ b/modular_zubbers/code/modules/customization/genitals.dm
@@ -1,0 +1,43 @@
+//Mostly copied from skyrat's genitals file.
+
+/obj/item/organ/genital/penis/get_description_string(datum/sprite_accessory/genital/gas)
+
+	var/returned_string = ""
+
+	var/pname = LOWER_TEXT(genital_name) == "nondescript" ? "" : LOWER_TEXT(genital_name) + " "
+
+	if(sheath != SHEATH_NONE && aroused != AROUSAL_FULL) //Hidden in sheath
+		switch(sheath)
+			if(SHEATH_NORMAL)
+				returned_string = "You see a sheath."
+			if(SHEATH_SLIT)
+				returned_string = "You see a slit." ///Typo fix.
+		if(aroused != AROUSAL_PARTIAL)
+			return
+		returned_string += " There's a [pname]penis poking out of it. "
+	else
+		returned_string += "You see a [pname]penis. "
+
+	var/reported_girth = CEILING( girth / 3.1415, 0.25) //Circum to Diameter
+	var/reported_length = genital_size
+
+	if(aroused != AROUSAL_FULL)
+		var/temperature_difference = owner.bodytemperature - owner.get_body_temp_normal()
+		if(abs(temperature_difference) > 1)
+			// https://www.desmos.com/calculator/ivauzad62s
+			//I love penis math
+			reported_length *= max(0.5, 1 - (-temperature_difference/50)**4)
+
+	reported_length = CEILING(reported_length,0.5)
+
+	returned_string = "You estimate it's about [genital_size] inches long, and about [girth] inches in diameter."
+
+	switch(aroused)
+		if(AROUSAL_NONE)
+			returned_string += " It seems flaccid."
+		if(AROUSAL_PARTIAL)
+			returned_string += " It's partically erect."
+		if(AROUSAL_FULL)
+			returned_string += " It's fully erect."
+
+	return returned_string

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9139,6 +9139,7 @@
 #include "modular_zubbers\code\modules\colony_fabricator\code\design_datums\fabricator_flag_additions\tools.dm"
 #include "modular_zubbers\code\modules\contractor\code\items\boxes.dm"
 #include "modular_zubbers\code\modules\credits\credits.dm"
+#include "modular_zubbers\code\modules\customization\genitals.dm"
 #include "modular_zubbers\code\modules\customization\height_scaling\icons.dm"
 #include "modular_zubbers\code\modules\customization\height_scaling\preferences.dm"
 #include "modular_zubbers\code\modules\customization\species\synths\death_sound.dm"


### PR DESCRIPTION
## About The Pull Request

Nerfs Icebox by adding shrinkage. Colder temperatures may result in shrinkage.
Converts girth measurements from circumference to diameter.
Fixes missing display if your member wasn't normal.

## Why It's Good For The Game

https://www.youtube.com/watch?v=GG2dF5PS0bI


## Proof Of Testing

Untested.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: BurgerBB
add: Nerfs Icebox by adding shrinkage.
/:cl:
