### PR TITLE
Weighted number of station goals

### DIFF
--- a/modular_zubbers/code/modules/storyteller/divergency_report.dm
+++ b/modular_zubbers/code/modules/storyteller/divergency_report.dm
@@ -1,6 +1,12 @@
 /datum/controller/subsystem/gamemode/proc/send_trait_report()
 	. = "<b><i>Central Command Status Summary</i></b><hr>"
-	SSstation.generate_station_goals(20)
+	// We don't want to roll all three goals every shift, so randomly choose how many we'll do, weighted towards doing none.
+	var/list/total_goal_weights = list(
+		0 = 65,
+		1 = 20,
+		2 = 10,
+		3 = 5)
+	SSstation.generate_station_goals(pick_weight(total_goal_weights))
 
 	var/list/station_goals = SSstation.get_station_goals()
 

--- a/modular_zubbers/code/modules/storyteller/divergency_report.dm
+++ b/modular_zubbers/code/modules/storyteller/divergency_report.dm
@@ -2,11 +2,11 @@
 	. = "<b><i>Central Command Status Summary</i></b><hr>"
 	// We don't want to roll all three goals every shift, so randomly choose how many we'll do, weighted towards doing none.
 	var/list/total_goal_weights = list(
-		0 = 65,
-		1 = 20,
-		2 = 10,
-		3 = 5)
-	SSstation.generate_station_goals(pick_weight(total_goal_weights))
+		"0" = 65,
+		"1" = 20,
+		"2" = 10,
+		"3" = 5)
+	SSstation.generate_station_goals(text2num(pick_weight(total_goal_weights))) // Yes, this is bad, but I can't use straight nums for assoc list keys. Sue me.
 
 	var/list/station_goals = SSstation.get_station_goals()
 


### PR DESCRIPTION
# TLDR:
This PR changes the number of station goals selected to be random, weighted towards zero. There's still a chance that more, or all three, are selected, albeit much rarer.

## About The Pull Request

In the original port of the storyteller system, the divergency report would always roll for station goals with a budget of 20. While this might otherwise fine, all three current goals (BSA, DNA Vault, Meteor Shields) each had a cost of 1, meaning all three rolled every single round.

This changes the budget to be weighted with the following weights:
```
0 Goals - 65%
1 Goal  - 20%
2 Goals - 10%
3 Goals -  5%
```
Numbers subject to change.

## Why It's Good For The Game

Having all three goals roll every single round has been a point of contention (especially amongst Engineering players), and having them be rarer means that they're more interesting when they *do* roll.

## Proof Of Testing

TBD

## Changelog
:cl:
fix: It is no longer guaranteed to roll all three station goals. Now, the number of goals selected will be random, weighted towards zero or one goals.
/:cl:
