### PR TITLE
Silicons can now Yip

### DIFF
--- a/modular_zubbers/code/modules/emotes/emotes.dm
+++ b/modular_zubbers/code/modules/emotes/emotes.dm
@@ -147,7 +147,6 @@
 	message = "yips!"
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
-	mob_type_allowed_typecache = list(/mob/living/carbon, /mob/living/silicon/pai)
 
 /datum/emote/living/yip/get_sound(mob/living/user)
 	return pick('modular_zubbers/code/modules/emotes/sound/voice/yip1.ogg',


### PR DESCRIPTION

## About The Pull Request
Silicons can now emit a singular yip so they can express their inner kobold but not too much.
## Why It's Good For The Game
Silicons can yipyip but not yip. This fixes it.
## Proof Of Testing
It compiles and was tested locally.
</details>

## Changelog
:cl:
fix: Silicons can now yip. 
/:cl:
