### PR TITLE
Lets Borgs pop out cells from cell chargers

### DIFF
--- a/modular_skyrat/modules/multicellcharger/code/multi_cell_charger.dm
+++ b/modular_skyrat/modules/multicellcharger/code/multi_cell_charger.dm
@@ -33,13 +33,13 @@
 		. += new /mutable_appearance(charge_overlay)
 		. += new /mutable_appearance(cell_overlay)
 
-/obj/machinery/cell_charger_multi/attack_hand_secondary(mob/user, list/modifiers)
+/obj/machinery/cell_charger_multi/click_alt(mob/user)
 	if(!can_interact(user) || !charging_batteries.len)
 		return
-	to_chat(user, span_notice("You press the quick release as all the cells pop out!"))
+	to_chat(user, span_notice("You activate the quick release as all the cells pop out!"))
 	for(var/i in charging_batteries)
 		removecell()
-	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	return CLICK_ACTION_SUCCESS
 
 /obj/machinery/cell_charger_multi/examine(mob/user)
 	. = ..()
@@ -51,7 +51,7 @@
 			. += "There's [charging] cell in the charger, current charge: [round(charging.percent(), 1)]%."
 	if(in_range(user, src) || isobserver(user))
 		. += span_notice("The status display reads: Charging power: <b>[display_power(charge_rate, convert = FALSE)]</b> per cell.")
-	. += span_notice("Right click it to remove all the cells at once!")
+	. += span_notice("Alt click it to remove all the cells at once!")
 
 /obj/machinery/cell_charger_multi/attackby(obj/item/tool, mob/user, params)
 	if(istype(tool, /obj/item/stock_parts/power_store/cell) && !panel_open)

--- a/modular_zubbers/code/game/machinery/cellchargers/cell_charger.dm
+++ b/modular_zubbers/code/game/machinery/cellchargers/cell_charger.dm
@@ -1,0 +1,11 @@
+/obj/machinery/cell_charger/click_alt(mob/user)
+	. = ..()
+	if(. || !charging)
+		return
+	to_chat(user, span_notice("You activate the quick release as the cell pops out!"))
+	removecell(charging.forceMove(drop_location()))
+	return CLICK_ACTION_SUCCESS
+
+/obj/machinery/cell_charger/examine(mob/user)
+	. = ..()
+	. += span_notice("Alt click it to engage the ejection lever!")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8925,6 +8925,7 @@
 #include "modular_zubbers\code\game\machinery\burger_reactor_sniffer\reactor_sniffer_processing.dm"
 #include "modular_zubbers\code\game\machinery\burger_reactor_sniffer\reactor_sniffer_wires.dm"
 #include "modular_zubbers\code\game\machinery\camera\camera.dm"
+#include "modular_zubbers\code\game\machinery\cellchargers\cell_charger.dm"
 #include "modular_zubbers\code\game\machinery\computer\crew.dm"
 #include "modular_zubbers\code\game\machinery\computer\orders\order_computer\cook_order_interdyne.dm"
 #include "modular_zubbers\code\game\machinery\computer\orders\order_computer\cook_order_tarkon.dm"


### PR DESCRIPTION

## About The Pull Request
Borgs can now remove cells from (multi)cell chargers. Does not touch the way carbons remove individual cells.
## Why It's Good For The Game
Engineering and Science borgs can put cells in cell chargers to recharge them but cannot remove them without help or destroying the charger. This fixes it by allowing borgs to make full use of cell chargers.
## Proof Of Testing
It compiles and was tested locally.
<details>
<summary>
 
https://github.com/user-attachments/assets/56fe06ed-4ffe-49b4-b67b-2331cd528bce

 </summary>

</details>

## Changelog
:cl:
add: Adds ability for borgs to eject cells from cell chargers by alt clicking on the charger
add: Changes popping cells out on multicell chargers from right click to alt click to keep the actions the same between chargers
/:cl:
