### PR TITLE
Nova Port: RB-MK2 GUI Rework (#5136)

### DIFF
--- a/modular_zubbers/code/game/machinery/burger_reactor/reactor.dm
+++ b/modular_zubbers/code/game/machinery/burger_reactor/reactor.dm
@@ -296,14 +296,13 @@
 
 	venting = desired_state
 
-	if(!venting)
-		var/turf/T = get_turf(src)
-		if(user)
-			user.log_message("had vents turned off by [src]", LOG_GAME)
-			investigate_log("had vents turned off by [key_name(user)] at [AREACOORD(src)].", INVESTIGATE_ENGINE)
-		else
-			log_game("[src] had vents turned off at [AREACOORD(T)]")
-			investigate_log("had vents turned off at [AREACOORD(T)]", INVESTIGATE_ENGINE)
+	if(user)
+		user.log_message("had vents turned [venting ? "on" : "off"] by [src]", LOG_GAME)
+		investigate_log("had vents turned [venting ? "on" : "off"] by [key_name(user)] at [AREACOORD(src)].", INVESTIGATE_ENGINE)
+	else
+		var/turf/our_turf = get_turf(src)
+		log_game("[src] had vents turned [venting ? "on" : "off"] at [AREACOORD(our_turf)]")
+		investigate_log("had vents turned [venting ? "on" : "off"] at [AREACOORD(our_turf)]", INVESTIGATE_ENGINE)
 
 	update_appearance(UPDATE_ICON)
 
@@ -317,18 +316,20 @@
 		return FALSE
 
 	if(venting) //Can't change when they're already on.
+		if(user)
+			balloon_alert(user, "turn vents off first")
 		return FALSE
 
 	vent_reverse_direction = desired_state
 
-	if(vent_reverse_direction)
-		var/turf/T = get_turf(src)
-		if(user)
-			user.log_message("had vents set in reverse by [src]", LOG_GAME)
-			investigate_log("had vents set in reverse by [key_name(user)] at [AREACOORD(src)].", INVESTIGATE_ENGINE)
-		else
-			log_game("[src] had vents set in reverse at [AREACOORD(T)]")
-			investigate_log("had vents set in reverse at [AREACOORD(T)]", INVESTIGATE_ENGINE)
+	if(user)
+		user.log_message("had vents set to [vent_reverse_direction ? "reverse" : "normal"] by [src]", LOG_GAME)
+		investigate_log("had vents set to [vent_reverse_direction ? "reverse" : "normal"] by [key_name(user)] at [AREACOORD(src)].", INVESTIGATE_ENGINE)
+		balloon_alert(user, "vents switched to [vent_reverse_direction ? "pulling" : "pushing"]")
+	else
+		var/turf/our_turf = get_turf(src)
+		log_game("[src] had vents set to [vent_reverse_direction ? "reverse" : "normal"] at [AREACOORD(our_turf)]")
+		investigate_log("had vents set to [vent_reverse_direction ? "reverse" : "normal"] at [AREACOORD(our_turf)]", INVESTIGATE_ENGINE)
 
 	return TRUE
 
@@ -365,42 +366,95 @@
 
 /obj/machinery/power/rbmk2/ui_data(mob/user)
 	var/list/data = list()
-	data["active"] = active
-	data["rod"] = stored_rod
+	// Progress Bars
+	data["criticality"] = criticality
+	data["health_percent"] = (atom_integrity/max_integrity)*100
+
+	// Used to display the current rod pressure
+	data["rod_mix_pressure"] = stored_rod?.air_contents.return_pressure() || 0
+	// Used as a comparison point for the progress bar
+	data["rod_pressure_limit"] = stored_rod?.pressure_limit || 0
+	// Look for specifically tritium, don't need to show moderators.
+	data["rod_trit_moles"] = stored_rod?.air_contents.gases[/datum/gas/tritium][MOLES] || 0
+	// rod temperature
+	data["rod_mix_temperature"] = stored_rod?.air_contents.temperature || 0
+
+	// This variable and the next allows our limits in the UI to change based on part tiers.
+	data["safeties_max_power_generation"] = safeties_max_power_generation
+	data["max_power_generation"] = max_power_generation
+	// We use this to display our power using this
 	data["last_power_output"] = display_power(last_power_generation)
-	data["efficiency"] = power_efficiency*100
-	data["consuming"] = last_tritium_consumption*10000
+	// but we use this raw to calculate the progress bar
+	data["raw_last_power_output"] = last_power_generation
+
+	// Changed because 1/10,000th is not a micromole and si makes more sense during meltdowns. Div 2 (x0.5) because only procs every two seconds not every second
+	data["consuming"] = siunit(last_tritium_consumption*0.5, "mole", maxdecimals=3)
+	// Required to calculate remaining fuel in the rod_trit_moles progressbar
+	data["raw_consuming"] = last_tritium_consumption*0.5
+
+	// Button data
+	data["venting"] = venting
+	data["vent_dir"] = vent_reverse_direction
+	data["active"] = active
+	data["safety"] = safety
+	data["overclocked"] = overclocked
+	data["rod"] = stored_rod
+
+	// Status displays
+	data["jammed"] = jammed
+	data["meltdown"] = meltdown
 	return data
 
-/obj/machinery/power/rbmk2/ui_act(action, params)
+/obj/machinery/power/rbmk2/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
 	if(.)
 		return
+	var/mob/user = ui.user
+	var/turf/machine_turf = get_turf(src) // Move up here, we only need this line once.
 
+	// all of procs here have logging
 	switch(action)
 		if("activate")
-			toggle_active(usr)
+			toggle_active(user)
 			. = TRUE
 		if("eject")
-			remove_rod(usr,do_throw=TRUE)
+			remove_rod(user, do_throw = TRUE)
 			. = TRUE
 		if("venttoggle")
-			toggle_vents(usr)
+			toggle_vents(user)
 			. = TRUE
-		if("ventdirection")
-			toggle_reverse_vents(usr)
-			balloon_alert(usr, "after a second you feel like the vents direction changed.")
+		if("ventpush") // Vent push and vent pull are separate because I wanted pretty buttons and didn't know how else to implement them.
+			toggle_reverse_vents(user, FALSE)
+			. = TRUE
+		if("ventpull")
+			toggle_reverse_vents(user, TRUE)
 			. = TRUE
 		if("safetytoggle")
-			if(safety == TRUE)
-				balloon_alert(usr, "safety lights are off!")
-				safety = FALSE
-				return
-			if(safety == FALSE)
-				balloon_alert(usr, "safety lights are on!")
-				safety = TRUE
-				return
+
+			safety = !safety
+
+			balloon_alert(user, "safeties are [safety ? "on" : "off"]")
 			. = TRUE
+			if(isliving(user))
+				user.log_message("turned the safety [safety ? "on" : "off"] of [src]", LOG_GAME)
+				investigate_log("had the safety turned [safety ? "on" : "off"] by [key_name(user)] at [AREACOORD(src)].", INVESTIGATE_ENGINE)
+			else
+				log_game("[src] had the safety turned [safety ? "on" : "off"] at [AREACOORD(machine_turf)]")
+				investigate_log("had the safety turned [safety ? "on" : "off"] at [AREACOORD(machine_turf)]", INVESTIGATE_ENGINE)
+			return
+		if("overclocktoggle")
+
+			overclocked = !overclocked
+
+			balloon_alert(user, "overclocking is [overclocked ? "on" : "off"]")
+			. = TRUE
+			if(isliving(user))
+				user.log_message("turned the overclock [overclocked ? "on" : "off"] of [src]", LOG_GAME)
+				investigate_log("had the overclock turned [overclocked ? "on" : "off"] by [key_name(user)] at [AREACOORD(src)].", INVESTIGATE_ENGINE)
+			else
+				log_game("[src] had the overclock turned [overclocked ? "on" : "off"] at [AREACOORD(machine_turf)]")
+				investigate_log("had the overclock turned [overclocked ? "on" : "off"] at [AREACOORD(machine_turf)]", INVESTIGATE_ENGINE)
+			return
 
 
 /obj/machinery/power/rbmk2/examine(mob/user)

--- a/tgui/packages/tgui/interfaces/RBMK2.tsx
+++ b/tgui/packages/tgui/interfaces/RBMK2.tsx
@@ -1,4 +1,6 @@
+// THIS IS A NOVA SECTOR UI FILE
 import {
+  Box,
   Button,
   LabeledList,
   NoticeBox,
@@ -11,34 +13,199 @@ import { useBackend } from '../backend';
 import { Window } from '../layouts';
 
 type ReactorInfo = {
+  venting: BooleanLike;
+  vent_dir: BooleanLike;
   active: BooleanLike;
+  safety: BooleanLike;
+  overclocked: BooleanLike;
+  criticality: number;
+  health_percent: number;
+  max_power_generation: number;
+  safeties_max_power_generation: number;
+  raw_last_power_output: number;
   last_power_output: string;
-  efficiency: number;
   consuming: string;
+  consuming_unit: string;
+  raw_consuming: number;
   rod: BooleanLike;
+  rod_mix_pressure: number;
+  rod_pressure_limit: number;
+  rod_mix_temperature: number;
+  rod_trit_moles: number;
+
+  // Misc
+  jammed: BooleanLike;
+  meltdown: BooleanLike;
 };
 
 export const RBMK2 = (props) => {
   const { act, data } = useBackend<ReactorInfo>();
   return (
-    <Window width={300} height={350}>
+    <Window width={360} height={710}>
       <Window.Content>
         <Section textAlign="center" title="Status">
           <LabeledList>
-            <LabeledList.Item label="Power Generation">
+            <LabeledList.Item
+              label="Activity"
+              tooltip="NOTICE: REACTOR CANNOT BE DEACTIVATED DURING MELTDOWN"
+            >
+              <NoticeBox
+                danger
+                textAlign="center"
+                backgroundColor={data.active ? 'good' : 'bad'}
+              >
+                {data.active ? 'ONLINE' : 'OFFLINE'}
+              </NoticeBox>
+            </LabeledList.Item>
+            <LabeledList.Item
+              label="Reaction"
+              tooltip="NOTICE: ATTEMPTING TO DEACTIVATE WHILE REACTION SAYS 'MELTDOWN' WILL RESULT IN A JAM."
+            >
+              <NoticeBox
+                danger
+                textAlign="center"
+                backgroundColor={data.meltdown ? 'bad' : 'good'}
+              >
+                {data.meltdown ? 'MELTDOWN' : 'STABLE'}
+              </NoticeBox>
+            </LabeledList.Item>
+            <LabeledList.Item
+              label="Clearance"
+              tooltip="NOTICE: DOES NOT SHOW WHETHER OR NOT THE ROD WILL JAM WHEN ATTEMPTING TO DEACTIVATE."
+            >
+              <NoticeBox
+                danger
+                textAlign="center"
+                backgroundColor={data.jammed ? 'bad' : 'good'}
+              >
+                {data.jammed ? 'JAMMED' : 'SAFE'}
+              </NoticeBox>
+            </LabeledList.Item>
+            <LabeledList.Item
+              label="Power Generation"
+              tooltip="Power generation is influenced by pressure and temperature. If unsure, view those meters for further explanations."
+            >
               <ProgressBar
-                value={parseInt(data.last_power_output, 10)}
+                value={data.raw_last_power_output}
+                minValue={0}
+                maxValue={data.safeties_max_power_generation}
                 ranges={{
-                  good: [100, Infinity],
-                  average: [30, 60],
-                  bad: [-Infinity, 30],
+                  maroon: [data.max_power_generation * 10, Infinity],
+                  bad: [
+                    data.max_power_generation,
+                    data.max_power_generation * 10,
+                  ],
+                  yellow: [
+                    data.safeties_max_power_generation,
+                    data.max_power_generation,
+                  ],
+                  good: [0, data.safeties_max_power_generation],
                 }}
               >
                 {data.last_power_output}
               </ProgressBar>
             </LabeledList.Item>
+            <LabeledList.Item
+              label="Rod Pressure"
+              tooltip="Pressures above 4500 kPa begin to increasingly slow down the reaction, with the slowest speed by 18,000 kPa. Safety systems will trigger at pressures exceeding 9000 kPa."
+            >
+              <ProgressBar
+                value={data.rod_mix_pressure}
+                minValue={0}
+                maxValue={data.rod_pressure_limit}
+                ranges={{
+                  maroon: [data.rod_pressure_limit * 2, Infinity],
+                  bad: [data.rod_pressure_limit, data.rod_pressure_limit * 2],
+                  orange: [
+                    data.rod_pressure_limit * 0.75,
+                    data.rod_pressure_limit,
+                  ],
+                  yellow: [
+                    data.rod_pressure_limit * 0.5,
+                    data.rod_pressure_limit * 0.75,
+                  ],
+                  good: [-Infinity, data.rod_pressure_limit * 0.5],
+                }}
+              >
+                {data.rod_mix_pressure} kPa
+              </ProgressBar>
+            </LabeledList.Item>
+            <LabeledList.Item
+              label="Rod Temperature"
+              tooltip="As the temperature of the mix increases, fuel consumption rises, leading to greater power generation. If safeties are disabled, the reactor will begin to meltdown at 2,073.15°K."
+            >
+              <ProgressBar
+                value={data.rod_mix_temperature}
+                // Thermomachine/gas meter colors + maroon.
+                ranges={{
+                  maroon: [2000, Infinity],
+                  red: [700, 2000],
+                  orange: [460, 700],
+                  yellow: [340, 460],
+                  good: [200, 340],
+                  cyan: [120, 200],
+                  blue: [60, 120],
+                  violet: [-Infinity, 60],
+                }}
+              >
+                {data.rod_mix_temperature} K
+              </ProgressBar>
+            </LabeledList.Item>
+            <LabeledList.Item
+              label="Remaining Fuel"
+              tooltip="Amount of tritium remaining in the current rod. Assuming a sane operator, 9 moles can produce 1 MW for 3 hours. We have calculated for 5, 10, and 15 minutes to give colored warnings."
+            >
+              <ProgressBar // Changes color based on rate of consumption while giving you a total reading.
+                value={data.rod_trit_moles}
+                minValue={0}
+                maxValue={9}
+                ranges={{
+                  bad: [-Infinity, data.raw_consuming * 300],
+                  orange: [data.raw_consuming * 300, data.raw_consuming * 600],
+                  yellow: [data.raw_consuming * 600, data.raw_consuming * 900],
+                  good: [data.raw_consuming * 900, Infinity],
+                }}
+              >
+                {data.rod_trit_moles} Moles
+              </ProgressBar>
+            </LabeledList.Item>
             <LabeledList.Item label="Tritium Usage">
-              {data.consuming} μmol/s
+              {data.consuming}/s
+            </LabeledList.Item>
+            <LabeledList.Item
+              label="Criticality"
+              tooltip="During meltdowns, criticality levels rise significantly. As criticality rises, the risk of explosive integrity failure intensifies (as does the blast radius.) Exceeding 100% criticality poses a severe risk of spontaneous reactor explosion. Kindly don't let this happen planetside; we don't want another incident."
+            >
+              <ProgressBar
+                value={data.criticality}
+                minValue={0}
+                maxValue={100}
+                ranges={{
+                  maroon: [100, Infinity],
+                  bad: [75, 100],
+                  orange: [50, 75],
+                  yellow: [25, 50],
+                  good: [-Infinity, 25],
+                }}
+              >
+                {data.criticality}%
+              </ProgressBar>
+            </LabeledList.Item>
+            <LabeledList.Item label="Integrity">
+              <ProgressBar
+                value={data.health_percent}
+                minValue={0}
+                maxValue={100}
+                ranges={{
+                  good: [80, Infinity],
+                  yellow: [50, 80],
+                  orange: [25, 50],
+                  bad: [5, 25],
+                  maroon: [-Infinity, 5],
+                }}
+              >
+                {data.health_percent}%
+              </ProgressBar>
             </LabeledList.Item>
           </LabeledList>
         </Section>
@@ -50,18 +217,18 @@ export const RBMK2 = (props) => {
               width="100%"
               icon="fa-power-off"
               confirmContent="Are you sure?"
-              selected={data.active}
+              color={data.active ? 'yellow' : 'good'}
               onClick={() => act('activate')}
             >
               {data.active ? 'Deactivate' : 'Activate'}
             </Button.Confirm>
             {data.rod ? (
               <Button.Confirm
-                tooltip="Fuel Rod Ejection Button"
+                tooltip="Ejects currently inserted rod. NOTE: We haven't been able to consistently recreate this in testing, but this button can (rarely) unjam the rod. It's better to use a crowbar."
                 textAlign="center"
                 width="100%"
                 icon="fa-eject"
-                color="purple"
+                color="bad"
                 onClick={() => act('eject')}
               >
                 Eject Fuel Rod
@@ -71,36 +238,98 @@ export const RBMK2 = (props) => {
                 No control rod to eject
               </NoticeBox>
             )}
-            <Button.Confirm
-              tooltip="Vent Control Button"
-              textAlign="center"
-              width="100%"
-              icon="fa-fan"
-              color="green"
-              onClick={() => act('venttoggle')}
-            >
-              Toggle Vents
-            </Button.Confirm>
-            <Button.Confirm
-              tooltip="Vent Direction Change Button"
-              textAlign="center"
-              width="100%"
-              icon="fa-clock-rotate-left"
-              color="blue"
-              onClick={() => act('ventdirection')}
-            >
-              Change Vents Direction
-            </Button.Confirm>
-            <Button.Confirm
-              tooltip="Safety Toggle Button"
-              textAlign="center"
-              width="100%"
-              icon="fa-helmet-safety"
-              color="red"
-              onClick={() => act('safetytoggle')}
-            >
-              Turn Off Safeties
-            </Button.Confirm>
+          </LabeledList>
+          <Section title="Vent Controls" textAlign="center">
+            NOTICE: The vents must be off to change directions.
+            <br />
+            <i>(This is a cost saving measure - do not print this part.)</i>
+          </Section>
+          <LabeledList>
+            <LabeledList.Item
+              label="Vent Power"
+              buttons={
+                <>
+                  <Box inline mx={2} color={data.venting ? 'good' : 'bad'}>
+                    {data.venting ? 'ONLINE' : 'OFFLINE'}
+                  </Box>
+                  <Button.Confirm
+                    tooltip="Toggle the vents On/Off."
+                    textAlign="center"
+                    icon="fa-fan"
+                    color={data.venting ? 'bad' : 'good'}
+                    onClick={() => act('venttoggle')}
+                  >
+                    TOGGLE
+                  </Button.Confirm>
+                </>
+              }
+            />
+            <LabeledList.Item
+              label="Vent Direction"
+              buttons={
+                <>
+                  <Box inline mx={5.68} color={data.vent_dir ? 'bad' : 'good'}>
+                    {data.vent_dir ? 'PULLING' : 'PUSHING'}
+                  </Box>
+                  <Button
+                    tooltip="Adjust the vents to draw air from the surrounding environment into the internal chamber of the RBMK2."
+                    icon="fa-clock-rotate-left"
+                    disabled={data.venting}
+                    color={data.vent_dir ? 'yellow' : 'blue'}
+                    onClick={() => act('ventpull')}
+                  />
+                  <Button
+                    tooltip="Adjust the vents to release the contents of the RBMK2's internal chamber into the surrounding environment."
+                    icon="fa-clock-rotate-left fa-flip-horizontal"
+                    disabled={data.venting}
+                    color={data.vent_dir ? 'blue' : 'good'}
+                    onClick={() => act('ventpush')}
+                  />
+                </>
+              }
+            />
+          </LabeledList>
+          <Section title="Adv. Controls" textAlign="center">
+            WARNING: Settings within this section may explosively void your
+            warranty.
+          </Section>
+          <LabeledList>
+            <LabeledList.Item
+              label="Safeties"
+              buttons={
+                <>
+                  <Box inline mx={2} color={data.safety ? 'good' : 'bad'}>
+                    {data.safety ? 'ONLINE' : 'OFFLINE'}
+                  </Box>
+                  <Button.Confirm
+                    tooltip="DANGER: Toggle safeties on/off. Only do this if you KNOW what you're doing!"
+                    icon="fa-helmet-safety"
+                    color={data.safety ? 'bad' : 'good'}
+                    onClick={() => act('safetytoggle')}
+                  >
+                    TOGGLE
+                  </Button.Confirm>
+                </>
+              }
+            />
+            <LabeledList.Item
+              label="Overclock"
+              buttons={
+                <>
+                  <Box inline mx={2} color={data.overclocked ? 'good' : 'bad'}>
+                    {data.overclocked ? 'ONLINE' : 'OFFLINE'}
+                  </Box>
+                  <Button.Confirm
+                    tooltip="DANGER: Toggle overclock on/off. When combined with disabled safeties, this can be very volatile! Make sure you know what you're doing!"
+                    icon="exclamation-triangle"
+                    color={data.overclocked ? 'yellow' : 'good'}
+                    onClick={() => act('overclocktoggle')}
+                  >
+                    TOGGLE
+                  </Button.Confirm>
+                </>
+              }
+            />
           </LabeledList>
         </Section>
       </Window.Content>


### PR DESCRIPTION
## About The Pull Request
A significant [rework of the RB-MK2 GUI](https://github.com/NovaSector/NovaSector/pull/5136) that I did over on Nova. The one you guys have now is painful to use in comparison so let's get it up to snuff.

## Why It's Good For The Game
More information makes the RB-MK2 easier to use and teach in character. With how the GUI is currently, it gives no intuitive explanation for what it's doing. You can't tell what's going on with it.

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

https://github.com/user-attachments/assets/7a178ac2-df8e-40d3-a6f3-b6aa617b69fd


</details>

## Changelog
:cl: Chestlet
admin: Improved RB-MK2 logging so admins have a full trace of exactly what happened with it.
fix: Corrected 'tritium usage' math in the RB-MK2.
code: We've noticed that the Radioscopical Bluespace Reactor Mark Two blueprints provided to our stations came with antiquated firmware. This issue has been rectified. (Significant rework of the RB-MK2 GUI)
/:cl:
