### PR TITLE
Xenoarch Machine QOL

### DIFF
--- a/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/designs_and_tech.dm
+++ b/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/designs_and_tech.dm
@@ -120,7 +120,7 @@
 
 /datum/design/xenoarch/equipment/bag
 	name = "Xenoarchaeology Bag"
-	desc = "A bag that can hold about twenty-five strange rocks."
+	desc = "A bag that can hold about twenty-five strange rocks or relics."
 	id = "xenoarch_bag"
 	build_path = /obj/item/storage/bag/xenoarch
 
@@ -132,7 +132,7 @@
 
 /datum/design/xenoarch/equipment/bag_adv
 	name = "Advanced Xenoarch Bag"
-	desc = "A bag that can hold about fifty strange rocks."
+	desc = "A bag that can hold about fifty strange rocks or relics."
 	id = "xenoarch_bag_adv"
 	materials = list(
 		/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT,

--- a/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_item.dm
+++ b/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_item.dm
@@ -240,7 +240,7 @@
 			The brushes allow you to uncover the items within the proper depths without damaging it.<br> \
 			The tape will allow you to tag the strange rock with the current depth. Continue to examine the rock for updates.<br> \
 			The belt will allow you to store your mobile/handheld tools for easy access.<br> \
-			The bag will allow you to store and automatically pickup strange rocks that you find lying on the floor.<br> \
+			The bag will allow you to store and automatically pickup strange rocks and relics that you find lying on the floor.<br> \
 			The handheld machines allow you to not have to be stuck at the machines. There are only handheld scanners and recoverers.<br> \
 			The Scanner is a machine which allows you to tag the strange rock with its max and safe depth.<br> \
 			The Researcher is a machine that allows you to compile/condense relics and items into larger strange artifacts.<br> \

--- a/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_machine.dm
+++ b/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_machine.dm
@@ -254,10 +254,21 @@
 	if(istype(held_item, /obj/item/xenoarch/broken_item))
 		context[SCREENTIP_CONTEXT_LMB] = "Insert item"
 		return CONTEXTUAL_SCREENTIP_SET
+	if(istype(held_item, /obj/item/storage/bag/xenoarch))
+		context[SCREENTIP_CONTEXT_LMB] = "Dump bag into machine"
+		return CONTEXTUAL_SCREENTIP_SET
 
 /obj/machinery/xenoarch/recoverer/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	if(user.combat_mode)
 		return ITEM_INTERACT_SKIP_TO_ATTACK
+
+	if(istype(tool, /obj/item/storage/bag/xenoarch))
+		for(var/obj/item/xenoarch/broken_item/current_item in tool.contents)
+			current_item.forceMove(src)
+			xenoarch_contents += current_item
+
+		balloon_alert(user, "items inserted!")
+		return ITEM_INTERACT_SUCCESS
 
 	if(istype(tool, /obj/item/xenoarch/broken_item))
 		tool.forceMove(src)

--- a/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_machine.dm
+++ b/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_machine.dm
@@ -191,6 +191,7 @@
 	var/reward_attempt = accepted_types[first_item.type]
 	current_research = min(current_research + reward_attempt, 300)
 	xenoarch_contents -= first_item
+	playsound(src, 'sound/machines/ping.ogg', 50, FALSE)
 	qdel(first_item)
 
 /obj/machinery/xenoarch/scanner
@@ -374,4 +375,5 @@
 	var/obj/item/xenoarch/strange_rock/first_item = xenoarch_contents[1]
 	new first_item.hidden_item(src_turf)
 	xenoarch_contents -= first_item
+	playsound(src, 'sound/machines/click.ogg', 50, TRUE)
 	qdel(first_item)

--- a/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_machine.dm
+++ b/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_machine.dm
@@ -114,11 +114,13 @@
 		return ITEM_INTERACT_SKIP_TO_ATTACK
 
 	if(istype(tool, /obj/item/storage/bag/xenoarch))
-		for(var/obj/item/xenoarch/strange_rocks in tool.contents)
+		for(var/obj/item/strange_rocks in tool.contents)
+			if(!is_type_in_list(strange_rocks, accepted_types))
+				continue
 			strange_rocks.forceMove(src)
 			xenoarch_contents += strange_rocks
 
-		balloon_alert(user, "rocks inserted!")
+		balloon_alert(user, "items inserted!")
 		return ITEM_INTERACT_SUCCESS
 
 	if(is_type_in_list(tool, accepted_types))
@@ -326,7 +328,7 @@
 		return ITEM_INTERACT_SKIP_TO_ATTACK
 
 	if(istype(tool, /obj/item/storage/bag/xenoarch))
-		for(var/obj/item/strange_rocks in tool.contents)
+		for(var/obj/item/xenoarch/strange_rock/strange_rocks in tool.contents)
 			strange_rocks.forceMove(src)
 			xenoarch_contents += strange_rocks
 

--- a/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_tool.dm
+++ b/modular_skyrat/modules/xenoarch/code/modules/research/xenoarch/xenoarch_tool.dm
@@ -201,7 +201,7 @@
 
 /obj/item/storage/bag/xenoarch
 	name = "xenoarch mining satchel"
-	desc = "This little bugger can be used to store and transport strange rocks."
+	desc = "This little bugger can be used to store and transport rocks and relics."
 	icon = 'modular_skyrat/modules/xenoarch/icons/xenoarch_items.dmi'
 	icon_state = "satchel"
 	worn_icon_state = "satchel"
@@ -220,7 +220,11 @@
 	atom_storage.max_total_storage = 1000
 	atom_storage.max_slots = 25
 	atom_storage.numerical_stacking = FALSE
-	atom_storage.can_hold = typecacheof(list(/obj/item/xenoarch/strange_rock))
+	atom_storage.can_hold = typecacheof(list(
+		/obj/item/xenoarch/strange_rock,
+		/obj/item/xenoarch/broken_item,
+		/obj/item/xenoarch/useless_relic,
+	))
 
 /obj/item/storage/bag/xenoarch/equipped(mob/user)
 	. = ..()
@@ -263,8 +267,8 @@
 
 	if(show_message)
 		playsound(user, SFX_RUSTLE, 50, TRUE)
-		user.visible_message(span_notice("[user] scoops up the rocks beneath [user.p_them()]."), \
-			span_notice("You scoop up the rocks beneath you with your [name]."))
+		user.visible_message(span_notice("[user] scoops up the items beneath [user.p_them()]."), \
+			span_notice("You scoop up the items beneath you with your [name]."))
 
 	spam_protection = FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A little treat for xenoarch
- The xenoarch bag can now hold broken items and useless relics in addition to strange rocks
- You can use the bag on both the researcher and the recoverer to dump the contents in
- The digger and the researcher make a sound now

## Why It's Good For The Game

A bag that holds only one type of item is annoying, you get a lot of the other two items too

## Proof Of Testing

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/e314f9e2-efd3-4e4a-a7ea-412c674f88bf)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: the xenoarch bag can now hold broken items and useless relics
qol: you can use the bag on the researcher and the recoverer to dump items in
sound: the digger and researcher now make a sound when they complete a cycle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
