### PR TITLE
Storyteller message formatting

### DIFF
--- a/modular_zubbers/code/controllers/subsystem/vote.dm
+++ b/modular_zubbers/code/controllers/subsystem/vote.dm
@@ -30,5 +30,5 @@
 		if(current_vote.vote_sound && (late_voter.prefs.read_preference(/datum/preference/toggle/sound_announcements)))
 			SEND_SOUND(late_voter, sound(current_vote.vote_sound))
 
-		to_chat(late_voter, span_yellowteamradio(span_soapbox("It's time to make your choices for [current_vote.name]! Type 'vote' or click <a href='byond://winset?command=vote'>here</a> to place your votes.")))
+		to_chat(late_voter, custom_boxed_message("purple_box", vote_font("[span_bold("[current_vote.name] Vote")]\n<hr>It's time to make your choices! Type 'vote' or click <a href='byond://winset?command=vote'>here</a> to place your votes.")))
 

--- a/modular_zubbers/code/modules/storyteller/event_defines/crewset/_antagonist_event.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/crewset/_antagonist_event.dm
@@ -1,6 +1,7 @@
 /datum/round_event_control/antagonist
 	reoccurence_penalty_multiplier = 0
 	track = EVENT_TRACK_CREWSET
+	alert_observers = FALSE
 	/// Protected roles from the antag roll. People will not get those roles if a config is enabled
 	var/protected_roles = list(
 		JOB_CAPTAIN,

--- a/modular_zubbers/code/modules/storyteller/event_defines/crewset/malf.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/crewset/malf.dm
@@ -8,6 +8,7 @@
 
 	min_players = 20
 	roundstart = FALSE
+	alert_observers = TRUE
 
 	antag_datum = /datum/antagonist/malf_ai
 	antag_flag = ROLE_MALF

--- a/modular_zubbers/code/modules/storyteller/gamemode.dm
+++ b/modular_zubbers/code/modules/storyteller/gamemode.dm
@@ -685,6 +685,7 @@ SUBSYSTEM_DEF(gamemode)
 /datum/controller/subsystem/gamemode/proc/storyteller_vote_choices()
 	var/client_amount = GLOB.clients.len
 	var/list/choices = list()
+	var/list/vote_message = list()
 	for(var/storyteller_type in storytellers)
 		var/datum/storyteller/storyboy = storytellers[storyteller_type]
 		/// Prevent repeating storytellers
@@ -696,8 +697,11 @@ SUBSYSTEM_DEF(gamemode)
 			continue
 		choices += storyboy.name
 		///Because the vote subsystem is dumb and does not support any descriptions, we dump them into world.
-		to_chat(world, span_notice("<b>[storyboy.name]</b>"))
-		to_chat(world, span_notice("[storyboy.desc]"))
+		vote_message += "<b>[storyboy.name]</b>"
+		vote_message += "[storyboy.desc]"
+		vote_message += ""
+	var/finalized_message = "[vote_message.Join("\n")]"
+	to_chat(world, custom_boxed_message("purple_box", vote_font("[span_bold("Storyteller Vote")]\n<hr>[finalized_message]")))
 	return choices
 
 /datum/controller/subsystem/gamemode/proc/storyteller_vote_result(winner_name)


### PR DESCRIPTION
## About The Pull Request

- Improves formatting of the storyteller description broadcast, using the vote span.
- Don't announce roundstart storyteller rule purchases.

## Proof Of Testing

![image](https://github.com/user-attachments/assets/e67939d7-b7c0-4756-8c12-c2a15e6a8c84)

## Changelog

:cl: LT3
code: Improved storyteller vote formatting
code: Storyteller doesn't announce the roundstart event purchase
/:cl: