### PR TITLE
Map vote is called automatically on blob/nukies/etc. round end

### DIFF
--- a/code/modules/shuttle/mobile_port/variants/emergency/emergency.dm
+++ b/code/modules/shuttle/mobile_port/variants/emergency/emergency.dm
@@ -234,7 +234,8 @@
 					color_override = "orange",
 				)
 				INVOKE_ASYNC(SSticker, TYPE_PROC_REF(/datum/controller/subsystem/ticker, poll_hearts))
-				INVOKE_ASYNC(SSvote, TYPE_PROC_REF(/datum/controller/subsystem/vote, initiate_vote), /datum/vote/map_vote, vote_initiator_name = "Map Rotation", forced = TRUE)
+				// INVOKE_ASYNC(SSvote, TYPE_PROC_REF(/datum/controller/subsystem/vote, initiate_vote), /datum/vote/map_vote, vote_initiator_name = "Map Rotation", forced = TRUE) // BUBBER EDIT CHANGE - Offset Map Vote
+				SSsecurity_level.offset_map_vote()
 
 				if(!is_reserved_level(z))
 					CRASH("Emergency shuttle did not move to transit z-level!")

--- a/modular_skyrat/modules/autotransfer/code/shuttle.dm
+++ b/modular_skyrat/modules/autotransfer/code/shuttle.dm
@@ -4,7 +4,6 @@
 /datum/controller/subsystem/shuttle/proc/autoEnd()
 	if(EMERGENCY_IDLE_OR_RECALLED)
 		SSshuttle.emergency.request()
-		priority_announce("The shift has come to an end and the shuttle called. [SSsecurity_level.get_current_level_as_number() == SEC_LEVEL_RED ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [emergency.timeLeft(600)] minutes.", null, ANNOUNCER_SHUTTLECALLED, "Priority", color_override = "orange")
 		log_game("Round end vote passed. Shuttle has been auto-called.")
 		message_admins("Round end vote passed. Shuttle has been auto-called.")
 	emergency_no_recall = TRUE

--- a/modular_zubbers/code/controllers/subsystem/security_level.dm
+++ b/modular_zubbers/code/controllers/subsystem/security_level.dm
@@ -7,7 +7,7 @@
 
 /// Calls the map vote with a time offset, to account for announcements and VOX playback, etc.
 /datum/controller/subsystem/security_level/proc/offset_map_vote(offset = 7 SECONDS)
-	if(GLOB.roundend_mapvote_called)
+	if(GLOB.roundend_mapvote_called || SSmap_vote.next_map_config)
 		return
 
 	addtimer(CALLBACK(src, PROC_REF(async_map_vote)), offset)

--- a/modular_zubbers/code/controllers/subsystem/security_level.dm
+++ b/modular_zubbers/code/controllers/subsystem/security_level.dm
@@ -1,0 +1,18 @@
+/datum/controller/subsystem/security_level/set_level(new_level, announce = TRUE)
+	. = ..()
+	new_level = istext(new_level) ? new_level : number_level_to_text(new_level)
+	var/datum/security_level/selected_level = available_levels[new_level]
+	if(selected_level.number_level >= SEC_LEVEL_DELTA)
+		offset_map_vote()
+
+/// Calls the map vote with a time offset, to account for announcements and VOX playback, etc.
+/datum/controller/subsystem/security_level/proc/offset_map_vote(offset = 7 SECONDS)
+	if(GLOB.roundend_mapvote_called)
+		return
+
+	addtimer(CALLBACK(src, PROC_REF(async_map_vote)), offset)
+
+/// Calls a map vote only if there has not yet been an automatically triggered map vote.
+/datum/controller/subsystem/security_level/proc/async_map_vote()
+	INVOKE_ASYNC(SSvote, TYPE_PROC_REF(/datum/controller/subsystem/vote, initiate_vote), /datum/vote/map_vote, vote_initiator_name = "Map Rotation", forced = TRUE)
+	GLOB.roundend_mapvote_called = TRUE

--- a/modular_zubbers/code/controllers/subsystem/security_level.dm
+++ b/modular_zubbers/code/controllers/subsystem/security_level.dm
@@ -7,11 +7,12 @@
 
 /// Calls the map vote with a time offset, to account for announcements and VOX playback, etc.
 /datum/controller/subsystem/security_level/proc/offset_map_vote(offset = 7 SECONDS)
-	if(GLOB.roundend_mapvote_called || SSmap_vote.next_map_config)
+	if(GLOB.roundend_mapvote_called)
 		return
 
 	GLOB.roundend_mapvote_called = TRUE
-	addtimer(CALLBACK(src, PROC_REF(async_map_vote)), offset)
+	if(!SSmap_vote.next_map_config)
+		addtimer(CALLBACK(src, PROC_REF(async_map_vote)), offset)
 
 /// Calls a map vote only if there has not yet been an automatically triggered map vote.
 /datum/controller/subsystem/security_level/proc/async_map_vote()

--- a/modular_zubbers/code/controllers/subsystem/security_level.dm
+++ b/modular_zubbers/code/controllers/subsystem/security_level.dm
@@ -10,9 +10,9 @@
 	if(GLOB.roundend_mapvote_called || SSmap_vote.next_map_config)
 		return
 
+	GLOB.roundend_mapvote_called = TRUE
 	addtimer(CALLBACK(src, PROC_REF(async_map_vote)), offset)
 
 /// Calls a map vote only if there has not yet been an automatically triggered map vote.
 /datum/controller/subsystem/security_level/proc/async_map_vote()
 	INVOKE_ASYNC(SSvote, TYPE_PROC_REF(/datum/controller/subsystem/vote, initiate_vote), /datum/vote/map_vote, vote_initiator_name = "Map Rotation", forced = TRUE)
-	GLOB.roundend_mapvote_called = TRUE

--- a/modular_zubbers/code/modules/shuttle/emergency.dm
+++ b/modular_zubbers/code/modules/shuttle/emergency.dm
@@ -5,5 +5,4 @@ GLOBAL_VAR_INIT(roundend_mapvote_called, FALSE)
 	if(mode == SHUTTLE_CALL && !SSshuttle.canRecall() && !GLOB.roundend_mapvote_called)
 		var/datum/vote/current_vote = SSvote.current_vote
 		if(!istype(current_vote, /datum/vote/map_vote))
-			INVOKE_ASYNC(SSvote, TYPE_PROC_REF(/datum/controller/subsystem/vote, initiate_vote), /datum/vote/map_vote, vote_initiator_name = "Map Rotation", forced = TRUE) //Do a map vote if we're at the point of no return.
-			GLOB.roundend_mapvote_called = TRUE
+			SSsecurity_level.offset_map_vote()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8786,6 +8786,7 @@
 #include "modular_zubbers\code\controllers\subsystem\map_vote.dm"
 #include "modular_zubbers\code\controllers\subsystem\mapping.dm"
 #include "modular_zubbers\code\controllers\subsystem\research.dm"
+#include "modular_zubbers\code\controllers\subsystem\security_level.dm"
 #include "modular_zubbers\code\controllers\subsystem\vote.dm"
 #include "modular_zubbers\code\controllers\subsystem\processing\nanites.dm"
 #include "modular_zubbers\code\controllers\subsystem\processing\sol_subsystem.dm"


### PR DESCRIPTION
## About The Pull Request

Triggers the automatic map vote when the round is about to end due to a station threat, if it hasn't happened.

## Why It's Good For The Game

Saves it delaying the next round if no admin catches it in time, causing a delay as the vote and another restart needs to occur.

## Changelog

:cl: LT3
admin: Map vote is automatically triggered near the conclusion of station ending threats
fix: Only a single announcement is sent when the shuttle is called, fixing the overlapping sounds
/:cl: