### PR TITLE
Fix being unable to remove cargo teleporter marks

### DIFF
--- a/modular_skyrat/modules/cargo_teleporter/code/cargo_teleporter.dm
+++ b/modular_skyrat/modules/cargo_teleporter/code/cargo_teleporter.dm
@@ -39,6 +39,12 @@ GLOBAL_LIST_EMPTY(cargo_marks)
 	return CLICK_ACTION_SUCCESS
 
 /obj/item/cargo_teleporter/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+	if(istype(interacting_with, /obj/effect/decal/cleanable/cargo_mark))
+		to_chat(user, span_notice("You remove [interacting_with] using [src]."))
+		playsound(interacting_with, 'sound/machines/click.ogg', 50)
+		qdel(interacting_with)
+		return ITEM_INTERACT_SUCCESS
+
 	if(!COOLDOWN_FINISHED(src, use_cooldown))
 		to_chat(user, span_warning("[src] is still on cooldown!"))
 		return ITEM_INTERACT_BLOCKING
@@ -102,14 +108,6 @@ GLOBAL_LIST_EMPTY(cargo_marks)
 
 	light_range = 3
 	light_color = COLOR_VIVID_YELLOW
-
-/obj/effect/decal/cleanable/cargo_mark/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/cargo_teleporter))
-		to_chat(user, span_notice("You remove [src] using [W]."))
-		playsound(src, 'sound/machines/click.ogg', 50)
-		qdel(src)
-		return
-	return ..()
 
 /obj/effect/decal/cleanable/cargo_mark/Destroy()
 	if(parent_item)


### PR DESCRIPTION

## About The Pull Request

Move the handling for removing cargo teleporter destinations from the mark to the teleporter itself

## Why It's Good For The Game

Fixes #3564 

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![dreamseeker_x74BVbncuK](https://github.com/user-attachments/assets/db96f1bb-a346-4fcb-b0fd-c5209972b132)

</details>

## Changelog
:cl:
fix: removing cargo teleporter destinations by clicking on them should work again
/:cl:
