### PR TITLE
Grammar fix for weapon beacons

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/misc/gun_redemption.dm
+++ b/modular_skyrat/modules/sec_haul/code/misc/gun_redemption.dm
@@ -4,7 +4,7 @@
 	name = "blueshield weapon beacon"
 	desc = "A single use beacon to deliver a weapon of your choice. Please only call this in your office"
 	company_source = "Sol Security Solution"
-	company_message = span_bold("Supply Pod incoming please stand by")
+	company_message = span_bold("Supply pod incoming, please stand by.)
 
 /obj/item/choice_beacon/blueshield/generate_display_names()
 	var/static/list/selectable_gun_types = list(
@@ -23,7 +23,7 @@
 	name = "gunset beacon"
 	desc = "A single use beacon to deliver a gunset of your choice. Please only call this in your office"
 	company_source = "Trappiste Fabriek Company"
-	company_message = span_bold("Supply Pod incoming please stand by")
+	company_message = span_bold("Supply pod incoming, please stand by.)
 
 /obj/item/choice_beacon/ntc/generate_display_names()
 	var/static/list/selectable_gun_types = list(
@@ -39,7 +39,7 @@
 	name = "nanotrasen dignitaries weapon beacon"
 	desc = "A single use beacon to deliver a weapon of your choice. Please only call this in your office"
 	company_source = "Romulus Armoury"
-	company_message = span_bold("Supply Pod incoming please stand by")
+	company_message = span_bold("Supply pod incoming, please stand by.)
 
 /obj/item/choice_beacon/station_magistrate/generate_display_names()
 	var/static/list/selectable_gun_types = list(
@@ -56,7 +56,7 @@
 	name = "sidearm weapon beacon"
 	desc = "A single use beacon to deliver a weapon of your choice. Please only call this in your office"
 	company_source = "Romulus Armoury"
-	company_message = span_bold("Supply Pod incoming please stand by")
+	company_message = span_bold("Supply pod incoming, please stand by.)
 
 /obj/item/choice_beacon/security_pistol/generate_display_names()
 	var/static/list/selectable_gun_types = list(

--- a/modular_zubbers/code/modules/syndicate_offstation/selection_beacons/weapon_redemption.dm
+++ b/modular_zubbers/code/modules/syndicate_offstation/selection_beacons/weapon_redemption.dm
@@ -5,7 +5,7 @@
 	name = "Standard Syndicate sidearm beacon"
 	desc = "A single use beacon to deliver a weapon kit of your choice. Please use this or store it in your safe."
 	company_source = "Gorlex Marauders"
-	company_message = span_bold("Supply Pod incoming please stand by")
+	company_message = span_bold("Supply pod incoming, please stand by.)
 
 /obj/item/choice_beacon/syndicateoffstation/generate_display_names()
 	var/static/list/selectable_gun_types = list(


### PR DESCRIPTION

## About The Pull Request

Weapon beacons had bad grammar in the headset message. This fixes that.

## Why It's Good For The Game

better :)

## Proof Of Testing

no

## Changelog
:cl:
spellcheck: The headset message from weapon beacons have been changed to have better grammar.
/:cl:
