### PR TITLE
Fix meow emote for cat tongues

### DIFF
--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -77,6 +77,7 @@
 	if(user.put_in_hands(N))
 		to_chat(user, span_notice("You make a circle with your hand."))
 
+/* BUBBER EDIT REMOVE - moved to modular_skyrat/modules/emotes/code/emotes.dm
 /datum/emote/living/carbon/meow
 	key = "meow"
 	key_third_person = "meows"
@@ -91,7 +92,6 @@
 		return FALSE
 	return ..()
 
-/* BUBBER EDIT REMOVE - moved to modular_skyrat/modules/emotes/code/emotes.dm
 /datum/emote/living/carbon/purr
 	key = "purr"
 	key_third_person = "purrs"

--- a/modular_skyrat/modules/emotes/code/emotes.dm
+++ b/modular_skyrat/modules/emotes/code/emotes.dm
@@ -177,7 +177,8 @@
 	key = "meow"
 	key_third_person = "meows"
 	message = "meows!"
-	emote_type = EMOTE_AUDIBLE
+	message_mime = "meows silently."
+	emote_type = EMOTE_VISIBLE | EMOTE_AUDIBLE
 	vary = TRUE
 	sound = 'modular_skyrat/modules/emotes/sound/emotes/meow.ogg'
 


### PR DESCRIPTION
## About The Pull Request

Fixes the meow emote to use the correct emote if you have a cat tongue

## Why It's Good For The Game

MEOW.

## Changelog

:cl: LT3
fix: Mobs with cat tongue get their alternate meow sound back
/:cl:
