### PR TITLE
Borgs now get alerted that someone's prying their cover

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -335,7 +335,7 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 			balloon_alert(user, "chassis cover locked!")
 		else
 			// BUBBER EDIT START
-			balloon_alert(user, "chassis cover opened")
+			balloon_alert_to_viewers("Cover Opening...", "Opening Cover...", SAMETILE_MESSAGE_RANGE)
 			if(!do_after(user, 0.5 SECONDS))
 				return FALSE
 			// BUBBER EDIT START


### PR DESCRIPTION

## About The Pull Request

Fixes a reversion from fca806da0c5ed9fb6889d7611eba4c5b7476e12b, which removed the balloon alert.

## Why It's Good For The Game

*beep :]

## Proof Of Testing

*no :[

## Changelog
:cl:
fix: Cyborgs once more get an alert if their cover is being pried open.
/:cl:
