### PR TITLE
restores RCD vending, moves RCD's to lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -18,10 +18,13 @@
 	new /obj/item/extinguisher/advanced(src)
 	new /obj/item/storage/photo_album/ce(src)
 	new /obj/item/storage/box/skillchips/engineering(src)
-	new /obj/item/storage/box/gas_miner_beacons(src) // SKYRAT EDIT ADDITION
-	new /obj/item/construction/plumbing/engineering(src) //SKYRAT EDIT ADDITION
-	new /obj/item/circuitboard/machine/rodstopper(src) //SKYRAT EDIT ADDITION
-	new /obj/item/card/id/departmental_budget/eng(src) //SKYRAT EDIT ADDITION
+	// BUBBER EDIT BEGIN
+	new /obj/item/storage/box/gas_miner_beacons(src)
+	new /obj/item/construction/plumbing/engineering(src)
+	new /obj/item/circuitboard/machine/rodstopper(src)
+	new /obj/item/card/id/departmental_budget/eng(src)
+	new /obj/item/construction/rcd/ce(src)
+	// BUBBER EDIT END
 	new /obj/item/storage/box/stickers/chief_engineer(src)
 
 /obj/structure/closet/secure_closet/engineering_chief/populate_contents_immediate()
@@ -80,7 +83,10 @@
 	new /obj/item/clothing/glasses/meson/engine(src)
 	new /obj/item/storage/box/emptysandbags(src)
 	new /obj/item/storage/bag/construction(src)
-	new /obj/item/construction/plumbing/engineering(src) //SKYRAT EDIT ADDITION
+	// BUBBER EDIT BEGIN
+	new /obj/item/construction/plumbing/engineering(src)
+	new /obj/item/construction/rcd(src)
+	// BUBBER EDIT END
 
 
 /obj/structure/closet/secure_closet/atmospherics

--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -68,7 +68,7 @@
 	uniform = /obj/item/clothing/under/rank/engineering/chief_engineer
 	backpack_contents = list(
 		/obj/item/melee/baton/telescopic/silver = 1,
-		/obj/item/construction/rcd/ce = 1,
+// 		/obj/item/construction/rcd/ce = 1, // BUBBER EDIT -> MOVED TO LOCKER
 	)
 	belt = /obj/item/storage/belt/utility/chief/full
 	ears = /obj/item/radio/headset/heads/ce

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -59,7 +59,7 @@
 	messenger = /obj/item/storage/backpack/messenger/eng
 
 	backpack_contents = list(
-		/obj/item/construction/rcd/loaded,
+//		/obj/item/construction/rcd/loaded, // BUBBER EDIT REMOVAL -> MOVED TO LOCKER
 	)
 
 	box = /obj/item/storage/box/survival/engineer

--- a/code/modules/vending/engivend.dm
+++ b/code/modules/vending/engivend.dm
@@ -23,7 +23,7 @@
 	)
 	premium = list(
 		/obj/item/storage/belt/utility = 3,
-		///obj/item/construction/rcd/loaded = 2, // SKYRAT EDIT REMOVAL
+		/obj/item/construction/rcd/loaded = 2,
 		/obj/item/storage/box/smart_metal_foam = 1,
 	)
 	refill_canister = /obj/item/vending_refill/engivend

--- a/modular_skyrat/modules/modular_vending/code/engivend.dm
+++ b/modular_skyrat/modules/modular_vending/code/engivend.dm
@@ -1,7 +1,6 @@
 /obj/machinery/vending/engivend
 	skyrat_products = list(
 		/obj/item/clothing/glasses/meson/engine = 5,
-		/obj/item/construction/rcd/loaded = 3,
 		/obj/item/storage/pouch/material = 2,
 		/obj/item/storage/bag/construction = 2,
 	)


### PR DESCRIPTION

## About The Pull Request
moves RCD's from engineers backpacks to their lockers roundstart - to accommodate the stowaway change aswell as keep a tab on infinite station resources. 
## Why It's Good For The Game

Above point

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
balance: reenabled the RCD vendors and moved RCD's from spawning in backpacks to lockers. 
/:cl:
