### PR TITLE
Adds Marish, Chitinclick and Carptongue to Silicon's Known languages

### DIFF
--- a/modular_skyrat/master_files/code/modules/language/language_holder.dm
+++ b/modular_skyrat/master_files/code/modules/language/language_holder.dm
@@ -95,6 +95,7 @@ GLOBAL_DATUM_INIT(language_holder_adjustor, /datum/language_holder_adjustor, new
 		/datum/language/akulan = list(LANGUAGE_ATOM),
 		/datum/language/marish = list(LANGUAGE_ATOM),
 		/datum/language/carptongue = list(LANGUAGE_ATOM),
+		/datum/language/chitinclick = list(LANGUAGE_ATOM),
 	)
 	spoken_languages = list(
 		/datum/language/common = list(LANGUAGE_ATOM),
@@ -126,4 +127,5 @@ GLOBAL_DATUM_INIT(language_holder_adjustor, /datum/language_holder_adjustor, new
 		/datum/language/akulan = list(LANGUAGE_ATOM),
 		/datum/language/marish = list(LANGUAGE_ATOM),
 		/datum/language/carptongue = list(LANGUAGE_ATOM),
+		/datum/language/chitinclick = list(LANGUAGE_ATOM),
 	)

--- a/modular_skyrat/master_files/code/modules/language/language_holder.dm
+++ b/modular_skyrat/master_files/code/modules/language/language_holder.dm
@@ -93,6 +93,8 @@ GLOBAL_DATUM_INIT(language_holder_adjustor, /datum/language_holder_adjustor, new
 		/datum/language/siiktajr = list(LANGUAGE_ATOM),
 		/datum/language/canilunzt = list(LANGUAGE_ATOM),
 		/datum/language/akulan = list(LANGUAGE_ATOM),
+		/datum/language/marish = list(LANGUAGE_ATOM),
+		/datum/language/carptongue = list(LANGUAGE_ATOM),
 	)
 	spoken_languages = list(
 		/datum/language/common = list(LANGUAGE_ATOM),
@@ -122,4 +124,6 @@ GLOBAL_DATUM_INIT(language_holder_adjustor, /datum/language_holder_adjustor, new
 		/datum/language/siiktajr = list(LANGUAGE_ATOM),
 		/datum/language/canilunzt = list(LANGUAGE_ATOM),
 		/datum/language/akulan = list(LANGUAGE_ATOM),
+		/datum/language/marish = list(LANGUAGE_ATOM),
+		/datum/language/carptongue = list(LANGUAGE_ATOM),
 	)


### PR DESCRIPTION

## About The Pull Request
Adds Marish, Chitinclick and Carptongue to known languages for borgs and AI
## Why It's Good For The Game
Adds Marish ( the shadekin Mar language) and Chitinclick to known languages for silicons because shadekin and bug people are often workers on NT stations and I dont see why NT would not provide the ability for silicons to understand and communicate with these crew.

Adds Carptongue for the same reason that silicons know how to speak with monkeys and slimes.
## Proof Of Testing
It compiles and was tested locally.
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
add: Adds Marish, Chitinclick and Carptongue to Silicon's Known languages
/:cl:
