### PR TITLE
Coom 2.0 - lets you cum on things

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/_masturbation_item.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/_masturbation_item.dm
@@ -18,7 +18,7 @@
 
 /obj/item/hand_item/coom
 	name = "cum"
-	desc = "Cum on? Cum in? Try filling a cup?" // 💀 - still cursed but actually descriptive
+	desc = "Cum on? Cum in? Try filling a cup?"
 	icon = 'icons/obj/service/hydroponics/harvest.dmi'
 	icon_state = "eggplant"
 	inhand_icon_state = "nothing"


### PR DESCRIPTION
## About The Pull Request

I was looking thru the code for ways to cum into beakers... and turns out we already had one. It just was impossible to use and kind of broken when you did use it. With this, you can now cum into reagent containers and make cum decals on floors by targeting other things. It comes with a 6 sec channel time by default so its not too spammable (can add a long emote cooldown timer or lengthen the channel time if it turne out to be an issue).

## Why It's Good For The Game

As it currently stands, there is no way to actually cum into beakers. There's the milking machine, but it's extremely awkward to use and doesn't fit most rp scenarios. We already had a code intended for this, it just wasn't used. Tremendous NSFW maintenance bar rp benefits?

## Proof Of Testing

I did test it. Quite a lot. Too much while trying to figure out sex code and why it wasn't working. In the end I had to cut the condom interaction because i just couldn't get it to use one properly, but anyways, it should work.

## Changelog
:cl:
add: adds a *fap emote, letting you jerk off onto a target - you can finally cum into reagent containers
fix: the old previously unused coom hand_item had a bunch of issues that should be fixed now
/:cl:
