### PR TITLE
Nerfs the backup hailer

### DIFF
--- a/modular_zubbers/code/game/Items/sec_hailer.dm
+++ b/modular_zubbers/code/game/Items/sec_hailer.dm
@@ -40,7 +40,7 @@
 		emped = TRUE
 		addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/item/clothing/mask/gas/sechailer, emp_reset)), 3 MINUTES)
 
-/// Reset EMP after 2 minutes
+/// Reset EMP after 3 minutes
 /obj/item/clothing/mask/gas/sechailer/proc/emp_reset()
 	SIGNAL_HANDLER
 	emped = FALSE


### PR DESCRIPTION
## About The Pull Request

- Bumps the EMP non-functionality to 3 minutes.
- You're unable to use it if muted. (This was an oversite)
- Adds a 2 second delay.


## Why It's Good For The Game

The purpose of it was to incentivise people to use this when engaging with mechanics or calling for backup. But it's too instant. So hopefully some downsides would help it be less stacked up against antags.

## Proof Of Testing

![dreamseeker_Q3JfeQq4RT](https://github.com/user-attachments/assets/3d94959b-2dd7-43ad-b841-f6925518eca7)

## Changelog
:cl:
balance: The sec hailer now has a 2 second delay. Bumped its EMP nonfunctionality to 3 minutes. You now can't use it while muted.
/:cl: