### PR TITLE
Heretic spawn changes, minimum pop 50 -> 35

### DIFF
--- a/modular_zubbers/code/modules/storyteller/event_defines/crewset/heretic.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/crewset/heretic.dm
@@ -5,7 +5,7 @@
 	antag_flag = ROLE_HERETIC
 	antag_datum = /datum/antagonist/heretic
 	weight = 3
-	min_players = 50
+	min_players = 35
 
 	maximum_antags_global = 2
 


### PR DESCRIPTION
## About The Pull Request

This PR brings the value of players necessary for the game to consider spawning heretics down to 35, which is 5 more than bloodsuckers. 
## Why It's Good For The Game

A foreword, this is a mechanical PR. The heretic was taken out behind the shed due to what I assume were oppressive mechanics and roundending, so a fair portion of this explanation will be defending said mechanics and disproving the notion that heretics are the worst thing since the bread unslicer machine of 1791- Roleplay is an individual matter of players and every player has a choice to make, the heretic uses standard RP escalation.

Let's begin. Heretic as is right now, is a non-existant antagonist. They are technically ingame, and technically you can roll it, but the pop requirement is almost TWICE the size of any other antagonist or dangerous event.

Currently with 5x the cap for xenos, 2.5x cap for blob, and 2x the cap necessary for catastrophic meteor waves, I think it's solid to say that IF the minimum pop cap as a function exists to make sure that challenges thrown at the crew are managable at their size, then the rating for heretic is skewed.

This makes little sense. Compared to our other mainstay snowballing antagonist, the bloodsucker, the heretic pales in comparison with all but burst and amount of teleports.

Survivability? Lower. 
Consistency? Lower. 
Difficulty? Higher. 
Counterplay? Way more for heretic. 
Ease of tell, so how easy it is to stealth as it? Lower. MUCH, much lower.


How are our players, who might want to try playing heretic, learn how to play heretic without going through the tiresome opfor system each time they would like to give it a go? There is this antagonist, which has by far over 100 abilities, summons, unique pieces of gear, upgrades total, which has the most flexibility for magic-related gimmicks without giving someone the goddamn wizard, known for instant death spells, and we swing not one hammer, but two?

Now, out of 100 abilities that sound DAUNTING, I would ask that you keep in mind, if you will merge this, and if you will face an onslaught of "This antagonist is too strong, why did we make it more common", that you can simply reply with "The holymelon blocks 22/28~ of those spells from interacting with you at all". The exceptions being, rust charge, furious steel, cosmic rune, ashen shift, space phaze, key keeper's burden, veil of shadow and rust construction. Of which rust charge is cast conditionally so you know when you can expect it, cosmic rune is destructible, key keeper's burden throws you out if you get hit by a nullrod, and veil of shadow throws you out if damaged with anything, on a chance.

To say our playerbase cannot handle this and that the mechanical power of the antagonist is the issue, is to say you lack trust in the skill of our security players and the rising amount of antagonist players.

And finally, I must add, that there is no other crew-based antagonist that can have their kit do absolutely nothing if you use an item, except for the changeling - and we know well that it doesn't affect them nearly as much, as the heretic. Which means it has more counterplay. AND EVEN IF, they can end the round, I ask you, is a bloodsucker who takes over command and thralls heads, or even just gets ERT’s called by themselves before slaughtering them all not essentially ending the round by having curb stomped all opposition? At which point it’s red alert and everyone is trying to kill them, so they will be killing everyone back? The truth is, bloodsuckers can roundend, too, but there is no big flashy warning about it being about to happen to help the crew, nor is there a big sign saying it. 

If the heretic didn’t ascend, they’d still be capable of roundend by virtue of killing all opposition if sufficiently skilled.

Then again. Not every bloodsucker and not every heretic roundends. 


## Proof Of Testing
Trust me bro

Unsure if correct CL tag
:cl:
config: Heretic spawn changes, minimum pop lowered 50 -> 35
/:cl:
