### PR TITLE
Fix double box on vote results chat message

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -119,7 +119,7 @@ SUBSYSTEM_DEF(vote)
 	)
 	log_vote("vote finalized", vote_log_data)
 	if(to_display)
-		to_chat(world, custom_boxed_message("purple_box", vote_font("[to_display]"))) // BUBBER EDIT CHANGE -  span_infoplain changed to examine_block
+		to_chat(world, span_infoplain(vote_font("[to_display]")))
 
 	// Finally, doing any effects on vote completion
 	current_vote.finalize_vote(final_winner)


### PR DESCRIPTION

## About The Pull Request

There's a redundant override in `vote.dm` to enclose the vote results in a purple examine box, this is the default way votes are displayed now so it's making vote results appear as a box within a box

## Why It's Good For The Game

Looks wrong

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
Before:

![image](https://github.com/user-attachments/assets/e85781f3-ee68-4581-8a26-42aa577479f9)

After:
![image](https://github.com/user-attachments/assets/b9ffda2a-950b-42e3-b476-c3b62dadd9a0)

</details>

## Changelog
:cl:
fix: fixed vote results in chat having an extra box around them
/:cl:
