### PR TITLE
Fix Minesweeper

### DIFF
--- a/modular_zubbers/code/modules/arcades/code/minesweeper/minesweeper.dm
+++ b/modular_zubbers/code/modules/arcades/code/minesweeper/minesweeper.dm
@@ -84,9 +84,11 @@
 
 	return data
 
-/obj/machinery/computer/arcade/minesweeper/ui_act(action, list/params, mob/user)
+/obj/machinery/computer/arcade/minesweeper/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	if(..())
 		return TRUE
+
+	var/mob/user = ui.user
 
 	switch(action)
 		if("PRG_do_tile")
@@ -231,7 +233,7 @@
 
 	return data
 
-/datum/computer_file/program/minesweeper/ui_act(action, list/params, mob/user)
+/datum/computer_file/program/minesweeper/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	if(..())
 		return TRUE
 
@@ -241,6 +243,7 @@
 	if(!board.host && computer)
 		board.host = computer
 
+	var/mob/user = ui.user
 
 	switch(action)
 		if("PRG_do_tile")


### PR DESCRIPTION

## About The Pull Request

`ui_act` for minesweeper was using args that weren't correct so it was taking the ui it was passed and treating it like a mob which makes it very unhappy, fixed the args and got the mob another way

## Why It's Good For The Game

Fixes #3588 

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/107adb3b-c265-4ec1-8942-4919428d53e1)

</details>

## Changelog
:cl:
fix: gamers rejoice, minesweeper works again
/:cl:
