### PR TITLE
Fix taur clothing being broken

### DIFF
--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -1160,6 +1160,14 @@ mutant_styles: The mutant style - taur bodytype, STYLE_TESHARI, etc. // SKYRAT E
 		draw_target.overlays += worn_overlays
 	draw_target = color_atom_overlay(draw_target)
 
+	// SKYRAT EDIT ADDITION START - Taur-friendly uniforms and suits
+	if (mutant_styles & STYLE_TAUR_ALL)
+		if (!using_taur_variant)
+			draw_target = wear_taur_version(draw_target.icon_state, draw_target.icon, layer2use, female_uniform, greyscale_colors)
+		else
+			draw_target.pixel_w -= 16 // it doesnt look right otherwise
+	// SKYRAT EDIT ADDITION END
+
 	// Okay so this has to be done because some overlays, like blood, want to be KEEP_APART
 	// but KEEP_APART breaks float layering, so what we need to do is make fake KEEP_APART for us to use
 	var/mutable_appearance/standing = mutable_appearance(layer = -layer2use, appearance_flags = KEEP_TOGETHER)
@@ -1169,14 +1177,6 @@ mutant_styles: The mutant style - taur bodytype, STYLE_TESHARI, etc. // SKYRAT E
 		standing.overlays += separate_overlays
 
 	standing = center_image(standing, isinhands ? inhand_x_dimension : worn_x_dimension, isinhands ? inhand_y_dimension : worn_y_dimension)
-
-	// SKYRAT EDIT ADDITION START - Taur-friendly uniforms and suits
-	if (mutant_styles & STYLE_TAUR_ALL)
-		if (!using_taur_variant)
-			standing = wear_taur_version(standing.icon_state, standing.icon, layer2use, female_uniform, greyscale_colors)
-		else
-			standing.pixel_w -= 16 // it doesnt look right otherwise
-	// SKYRAT EDIT ADDITION END
 
 	//Worn offsets
 	var/list/offsets = get_worn_offsets(isinhands)

--- a/modular_skyrat/modules/taur_mechanics/code/taur_clothing_offset.dm
+++ b/modular_skyrat/modules/taur_mechanics/code/taur_clothing_offset.dm
@@ -35,7 +35,7 @@
 	var/offset = taur_body.taur_specific_clothing_y_offsets?["[icon_dir]"]
 	if (!offset)
 		return
-	standing.pixel_y += offset
+	standing.pixel_z += offset
 
 /// Signal handler for COMSIG_ITEM_EQUIPPED. Handles registering signals.
 /datum/component/taur_clothing_offset/proc/parent_equipped(datum/signal_source, mob/equipper, slot)


### PR DESCRIPTION

## About The Pull Request

update a `pixel_y` to `pixel_z` and move a bit of code higher up in a proc call and switch which mutable appearance it works on, because upstream added another step in clothing overlay drawing

## Why It's Good For The Game

Fixes #3563 

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/29d8a02f-fdfa-48a8-b82f-f4b5f1e3c917)

</details>

## Changelog
:cl:
fix: taur clothing should now draw on the body properly
/:cl:
