### PR TITLE
Increase wildcard slots

### DIFF
--- a/code/__DEFINES/id_cards.dm
+++ b/code/__DEFINES/id_cards.dm
@@ -11,13 +11,13 @@
  */
 
 /// Wildcard slot define for basic grey cards. Only hold 4 common wildcards.
-#define WILDCARD_LIMIT_GREY list(WILDCARD_NAME_COMMON = list(limit = 4, usage = list()))
+#define WILDCARD_LIMIT_GREY list(WILDCARD_NAME_COMMON = list(limit = 10, usage = list())) //BUBBER EDITS: More slots
 /// Wildcard slot define for Head of Staff silver cards. Can hold 6 common, 2 command and 1 private command.
 #define WILDCARD_LIMIT_SILVER list( \
-	WILDCARD_NAME_COMMON = list(limit = 6, usage = list()), \
+	WILDCARD_NAME_COMMON = list(limit = 8, usage = list()), \
 	WILDCARD_NAME_COMMAND = list(limit = 2, usage = list()), \
 	WILDCARD_NAME_PRV_COMMAND = list(limit = 1, usage = list()) \
-)
+) //BUBBER EDIT: More slots
 /// Wildcard slot define for Captain gold cards. Can hold infinite of any Captain level wildcard.
 #define WILDCARD_LIMIT_GOLD list(WILDCARD_NAME_CAPTAIN = list(limit = -1, usage = list()))
 /// Wildcard slot define for select Syndicate-affiliated cards. Can hold infinite of any Syndicate level wildcard. Syndicate includes all station accesses.


### PR DESCRIPTION

## About The Pull Request
Increases wildcard slots:
Normal cards: 4->10 common slots
Silver cards: 6->8 common slots. These have 2 command and 1 private command slot, which can both carry common accesses

## Why It's Good For The Game

I believe the current amount of wildcards is still fairly restrictive- giving someone access to part of a department similiar to what a job would have and, say, janitorial is often not possible with only four slots. 

Having insufficient slots is very frustrating for both the HoP and the person asking for access. Having to issue a silver ID just to have enough slots is very awkward and some HoP players do not consider this option- Silver IDs can be seen as reserved for members of command.

The numbers for silver may look odd, these can now carry 11 common accesses(8+2+1), so they are still strictly superior to grey cards. I did not increase this further because some silver ID users(command staff) have a lot of trim slots already, and I do not want them to have AA on a silver card.

## Changelog
:cl:
balance: More wildcard slots on IDs
/:cl: