### PR TITLE
Nerfs super syndicat and makes it no longer a freedom implant.

### DIFF
--- a/modular_zubbers/code/modules/spells/spell_types/shapeshift/kittyform.dm
+++ b/modular_zubbers/code/modules/spells/spell_types/shapeshift/kittyform.dm
@@ -20,7 +20,6 @@
 
 //Traitor's Super cat spell
 /datum/action/cooldown/spell/shapeshift/kitty/syndie
-	cooldown_time = 120 SECONDS
 	name = "SYNDICATE KITTY POWER!!"
 	desc = "Take on the shape of an kitty cat, clad in blood-red armor! Gain their powers at a loss of vitality."
 	possible_shapes = list(/mob/living/basic/pet/cat/syndicat/super)


### PR DESCRIPTION
## About The Pull Request
- This PR makes the new syndicat ears item have a 1 minute cool down when used and the normal ears have the same thing.

- This also ports a fix that was done on monkey station: https://github.com/Monkestation/Monkestation2.0/pull/6017

## Why It's Good For The Game
- After watching a round on here and getting complaints about this from SPLURT I understand now why 20 seconds is too short for such a item like this if your gonna be a cat your gonna be a cat for a long while.

- Also to quote monkey station:
"It will make the cat not able to bypass any security non-lethal means, which in turns mean security won't be forced to lethal them everytime they see it."

## Proof Of Testing
Should work only changed the time values.

Edit: Compiled and tested locally

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
balance: Super cat ear cool downs are longer and removed the freedom implant function.
/:cl:
