### PR TITLE
Reverts "Adds crew monitors to Advanced biotech and lathes"

### DIFF
--- a/modular_zubbers/code/modules/research/designs/medical_designs.dm
+++ b/modular_zubbers/code/modules/research/designs/medical_designs.dm
@@ -1,15 +1,3 @@
-/datum/design/crewmonitor
-	name = "Handheld crew monitor"
-	desc = "A miniature machine that tracks suit sensors across the station."
-	id = "crewmonitor"
-	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT * 1.5, /datum/material/silver = SMALL_MATERIAL_AMOUNT*5)
-	build_path = /obj/item/sensor_device
-	category = list(
-		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_MEDICAL
-	)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
-
 /datum/design/empathic_sensor
 	name = "Empathic sensor implant"
 	desc = "An implant which allows one to intuit the thoughts of some."

--- a/modular_zubbers/code/modules/research/techweb/all_nodes.dm
+++ b/modular_zubbers/code/modules/research/techweb/all_nodes.dm
@@ -42,7 +42,6 @@
 /datum/techweb_node/medbay_equip_adv/New()
 	. = ..()
 	design_ids += list(
-		"crewmonitor",
 		"borg_upgrade_advancedanalyzer",
 	)
 


### PR DESCRIPTION
## About The Pull Request

This removes the handheld crew monitor from the medical lathe.

## Why It's Good For The Game

Alright, I just want to start out with all sources of the handheld crew monitor after this PR
- Paramedics spawn with them
- Blueshield (command only)
- The medical vendor premium section.
- Borg upgrades

Overall while there's been a lot of QOL to the crew monitor which I enjoy, it's all gradually made it so deaths are very noticable and often times with someone in medical 1 second later running towards an active fight to drag corpses away. 

- I think overall we have a sort of medical omnipresence issue, especially with an easy research destroying a level of scarcity with the hand held crew monitor. 

Anyone can print it if they have the materials and access to the lathe versus only a few existing outside of the paramedic starting with them. 

This PR of course is not going to fully tackle it. It's not going to stop a paramedic constantly staring at sensors or the medical console beeping when someone's in crit. But this aims to get less eyes on sensors, mostly the ability for everyone in medical to have a little screen to pull out and see the live feed without actively moving to a console.

Overall I think we have this issue (a lot of it being administrative) where every single death must be immedietly found and the person revived in 10 minutes. This won't fully tackle that, but if the solution is we must bloat a ton of antag abilities and items to combat sensors then I think we have too many eyes on sensors.

## Proof Of Testing

![image](https://github.com/user-attachments/assets/9d845341-7441-4beb-bb61-579b01222190)

## Changelog

:cl:
del: Removes the handheld crew monitor from the medical lathes.
/:cl: