### PR TITLE
Remove the random "digi" from greyscale_configs.dm

### DIFF
--- a/modular_skyrat/modules/GAGS/greyscale_configs.dm
+++ b/modular_skyrat/modules/GAGS/greyscale_configs.dm
@@ -1220,7 +1220,7 @@ TREK
 /datum/greyscale_config/sneakers/worn/teshari
 	name = "Sneakers (Worn, Teshari)"
 	icon_file = 'modular_skyrat/modules/GAGS/icons/sneakers_teshari.dmi'
-digi
+
 /datum/greyscale_config/sneakers_orange/worn/teshari
 	name = "Orange Sneakers (Worn, Teshari)"
 	icon_file = 'modular_skyrat/modules/GAGS/icons/sneakers_teshari.dmi'


### PR DESCRIPTION
## About The Pull Request

Remove the word `digi` that is just sitting in a random code file from years ago and also counts as a type declaration for some reason

## Why It's Good For The Game

Digi

## Proof Of Testing

Digi

## Changelog

No
