### PR TITLE
take two: Reverts the disaboot apirl fools

### DIFF
--- a/modular_zubbers/code/modules/security/security_glock/lockers.dm
+++ b/modular_zubbers/code/modules/security/security_glock/lockers.dm
@@ -1,8 +1,6 @@
 /obj/structure/closet/secure_closet/security/sec/PopulateContents()
 	. = ..()
 	new /obj/item/storage/toolbox/guncase/skyrat/pistol/sec_glock(src)
-	if(check_holidays(APRIL_FOOLS))
-		new /obj/item/clothing/shoes/gunboots/disabler(src)
 
 /obj/structure/closet/secure_closet/warden/PopulateContents()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Apirl fools code cleanup. Was a funny meme, but I don't think they should happen next year.

## Changelog

:cl:
del: Disaboots have been removed from apirl fools.
/:cl:

