### PR TITLE
Fixes surgery tray starting items

### DIFF
--- a/code/game/objects/items/surgery_tray.dm
+++ b/code/game/objects/items/surgery_tray.dm
@@ -171,7 +171,7 @@
 		/obj/item/bonesetter,
 		/obj/item/cautery,
 		/obj/item/circular_saw,
-		/obj/item/clothing/mask/surgical,
+		/obj/item/clothing/suit/toggle/labcoat/hospitalgown, // BUBBER EDIT CHANGE - Original: /obj/item/clothing/mask/surgical
 		/obj/item/hemostat,
 		/obj/item/storage/pill_bottle/lidocaine, // BUBBER EDIT CHANGE - Original: /obj/item/razor/surgery
 		/obj/item/retractor,
@@ -181,7 +181,6 @@
 		/obj/item/surgical_drapes,
 		/obj/item/surgicaldrill,
 		/obj/item/reagent_containers/medigel/sterilizine, // BUBBER EDIT CHANGE
-		/obj/item/clothing/suit/toggle/labcoat/hospitalgown, // BUBBER EDIT ADDITION
 	)
 
 /obj/item/surgery_tray/full/deployed


### PR DESCRIPTION
## About The Pull Request

Fixes a merge conflict error in the upstream, trying to populate the surgery tray with more items than the storage capacity.

## Changelog

:cl: LT3
fix: Surgery tray has the correct starting items
/:cl: