### PR TITLE
Mr. President, a third romerol PR has hit the hub (Makes romerol nukie only, adds Changeling Zombie virus to traitor uplink)

### DIFF
--- a/modular_zubbers/code/modules/uplink/uplink_items/dangerous.dm
+++ b/modular_zubbers/code/modules/uplink/uplink_items/dangerous.dm
@@ -1,0 +1,15 @@
+/datum/uplink_item/dangerous/changelingzombie
+	name = "Changeling Zombie Virus Vial"
+	desc = "Stolen from a Nanotrasen research facility, this experimental vial infects people with the changeling zombie virus on contact. \
+	Our legal team says that this doesn't give you any sort of superpowers and should only be used on living beings other than yourself."
+
+	progression_minimum = 30 MINUTES
+	population_minimum = TRAITOR_POPULATION_LOWPOP
+
+	item = /obj/item/reagent_containers/cup/glass/changeling_zombie_virus
+
+	cost = 15
+
+	purchasable_from = UPLINK_TRAITORS | UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS //Spies and loneops excluded.
+	uplink_item_flags = SYNDIE_TRIPS_CONTRABAND //Technically this is NT research, so it isn't syndicate tech.
+

--- a/modular_zubbers/code/modules/uplink/uplink_items/nukeops.dm
+++ b/modular_zubbers/code/modules/uplink/uplink_items/nukeops.dm
@@ -1,0 +1,2 @@
+/datum/uplink_item/stealthy_weapons/romerol_kit
+	purchasable_from = UPLINK_CLOWN_OPS | UPLINK_NUKE_OPS //Team operatives only

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9489,6 +9489,8 @@
 #include "modular_zubbers\code\modules\title_screen\code\title_screen_subsystem.dm"
 #include "modular_zubbers\code\modules\tojo_outfits\tojos_outfits.dm"
 #include "modular_zubbers\code\modules\uplink\uplink_items\badass.dm"
+#include "modular_zubbers\code\modules\uplink\uplink_items\dangerous.dm"
+#include "modular_zubbers\code\modules\uplink\uplink_items\nukeops.dm"
 #include "modular_zubbers\code\modules\vehicles\mech_fabricator.dm"
 #include "modular_zubbers\code\modules\vending\armadyne.dm"
 #include "modular_zubbers\code\modules\vending\clothmate.dm"


### PR DESCRIPTION

## About The Pull Request

- Romerol can only be purchased by nukies, including clown ops.
- A Changeling Zombie vial can be purchased by traitors, nukies, and clown ops for 15TC.

## Why It's Good For The Game

Romerol is super hard to cure and quite infectious. Changeling Zombies were coded a bit back to be a softer alternative to that. Instead of removing romerol outright, the Changeling Zombie virus was added to select uplinks.

The 15TC price is subject to change based on feedback. I have no idea what an appropriate price is since I've been told that Changeling Zombies are mid in terms of chaos by some people, and been told it's worse than romerol by others.

## Proof Of Testing

Untested.

## Changelog

:cl: BurgerBB
add: A Changeling Zombie vial can be purchased by traitors, nukies, and clown ops for 15TC.
del: Romerol can only be purchased by nukies, including clown ops.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
