### PR TITLE
Non-living beings no longer glow from being irradiated.

### DIFF
--- a/code/datums/components/irradiated.dm
+++ b/code/datums/components/irradiated.dm
@@ -61,7 +61,7 @@
 	))
 
 /datum/component/irradiated/Destroy(force)
-	var/mob/living//parent_movable = parent //BUBBERSTATION CHANGE: MOVABLE TO LIVING
+	var/mob/living/parent_movable = parent //BUBBERSTATION CHANGE: MOVABLE TO LIVING
 	if (istype(parent_movable))
 		parent_movable.remove_filter("rad_glow")
 

--- a/code/datums/components/irradiated.dm
+++ b/code/datums/components/irradiated.dm
@@ -61,7 +61,7 @@
 	))
 
 /datum/component/irradiated/Destroy(force)
-	var/atom/movable/parent_movable = parent
+	var/mob/living//parent_movable = parent //BUBBERSTATION CHANGE: MOVABLE TO LIVING
 	if (istype(parent_movable))
 		parent_movable.remove_filter("rad_glow")
 
@@ -149,7 +149,7 @@
 	)
 
 /datum/component/irradiated/proc/create_glow()
-	var/atom/movable/parent_movable = parent
+	var/mob/living/parent_movable = parent //BUBBERSTATION CHANGE: MOVABLE TO LIVING.
 	if (!istype(parent_movable))
 		return
 


### PR DESCRIPTION
## About The Pull Request

Non-living beings no longer glow from being irradiated.

## Why It's Good For The Game

Massive GPU lag on the client from the amount of radiation filters any time something is irradiated is not good. This PR makes it so that radiation is no longer visible on things that aren't living. You can still check if something is irradiated by scanning it with a Geiger counter.

## Proof Of Testing

Untested.

## Changelog

:cl: BurgerBB
del: Non-living beings no longer glow from being irradiated.
/:cl:

