### PR TITLE
Fix SAD throwing up circuit board

### DIFF
--- a/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
+++ b/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
@@ -16,7 +16,7 @@
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
 /obj/item/circuitboard/machine/self_actualization_device
-	name = "Self-Actualization Device (Machine Board)"
+	name = "Self-Actualization Device"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
 	build_path = /obj/machinery/self_actualization_device
 

--- a/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
+++ b/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
@@ -19,6 +19,7 @@
 	name = "Self-Actualization Device"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
 	build_path = /obj/machinery/self_actualization_device
+	req_components = list()
 
 /obj/machinery/self_actualization_device
 	name = "Self-Actualization Device"


### PR DESCRIPTION

## About The Pull Request

`req_components` needs to be an empty list, not null, otherwise it doesn't call parent and the circuitboard doesn't get added to `component_parts`. Also removed the extra (Machine Board) in the name

## Why It's Good For The Game

Fixes #3602 

## Proof Of Testing

I didddd

## Changelog
:cl:
fix: fixed SADs spitting out a circuit board when you open them
/:cl:
