### PR TITLE
Revert "Reverts "Adds crew monitors to Advanced biotech and lathes""

### DIFF
--- a/modular_zubbers/code/modules/research/designs/medical_designs.dm
+++ b/modular_zubbers/code/modules/research/designs/medical_designs.dm
@@ -1,3 +1,15 @@
+/datum/design/crewmonitor
+	name = "Handheld crew monitor"
+	desc = "A miniature machine that tracks suit sensors across the station."
+	id = "crewmonitor"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT * 1.5, /datum/material/silver = SMALL_MATERIAL_AMOUNT*5)
+	build_path = /obj/item/sensor_device
+	category = list(
+		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_MEDICAL
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+
 /datum/design/empathic_sensor
 	name = "Empathic sensor implant"
 	desc = "An implant which allows one to intuit the thoughts of some."

--- a/modular_zubbers/code/modules/research/techweb/all_nodes.dm
+++ b/modular_zubbers/code/modules/research/techweb/all_nodes.dm
@@ -42,6 +42,7 @@
 /datum/techweb_node/medbay_equip_adv/New()
 	. = ..()
 	design_ids += list(
+		"crewmonitor",
 		"borg_upgrade_advancedanalyzer",
 	)
 


### PR DESCRIPTION
Reverts Bubberstation/Bubberstation#3407

By popular demand; There's been a substantial amount of backlash on discord over this, with players being... confused over the reasoning - That PR doesnt really do anything to adress the "you must get revived quickly" expectation, and it doesn't actually do anything to stop the crew from getting extra monitors. The entire change merely adds tedium to getting them (not that expensive purchase from a vending machine which you can refill). As one person summed it;

>QoL has been declared as bad
Average ss13 development
Extra tedium for you sir
Served fresh

On a more serious note, yeah - someone has to make it a PR if most of the people who are getting upset about it don't use or know how to use github