### PR TITLE
Fix two duplicate APC warnings in tarkon areas

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon.dmm
@@ -9052,7 +9052,7 @@
 	key = "dorm"
 	},
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/port_tarkon/dorms)
+/area/ruin/space/has_grav/port_tarkon/random_dorm)
 "Ho" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10847,6 +10847,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/port_tarkon/developement)
+"Oi" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/port_tarkon/random_dorm)
 "Oj" = (
 /obj/effect/turf_decal/tile/purple/half,
 /obj/structure/alien/weeds/node,
@@ -12717,6 +12720,9 @@
 /obj/structure/shipping_container/donk_co,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/cargo)
+"Uw" = (
+/turf/open/floor/wood/large,
+/area/ruin/space/has_grav/port_tarkon/random_dorm)
 "Uy" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -13860,7 +13866,7 @@
 "Yy" = (
 /obj/machinery/camera/directional/east,
 /turf/open/floor/wood/large,
-/area/ruin/space/has_grav/port_tarkon/dorms)
+/area/ruin/space/has_grav/port_tarkon/random_dorm)
 "Yz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -25282,14 +25288,14 @@ wB
 Yk
 Hc
 zG
-pu
-og
-og
-og
+Oi
+Uw
+Uw
+Uw
 Hm
-og
-og
-og
+Uw
+Uw
+Uw
 Qi
 hP
 rw
@@ -25404,14 +25410,14 @@ Wj
 Yk
 Cx
 Nc
-pu
-og
-og
-og
-og
-og
-og
-og
+Oi
+Uw
+Uw
+Uw
+Uw
+Uw
+Uw
+Uw
 Qi
 iD
 Ii
@@ -25526,14 +25532,14 @@ wB
 Yk
 hs
 eT
-pu
-og
-og
-og
-og
-og
-og
-og
+Oi
+Uw
+Uw
+Uw
+Uw
+Uw
+Uw
+Uw
 Qi
 TZ
 TZ
@@ -25648,14 +25654,14 @@ yD
 Hc
 hg
 Fk
-pu
-og
-og
-og
-og
-og
-og
-og
+Oi
+Uw
+Uw
+Uw
+Uw
+Uw
+Uw
+Uw
 xi
 ck
 Aq
@@ -25770,14 +25776,14 @@ GM
 Cv
 qc
 uX
-pu
-og
-og
-og
+Oi
+Uw
+Uw
+Uw
 Yy
-og
-og
-og
+Uw
+Uw
+Uw
 xi
 yc
 Aq
@@ -25892,14 +25898,14 @@ pu
 pu
 pu
 pu
-pu
-pu
-pu
-pu
-pu
-pu
-pu
-pu
+Oi
+Oi
+Oi
+Oi
+Oi
+Oi
+Oi
+Oi
 xi
 Jz
 UR

--- a/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon.dmm
@@ -672,7 +672,7 @@
 /obj/effect/mapping_helpers/apc/full_charge,
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/port_tarkon/power1)
+/area/ruin/space/has_grav/port_tarkon/power2)
 "cA" = (
 /obj/structure/alien/egg/burst,
 /turf/open/floor/plating,
@@ -942,7 +942,7 @@
 /obj/structure/closet/firecloset/full,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/port_tarkon/power1)
+/area/ruin/space/has_grav/port_tarkon/power2)
 "ds" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1131,7 +1131,7 @@
 "eb" = (
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall,
-/area/ruin/space/has_grav/port_tarkon/power1)
+/area/ruin/space/has_grav/port_tarkon/power2)
 "ec" = (
 /turf/closed/mineral/random/high_chance,
 /area/ruin/space/has_grav/port_tarkon/aichamber)
@@ -2207,7 +2207,7 @@
 /obj/structure/cable,
 /obj/machinery/camera/directional/south,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/port_tarkon/power1)
+/area/ruin/space/has_grav/port_tarkon/power2)
 "hJ" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/light/directional/north,
@@ -2955,7 +2955,7 @@
 "kz" = (
 /obj/structure/sign/warning/electric_shock,
 /turf/closed/wall,
-/area/ruin/space/has_grav/port_tarkon/power1)
+/area/ruin/space/has_grav/port_tarkon/power2)
 "kA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5945,7 +5945,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/space/has_grav/port_tarkon/power1)
+/area/ruin/space/has_grav/port_tarkon/power2)
 "vX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6083,7 +6083,7 @@
 /obj/item/stack/sheet/mineral/uranium/five,
 /obj/item/stack/sheet/mineral/uranium/five,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/port_tarkon/power1)
+/area/ruin/space/has_grav/port_tarkon/power2)
 "wr" = (
 /obj/effect/turf_decal/tile/neutral/anticorner,
 /obj/machinery/light/directional/east,
@@ -8475,7 +8475,7 @@
 	},
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/port_tarkon/power1)
+/area/ruin/space/has_grav/port_tarkon/power2)
 "Fc" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external,
@@ -9188,7 +9188,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/port_tarkon/power1)
+/area/ruin/space/has_grav/port_tarkon/power2)
 "HN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9466,7 +9466,7 @@
 /obj/machinery/light/directional/north,
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/port_tarkon/power1)
+/area/ruin/space/has_grav/port_tarkon/power2)
 "IY" = (
 /obj/effect/turf_decal/tile/purple/anticorner{
 	dir = 4
@@ -10665,6 +10665,9 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/atmos)
+"Nv" = (
+/turf/closed/wall,
+/area/ruin/space/has_grav/port_tarkon/power2)
 "Nw" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -13946,7 +13949,7 @@
 /area/ruin/space/has_grav/port_tarkon/scienceaway)
 "YL" = (
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/port_tarkon/power1)
+/area/ruin/space/has_grav/port_tarkon/power2)
 "YP" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/iron/white,
@@ -14244,7 +14247,7 @@
 "ZY" = (
 /obj/structure/cable,
 /turf/closed/wall,
-/area/ruin/space/has_grav/port_tarkon/power1)
+/area/ruin/space/has_grav/port_tarkon/power2)
 "ZZ" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -22619,7 +22622,7 @@ vB
 Sa
 Sa
 Sa
-hR
+Nv
 dr
 YL
 hI
@@ -22866,7 +22869,7 @@ xm
 ul
 ZY
 vW
-hR
+Nv
 Dq
 hi
 bO

--- a/modular_skyrat/modules/mapping/code/areas/space.dm
+++ b/modular_skyrat/modules/mapping/code/areas/space.dm
@@ -191,6 +191,10 @@
 	name = "P-T Solar Control"
 	icon_state = "engine"
 
+/area/ruin/space/has_grav/port_tarkon/power2
+	name = "P-T Backup Generator Room"
+	icon_state = "engine"
+
 /area/ruin/space/has_grav/port_tarkon/centerhall
 	name = "P-T Central Hallway"
 	icon_state = "centralhall"

--- a/modular_skyrat/modules/mapping/code/areas/space.dm
+++ b/modular_skyrat/modules/mapping/code/areas/space.dm
@@ -251,6 +251,10 @@
 	name = "P-T Dorms"
 	icon_state = "dorms"
 
+/area/ruin/space/has_grav/port_tarkon/random_dorm
+	name = "P-T Deluxe Dorm Room"
+	icon_state = "dorms"
+
 /area/solars/tarkon
 	name = "\improper P-T Solar Array"
 	icon_state = "space_near"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Port Tarkon reuses areas in two rooms which leads to mapping warnings for areas having duplicate APCs, I just added two new area types and made the rooms use those instead

## Why It's Good For The Game

Map correctness

## Proof Of Testing

I checked and there was no errors anymore I prommy

## Changelog

No player facing changes
