### PR TITLE
Entombed Balancing Changes

### DIFF
--- a/modular_zubbers/code/datums/quirks/neutral_quirks/entombed.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/entombed.dm
@@ -63,7 +63,15 @@
 	life_support_failed = TRUE
 
 /datum/quirk/equipping/entombed/add_unique(client/client_source)
+	var/lock_deploy = client_source?.prefs.read_preference(/datum/preference/toggle/entombed_deploy_lock)
+	if (!isnull(lock_deploy))
+		deploy_locked = lock_deploy
+
+	if(deploy_locked)
+		forced_items = list(/obj/item/mod/control/pre_equipped/entombed/locked = list(ITEM_SLOT_BACK))
+
 	. = ..()
+
 	var/mob/living/carbon/human/human_holder = quirk_holder
 	if (istype(human_holder.back, /obj/item/mod/control/pre_equipped/entombed))
 		modsuit = human_holder.back // link this up to the quirk for easy access
@@ -72,10 +80,6 @@
 		stack_trace("Entombed quirk couldn't create a fused MODsuit on [quirk_holder] and was force-removed.")
 		qdel(src)
 		return
-
-	var/lock_deploy = client_source?.prefs.read_preference(/datum/preference/toggle/entombed_deploy_lock)
-	if (!isnull(lock_deploy))
-		deploy_locked = lock_deploy
 
 	// set no dismember trait for deploy-locked dudes, i'm sorry, there's basically no better way to do this.
 	// it's a pretty ample buff but i dunno what else to do...

--- a/modular_zubbers/master_files/code/modules/entombed_quirk/code/entombed_mod.dm
+++ b/modular_zubbers/master_files/code/modules/entombed_quirk/code/entombed_mod.dm
@@ -39,6 +39,11 @@
 		/obj/item/mod/module/storage
 	)
 
+/obj/item/mod/control/pre_equipped/entombed/locked
+	applied_modules = list(
+		/obj/item/mod/module/storage/large_capacity
+	)
+
 /obj/item/mod/control/pre_equipped/entombed/canStrip(mob/who)
 	return TRUE //you can always try, and it'll hit doStrip below
 


### PR DESCRIPTION
## About The Pull Request

makes it so entombed modsuits can not have AI's installed in them and start with non-upgraded storage.

## Why It's Good For The Game

I could go on about how entombed suits are supposed to be old, decrepit, and cheap. But I have genuine gameplay reasons.

Entombed is a round start modsuit. Overall it's very powerful and more an unremovable modsuit that you just passively exist with then the downsides which are largely ignored outside of you dying if you don't have it equipped (which you can't even remove it anyway). This sort of gives you full blown round start immunity to any atmospheric hazards with the low cost of needing it to live. If you get a normal modsuit, it's not like you'll ever going to take it off anyway.

The AI change is because you can not remove an AI from an entombed modsuit forcefully. It's pretty much just that, especially if it's a roundstart modsuit. You can keep the AI in your pocket.

The storage capacity reduction round start is also just so it's a little more of a downside since it will effect your storage slots. As I said, round start modsuit should have the cheap things. I know it was passed as a QOL change, but I do not feel like all friction is anti-QOL and bad. You can order it from cargo.

## Proof Of Testing

It works.

## Changelog

:cl:
balance: Non-locked entombed starts with a unupgraded storage module instead of an expanded one.
balance: You can no longer insert AIs into any entombed modsuits.
/:cl:

