### PR TITLE
Removes tackle buff for having cat ears

### DIFF
--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -445,11 +445,6 @@
 	var/obj/item/organ/wings/sacker_wing = sacker.get_organ_slot(ORGAN_SLOT_EXTERNAL_WINGS)
 	if(sacker_wing)
 		attack_mod += 2
-	// BUBBER EDIT START - Taj tackle bonus
-	var/obj/item/organ/ears/cat/tajaran/sacker_tajaran_ears = sacker.get_organ_slot(ORGAN_SLOT_EARS)
-	if(istype(sacker_tajaran_ears) && HAS_TRAIT(sacker, TRAIT_CATLIKE_GRACE))
-		attack_mod += 2 // UwU pounces on you
-	// BUBBER EDIT END
 
 	var/obj/item/organ/cyberimp/chest/spine/potential_spine = sacker.get_organ_slot(ORGAN_SLOT_SPINE)
 	if(istype(potential_spine))


### PR DESCRIPTION
## About The Pull Request

Title, manual revert of #1513 

## Why It's Good For The Game

Tackle chance could be brought to 100% and people have reportedly been exploiting this fact.

## Proof Of Testing

I think it will complie 

## Changelog

:cl:Swiftfeather
balance: Cat ears no longer provide a tackle bonus
/:cl:
