### PR TITLE
Adjusts Default Andy's chaotic tag multiplier to 0.7

### DIFF
--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_3_default.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_3_default.dm
@@ -5,3 +5,7 @@
 	welcome_text = "If I chopped you up in a meat grinder..."
 	antag_divisor = 8
 	storyteller_type = STORYTELLER_TYPE_ALWAYS_AVAILABLE
+
+	tag_multipliers = list(
+		TAG_CHAOTIC = 0.7
+	)


### PR DESCRIPTION
## About The Pull Request
Default Andy seems to be a little bit high on the high-impact events towards the end of the round, so I want to try temporarily setting TAG_CHAOTIC to 0.8 rather than 1.0, which should have a noticeable impact on them on this storyteller.

## Why It's Good For The Game
This should reduce the weight of chaotic rulesets by about 20%, I'm curious to see what effect this will have on default Andy shifts. Right now, all the low-impact storytellers are at 0.1, whereas the Default is at 1.0, and the Gamer is at 1.3. There isn't much of a midpoint, Default Andy feels a lot stronger than the low impact rulesets.

This is good for the game because it makes Default Andy feel closer to a midpoint between low and high impact shifts with regards to round-ending events, rather than the 3/4 it currently is.

## Proof Of Testing
Can't compile on 516, but it should work

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl: ReturnToZender
bal: Better positions Default Andy between low and high impact storytellers on events marked as chaotic
/:cl:

