### PR TITLE
S.W.A.T part 2

### DIFF
--- a/modular_zubbers/code/modules/vending/multisec.dm
+++ b/modular_zubbers/code/modules/vending/multisec.dm
@@ -128,8 +128,6 @@
 					/obj/item/clothing/head/beret/sec/navyofficer = 6,
 					/obj/item/clothing/suit/jacket/officer/tan = 6,
 					/obj/item/clothing/head/helmet/metrocophelmet = 6,
-					/obj/item/clothing/suit/armor/metrocop = 6,
-					/obj/item/clothing/suit/armor/metrocopriot = 6,
 					/obj/item/clothing/accessory/badge/holo = 10, //I know there's a box of them but, why not have more, eh?
 					/obj/item/clothing/accessory/badge/holo/cord = 10,
 					/obj/item/clothing/head/helmet/blueshirt = 3,


### PR DESCRIPTION

## About The Pull Request
Removes the insane metrocop armor from vendors. This not only has full protection unlike standard armor, but it also has a riot varient. Why can you buy full prot armor (defeats the point of swat armor) and riot armor (that should be in armory only) from a clothing vendor that's in every outpost???
## Why It's Good For The Game
## Proof Of Testing
I didn't. It's removing two lines from a vendor.
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl: UvvU
del: Removed metro cop armor from the sec vendors
/:cl:
