### PR TITLE
Self-Actualization Device is available without research

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -39939,13 +39939,10 @@
 /turf/open/floor/glass/reinforced,
 /area/station/service/chapel/monastery)
 "mYV" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 1
 	},
+/obj/machinery/self_actualization_device,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/lobby)
 "mYX" = (

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -13199,7 +13199,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
-/obj/item/banner/medical/mundane,
+/obj/machinery/self_actualization_device,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "dRZ" = (

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -44875,6 +44875,7 @@
 /area/station/engineering/atmos)
 "poh" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/self_actualization_device,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "poj" = (

--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -13354,10 +13354,10 @@
 "dKc" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/effect/spawner/random/medical/patient_stretcher,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/self_actualization_device,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "dKl" = (

--- a/modular_skyrat/master_files/code/modules/research/techweb/all_nodes.dm
+++ b/modular_skyrat/master_files/code/modules/research/techweb/all_nodes.dm
@@ -173,7 +173,7 @@
 
 ////////////////////////Medical////////////////////////
 
-/datum/techweb_node/cytology/New()
+/datum/techweb_node/medbay_equip/New()
 	design_ids += list(
 		"self_actualization_device",
 	)

--- a/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
+++ b/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
@@ -5,7 +5,7 @@
 /// How long does it take to break out of the machine?
 #define BREAKOUT_TIME 5 SECONDS
 /// The interval that advertisements are said by the machine's speaker.
-#define ADVERT_TIME 18 SECONDS
+#define ADVERT_TIME 14 SECONDS
 
 /datum/design/board/self_actualization_device
 	name = "Machine Design (Self-Actualization Device)"
@@ -19,7 +19,6 @@
 	name = "Self-Actualization Device (Machine Board)"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
 	build_path = /obj/machinery/self_actualization_device
-	req_components = list(/datum/stock_part/micro_laser = 1)
 
 /obj/machinery/self_actualization_device
 	name = "Self-Actualization Device"
@@ -29,10 +28,12 @@
 	circuit = /obj/item/circuitboard/machine/self_actualization_device
 	state_open = FALSE
 	density = TRUE
+	active_power_usage = 240 KILO WATTS
+	idle_power_usage = 24 KILO WATTS
 	/// Is someone being processed inside of the machine?
 	var/processing = FALSE
 	/// How long does the machine take to work?
-	var/processing_time = 1 MINUTES
+	var/processing_time = 30 SECONDS
 	/// wzhzhzh
 	var/datum/looping_sound/microwave/sound_loop
 	/// Has the player consented to the DNA change
@@ -214,15 +215,11 @@
 	patient.client?.prefs?.safe_transfer_prefs_to_with_damage(patient, visuals_only = TRUE)
 	patient.dna.update_dna_identity()
 	SSquirks.AssignQuirks(patient, patient.client)
-	log_game("[key_name(patient)] used a Self-Actualization Device at [loc_name(src)].")
-
 	if(patient.dna.real_name != original_name)
-		message_admins("[key_name_admin(patient)] has used the Self-Actualization Device, and changed the name of their character. \
-		Original Name: [original_name], New Name: [patient.dna.real_name]. \
-		This may be a false positive from changing from a humanized monkey into a character, so be careful.")
+		log_game("[key_name(patient)] has used the Self-Actualization Device at [loc_name(src)], changed the name of their character. \
+		Original Name: [original_name], New Name: [patient.dna.real_name].")
 	else
-		message_admins("[key_name_admin(patient)] has used the Self-Actualization Device, and potentially changed their quirks. \
-		This may be a false positive from restoring an altered body of the same name, so be careful.")
+		log_game("[key_name(patient)] has used the Self-Actualization Device at [loc_name(src)].")
 
 	playsound(src, 'sound/machines/microwave/microwave-end.ogg', 100, FALSE)
 	say("Procedure complete! Enjoy your life being a new you!")
@@ -296,14 +293,6 @@
 
 	if(default_deconstruction_crowbar(used_item))
 		return TRUE
-
-/obj/machinery/self_actualization_device/RefreshParts()
-	. = ..()
-	processing_time = 70 SECONDS
-	for(var/datum/stock_part/micro_laser/laser in component_parts) // Laser tier increases speed, at the expense of power.
-		processing_time -= laser.tier * 10 SECONDS
-		active_power_usage = 7200000 / processing_time WATTS
-		idle_power_usage = active_power_usage / 4
 
 #undef NO_CONSENT
 #undef CONSENT_GRANTED


### PR DESCRIPTION
## About The Pull Request

As per adding the SAD to be roundstart available as per admin request, eliminates the research requirement to build new ones. Places a SAD on the Bubberstation specific maps. Updates the logging to properly log instead of spitting into the admin chat.

## Why It's Good For The Game

Now everyone is free to be SAD, anytime, anywhere.

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl: LT3
balance: SAD is now available to be built roundstart
map: Added roundstart SAD to Bubberstation maps
/:cl:
