### PR TITLE
Fixes the storyteller default configs

### DIFF
--- a/config/bubbers/bubbers_config.txt
+++ b/config/bubbers/bubbers_config.txt
@@ -16,6 +16,3 @@ INTERN_THRESHOLD_COMMAND 20
 # Vetted player system
 ## If enabled, it will use checks to determine if a player is vetted or not in different parts of the game
 #CHECK_VETTED
-
-## Default Storyteller. Comment out to enable voting.
-DEFAULT_STORYTELLER /datum/storyteller/extended

--- a/config/bubbers/storyteller.txt
+++ b/config/bubbers/storyteller.txt
@@ -1,0 +1,50 @@
+## Default Storyteller. Comment out to enable voting.
+DEFAULT_STORYTELLER /datum/storyteller/extended
+
+## Gamemode configurations
+
+## Multipliers for points gained over time for event tracks.
+MUNDANE_POINT_GAIN_MULTIPLIER 1
+MODERATE_POINT_GAIN_MULTIPLIER 1
+MAJOR_POINT_GAIN_MULTIPLIER 1
+ROLESET_POINT_GAIN_MULTIPLIER 1
+OBJECTIVES_POINT_GAIN_MULTIPLIER 1
+
+## Multipliers for points to spend on roundstart events.
+MUNDANE_ROUNDSTART_POINT_MULTIPLIER 1
+MODERATE_ROUNDSTART_POINT_MULTIPLIER 1
+MAJOR_ROUNDSTART_POINT_MULTIPLIER 1
+ROLESET_ROUNDSTART_POINT_MULTIPLIER 1
+OBJECTIVES_ROUNDSTART_POINT_MULTIPLIER 1
+
+## Minimum population caps for event tracks to run their events.
+MUNDANE_MIN_POP 0
+MODERATE_MIN_POP 0
+MAJOR_MIN_POP 0
+ROLESET_MIN_POP 0
+OBJECTIVES_MIN_POP 0
+
+## Point thresholds for tracks to run events. The lesser the more frequent events will be.
+MUNDANE_POINT_THRESHOLD 25
+MODERATE_POINT_THRESHOLD 50
+MAJOR_POINT_THRESHOLD 90
+ROLESET_POINT_THRESHOLD 120
+OBJECTIVES_POINT_THRESHOLD 130
+
+## Allows the storyteller to scale event frequencies based on population
+ALLOW_STORYTELLER_POP_SCALING
+
+## Thresholds that population frequency scalling penalize up to.
+MUNDANE_POP_SCALE_THRESHOLD 10
+MODERATE_POP_SCALE_THRESHOLD 15
+MAJOR_POP_SCALE_THRESHOLD 40
+ROLESET_POP_SCALE_THRESHOLD 45
+OBJECTIVES_POP_SCALE_THRESHOLD 40
+
+## The maximum penalties population scalling will apply to the tracks for having less pop than POP_SCALE_THRESHOLD. This is treated as percentages
+MUNDANE_POP_SCALE_PENALTY 30
+MODERATE_POP_SCALE_PENALTY 30
+MAJOR_POP_SCALE_PENALTY 30
+ROLESET_POP_SCALE_PENALTY 30
+OBJECTIVES_POP_SCALE_PENALTY 30
+

--- a/config/config.txt
+++ b/config/config.txt
@@ -8,6 +8,7 @@ $include resources.txt
 $include skyrat/skyrat_config.txt
 $include bubbers/bubbers_config.txt
 $include bubbers/vore_config.txt
+$include bubbers/storyteller.txt
 $include interviews.txt
 $include lua.txt
 $include auxtools.txt

--- a/modular_zubbers/code/modules/storyteller/config.dm
+++ b/modular_zubbers/code/modules/storyteller/config.dm
@@ -1,95 +1,95 @@
 ///Gamemode related configs below
 // Point Gain Multipliers
 /datum/config_entry/number/mundane_point_gain_multiplier
-	config_entry_value = 1
+	default = 1
 	min_val = 0
 
 /datum/config_entry/number/moderate_point_gain_multiplier
-	config_entry_value = 1
+	default = 1
 	min_val = 0
 
 /datum/config_entry/number/major_point_gain_multiplier
-	config_entry_value = 1
+	default = 1
 	min_val = 0
 
 /datum/config_entry/number/crewset_point_gain_multiplier
-	config_entry_value = 1
+	default = 1
 	min_val = 0
 
 /datum/config_entry/number/ghostset_point_gain_multiplier
-	config_entry_value = 1
+	default = 1
 	min_val = 0
 
 // Roundstart points Multipliers
 /datum/config_entry/number/mundane_roundstart_point_multiplier
-	config_entry_value = 1
+	default = 1
 	min_val = 0
 
 /datum/config_entry/number/moderate_roundstart_point_multiplier
-	config_entry_value = 1
+	default = 1
 	min_val = 0
 
 /datum/config_entry/number/major_roundstart_point_multiplier
-	config_entry_value = 1
+	default = 1
 	min_val = 0
 
 /datum/config_entry/number/crewset_roundstart_point_multiplier
-	config_entry_value = 1
+	default = 1
 	min_val = 0
 
 /datum/config_entry/number/ghostset_roundstart_point_multiplier
-	config_entry_value = 1
+	default = 1
 	min_val = 0
 
 // Minimum population
 /datum/config_entry/number/mundane_min_pop
-	config_entry_value = MUNDANE_MIN_POP
+	default = MUNDANE_MIN_POP
 	integer = TRUE
 	min_val = 0
 
 /datum/config_entry/number/moderate_min_pop
-	config_entry_value = MODERATE_MIN_POP
+	default = MODERATE_MIN_POP
 	integer = TRUE
 	min_val = 0
 
 /datum/config_entry/number/major_min_pop
-	config_entry_value = MAJOR_MIN_POP
+	default = MAJOR_MIN_POP
 	integer = TRUE
 	min_val = 0
 
 /datum/config_entry/number/crewset_min_pop
-	config_entry_value = CREWSET_MIN_POP
+	default = CREWSET_MIN_POP
 	integer = TRUE
 	min_val = 0
 
 /datum/config_entry/number/ghostset_min_pop
-	config_entry_value = GHOSTSET_MIN_POP
+	default = GHOSTSET_MIN_POP
 	integer = TRUE
 	min_val = 0
 
 // Point Thresholds
 /datum/config_entry/number/mundane_point_threshold
-	config_entry_value = MUNDANE_POINT_THRESHOLD
+	default = MUNDANE_POINT_THRESHOLD
 	integer = TRUE
 	min_val = 0
 
 /datum/config_entry/number/moderate_point_threshold
-	config_entry_value = MODERATE_POINT_THRESHOLD
+	default = MODERATE_POINT_THRESHOLD
 	integer = TRUE
 	min_val = 0
 
 /datum/config_entry/number/major_point_threshold
-	config_entry_value = MAJOR_POINT_THRESHOLD
+	default = MAJOR_POINT_THRESHOLD
 	integer = TRUE
 	min_val = 0
 
 /datum/config_entry/number/crewset_point_threshold
-	config_entry_value = CREWSET_POINT_THRESHOLD
+	default = CREWSET_POINT_THRESHOLD
 	integer = TRUE
 	min_val = 0
 
 /datum/config_entry/number/ghostset_point_threshold
-	config_entry_value = GHOSTSET_POINT_THRESHOLD
+	default = GHOSTSET_POINT_THRESHOLD
 	integer = TRUE
 	min_val = 0
 
@@ -98,52 +98,52 @@
 
 // Pop scalling thresholds
 /datum/config_entry/number/mundane_pop_scale_threshold
-	config_entry_value = MUNDANE_POP_SCALE_THRESHOLD
+	default = MUNDANE_POP_SCALE_THRESHOLD
 	integer = TRUE
 	min_val = 0
 
 /datum/config_entry/number/moderate_pop_scale_threshold
-	config_entry_value = MODERATE_POP_SCALE_THRESHOLD
+	default = MODERATE_POP_SCALE_THRESHOLD
 	integer = TRUE
 	min_val = 0
 
 /datum/config_entry/number/major_pop_scale_threshold
-	config_entry_value = MAJOR_POP_SCALE_THRESHOLD
+	default = MAJOR_POP_SCALE_THRESHOLD
 	integer = TRUE
 	min_val = 0
 
 /datum/config_entry/number/crewset_pop_scale_threshold
-	config_entry_value = CREWSET_POP_SCALE_THRESHOLD
+	default = CREWSET_POP_SCALE_THRESHOLD
 	integer = TRUE
 	min_val = 0
 
 /datum/config_entry/number/ghostset_pop_scale_threshold
-	config_entry_value = GHOSTSET_POP_SCALE_THRESHOLD
+	default = GHOSTSET_POP_SCALE_THRESHOLD
 	integer = TRUE
 	min_val = 0
 
 // Pop scalling penalties
 /datum/config_entry/number/mundane_pop_scale_penalty
-	config_entry_value = MUNDANE_POP_SCALE_PENALTY
+	default = MUNDANE_POP_SCALE_PENALTY
 	integer = TRUE
 	min_val = 0
 
 /datum/config_entry/number/moderate_pop_scale_penalty
-	config_entry_value = MODERATE_POP_SCALE_PENALTY
+	default = MODERATE_POP_SCALE_PENALTY
 	integer = TRUE
 	min_val = 0
 
 /datum/config_entry/number/major_pop_scale_penalty
-	config_entry_value = MAJOR_POP_SCALE_PENALTY
+	default = MAJOR_POP_SCALE_PENALTY
 	integer = TRUE
 	min_val = 0
 
 /datum/config_entry/number/crewset_pop_scale_penalty
-	config_entry_value = CREWSET_POP_SCALE_PENALTY
+	default = CREWSET_POP_SCALE_PENALTY
 	integer = TRUE
 	min_val = 0
 
 /datum/config_entry/number/ghostset_pop_scale_penalty
-	config_entry_value = GHOSTSET_POP_SCALE_PENALTY
+	default = GHOSTSET_POP_SCALE_PENALTY
 	integer = TRUE
 	min_val = 0


### PR DESCRIPTION
I guess the latest upstream nuked the configs from the repo and the default code values never worked. So storyteller just went uncapped and wild on downstreams. 

We have the configs still on the server itself, so it didn't effect us. Storyteller did not break or change.

## Changelog

:cl:
config: Storyteller default configs now exist and should work again
/:cl:
