### PR TITLE
Deathmatch now stores and reapplies your respawn timer prior to being spawned

### DIFF
--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -130,7 +130,9 @@
 	if (isnull(observer) || !observer.client)
 		remove_ckey_from_play(ckey)
 		return
-
+	//Bubber edit - storing time of death before deathmatch
+	player_previous_death_times[observer.ckey] = list("previous_time_of_death" = observer.persistent_client.time_of_death)
+	//Bubber edit end
 	// equip player
 	var/datum/outfit/deathmatch_loadout/loadout = players_info["loadout"]
 	if (!(loadout in loadouts))
@@ -200,7 +202,10 @@
 		players[ckey]["mob"] = null
 		loser.ghostize(can_reenter_corpse = FALSE)
 		qdel(loser)
-
+		//bubber edit - give them their death timer back
+		var/mob/player_mob = get_mob_by_ckey(ckey)
+		player_mob.persistent_client.time_of_death = player_previous_death_times[ckey]["previous_time_of_death"]
+		//bubber edit end
 	for(var/datum/deathmatch_modifier/modifier in modifiers)
 		GLOB.deathmatch_game.modifiers[modifier].on_end_game(src)
 

--- a/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/code/modules/deathmatch/deathmatch_lobby.dm
@@ -241,6 +241,11 @@
 		add_observer(ghost, (host == ckey))
 	announce(span_reallybig("[player.real_name] HAS DIED.<br>[players.len] REMAIN."))
 
+	//Bubber Edit - retain respawn timer
+	var/mob/dead_player_mob = get_mob_by_ckey(ckey)
+	dead_player_mob.persistent_client.time_of_death = player_previous_death_times[ckey]["previous_time_of_death"]
+	//BUBBER EDIT END
+
 	if(!gibbed && !QDELING(player) && !isdead(player))
 		if(!HAS_TRAIT(src, TRAIT_DEATHMATCH_EXPLOSIVE_IMPLANTS))
 			unregister_player_signals(player)

--- a/modular_zubbers/code/modules/deathmatch/deathmatch_lobby.dm
+++ b/modular_zubbers/code/modules/deathmatch/deathmatch_lobby.dm
@@ -1,0 +1,3 @@
+/datum/deathmatch_lobby
+	//assoc list of players death timers prior to joined a deathmatch lobby
+	var/list/player_previous_death_times = list()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9175,6 +9175,7 @@
 #include "modular_zubbers\code\modules\customization\sprite_accessories\tails.dm"
 #include "modular_zubbers\code\modules\customization\sprite_accessories\taurs.dm"
 #include "modular_zubbers\code\modules\customization\sprite_accessories\wings.dm"
+#include "modular_zubbers\code\modules\deathmatch\deathmatch_lobby.dm"
 #include "modular_zubbers\code\modules\debug_tools\debug_items.dm"
 #include "modular_zubbers\code\modules\debug_tools\debug_machinery.dm"
 #include "modular_zubbers\code\modules\debug_tools\physgun.dm"


### PR DESCRIPTION

## About The Pull Request
Title
## Why It's Good For The Game
item number TWO on the list
## Proof Of Testing
![image](https://github.com/user-attachments/assets/3f6fd5d7-1d62-41a5-9c97-3178585f350a)
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
code: deathmatch doesn't reset your respawn timer
/:cl:
