### PR TITLE
Xenoarch machines cleanup

### DIFF
--- a/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_machine.dm
+++ b/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_machine.dm
@@ -85,7 +85,7 @@
 	/// the max amount of value we can have
 	var/max_research = 300
 	/// the value of each accepted item
-	var/list/accepted_types = list(
+	var/static/list/accepted_types = list(
 		/obj/item/xenoarch/strange_rock = 1,
 		/obj/item/xenoarch/useless_relic = 5,
 		/obj/item/xenoarch/useless_relic/magnified = 10,

--- a/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_machine.dm
+++ b/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_machine.dm
@@ -107,7 +107,7 @@
 
 /obj/machinery/xenoarch/researcher/examine(mob/user)
 	. = ..()
-	. += span_notice("<br>[current_research]/[max_research] research available.")
+	. += span_notice("[current_research]/[max_research] research available.")
 
 /obj/machinery/xenoarch/researcher/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	if(istype(tool, /obj/item/storage/bag/xenoarch))

--- a/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_machine.dm
+++ b/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_machine.dm
@@ -227,6 +227,16 @@
 	desc = "A machine that will recover the damaged, destroyed objects found within the strange rocks."
 	icon_state = "recoverer"
 	circuit = /obj/item/circuitboard/machine/xenoarch_machine/xenoarch_recoverer
+	/// Assoc list of item type to reward pool
+	var/static/list/reward_pools = list(
+		/obj/item/xenoarch/broken_item/tech = GLOB.tech_reward,
+		/obj/item/xenoarch/broken_item/weapon = GLOB.weapon_reward,
+		/obj/item/xenoarch/broken_item/illegal = GLOB.illegal_reward,
+		/obj/item/xenoarch/broken_item/alien = GLOB.alien_reward,
+		/obj/item/xenoarch/broken_item/plant = GLOB.plant_reward,
+		/obj/item/xenoarch/broken_item/clothing = GLOB.clothing_reward,
+		/obj/item/xenoarch/broken_item/animal = GLOB.animal_reward,
+	)
 
 /obj/machinery/xenoarch/recoverer/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
@@ -269,44 +279,13 @@
 		qdel(content_obj)
 		return
 
-	if(istype(content_obj, /obj/item/xenoarch/broken_item/tech))
-		var/spawn_item = pick_weight(GLOB.tech_reward)
-		recover_item(spawn_item, content_obj)
-		return
-
-	if(istype(content_obj, /obj/item/xenoarch/broken_item/weapon))
-		var/spawn_item = pick_weight(GLOB.weapon_reward)
-		recover_item(spawn_item, content_obj)
-		return
-
-	if(istype(content_obj, /obj/item/xenoarch/broken_item/illegal))
-		var/spawn_item = pick_weight(GLOB.illegal_reward)
-		recover_item(spawn_item, content_obj)
-		return
-
-	if(istype(content_obj, /obj/item/xenoarch/broken_item/alien))
-		var/spawn_item = pick_weight(GLOB.alien_reward)
-		recover_item(spawn_item, content_obj)
-		return
-
-	if(istype(content_obj, /obj/item/xenoarch/broken_item/plant))
-		var/spawn_item = pick_weight(GLOB.plant_reward)
-		recover_item(spawn_item, content_obj)
-		return
-
-	if(istype(content_obj, /obj/item/xenoarch/broken_item/clothing))
-		var/spawn_item = pick_weight(GLOB.clothing_reward)
-		recover_item(spawn_item, content_obj)
-		return
-
+	var/spawn_item = pick_weight(reward_pools[content_obj.type])
 	if(istype(content_obj, /obj/item/xenoarch/broken_item/animal))
-		var/spawn_item
 		for(var/looptime in 1 to rand(1,4))
-			spawn_item = pick_weight(GLOB.animal_reward)
+			spawn_item = pick_weight(reward_pools[content_obj.type])
 			new spawn_item(src_turf)
 
-		recover_item(spawn_item, content_obj)
-		return
+	recover_item(spawn_item, content_obj)
 
 /obj/machinery/xenoarch/recoverer/proc/recover_item(obj/insert_obj, obj/delete_obj)
 	var/src_turf = get_turf(src)

--- a/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_machine.dm
+++ b/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_machine.dm
@@ -7,19 +7,29 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 100
 	pass_flags = PASSTABLE
-	/// the item that holds everything
-	var/obj/item/storage_unit
+	/// Xenoarch-related things we're currently storing
+	var/list/obj/item/xenoarch_contents = list()
 	///how long between each process
 	var/process_speed = 10 SECONDS
 	COOLDOWN_DECLARE(process_delay)
 
 /obj/machinery/xenoarch/Initialize(mapload)
 	. = ..()
-	storage_unit = new /obj/item(src)
+	register_context()
 
-/obj/machinery/xenoarch/Destroy()
-	QDEL_NULL(storage_unit)
-	return ..()
+/obj/machinery/xenoarch/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+	switch(held_item.tool_behaviour)
+		if(TOOL_WRENCH)
+			context[SCREENTIP_CONTEXT_LMB] = "[src.anchored ? "Unanchor" : "Anchor"]"
+			return CONTEXTUAL_SCREENTIP_SET
+		if(TOOL_SCREWDRIVER)
+			context[SCREENTIP_CONTEXT_LMB] = "[src.panel_open ? "Close" : "Open"] panel"
+			return CONTEXTUAL_SCREENTIP_SET
+		if(TOOL_CROWBAR)
+			if(panel_open)
+				context[SCREENTIP_CONTEXT_LMB] = "Deconstruct machine"
+				return CONTEXTUAL_SCREENTIP_SET
 
 /obj/machinery/xenoarch/RefreshParts()
 	. = ..()
@@ -80,26 +90,39 @@
 		/obj/item/xenoarch/broken_item = 10,
 	)
 
+/obj/machinery/xenoarch/researcher/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+	if(!held_item)
+		context[SCREENTIP_CONTEXT_LMB] = "Eject rocks"
+		context[SCREENTIP_CONTEXT_RMB] = "Use research points"
+		return CONTEXTUAL_SCREENTIP_SET
+	if(is_type_in_list(held_item, accepted_types))
+		context[SCREENTIP_CONTEXT_LMB] = "Insert item"
+		return CONTEXTUAL_SCREENTIP_SET
+	if(istype(held_item, /obj/item/storage/bag/xenoarch))
+		context[SCREENTIP_CONTEXT_LMB] = "Dump bag into machine"
+		return CONTEXTUAL_SCREENTIP_SET
+
 /obj/machinery/xenoarch/researcher/examine(mob/user)
 	. = ..()
-
 	. += span_notice("<br>[current_research]/[max_research] research available.")
-	. += span_notice("L-Click to insert items or take out all the strange rocks. R-Click to use research points.")
 
-/obj/machinery/xenoarch/researcher/attackby(obj/item/weapon, mob/user, params)
-	if(istype(weapon, /obj/item/storage/bag/xenoarch))
-		for(var/obj/strange_rocks in weapon.contents)
-			strange_rocks.forceMove(storage_unit)
+/obj/machinery/xenoarch/researcher/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(istype(tool, /obj/item/storage/bag/xenoarch))
+		for(var/obj/item/xenoarch/strange_rocks in tool.contents)
+			strange_rocks.forceMove(src)
+			xenoarch_contents += strange_rocks
 
 		balloon_alert(user, "rocks inserted!")
-		return
+		return ITEM_INTERACT_SUCCESS
 
-	if(is_type_in_list(weapon, accepted_types))
-		weapon.forceMove(storage_unit)
+	if(is_type_in_list(tool, accepted_types))
+		tool.forceMove(src)
+		xenoarch_contents += tool
 		balloon_alert(user, "item inserted!")
-		return
+		return ITEM_INTERACT_SUCCESS
 
-	return ..()
+	return NONE
 
 /obj/machinery/xenoarch/researcher/attack_hand(mob/living/user, list/modifiers)
 	. = ..()
@@ -108,8 +131,9 @@
 		return
 
 	var/turf/src_turf = get_turf(src)
-	for(var/obj/item/removed_item in storage_unit.contents)
+	for(var/obj/item/removed_item in xenoarch_contents)
 		removed_item.forceMove(src_turf)
+		xenoarch_contents -= removed_item
 
 	balloon_alert(user, "items removed!")
 
@@ -150,15 +174,16 @@
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/machinery/xenoarch/researcher/xenoarch_process()
-	if(length(storage_unit.contents) <= 0)
+	if(length(xenoarch_contents) <= 0)
 		return
 
 	if(current_research >= max_research)
 		return
 
-	var/obj/item/first_item = storage_unit.contents[1]
+	var/obj/item/first_item = xenoarch_contents[1]
 	var/reward_attempt = accepted_types[first_item.type]
 	current_research = min(current_research + reward_attempt, 300)
+	xenoarch_contents -= first_item
 	qdel(first_item)
 
 /obj/machinery/xenoarch/scanner
@@ -167,22 +192,31 @@
 	icon_state = "scanner"
 	circuit = /obj/item/circuitboard/machine/xenoarch_machine/xenoarch_scanner
 
-/obj/machinery/xenoarch/scanner/attackby(obj/item/weapon, mob/user, params)
-	if(istype(weapon, /obj/item/storage/bag/xenoarch))
-		for(var/obj/item/xenoarch/strange_rock/chosen_rocks in weapon.contents)
+/obj/machinery/xenoarch/scanner/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+	if(istype(held_item, /obj/item/storage/bag/xenoarch))
+		context[SCREENTIP_CONTEXT_LMB] = "Scan items in bag"
+		return CONTEXTUAL_SCREENTIP_SET
+	if(istype(held_item, /obj/item/xenoarch/strange_rock))
+		context[SCREENTIP_CONTEXT_LMB] = "Scan item"
+		return CONTEXTUAL_SCREENTIP_SET
+
+/obj/machinery/xenoarch/scanner/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(istype(tool, /obj/item/storage/bag/xenoarch))
+		for(var/obj/item/xenoarch/strange_rock/chosen_rocks in tool.contents)
 			chosen_rocks.get_scanned()
 
 		balloon_alert(user, "scan complete!")
-		return
+		return ITEM_INTERACT_SUCCESS
 
-	if(istype(weapon, /obj/item/xenoarch/strange_rock))
-		var/obj/item/xenoarch/strange_rock/chosen_rock
+	if(istype(tool, /obj/item/xenoarch/strange_rock))
+		var/obj/item/xenoarch/strange_rock/chosen_rock = tool
 		if(chosen_rock.get_scanned())
 			balloon_alert(user, "scan complete!")
-			return
-
-		to_chat(user, span_warning("[chosen_rock] was unable to be scanned, perhaps it was already scanned?"))
-		return
+			return ITEM_INTERACT_SUCCESS
+		else
+			to_chat(user, span_warning("[chosen_rock] was unable to be scanned, perhaps it was already scanned?"))
+			return ITEM_INTERACT_BLOCKING
 
 	return ..()
 
@@ -192,15 +226,21 @@
 	icon_state = "recoverer"
 	circuit = /obj/item/circuitboard/machine/xenoarch_machine/xenoarch_recoverer
 
-/obj/machinery/xenoarch/recoverer/examine(mob/user)
+/obj/machinery/xenoarch/recoverer/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
-	. += span_notice("<br>L-Click to remove all items inside [src].")
+	if(!held_item)
+		context[SCREENTIP_CONTEXT_LMB] = "Eject all items"
+		return CONTEXTUAL_SCREENTIP_SET
+	if(istype(held_item, /obj/item/xenoarch/broken_item))
+		context[SCREENTIP_CONTEXT_LMB] = "Insert item"
+		return CONTEXTUAL_SCREENTIP_SET
 
-/obj/machinery/xenoarch/recoverer/attackby(obj/item/weapon, mob/user, params)
-	if(istype(weapon, /obj/item/xenoarch/broken_item))
-		weapon.forceMove(storage_unit)
+/obj/machinery/xenoarch/recoverer/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(istype(tool, /obj/item/xenoarch/broken_item))
+		tool.forceMove(src)
+		xenoarch_contents += tool
 		balloon_alert(user, "item inserted!")
-		return
+		return ITEM_INTERACT_SUCCESS
 
 	return ..()
 
@@ -210,18 +250,20 @@
 		return
 
 	var/turf/src_turf = get_turf(src)
-	for(var/obj/item/removed_item in storage_unit.contents)
+	for(var/obj/item/removed_item in xenoarch_contents)
 		removed_item.forceMove(src_turf)
+		xenoarch_contents -= removed_item
 
 	balloon_alert(user, "items removed!")
 
 /obj/machinery/xenoarch/recoverer/xenoarch_process()
 	var/turf/src_turf = get_turf(src)
-	if(length(storage_unit.contents) <= 0)
+	if(length(xenoarch_contents) <= 0)
 		return
 
-	var/obj/item/content_obj = storage_unit.contents[1]
+	var/obj/item/content_obj = xenoarch_contents[1]
 	if(!istype(content_obj, /obj/item/xenoarch/broken_item))
+		xenoarch_contents -= content_obj
 		qdel(content_obj)
 		return
 
@@ -268,6 +310,7 @@
 	var/src_turf = get_turf(src)
 	new insert_obj(src_turf)
 	playsound(src, 'sound/machines/click.ogg', 50, TRUE)
+	xenoarch_contents -= delete_obj
 	qdel(delete_obj)
 
 /obj/machinery/xenoarch/digger
@@ -276,22 +319,34 @@
 	icon_state = "digger"
 	circuit = /obj/item/circuitboard/machine/xenoarch_machine/xenoarch_digger
 
-/obj/machinery/xenoarch/digger/examine(mob/user)
+/obj/machinery/xenoarch/digger/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
-	. += span_notice("<br>L-Click to remove all items inside [src].")
+	if(!held_item)
+		context[SCREENTIP_CONTEXT_LMB] = "Eject all items"
+		return CONTEXTUAL_SCREENTIP_SET
+	if(istype(held_item, /obj/item/storage/bag/xenoarch))
+		context[SCREENTIP_CONTEXT_LMB] = "Dump bag into machine"
+		return CONTEXTUAL_SCREENTIP_SET
+	if(istype(held_item, /obj/item/xenoarch/strange_rock))
+		context[SCREENTIP_CONTEXT_LMB] = "Insert item"
+		return CONTEXTUAL_SCREENTIP_SET
 
-/obj/machinery/xenoarch/digger/attackby(obj/item/weapon, mob/user, params)
-	if(istype(weapon, /obj/item/storage/bag/xenoarch))
-		for(var/obj/strange_rocks in weapon.contents)
-			strange_rocks.forceMove(storage_unit)
+/obj/machinery/xenoarch/digger/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(istype(tool, /obj/item/storage/bag/xenoarch))
+		for(var/obj/item/strange_rocks in tool.contents)
+			strange_rocks.forceMove(src)
+			xenoarch_contents += strange_rocks
 
 		balloon_alert(user, "rocks inserted!")
-		return
+		return ITEM_INTERACT_SUCCESS
 
-	if(istype(weapon, /obj/item/xenoarch/strange_rock))
-		weapon.forceMove(src)
+	if(istype(tool, /obj/item/xenoarch/strange_rock))
+		tool.forceMove(src)
+		xenoarch_contents += tool
 		balloon_alert(user, "rock inserted!")
-		return
+		return ITEM_INTERACT_SUCCESS
+
+	return ..()
 
 /obj/machinery/xenoarch/digger/attack_hand(mob/living/user, list/modifiers)
 	var/choice = tgui_input_list(user, "Remove the rocks from [src]?", "Rock Removal", list("Yes", "No"))
@@ -299,16 +354,18 @@
 		return
 
 	var/turf/src_turf = get_turf(src)
-	for(var/obj/item/removed_item in storage_unit.contents)
+	for(var/obj/item/removed_item in xenoarch_contents)
 		removed_item.forceMove(src_turf)
+		xenoarch_contents -= removed_item
 
 	balloon_alert(user, "items removed!")
 
 /obj/machinery/xenoarch/digger/xenoarch_process()
 	var/turf/src_turf = get_turf(src)
-	if(length(storage_unit.contents) <= 0)
+	if(length(xenoarch_contents) <= 0)
 		return
 
-	var/obj/item/xenoarch/strange_rock/first_item = storage_unit.contents[1]
+	var/obj/item/xenoarch/strange_rock/first_item = xenoarch_contents[1]
 	new first_item.hidden_item(src_turf)
+	xenoarch_contents -= first_item
 	qdel(first_item)

--- a/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_machine.dm
+++ b/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_machine.dm
@@ -95,7 +95,7 @@
 /obj/machinery/xenoarch/researcher/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
 	if(!held_item)
-		context[SCREENTIP_CONTEXT_LMB] = "Eject rocks"
+		context[SCREENTIP_CONTEXT_LMB] = "Eject all items"
 		context[SCREENTIP_CONTEXT_RMB] = "Use research points"
 		return CONTEXTUAL_SCREENTIP_SET
 	if(is_type_in_list(held_item, accepted_types))

--- a/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_machine.dm
+++ b/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_machine.dm
@@ -110,6 +110,9 @@
 	. += span_notice("[current_research]/[max_research] research available.")
 
 /obj/machinery/xenoarch/researcher/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(user.combat_mode)
+		return ITEM_INTERACT_SKIP_TO_ATTACK
+
 	if(istype(tool, /obj/item/storage/bag/xenoarch))
 		for(var/obj/item/xenoarch/strange_rocks in tool.contents)
 			strange_rocks.forceMove(src)
@@ -204,6 +207,9 @@
 		return CONTEXTUAL_SCREENTIP_SET
 
 /obj/machinery/xenoarch/scanner/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(user.combat_mode)
+		return ITEM_INTERACT_SKIP_TO_ATTACK
+
 	if(istype(tool, /obj/item/storage/bag/xenoarch))
 		for(var/obj/item/xenoarch/strange_rock/chosen_rocks in tool.contents)
 			chosen_rocks.get_scanned()
@@ -248,6 +254,9 @@
 		return CONTEXTUAL_SCREENTIP_SET
 
 /obj/machinery/xenoarch/recoverer/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(user.combat_mode)
+		return ITEM_INTERACT_SKIP_TO_ATTACK
+
 	if(istype(tool, /obj/item/xenoarch/broken_item))
 		tool.forceMove(src)
 		xenoarch_contents += tool
@@ -313,6 +322,9 @@
 		return CONTEXTUAL_SCREENTIP_SET
 
 /obj/machinery/xenoarch/digger/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(user.combat_mode)
+		return ITEM_INTERACT_SKIP_TO_ATTACK
+
 	if(istype(tool, /obj/item/storage/bag/xenoarch))
 		for(var/obj/item/strange_rocks in tool.contents)
 			strange_rocks.forceMove(src)

--- a/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_machine.dm
+++ b/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_machine.dm
@@ -19,6 +19,8 @@
 
 /obj/machinery/xenoarch/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
+	if(!held_item)
+		return
 	switch(held_item.tool_behaviour)
 		if(TOOL_WRENCH)
 			context[SCREENTIP_CONTEXT_LMB] = "[src.anchored ? "Unanchor" : "Anchor"]"


### PR DESCRIPTION

## About The Pull Request

Clean up the code for xenoarch machines some because it made me sad. 
- Changes `attackby`'s to `item_interaction`
- Keep a list of xenoarch items in contents instead of storing them in **an instance of `/obj/item` (yes the abstract concept of an item)**
- Add context tips for all item interactions and removes that info from examine text
- Switched a list to `static`
- Add assoc list of `broken_item` types to reward pools instead of having a nightmare ladder of `istype` checks

## Why It's Good For The Game

Fixes #3442 

## Proof Of Testing

Scout's honor

## Changelog
:cl:
qol: xenoarch machines have context tooltips now
fix: fixed xenoarch diggers not working
/:cl:
