### PR TITLE
Restore frog mob sounds

### DIFF
--- a/code/modules/mob/living/basic/vermin/frog.dm
+++ b/code/modules/mob/living/basic/vermin/frog.dm
@@ -26,7 +26,7 @@
 	response_harm_simple = "splat"
 	density = FALSE
 	faction = list(FACTION_HOSTILE, FACTION_MAINT_CREATURES)
-	attack_sound = null // SKYRAT EDIT - No more frog ear-rape - ORIGINAL: attack_sound = 'sound/effects/reee.ogg'
+	attack_sound = 'sound/mobs/non-humanoids/frog/reee.ogg'
 	butcher_results = list(/obj/item/food/nugget = 1)
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
 	mob_size = MOB_SIZE_TINY
@@ -40,7 +40,7 @@
 
 	ai_controller = /datum/ai_controller/basic_controller/frog
 
-	var/stepped_sound = null // SKYRAT EDIT - No more frog ear-rape - ORIGINA: var/stepped_sound = 'sound/effects/huuu.ogg'
+	var/stepped_sound = 'sound/mobs/non-humanoids/frog/huuu.ogg'
 	///How much of a reagent the mob injects on attack
 	var/poison_per_bite = 3
 	///What reagent the mob injects targets with


### PR DESCRIPTION

## About The Pull Request

Revert a skyrat edit that changed frogs `attack_sound` and `stepped_sound` to null

## Why It's Good For The Game

This is a very specific change that I don't really see a point in, the sounds aren't terrible and the shitty way this was coded means now we get runtimes (causing flaky CI) whenever it tries to play one of their sounds because you can't pass null to `playsound`

## Proof Of Testing

If it compiles it works

## Changelog
:cl:
sound: frogs make sounds again
/:cl:
