### PR TITLE
Disable lean reset on direction change

### DIFF
--- a/code/datums/components/leanable.dm
+++ b/code/datums/components/leanable.dm
@@ -106,7 +106,7 @@
 	), PROC_REF(stop_leaning))
 
 	RegisterSignal(src, COMSIG_MOVABLE_TELEPORTED, PROC_REF(teleport_away_while_leaning))
-	RegisterSignal(src, COMSIG_ATOM_POST_DIR_CHANGE, PROC_REF(lean_dir_changed))
+	// RegisterSignal(src, COMSIG_ATOM_POST_DIR_CHANGE, PROC_REF(lean_dir_changed)) // BUBBER EDIT REMOVE - Don't reset leaning on direction change
 	update_fov()
 
 /// You fall on your face if you get teleported while leaning


### PR DESCRIPTION
## About The Pull Request

Edits TG's lean component to perform the same as the pixel shift component

## Why It's Good For The Game

Consistent shifting movement

## Changelog

:cl: LT3
qol: Leaning no longer resets with directional change
/:cl: