### PR TITLE
Fix admin chat buttons to cancel/refund storyteller events not working

### DIFF
--- a/modular_zubbers/code/modules/storyteller/scheduled_event.dm
+++ b/modular_zubbers/code/modules/storyteller/scheduled_event.dm
@@ -66,3 +66,28 @@
 	remove_occurence()
 	event = null
 	return ..()
+
+/datum/scheduled_event/Topic(href, list/href_list)
+	. = ..()
+	switch(href_list["action"])
+		if("cancel")
+			message_admins("[key_name_admin(usr)] cancelled scheduled event [src.event.name].")
+			log_admin_private("[key_name(usr)] cancelled scheduled event [src.event.name].")
+			SSgamemode.remove_scheduled_event(src)
+		if("refund")
+			message_admins("[key_name_admin(usr)] refunded scheduled event [src.event.name].")
+			log_admin_private("[key_name(usr)] refunded scheduled event [src.event.name].")
+			SSgamemode.refund_scheduled_event(src)
+		if("reschedule")
+			var/new_schedule = tgui_input_number(usr, "Set time in seconds in which to fire event", "Rescheduling event", 0, 3600, 0)
+			if(isnull(new_schedule) || QDELETED(src))
+				return
+			src.start_time = world.time + (new_schedule SECONDS)
+			message_admins("[key_name_admin(usr)] rescheduled event [src.event.name] to [new_schedule] seconds.")
+			log_admin_private("[key_name(usr)] rescheduled event [src.event.name] to [new_schedule] seconds.")
+		if("fire")
+			if(!SSticker.HasRoundStarted())
+				return
+			message_admins("[key_name_admin(usr)] has fired scheduled event [src.event.name].")
+			log_admin_private("[key_name(usr)] has fired scheduled event [src.event.name].")
+			src.try_fire()


### PR DESCRIPTION

## About The Pull Request

The chat messages that get sent when a storyteller event is about to run try to call `Topic` on the scheduled event datum but there isn't actually a `Topic` proc defined for them

## Why It's Good For The Game

It's mean to trick admins with fake buttons

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/41d0df79-3220-4b8e-8f86-63df97b2d540)

</details>

## Changelog
:cl:
admin: the cancel and refund buttons in storyteller event notifications will actually do something now
/:cl:
