### PR TITLE
Allows shadekin to jaunt as god intended

### DIFF
--- a/modular_zubbers/code/modules/mob/living/carbon/human/species_types/shadekin.dm
+++ b/modular_zubbers/code/modules/mob/living/carbon/human/species_types/shadekin.dm
@@ -106,15 +106,8 @@
 	desc = "A mysterious brain."
 	icon = 'icons/obj/medical/organs/organs.dmi'
 	icon_state = "brain-x-d"
+	actions_types = list(/datum/action/cooldown/spell/jaunt/shadow_walk)
 	var/applied_status = /datum/status_effect/shadekin_regeneration
-
-	///April fools! Shadekin get nightmare jaunt
-	var/datum/action/cooldown/spell/jaunt/shadow_walk/shadekin_jaunt
-
-/obj/item/organ/brain/shadekin/on_mob_insert(mob/living/carbon/brain_owner, special, movement_flags)
-	. = ..()
-	shadekin_jaunt = new(brain_owner)
-	shadekin_jaunt.Grant(brain_owner)
 
 /obj/item/organ/brain/shadekin/on_life(seconds_per_tick, times_fired)
 	. = ..()

--- a/modular_zubbers/code/modules/mob/living/carbon/human/species_types/shadekin.dm
+++ b/modular_zubbers/code/modules/mob/living/carbon/human/species_types/shadekin.dm
@@ -108,6 +108,14 @@
 	icon_state = "brain-x-d"
 	var/applied_status = /datum/status_effect/shadekin_regeneration
 
+	///April fools! Shadekin get nightmare jaunt
+	var/datum/action/cooldown/spell/jaunt/shadow_walk/shadekin_jaunt
+
+/obj/item/organ/brain/shadekin/on_mob_insert(mob/living/carbon/brain_owner, special, movement_flags)
+	. = ..()
+	shadekin_jaunt = new(brain_owner)
+	shadekin_jaunt.Grant(brain_owner)
+
 /obj/item/organ/brain/shadekin/on_life(seconds_per_tick, times_fired)
 	. = ..()
 	var/turf/owner_turf = owner.loc


### PR DESCRIPTION

## About The Pull Request
For a very long time we've had shadekin, and I look at chompers and virgo and think to myself "you know what we need? Full shadekin!" That's right baybee, we (shadekin) will now be jaunting all over the place, being silly little guys
## Why It's Good For The Game
Shadekin need buffs, too weak for SURE
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
add: Nightmare jaunt to shadekin
balance: Shadekins get jaunt
/:cl:
