### PR TITLE
Fix incorrect pixel shift behavior for mobs with nonzero base pixel x/y

### DIFF
--- a/modular_skyrat/modules/pixel_shift/code/pixel_shift_component.dm
+++ b/modular_skyrat/modules/pixel_shift/code/pixel_shift_component.dm
@@ -137,22 +137,22 @@
 		if(SHIFTING_PARENT)
 			switch(direct)
 				if(NORTH)
-					if(shift_y <= maximum_pixel_shift + owner.base_pixel_y)
+					if(shift_y <= maximum_pixel_shift)
 						shift_y++
 						owner.add_offsets(type, y_add = shift_y)
 						is_shifted = TRUE
 				if(EAST)
-					if(shift_x <= maximum_pixel_shift + owner.base_pixel_x)
+					if(shift_x <= maximum_pixel_shift)
 						shift_x++
 						owner.add_offsets(type, x_add = shift_x)
 						is_shifted = TRUE
 				if(SOUTH)
-					if(shift_y >= -maximum_pixel_shift + owner.base_pixel_y)
+					if(shift_y >= -maximum_pixel_shift)
 						shift_y--
 						owner.add_offsets(type, y_add = shift_y)
 						is_shifted = TRUE
 				if(WEST)
-					if(shift_x >= -maximum_pixel_shift + owner.base_pixel_x)
+					if(shift_x >= -maximum_pixel_shift)
 						shift_x--
 						owner.add_offsets(type, x_add = shift_x)
 						is_shifted = TRUE


### PR DESCRIPTION
## About The Pull Request

When I was reworking the pixel shift component to accommodate upstream changes to mob pixel offset behavior I changed it to track offset in the component instead of reading pixel x/y directly, but forgot to remove the calculations that take the base pixel x/y into account, which would no longer be needed

## Why It's Good For The Game

Fixes #3341 

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/2c12155f-2c8f-4867-ab48-f687b191a71e)

</details>

## Changelog

:cl:
fix: fixed larger sprite size mobs being unable to pixel shift properly
/:cl:

