### PR TITLE
[MAPPING]: Change Kilo Station dorms area type from Locker to Dorms.

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -834,7 +834,7 @@
 /obj/machinery/newscaster/directional/east,
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/wood,
-/area/station/commons/locker)
+/area/station/commons/dorms)
 "amq" = (
 /mob/living/basic/mining/basilisk{
 	environment_smash = 0
@@ -1435,7 +1435,7 @@
 	},
 /obj/item/pillow/random,
 /turf/open/floor/wood,
-/area/station/commons/locker)
+/area/station/commons/dorms)
 "awG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
@@ -6026,7 +6026,7 @@
 "cee" = (
 /obj/structure/sign/poster/contraband/revolver,
 /turf/closed/wall,
-/area/station/commons/locker)
+/area/station/commons/dorms)
 "ceg" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/corner{
@@ -8742,7 +8742,7 @@
 /obj/effect/landmark/start/hangover,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
-/area/station/commons/locker)
+/area/station/commons/dorms)
 "cYy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -10947,7 +10947,7 @@
 /obj/effect/landmark/start/hangover,
 /obj/item/pillow/random,
 /turf/open/floor/wood,
-/area/station/commons/locker)
+/area/station/commons/dorms)
 "dJU" = (
 /obj/machinery/door/window/left/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -11826,7 +11826,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
-/area/station/commons/locker)
+/area/station/commons/dorms)
 "dZA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15112,7 +15112,7 @@
 /obj/effect/landmark/start/hangover,
 /obj/item/pillow/random,
 /turf/open/floor/wood,
-/area/station/commons/locker)
+/area/station/commons/dorms)
 "fhe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
@@ -16090,6 +16090,9 @@
 "fuB" = (
 /turf/closed/wall/rust,
 /area/station/maintenance/starboard/aft)
+"fuM" = (
+/turf/closed/wall,
+/area/station/commons/dorms)
 "fuX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -18383,7 +18386,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
-/area/station/commons/locker)
+/area/station/commons/dorms)
 "gdP" = (
 /obj/structure/chair{
 	dir = 1
@@ -19866,7 +19869,7 @@
 	specialfunctions = 4
 	},
 /turf/open/floor/wood,
-/area/station/commons/locker)
+/area/station/commons/dorms)
 "gDl" = (
 /obj/effect/spawner/random/entertainment/arcade,
 /turf/open/floor/iron/grimy,
@@ -22306,7 +22309,7 @@
 "hri" = (
 /obj/structure/dresser,
 /turf/open/floor/wood,
-/area/station/commons/locker)
+/area/station/commons/dorms)
 "hrN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -30186,7 +30189,7 @@
 	specialfunctions = 4
 	},
 /turf/open/floor/wood,
-/area/station/commons/locker)
+/area/station/commons/dorms)
 "jPB" = (
 /turf/closed/wall/rust,
 /area/station/security/courtroom)
@@ -34844,7 +34847,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
-/area/station/commons/locker)
+/area/station/commons/dorms)
 "lqR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
@@ -35285,6 +35288,9 @@
 	},
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"lxl" = (
+/turf/closed/wall/rust,
+/area/station/commons/dorms)
 "lxo" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt,
@@ -35964,7 +35970,7 @@
 /obj/item/folder/red,
 /obj/item/lighter,
 /turf/open/floor/wood,
-/area/station/commons/locker)
+/area/station/commons/dorms)
 "lJD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44586,7 +44592,7 @@
 /obj/effect/mapping_helpers/broken_floor,
 /obj/item/pillow/random,
 /turf/open/floor/wood,
-/area/station/commons/locker)
+/area/station/commons/dorms)
 "oIg" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
@@ -45934,7 +45940,7 @@
 	},
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
-/area/station/commons/locker)
+/area/station/commons/dorms)
 "pfc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/monitored/air_output{
 	dir = 4
@@ -48679,7 +48685,7 @@
 /obj/effect/landmark/start/hangover/closet,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
-/area/station/commons/locker)
+/area/station/commons/dorms)
 "pXU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -49909,7 +49915,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/station/commons/locker)
+/area/station/commons/dorms)
 "quG" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -60887,7 +60893,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
-/area/station/commons/locker)
+/area/station/commons/dorms)
 "tSN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -61869,7 +61875,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/station/commons/locker)
+/area/station/commons/dorms)
 "uib" = (
 /obj/machinery/status_display/evac/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -64574,7 +64580,7 @@
 	},
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
-/area/station/commons/locker)
+/area/station/commons/dorms)
 "vef" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/east,
@@ -94837,8 +94843,8 @@ uQE
 qHu
 mqU
 qEJ
-rhN
-esq
+fuM
+lxl
 pqD
 pqD
 fKJ
@@ -95094,7 +95100,7 @@ obM
 wij
 fDB
 lsX
-rhN
+fuM
 jPq
 peZ
 iuC
@@ -95608,9 +95614,9 @@ rNo
 vPX
 dQC
 uAF
-rhN
-rhN
-rhN
+fuM
+fuM
+fuM
 iza
 guJ
 yfc
@@ -95865,7 +95871,7 @@ iYa
 bCO
 uHv
 nQX
-rhN
+fuM
 aww
 vea
 jWD
@@ -96379,8 +96385,8 @@ bkT
 jTc
 hoE
 rhN
-esq
-rhN
+lxl
+fuM
 cee
 pqD
 fNy
@@ -96893,7 +96899,7 @@ nKh
 nkd
 tDs
 xTt
-rhN
+fuM
 oIe
 amn
 pqD
@@ -97150,9 +97156,9 @@ nKh
 iku
 ikE
 uwG
-rhN
-esq
-rhN
+fuM
+lxl
+fuM
 pqD
 llI
 ncj
@@ -97664,7 +97670,7 @@ fmy
 fti
 aBF
 bJU
-rhN
+fuM
 gDe
 pXN
 iza
@@ -97921,9 +97927,9 @@ otS
 uAA
 otb
 lXe
-rhN
-rhN
-rhN
+fuM
+fuM
+fuM
 pqD
 jqI
 hWw


### PR DESCRIPTION

## About The Pull Request
Makes sure Kilo Station's dorms area actually is a Dorms area.
## Why It's Good For The Game
Other stations' dorms are inside actual Dorms areas, effectively granting protection from events like sudden brain trauma/heart attack, but Kilo Station didn't have this, they were classified as lockers instead.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
![e](https://github.com/user-attachments/assets/ae6e79db-d68f-4895-a661-e5fa5b0383de)
</details>

## Changelog
:cl:Goku
map: Kilo Station's Dormitories area type is now classified as dormitories, not as a Locker room.
/:cl:
