### PR TITLE
Fixes a oversight with frangible slugs.

### DIFF
--- a/modular_skyrat/modules/shotgunrebalance/code/shotgun.dm
+++ b/modular_skyrat/modules/shotgunrebalance/code/shotgun.dm
@@ -256,7 +256,7 @@
 
 /obj/projectile/bullet/frangible_slug/on_hit(atom/target, blocked = 0, pierce_hit)
 	. = ..()
-	if(istype(target, /obj/structure/window) || istype(target, /obj/machinery/door/airlock) || istype(target, /obj/structure/grille) || istype(target,/obj/structure/door_assembly))
+	if(istype(target, /obj/structure/window) || istype(target, /obj/machinery/door/airlock) || istype(target, /obj/structure/grille) || istype(target,/obj/structure/door_assembly) || istype(target,/obj/machinery/door/window/))
 		if(isobj(target))
 			demolition_mod = 50
 			damage = 30


### PR DESCRIPTION

## About The Pull Request
Fixes windoors being immune to the destructive effects of frangible slugs.
## Why It's Good For The Game
Bugfix :)
## Proof Of Testing
I had fun on icebox destroying the armory windoors. It works.
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl: UvvU
fix: Windoors are no longer immune to frangible slugs effects.
/:cl:
