### PR TITLE
remove the skyrat emergency medkit sprite override

### DIFF
--- a/modular_skyrat/modules/aesthetics/storage/storage.dm
+++ b/modular_skyrat/modules/aesthetics/storage/storage.dm
@@ -1,6 +1,3 @@
-/obj/item/storage/medkit/emergency
-	icon = 'modular_skyrat/modules/aesthetics/storage/storage.dmi'
-
 /obj/item/borg/upgrade/rped
 	icon = 'modular_skyrat/modules/aesthetics/storage/storage.dmi'
 	icon_state = "borgrped"


### PR DESCRIPTION

## About The Pull Request

Removes the skyrat override for emergency medkit sprite

## Why It's Good For The Game

The skyrat sprite is so out of sync with other medkits that its hard to tell its supposed to be a medkit. Doing this makes it look like the other medkits and be easier to pick out from lockers since its red and stuff.

## Proof Of Testing

No

## Changelog

:cl:
image: removes the sprite override for emergency medkits
/:cl:
