### PR TITLE
Adds an RLD upgrade to engineering borgs

### DIFF
--- a/code/game/objects/items/rcd/RLD.dm
+++ b/code/game/objects/items/rcd/RLD.dm
@@ -231,6 +231,47 @@
 	matter = 100
 	max_matter = 100
 
+/obj/item/construction/rld/cyborg
+	name = "Cyborg rapid-light-device"
+	desc = "A device used to rapidly provide lighting sources to an area. Runs off a cyborg's internal power supply"
+	// Energy Use
+	var/energyfactor = 0.050 * STANDARD_CELL_CHARGE
+
+/obj/item/construction/rld/cyborg/get_matter(mob/user)
+	if(!iscyborg(user))
+		return 0
+	var/mob/living/silicon/robot/borgy = user
+	if(!borgy.cell)
+		return 0
+	max_matter = borgy.cell.maxcharge
+	return borgy.cell.charge
+
+/obj/item/construction/rld/cyborg/useResource(amount, mob/user)
+	if(!iscyborg(user))
+		return 0
+	var/mob/living/silicon/robot/borgy = user
+	if(!borgy.cell)
+		if(user)
+			balloon_alert(user, "no cell found!")
+		return 0
+	. = borgy.cell.use(amount * energyfactor)
+	if(!. && user)
+		balloon_alert(user, "insufficient charge!")
+	return .
+
+/obj/item/construction/rld/cyborg/checkResource(amount, mob/user)
+	if(!iscyborg(user))
+		return 0
+	var/mob/living/silicon/robot/borgy = user
+	if(!borgy.cell)
+		if(user)
+			balloon_alert(user, "no cell found!")
+		return 0
+	. = borgy.cell.charge >= (amount * energyfactor)
+	if(!. && user)
+		balloon_alert(user, "insufficient charge!")
+	return .
+
 #undef LIGHT_TUBE_COST
 #undef FLOOR_LIGHT_COST
 #undef GLOW_STICK_COST

--- a/modular_zubbers/code/modules/research/designs/mechfab_designs.dm
+++ b/modular_zubbers/code/modules/research/designs/mechfab_designs.dm
@@ -120,3 +120,14 @@
 	category = list(
 		RND_CATEGORY_MODSUIT_MODULES + RND_SUBCATEGORY_MODSUIT_MODULES_GENERAL
 	)
+
+/datum/design/rld
+	name = "Cyborg Rapid Lighting Device"
+	desc = "A device that allows rapid, range deployment of lights and glowsticks."
+	id = "rld_cyborg"
+	build_type = MECHFAB
+	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 7.5, /datum/material/glass =SHEET_MATERIAL_AMOUNT * 2.5, /datum/material/silver = HALF_SHEET_MATERIAL_AMOUNT * 2.5)
+	build_path = /obj/item/borg/upgrade/rld
+	category = list(
+		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_ENGINEERING
+	)

--- a/modular_zubbers/code/modules/research/techweb/all_nodes.dm
+++ b/modular_zubbers/code/modules/research/techweb/all_nodes.dm
@@ -76,7 +76,8 @@
 	design_ids += list(
 		"borg_upgrade_advcutter",
 		"borg_upgrade_inducer_sci",
-		"borg_upgrade_brped"
+		"borg_upgrade_brped",
+		"rld_cyborg"
 	)
 
 /datum/techweb_node/borg_medical/New()
@@ -172,4 +173,3 @@
 	research_costs = list(
 		TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_4_POINTS
 	)
-

--- a/modular_zubbers/code/modules/silicons/borgs/code/robot_upgrade.dm
+++ b/modular_zubbers/code/modules/silicons/borgs/code/robot_upgrade.dm
@@ -78,3 +78,13 @@
 /obj/item/borg/upgrade/dominatrixmodule/deactivate(mob/living/silicon/robot/borg, mob/living/user)
 	. = ..()
 	borg.remove_quirk(/datum/quirk/dominant_aura)
+
+// Engineering RLD
+/obj/item/borg/upgrade/rld
+	name = "Research cyborg Rapid Lighting Device Upgrade"
+	desc = "An upgrade to allow a cybrog to use a Rapid Lighting Device."
+	icon_state = "module_engineer"
+	require_model = TRUE
+	model_type = list(/obj/item/robot_model/engineering)
+	model_flags = BORG_MODEL_ENGINEERING
+	items_to_add = list(/obj/item/construction/rld/cyborg)

--- a/modular_zubbers/code/modules/silicons/borgs/code/robot_upgrade.dm
+++ b/modular_zubbers/code/modules/silicons/borgs/code/robot_upgrade.dm
@@ -81,7 +81,7 @@
 
 // Engineering RLD
 /obj/item/borg/upgrade/rld
-	name = "Research cyborg Rapid Lighting Device Upgrade"
+	name = "Engineering Cyborg Rapid Lighting Device Upgrade"
 	desc = "An upgrade to allow a cybrog to use a Rapid Lighting Device."
 	icon_state = "module_engineer"
 	require_model = TRUE

--- a/modular_zubbers/code/modules/silicons/borgs/code/robot_upgrade.dm
+++ b/modular_zubbers/code/modules/silicons/borgs/code/robot_upgrade.dm
@@ -82,7 +82,7 @@
 // Engineering RLD
 /obj/item/borg/upgrade/rld
 	name = "Engineering Cyborg Rapid Lighting Device Upgrade"
-	desc = "An upgrade to allow a cybrog to use a Rapid Lighting Device."
+	desc = "An upgrade to allow a cyborg to use a Rapid Lighting Device."
 	icon_state = "module_engineer"
 	require_model = TRUE
 	model_type = list(/obj/item/robot_model/engineering)


### PR DESCRIPTION

## About The Pull Request

Adds an RLD to the cyborg engineering upgrades, in the same techweb. No longer shall man live in darkness.
## Why It's Good For The Game

PLEASE I DONT NEED TO SPEND 6000 YEARS MAKING LIGHTS!! 
I want FLOORLIGHTS, I want CHEMLIGHTS, let me SEE!!
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/0c1ab884-dbf9-4826-b06e-42f288572d83)

![image](https://github.com/user-attachments/assets/74c66b34-224b-4db7-9e74-2d009ed02fe8)



</details>

## Changelog
:cl:
add: With a new upgrade, Borgs get an RLD. Let there be light.
/:cl:
