### PR TITLE
Adds the fish infusion chat bubble to the akula tongue

### DIFF
--- a/modular_zubbers/code/modules/mob/living/carbon/human/species/akula.dm
+++ b/modular_zubbers/code/modules/mob/living/carbon/human/species/akula.dm
@@ -1,2 +1,6 @@
 /obj/item/organ/tongue/akula
 	say_mod = "bubbles"
+
+/obj/item/organ/tongue/akula/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/bubble_icon_override, "fish", BUBBLE_ICON_PRIORITY_ORGAN)


### PR DESCRIPTION

## About The Pull Request
Does as the title says.


https://github.com/user-attachments/assets/43dbe941-d8f1-4b9d-a845-4a152076a5e3
## Why It's Good For The Game
It's funny and adds a bit more soul to the akula tongue.
## Proof Of Testing

It compiled and ran, see the above video for proof.

## Changelog
:cl:
add: akula tongues now have the fish chat bubble effect tied to them
/:cl:
