### PR TITLE
give blacksmith wood and apron

### DIFF
--- a/modular_zubbers/code/modules/jobs/job_types/blacksmith.dm
+++ b/modular_zubbers/code/modules/jobs/job_types/blacksmith.dm
@@ -42,10 +42,12 @@
 
 	id_trim = /datum/id_trim/job/blacksmith
 	uniform = /obj/item/clothing/under/rank/cargo/tech/skyrat/long
+	suit = /obj/item/clothing/suit/leatherapron
 	backpack_contents = list(
 		/obj/item/forging/hammer = 1,
 		/obj/item/forging/tongs = 1,
 		/obj/item/forging/billow = 1,
+		/obj/item/stack/sheet/mineral/wood = 25,
 	)
 	belt = /obj/item/modular_computer/pda/cargo
 	ears = /obj/item/radio/headset/headset_cargo


### PR DESCRIPTION
## About The Pull Request

Makes the blacksmith suffer less by giving them a bunch of wood in their backpack

## Why It's Good For The Game

Lets you get forging right away without having to steal wood from chapel or wait for cargo/botany
also the apron makes sense and lets you put your hammer in there or whatever
![image](https://github.com/user-attachments/assets/8b62ef47-a22a-4d2e-b572-2980837016dc)

## Proof Of Testing

I didnt test it

## Changelog

:cl:
add: blacksmith starts out with wood and a leather apron
/:cl:

