### PR TITLE
Adds Captain-Cast (and more features and fixes) to Box Station

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -12,8 +12,9 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/item/radio/intercom/directional/north,
 /obj/machinery/vending/boozeomat,
+/obj/item/radio/intercom/directional/east,
+/obj/structure/fish_mount/bar/directional/north,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "aac" = (
@@ -2542,6 +2543,10 @@
 /obj/machinery/door/airlock/external{
 	name = "External Access"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aqK" = (
@@ -4372,6 +4377,10 @@
 	space_dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -6553,7 +6562,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
 	},
-/turf/open/floor/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
 "aGy" = (
 /obj/structure/disposalpipe/segment{
@@ -6999,8 +7011,13 @@
 /turf/open/floor/wood/tile,
 /area/station/service/lawoffice)
 "aHV" = (
-/turf/closed/wall,
-/area/station/hallway/primary/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/captain)
 "aHY" = (
 /obj/effect/turf_decal/trimline/white/line,
 /turf/open/floor/wood,
@@ -12561,7 +12578,10 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
 "bbp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
@@ -12814,7 +12834,10 @@
 /area/station/commons/fitness/recreation/entertainment)
 "bch" = (
 /obj/machinery/vending/cigarette,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
 "bci" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12860,8 +12883,17 @@
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/captain)
 "bcn" = (
-/obj/structure/displaycase/captain,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/item/storage/photo_album{
+	pixel_y = -3
+	},
+/obj/structure/table/wood,
+/obj/item/camera{
+	pixel_y = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
 "bcp" = (
 /obj/structure/sign/directions/security{
@@ -13110,8 +13142,13 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "bdi" = (
-/obj/effect/spawner/random/entertainment/arcade,
-/turf/open/floor/wood,
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
 "bdj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -13387,7 +13424,11 @@
 /area/station/ai_monitored/turret_protected/ai_upload)
 "bei" = (
 /obj/machinery/light/directional/west,
-/turf/open/floor/wood,
+/obj/structure/filingcabinet,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
 "bej" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -13422,12 +13463,23 @@
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/captain)
 "ben" = (
-/obj/structure/table/wood,
 /obj/machinery/camera/directional/east{
 	c_tag = "Captain's Office"
 	},
-/obj/item/storage/lockbox/medal,
-/turf/open/floor/wood,
+/obj/item/storage/lockbox/medal{
+	pixel_y = 9
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/item/pinpointer/nuke{
+	pixel_y = -9
+	},
+/obj/item/disk/nuclear{
+	pixel_y = -9
+	},
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
 "bep" = (
 /obj/structure/disposalpipe/segment,
@@ -13821,12 +13873,13 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "bfE" = (
-/obj/structure/table/wood,
-/obj/item/pinpointer/nuke,
-/obj/item/disk/nuclear,
 /obj/structure/secure_safe/directional/east,
 /obj/machinery/light/directional/east,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
 "bfF" = (
 /turf/closed/wall,
@@ -14180,13 +14233,11 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "bgX" = (
-/obj/structure/table/wood,
-/obj/item/camera,
-/obj/item/storage/photo_album{
-	pixel_y = -10
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/wood,
+/obj/structure/sign/poster/greenscreen/directional/east,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
 "bhb" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -25662,13 +25713,14 @@
 	name = "External Access"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "bWU" = (
 /obj/machinery/light/directional/east,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix to Engine"
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -25826,6 +25878,10 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "External Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
@@ -27073,6 +27129,8 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating/airless,
 /area/station/maintenance/aft)
 "ccA" = (
@@ -31039,6 +31097,10 @@
 /obj/machinery/door/airlock/external{
 	name = "External Access"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "cyK" = (
@@ -31811,12 +31873,12 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
-"cCD" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "cCE" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix to Engine"
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cCF" = (
@@ -33227,6 +33289,9 @@
 	},
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating/airless,
 /area/station/maintenance/starboard/aft)
 "cPI" = (
@@ -33235,6 +33300,9 @@
 	},
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating/airless,
 /area/station/maintenance/starboard/aft)
 "cPX" = (
@@ -33824,6 +33892,7 @@
 	cycle_id = "lower-airlock-bend"
 	},
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/plating/airless,
 /area/station/maintenance/starboard/aft)
 "deg" = (
@@ -36819,6 +36888,8 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "fbW" = (
@@ -39452,6 +39523,10 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "gLJ" = (
@@ -39886,9 +39961,11 @@
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "hec" = (
-/obj/structure/bed/dogbed/renault,
-/mob/living/basic/pet/fox/renault,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/displaycase/captain,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
 "heL" = (
 /obj/machinery/power/tracker,
@@ -48007,6 +48084,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "lWC" = (
@@ -49208,8 +49286,13 @@
 /turf/open/floor/carpet/blue,
 /area/station/medical/psychology)
 "mNP" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/bed/dogbed/renault,
+/mob/living/basic/pet/fox/renault,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
 "mOf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -51473,6 +51556,10 @@
 "ooW" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "opE" = (
@@ -54752,9 +54839,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "qti" = (
-/obj/effect/turf_decal/bot_blue,
-/turf/closed/wall/r_wall,
-/area/station/security/office)
+/obj/machinery/greenscreen_camera{
+	dir = 4;
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/captain)
 "qtJ" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4
@@ -55838,7 +55929,10 @@
 /area/station/science/genetics)
 "raa" = (
 /obj/machinery/vending/boozeomat,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
 "rai" = (
 /obj/machinery/door/airlock/multi_tile/public/glass{
@@ -57174,8 +57268,11 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit)
 "rQo" = (
-/turf/closed/wall/r_wall,
-/area/station/security/evidence)
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/captain)
 "rQD" = (
 /obj/machinery/light/dim/directional/north,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -57433,6 +57530,10 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "rZR" = (
@@ -61708,6 +61809,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/plating/airless,
 /area/station/maintenance/starboard/aft)
 "uNf" = (
@@ -62404,6 +62506,10 @@
 	pixel_x = 7;
 	pixel_y = -2
 	},
+/obj/item/flesh_shears{
+	pixel_y = 6;
+	pixel_x = 9
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/science/genetics)
 "viy" = (
@@ -62774,6 +62880,10 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "vtB" = (
@@ -92863,7 +92973,7 @@ afA
 qzU
 mCx
 tet
-rQo
+apb
 apb
 apb
 adG
@@ -94931,7 +95041,7 @@ aWG
 agj
 agj
 agj
-aHV
+iSr
 owz
 xcU
 wYB
@@ -95959,7 +96069,7 @@ yls
 agj
 agj
 agj
-aHV
+iSr
 aFg
 uJd
 avt
@@ -98307,7 +98417,7 @@ aYD
 aZX
 baf
 aGv
-aGv
+aHV
 bek
 bfB
 bbw
@@ -98525,9 +98635,9 @@ czy
 xqA
 svw
 yls
-agj
-agj
-agj
+aiX
+aiX
+aiX
 aiX
 rzp
 aBS
@@ -98564,7 +98674,7 @@ aYq
 aZV
 aZG
 bbw
-bbw
+rQo
 roW
 bfA
 bbw
@@ -99043,9 +99153,9 @@ ooJ
 xXm
 lIZ
 aiX
-ajo
+wHs
 oeg
-ajo
+wHs
 vvD
 dFo
 dFo
@@ -99275,7 +99385,7 @@ adR
 adR
 adR
 adR
-qti
+adR
 xjQ
 jaY
 iVu
@@ -99532,7 +99642,7 @@ xzh
 xzh
 sUX
 cgh
-qti
+adR
 sni
 gzK
 imo
@@ -99595,7 +99705,7 @@ bbw
 bbw
 bbw
 bbw
-bbw
+qti
 bbw
 bjH
 yfk
@@ -101941,7 +102051,7 @@ idR
 bTU
 bRF
 bzq
-cCD
+bXU
 wHy
 bRF
 bRF

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -13479,6 +13479,7 @@
 /obj/item/disk/nuclear{
 	pixel_y = -9
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
 "bep" = (
@@ -14982,6 +14983,8 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/structure/bed/dogbed/renault,
+/mob/living/basic/pet/fox/renault,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "bjI" = (
@@ -39874,6 +39877,7 @@
 	},
 /obj/item/storage/medkit/regular,
 /obj/machinery/camera/directional/north,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "gZS" = (
@@ -49289,9 +49293,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/structure/bed/dogbed/renault,
-/mob/living/basic/pet/fox/renault,
-/obj/machinery/airalarm/directional/east,
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
 "mOf" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -12364,6 +12364,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/sign/painting/library{
+	pixel_x = -32
+	},
 /turf/open/floor/wood,
 /area/station/service/library)
 "bax" = (
@@ -67112,12 +67115,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
-"xWr" = (
-/obj/structure/sign/painting/library{
-	pixel_x = -32
-	},
-/turf/closed/wall,
-/area/station/maintenance/starboard/fore)
 "xWD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/melee/baton/security/cattleprod,
@@ -110446,7 +110443,7 @@ xuF
 ffa
 ffa
 alP
-xWr
+alP
 bav
 aLf
 aPb

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -15417,6 +15417,7 @@
 	c_tag = "Medbay Lobby";
 	network = list("ss13","medbay")
 	},
+/obj/structure/sign/warning/no_smoking/circle/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "blo" = (
@@ -48664,17 +48665,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/explab)
-"msc" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/sign/warning/no_smoking/circle/directional/east,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "msK" = (
 /obj/machinery/camera{
 	c_tag = "Prison - Garden";
@@ -105085,7 +105075,7 @@ sjV
 bmR
 pkL
 bES
-msc
+uGy
 pnW
 jsH
 odp

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -1599,7 +1599,6 @@
 /area/station/maintenance/port/fore)
 "alV" = (
 /obj/effect/spawner/random/burgerstation/table,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "alW" = (
@@ -1679,6 +1678,7 @@
 "amx" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/wood,
 /area/station/maintenance/port/fore)
 "amy" = (
@@ -1890,7 +1890,6 @@
 "ann" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance/three,
-/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/wood,
 /area/station/maintenance/port/fore)
 "ano" = (
@@ -3031,6 +3030,7 @@
 	dir = 6
 	},
 /obj/structure/cable,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "asS" = (
@@ -3592,6 +3592,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron/white,
 /area/station/maintenance/port/fore)
 "avc" = (
@@ -5593,7 +5594,9 @@
 	},
 /area/station/service/hydroponics)
 "aCu" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/table,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "aCv" = (
@@ -7011,13 +7014,10 @@
 /turf/open/floor/wood/tile,
 /area/station/service/lawoffice)
 "aHV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/captain)
+/obj/structure/closet/emcloset,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "aHY" = (
 /obj/effect/turf_decal/trimline/white/line,
 /turf/open/floor/wood,
@@ -9672,6 +9672,7 @@
 "aRN" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
 "aRO" = (
@@ -10831,7 +10832,6 @@
 "aVZ" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron/dark/side,
 /area/station/security/checkpoint/escape)
 "aWa" = (
@@ -18877,7 +18877,6 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/dark_blue,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron/white,
 /area/station/maintenance/port/fore)
 "bvP" = (
@@ -19286,10 +19285,13 @@
 	},
 /area/station/science/research)
 "bxg" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/machinery/greenscreen_camera{
+	dir = 4;
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/captain)
 "bxi" = (
 /obj/structure/sign/poster/official/random/directional/north,
 /obj/structure/disposalpipe/trunk{
@@ -19730,6 +19732,7 @@
 	id = "serverroomrd"
 	},
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "bzA" = (
@@ -19998,7 +20001,6 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "bAD" = (
@@ -22964,6 +22966,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "bKM" = (
@@ -24977,6 +24980,7 @@
 /area/station/engineering/atmos/hfr_room)
 "bTS" = (
 /obj/item/kirbyplants/random/dead,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "bTU" = (
@@ -26040,6 +26044,7 @@
 /area/station/engineering/atmos)
 "bXZ" = (
 /obj/effect/spawner/random/structure/crate,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "bYa" = (
@@ -26481,6 +26486,7 @@
 "bZO" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/spawner/random/trash/moisture_trap,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "bZQ" = (
@@ -26619,6 +26625,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "cay" = (
@@ -26897,7 +26904,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "cby" = (
@@ -27849,6 +27855,7 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/box,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/maintenance/disposal/incinerator)
 "cgg" = (
@@ -28073,7 +28080,6 @@
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "chz" = (
@@ -32354,6 +32360,7 @@
 /obj/structure/table,
 /obj/item/modular_computer/laptop/preset/civilian,
 /obj/item/clothing/suit/costume/wellworn_shirt/messy/graphic/gamer,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron/dark/small,
 /area/station/cargo/bitrunning/den)
 "cFu" = (
@@ -33799,7 +33806,6 @@
 "cZZ" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/bot_blue,
-/obj/item/clothing/neck/pauldron,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "daa" = (
@@ -34187,7 +34193,6 @@
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/bot_blue,
 /obj/machinery/light/directional/east,
-/obj/item/clothing/neck/pauldron,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "dlW" = (
@@ -34963,6 +34968,7 @@
 "dOo" = (
 /obj/structure/trash_pile,
 /obj/item/trash/energybar,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "dOq" = (
@@ -39191,6 +39197,7 @@
 /obj/item/kirbyplants/random,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
 "gAS" = (
@@ -40544,6 +40551,7 @@
 "hvD" = (
 /obj/structure/closet/secure_closet/courtroom,
 /obj/item/gavelhammer,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "hvJ" = (
@@ -41225,6 +41233,7 @@
 /area/station/commons/fitness/recreation/entertainment)
 "hRF" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "hSa" = (
@@ -42799,6 +42808,7 @@
 "iMV" = (
 /obj/structure/table/reinforced,
 /obj/item/surgery_tray/full/morgue,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "iNi" = (
@@ -43365,7 +43375,6 @@
 "jeI" = (
 /obj/effect/spawner/random/entertainment/drugs,
 /obj/effect/spawner/random/burgerstation/loot/with_maintenance_loot,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "jeQ" = (
@@ -43950,7 +43959,6 @@
 "jsP" = (
 /obj/structure/table/optable,
 /obj/item/paper/guides/jobs/medical/morgue,
-/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "jsT" = (
@@ -44176,13 +44184,11 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "jAi" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/captain)
 "jAv" = (
 /obj/machinery/space_heater,
 /obj/structure/sign/poster/official/random/directional/east,
@@ -45340,7 +45346,6 @@
 /obj/structure/chair/office/light{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron/dark/small,
 /area/station/cargo/bitrunning/den)
 "kkc" = (
@@ -45914,10 +45919,10 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/command/nuke_storage)
 "kAH" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/cobweb,
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
+/area/station/maintenance/aft)
 "kAJ" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/spawner/structure/window/reinforced,
@@ -46089,10 +46094,6 @@
 /obj/structure/weightmachine,
 /turf/open/floor/iron/dark/side,
 /area/station/security/prison)
-"kFm" = (
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
 "kFx" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -46477,7 +46478,6 @@
 /obj/structure/table/wood,
 /obj/machinery/light/directional/east,
 /obj/item/flashlight/lamp,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
 "kRc" = (
@@ -46946,7 +46946,6 @@
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/bot_blue,
 /obj/item/radio/intercom/directional/east,
-/obj/item/clothing/neck/pauldron,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "lnk" = (
@@ -48490,6 +48489,7 @@
 /obj/structure/bodycontainer/morgue/beeper_off{
 	dir = 2
 	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "mlh" = (
@@ -50676,10 +50676,10 @@
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "nLO" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/burgerstation/loot/with_maintenance_loot,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/area/station/maintenance/aft)
 "nLS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -53173,7 +53173,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "pqP" = (
@@ -54839,13 +54838,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "qti" = (
-/obj/machinery/greenscreen_camera{
-	dir = 4;
-	pixel_x = -4;
-	pixel_y = 6
-	},
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/captain)
+/obj/structure/trash_pile,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "qtJ" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4
@@ -55143,7 +55139,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
 "qFo" = (
@@ -57268,6 +57263,8 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit)
 "rQo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
@@ -58541,6 +58538,7 @@
 /obj/item/pen/fourcolor{
 	pixel_y = 6
 	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
 "sHn" = (
@@ -58595,7 +58593,6 @@
 	name = "Secure Storage";
 	req_access = list("morgue_secure")
 	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "sIZ" = (
@@ -59336,7 +59333,6 @@
 /area/station/security/prison)
 "tgp" = (
 /obj/machinery/atmospherics/components/binary/pump,
-/obj/effect/decal/cleanable/cobweb,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
@@ -62606,20 +62602,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen,
 /area/station/security/prison)
-"vlw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
 "vlB" = (
 /obj/structure/chair{
 	dir = 8
@@ -63430,7 +63412,6 @@
 "vHb" = (
 /obj/effect/turf_decal/bot_blue,
 /obj/structure/closet/secure_closet/security/sec,
-/obj/item/clothing/neck/pauldron,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "vHB" = (
@@ -64511,6 +64492,7 @@
 	c_tag = "Xenobiology Cell 3";
 	network = list("ss13","xeno")
 	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "wuE" = (
@@ -65132,7 +65114,6 @@
 /area/station/maintenance/starboard/aft)
 "wOS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
 /turf/closed/wall,
 /area/station/maintenance/aft)
 "wPd" = (
@@ -65649,11 +65630,6 @@
 /obj/effect/landmark/start/customs_agent,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/supply)
-"xec" = (
-/obj/machinery/light/small/directional/east,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "xey" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -65682,7 +65658,6 @@
 	},
 /obj/effect/turf_decal/bot_blue,
 /obj/structure/closet/secure_closet/security/sec,
-/obj/item/clothing/neck/pauldron,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "xeQ" = (
@@ -67405,7 +67380,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
-/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "yeI" = (
@@ -88944,7 +88918,7 @@ fdJ
 jra
 qhp
 dOo
-nLO
+vLX
 luh
 bCq
 fLp
@@ -98417,7 +98391,7 @@ aYD
 aZX
 baf
 aGv
-aHV
+rQo
 bek
 bfB
 bbw
@@ -98674,7 +98648,7 @@ aYq
 aZV
 aZG
 bbw
-rQo
+jAi
 roW
 bfA
 bbw
@@ -99705,7 +99679,7 @@ bbw
 bbw
 bbw
 bbw
-qti
+bxg
 bbw
 bjH
 yfk
@@ -105125,7 +105099,7 @@ lCT
 bIn
 bzs
 bKL
-jAi
+nEs
 nEs
 nEs
 nEs
@@ -105138,7 +105112,7 @@ bzs
 bAw
 bzs
 bXZ
-kFm
+bAw
 sUi
 bzs
 mll
@@ -106424,9 +106398,9 @@ bRa
 bRa
 bRa
 bZO
-vlw
+hxs
 bzs
-ccG
+nLO
 alV
 vmy
 bRa
@@ -108736,7 +108710,7 @@ bNk
 gIB
 bbE
 bRa
-bIx
+aHV
 yeE
 nEs
 ccN
@@ -109742,8 +109716,8 @@ bto
 buL
 bvB
 bzs
-bZN
-bxg
+kAH
+bBR
 bRa
 bRa
 bRa
@@ -113109,7 +113083,7 @@ fOT
 kDh
 bJN
 wuD
-xec
+fOT
 kDh
 bJN
 rqY
@@ -116970,8 +116944,8 @@ iRQ
 mtK
 jVl
 ciL
-bFZ
 oOj
+bFZ
 clw
 cNW
 xzh
@@ -118489,8 +118463,8 @@ bHu
 bIV
 ktt
 mtK
-wZQ
-aCu
+qti
+cOe
 cOe
 cOe
 cOe
@@ -118505,8 +118479,8 @@ cOe
 cad
 cbi
 cNW
-ccV
-kAH
+aCu
+cdV
 cOe
 cNW
 cgy


### PR DESCRIPTION
## About The Pull Request

This PR brings mapping additions from upstream to box station. New features include: the Captain-Cast in the captain's office, feature sheers in genetics, and wall fish display in the bar. Some fixes are: More reinforced iron walls to match IceBox's cells, misplaced floor decals in the firing range, redsec pauldrons in security lockers removed (Since they can be found in the secdrobe vendor anyways) hanging cobwebs from after Wallening. 

This also re-adds maints access to airlocks that exit to space. Turns out scared mice in maints run into space if they wanted to.

This also adds a pipe in Atmos that fully connects a mix pipe to the SM, if someone wanted to do that. Don't know how I never spotted this. Someone else did.

## Why It's Good For The Game

New features are good, which is why we should stick with being updated with upstream.

## Proof Of Testing

Works on local with no errors on testing. And every new feature worked on my end. Trust.

![Screenshot_7](https://github.com/user-attachments/assets/39b91bb8-4b49-4f26-ab96-8711d1f276c2)


## Changelog

:cl:
map: Box Station now has the Captain's cast and green screen.
map: Fixed the Mix to SM pipe in Box Station's Atmos never being connected.
map: On Box Station, a few more walls in the brig are now reinforced walls.
/:cl:

