### PR TITLE
Allow hypospray in medical pouch

### DIFF
--- a/modular_skyrat/modules/modular_items/code/bags.dm
+++ b/modular_skyrat/modules/modular_items/code/bags.dm
@@ -74,11 +74,13 @@
 	/// The list of things that medical pouches can hold. Stolen from what medkits can hold, but modified for things you would probably want at pocket-access.
 	var/static/list/med_pouch_holdables = list(
 		/obj/item/healthanalyzer,
+		/obj/item/hypospray/mkii,
 		/obj/item/dnainjector,
 		/obj/item/reagent_containers/dropper,
 		/obj/item/reagent_containers/cup/beaker,
 		/obj/item/reagent_containers/cup/bottle,
 		/obj/item/reagent_containers/cup/tube,
+		/obj/item/reagent_containers/cup/vial,
 		/obj/item/reagent_containers/pill,
 		/obj/item/reagent_containers/syringe,
 		/obj/item/reagent_containers/medigel,
@@ -86,6 +88,7 @@
 		/obj/item/reagent_containers/hypospray,
 		/obj/item/storage/pill_bottle,
 		/obj/item/storage/box/bandages,
+		/obj/item/stack/cable_coil,
 		/obj/item/stack/medical,
 		/obj/item/flashlight/pen,
 		/obj/item/bonesetter,


### PR DESCRIPTION
## About The Pull Request

Adds hypospray and cable to the allowed list of items in the medical pouch

## Why It's Good For The Game

Commonly held items, other reagent containers are accepted but hypo is missing.

## Changelog

:cl: LT3
qol: The medical pouch can now hold hyposprays and cable coil
/:cl: