### PR TITLE
Exploitables no longer runtime on examine and don't expose antags.

### DIFF
--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -329,7 +329,7 @@
 		. += flavor_text_link
 
 	//BUBBER EDIT ADDITION BEGIN - EXAMINE RECORDS
-	if (isobserver(usr) || mind.can_see_exploitables || mind.has_exploitables_override)
+	if (isobserver(user) || user.mind.can_see_exploitables || user.mind.has_exploitables_override)
 		var/perpname = get_face_name(get_id_name(""))
 		var/datum/record/locked/target_records = find_record(perpname, TRUE) //apparantly golden is okay with offstation roles having no records, FYI
 		var/exploitable_text = target_records?.exploitable_information


### PR DESCRIPTION

## About The Pull Request

Seems the logic here was reading variables from the person being examined.. not the person examining.

Yes this meant that souless mobs would runtime, and anyone could meta an antag because antags would show the option to view exploitables when others would not.
## Why It's Good For The Game

Holy shit how did I miss this in a review
## Proof Of Testing
I tested it, no runtimes related to examination
![image](https://github.com/user-attachments/assets/95481d2d-d115-4e04-88c5-75429f31d7d9)

## Changelog
:cl:
fix: Exploitables no longer show up when you examine an antag, exposing them
fix: Exploitables now check the variables of the correct mob
/:cl:
