### PR TITLE
[MODULAR] Puts the Sol/Carwo/Romulus/Szot/Trappiste gun magazine sizes in line with /tg/ standards (tiny for everything but rifles which are normal)

### DIFF
--- a/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/magazines.dm
+++ b/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/carwo_defense_systems/magazines.dm
@@ -3,14 +3,9 @@
 /obj/item/ammo_box/magazine/c35sol_pistol
 	name = "\improper Sol pistol magazine"
 	desc = "A standard size magazine for TerraGov pistols, holds twelve rounds."
-
 	icon = 'modular_skyrat/modules/modular_weapons/icons/obj/company_and_or_faction_based/carwo_defense_systems/ammo.dmi'
 	icon_state = "pistol_35_standard"
-
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
-
-	w_class = WEIGHT_CLASS_TINY
-
 	ammo_type = /obj/item/ammo_casing/c35sol
 	caliber = CALIBER_SOL35SHORT
 	max_ammo = 12
@@ -21,11 +16,7 @@
 /obj/item/ammo_box/magazine/c35sol_pistol/stendo
 	name = "\improper Sol extended pistol magazine"
 	desc = "An extended magazine for TerraGov pistols, holds twenty-four rounds."
-
 	icon_state = "pistol_35_stended"
-
-	w_class = WEIGHT_CLASS_NORMAL
-
 	max_ammo = 24
 
 /obj/item/ammo_box/magazine/c35sol_pistol/stendo/starts_empty
@@ -36,30 +27,21 @@
 /obj/item/ammo_box/magazine/c40sol_rifle
 	name = "\improper Sol rifle short magazine"
 	desc = "A shortened magazine for TerraGov rifles, holds fifteen rounds."
-
 	icon = 'modular_skyrat/modules/modular_weapons/icons/obj/company_and_or_faction_based/carwo_defense_systems/ammo.dmi'
 	icon_state = "rifle_short"
-
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
-
-	w_class = WEIGHT_CLASS_TINY
-
 	ammo_type = /obj/item/ammo_casing/c40sol
 	caliber = CALIBER_SOL40LONG
 	max_ammo = 15
 
 /obj/item/ammo_box/magazine/c40sol_rifle/starts_empty
-
 	start_empty = TRUE
 
 /obj/item/ammo_box/magazine/c40sol_rifle/standard
 	name = "\improper Sol rifle magazine"
 	desc = "A standard size magazine for TerraGov rifles, holds thirty rounds."
-
 	icon_state = "rifle_standard"
-
 	w_class = WEIGHT_CLASS_NORMAL
-
 	max_ammo = 30
 
 /obj/item/ammo_box/magazine/c40sol_rifle/standard/starts_empty
@@ -69,11 +51,8 @@
 /obj/item/ammo_box/magazine/c40sol_rifle/drum
 	name = "\improper Sol rifle drum magazine"
 	desc = "A massive drum magazine for TerraGov rifles, holds sixty rounds."
-
 	icon_state = "rifle_drum"
-
-	w_class = WEIGHT_CLASS_BULKY
-
+	w_class = WEIGHT_CLASS_NORMAL
 	max_ammo = 60
 
 /obj/item/ammo_box/magazine/c40sol_rifle/drum/starts_empty
@@ -84,14 +63,10 @@
 /obj/item/ammo_box/magazine/c980_grenade
 	name = "\improper Kiboko grenade box"
 	desc = "A standard size box for .980 grenades, holds four shells."
-
 	icon = 'modular_skyrat/modules/modular_weapons/icons/obj/company_and_or_faction_based/carwo_defense_systems/ammo.dmi'
 	icon_state = "granata_standard"
-
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
-
-	w_class = WEIGHT_CLASS_SMALL
-
+	w_class = WEIGHT_CLASS_NORMAL
 	ammo_type = /obj/item/ammo_casing/c980grenade
 	caliber = CALIBER_980TYDHOUER
 	max_ammo = 4
@@ -102,11 +77,8 @@
 /obj/item/ammo_box/magazine/c980_grenade/drum
 	name = "\improper Kiboko grenade drum"
 	desc = "A drum for .980 grenades, holds six shells."
-
 	icon_state = "granata_drum"
-
 	w_class = WEIGHT_CLASS_NORMAL
-
 	max_ammo = 6
 
 /obj/item/ammo_box/magazine/c980_grenade/drum/starts_empty

--- a/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/romulus_technology/magazines.dm
+++ b/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/romulus_technology/magazines.dm
@@ -3,14 +3,9 @@
 /obj/item/ammo_box/magazine/m45a5
 	name = "\improper m45a5 magazine (Rose)"
 	desc = "A magazine for the m45a5 chambered in .460 Rowland, holds ten rounds. Warning, contains expanding head that deform on contact, may cause excessive bleeding."
-
 	icon = 'modular_skyrat/modules/modular_weapons/icons/obj/company_and_or_faction_based/romulus_technology/ammo.dmi'
 	icon_state = "rowlandmodular"
-
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
-
-	w_class = WEIGHT_CLASS_NORMAL
-
 	ammo_type = /obj/item/ammo_casing/c460rowland
 	caliber = CALIBER_460ROWLAND
 	max_ammo = 10
@@ -38,6 +33,7 @@
 	max_ammo = 25
 	multitype = TRUE
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
+	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/ammo_box/magazine/caflechette/ripper
 	name = "flechette ripper box"

--- a/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/magazines.dm
+++ b/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/magazines.dm
@@ -6,7 +6,7 @@
 
 	icon = 'modular_skyrat/modules/modular_weapons/icons/obj/company_and_or_faction_based/szot_dynamica/ammo.dmi'
 	icon_state = "lanca_mag"
-
+	w_class = WEIGHT_CLASS_NORMAL
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
 
 	ammo_type = /obj/item/ammo_casing/strilka310
@@ -71,3 +71,4 @@
 	ammo_type = /obj/item/ammo_casing/p60strela
 	max_ammo = 3
 	caliber = CALIBER_60STRELA
+	w_class = WEIGHT_CLASS_NORMAL

--- a/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/trappiste_fabriek/magazines.dm
+++ b/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/trappiste_fabriek/magazines.dm
@@ -3,14 +3,9 @@
 /obj/item/ammo_box/magazine/c585trappiste_pistol
 	name = "\improper Trappiste pistol magazine"
 	desc = "A standard size magazine for Trappiste pistols, holds six rounds."
-
 	icon = 'modular_skyrat/modules/modular_weapons/icons/obj/company_and_or_faction_based/trappiste_fabriek/ammo.dmi'
 	icon_state = "pistol_585_standard"
-
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
-
-	w_class = WEIGHT_CLASS_SMALL
-
 	ammo_type = /obj/item/ammo_casing/c585trappiste
 	caliber = CALIBER_585TRAPPISTE
 	max_ammo = 6


### PR DESCRIPTION
## About The Pull Request

Puts the Sol/Carwo/Romulus/Szot/Trappiste gun magazine sizes in line with /tg/ standards (tiny for everything but rifles which are normal)

## Why It's Good For The Game

Size inconsistencies between items results in confused players; it's good to keep this sort of thing synced up so that we're not having players ask why one pistol magazine fits in a box while another pistol magazine doesn't fit in a box when the air tank that's bigger than both of them does fit in the box.

If I find other guns with weird weight classes I'll fix those too.

## Proof Of Testing

Single-line changes, weight classes is a proven working system already.

## Changelog
:cl:
qol: Puts the Sol/Carwo/Romulus/Szot/Trappiste gun magazine weight classes in line with /tg/ standards for magazine weight classes (tiny for everything but rifles or larger which are normal)
/:cl:
