### PR TITLE
Changes access to AI upload boards.

### DIFF
--- a/code/modules/research/techweb/nodes/cyborg_nodes.dm
+++ b/code/modules/research/techweb/nodes/cyborg_nodes.dm
@@ -31,7 +31,9 @@
 	prereq_ids = list(TECHWEB_NODE_AUGMENTATION)
 	design_ids = list(
 		"robocontrol",
+/* // BUBBER EDIT
 		"borgupload",
+*/
 		"cyborgrecharger",
 		"mmi_posi",
 		"mmi",

--- a/code/modules/research/techweb/nodes/robo_nodes.dm
+++ b/code/modules/research/techweb/nodes/robo_nodes.dm
@@ -31,7 +31,9 @@
 	design_ids = list(
 		"aicore",
 		"aifixer",
+/* // BUBBER EDIT
 		"aiupload",
+*/
 		"asimov_module",
 		"borg_ai_control",
 		"corporate_module",

--- a/modular_zubbers/code/modules/cargo/packs/science.dm
+++ b/modular_zubbers/code/modules/cargo/packs/science.dm
@@ -1,0 +1,11 @@
+/datum/supply_pack/science/upload
+	name = "Upload Console Crate"
+	desc = "AI Upload console destroyed in an unfortunate accident? These replacement circuits will get you re-lawing rogue AI in no time!"
+	cost = CARGO_CRATE_VALUE * 12
+	access = ACCESS_AI_UPLOAD
+	access_view = ACCESS_AI_UPLOAD
+	contains = list(/obj/item/circuitboard/computer/aiupload = 1,
+					/obj/item/circuitboard/computer/borgupload = 1)
+	crate_name = "upload console crate"
+	crate_type = /obj/structure/closet/crate/secure/science
+	dangerous = TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9076,6 +9076,7 @@
 #include "modular_zubbers\code\modules\cargo\packs\general.dm"
 #include "modular_zubbers\code\modules\cargo\packs\goodies.dm"
 #include "modular_zubbers\code\modules\cargo\packs\metalsheets.dm"
+#include "modular_zubbers\code\modules\cargo\packs\science.dm"
 #include "modular_zubbers\code\modules\cargo\packs\security.dm"
 #include "modular_zubbers\code\modules\cargo\packs\service.dm"
 #include "modular_zubbers\code\modules\changeling_zombies\antagonist.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes (comments out) access to the AI upload board in the artificial intelligence tech node, and the cyborg upload board in the cybernetics tech node.

Adds an upload board crate to cargo that contains an AI upload board and a cyborg upload board. It can only be opened by a crew member with access to the AI upload, and can only be privately purchased by a crew member with access to the AI upload.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

AI and cyborg upload consoles being printable at the engineering and science circuit imprinters makes changing their laws far too easy, and makes the AI upload room almost entirely redundant. This PR makes the AI upload room something actually worth to hijack into as an antagonist and raises the bar in terms of effort required to change the AI's laws.

Science and engineering both retain access to actual AI law boards via the circuit imprinter, but will need to hack into the AI upload or somehow steal an AI upload crate from cargo.

Cargo does now have an easier way to steal AI boards, however they still have to find a way to get AI law boards (unless using a syndicate one).  And in terms of balance, they already have access to more dangerous or as dangerous crates, such as the supermatter or TTV crate.  (Also it's arguable if ordering a crate as cargo is actually easier than just hacking into the sci or engie circuit imprinter to print an AI upload board.)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Proof Of Testing

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->
<details>
<summary> 

![image](https://github.com/user-attachments/assets/d296a64f-a85d-4ad9-82e9-6836f75becde)

![image](https://github.com/user-attachments/assets/13811678-d017-4d7e-809e-2218acf34a9b)

![image](https://github.com/user-attachments/assets/2487b32d-4132-4b62-9bf1-f9cd3f39814c)

![image](https://github.com/user-attachments/assets/63228d31-535e-48bb-a734-9814c3f636f7)

![image](https://github.com/user-attachments/assets/fb2f9dd0-dd91-44be-962f-99f9d825ac0f)

</summary>

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: New AI upload board crate to get more upload boards.
balance: Removed access to AI upload and cyborg upload via research.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
