### PR TITLE
30 minute grace period to respawn (world time, not round time)

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -846,7 +846,8 @@
 	if(!override_delay && !CONFIG_GET(number/respawn_delay))
 		return TRUE
 	//BUBBER EDIT 30 minute grace period
-	if(world.time < 30 MINUTES)
+	var/respawn_grace_period = CONFIG_GET(number/respawn_grace_period)
+	if(world.time < respawn_grace_period)
 		return TRUE
 	//BUBBER EDIT END
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -845,6 +845,10 @@
 /mob/proc/check_respawn_delay(override_delay = 0)
 	if(!override_delay && !CONFIG_GET(number/respawn_delay))
 		return TRUE
+	//BUBBER EDIT 30 minute grace period
+	if(world.time < 30 MINUTES)
+		return TRUE
+	//BUBBER EDIT END
 
 	var/death_time = world.time - persistent_client.time_of_death
 

--- a/config/bubbers/bubbers_config.txt
+++ b/config/bubbers/bubbers_config.txt
@@ -16,3 +16,6 @@ INTERN_THRESHOLD_COMMAND 20
 # Vetted player system
 ## If enabled, it will use checks to determine if a player is vetted or not in different parts of the game
 #CHECK_VETTED
+
+## Respawn grace period (deciseconds), which allows to return to the lobby some amount of time after the world loads - default 30 minutes
+RESPAWN_GRACE_PERIOD 18000

--- a/modular_zubbers/code/controllers/configuration/general.dm
+++ b/modular_zubbers/code/controllers/configuration/general.dm
@@ -1,0 +1,2 @@
+/datum/config_entry/number/respawn_grace_period
+	default = 30 MINUTES

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8780,6 +8780,7 @@
 #include "modular_zubbers\code\_globalvars\lists\quirks.dm"
 #include "modular_zubbers\code\_globalvars\lists\~maintenance_loot.dm"
 #include "modular_zubbers\code\_onclick\hud\screen_objects\hud_timer.dm"
+#include "modular_zubbers\code\controllers\configuration\general.dm"
 #include "modular_zubbers\code\controllers\configuration\entries\nsfw.dm"
 #include "modular_zubbers\code\controllers\subsystem\air.dm"
 #include "modular_zubbers\code\controllers\subsystem\job.dm"


### PR DESCRIPTION
## About The Pull Request
from when the server starts to 30 minutes after, respawning is free of charge
## Why It's Good For The Game
item #1 on the list
## Proof Of Testing
it works dude trust me
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
code: respawn enabled until 30 min (world time)
config: adds a respawn grace period
/:cl:
