### PR TITLE
Fix invisible sprites on security HUD nightvision goggles

### DIFF
--- a/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
+++ b/modular_skyrat/modules/goofsec/code/sec_clothing_overrides.dm
@@ -203,8 +203,8 @@
 	base_icon_state = "security_eyepatch"
 
 /obj/item/clothing/glasses/hud/security/night
-	icon_state = "security_hud_nv"
-	glass_colour_type = /datum/client_colour/glass_colour/green
+	icon = 'icons/obj/clothing/glasses.dmi'
+	worn_icon = 'icons/mob/clothing/eyes.dmi'
 
 /*
 * HEAD


### PR DESCRIPTION
## About The Pull Request

Upstream changed NV goggles to have different icon states for on and off and we dont have that so I reverted it to the tg sprite

## Why It's Good For The Game

Fixes #3383 

## Proof Of Testing

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/77943197-de8f-409a-86c3-bad205888054)

</details>

## Changelog

:cl:
fix: fixed sechud nv goggles being invisible when off
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
