### PR TITLE
Revert storyteller tags from lone operative

### DIFF
--- a/modular_zubbers/code/modules/storyteller/event_defines/moderate/moderate_overrides.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/moderate/moderate_overrides.dm
@@ -57,4 +57,3 @@
 
 /datum/round_event_control/operative
 	track = EVENT_TRACK_MODERATE
-	tags = list(TAG_COMBAT, TAG_CHAOTIC, TAG_CREW_ANTAG)


### PR DESCRIPTION
## About The Pull Request

Reverts a change I did adding storyteller tags to lone operative in https://github.com/Bubberstation/Bubberstation/pull/2061. The correct fix for it was instead https://github.com/Bubberstation/Bubberstation/pull/3012 and having the tags just screws with the weight set by the disk proc.