### PR TITLE
New Quirk: Glowy

### DIFF
--- a/code/__DEFINES/~~bubber_defines/signals.dm
+++ b/code/__DEFINES/~~bubber_defines/signals.dm
@@ -12,3 +12,5 @@
 #define COMSIG_MOB_ALWAYS_APPLY_DAMAGE "mob_always_apply_damage"
 /// From modular_zubbers/code/modules/disease/disease_transmission.dm
 #define COMSIG_DISEASE_COUNT_UPDATE "disease_count_update"
+/// From /datum/mutation/human/proc/on_acquiring(mob/living/carbon/human/acquirer)
+#define COMSIG_TRY_GAIN_MUTATION "try_gain_mutation"

--- a/code/datums/mutations/_mutations.dm
+++ b/code/datums/mutations/_mutations.dm
@@ -122,6 +122,10 @@
 	if(acquirer.has_borer())
 		to_chat(acquirer, span_warning("Something inside holds dearly to your humanity!"))
 	// SKYRAT EDIT END
+	// BUBBER EDIT ADDITION
+	if(SEND_SIGNAL(src, COMSIG_TRY_GAIN_MUTATION, acquirer))
+		return TRUE
+	// BUBBER EDIT END
 	if(species_allowed && !species_allowed.Find(acquirer.dna.species.id))
 		return TRUE
 	if(health_req && acquirer.health < health_req)

--- a/modular_zubbers/modules/quirks/negative.dm
+++ b/modular_zubbers/modules/quirks/negative.dm
@@ -1,0 +1,1 @@
+// Bubber quirks

--- a/modular_zubbers/modules/quirks/neutral.dm
+++ b/modular_zubbers/modules/quirks/neutral.dm
@@ -9,7 +9,7 @@
 	var/glowy_color = null /// Holds player's selected color
 	var/glowy_power = 1
 	var/glowy_range = 1
-	var/obj/effect/dummy/lighting_obj/moblight/glowy
+	var/obj/effect/dummy/lighting_obj/moblight/glowy_light
 
 /datum/quirk/glowy/add_unique(client/client_source)
 	. = ..()
@@ -24,15 +24,14 @@
 	. = ..()
 	if(.)
 		return
-	glowy = owner.mob_light()
-	glowy.set_light_range_power_color(glowy_range, glowy_power, glowy_color)
+	glowy_light = owner.mob_light(glowy_range, glowy_power, glowy_color)
 
 /datum/quirk/glowy/remove()
 	. = ..()
 
 	if(QDELETED(quirk_holder))
 		return
-	QDEL_NULL(glowy)
+	QDEL_NULL(glowy_light)
 
 // Client preference for glow color
 /datum/preference/color/glowy_color

--- a/modular_zubbers/modules/quirks/neutral.dm
+++ b/modular_zubbers/modules/quirks/neutral.dm
@@ -58,13 +58,13 @@
 
 // Handles mutation conflicts
 /datum/quirk/glowy/add(client/client_source)
-    . = ..()
-    RegisterSignal(quirk_holder, COMSIG_TRY_GAIN_MUTATION, PROC_REF(on_mutation_gained))
+	. = ..()
+	RegisterSignal(quirk_holder, COMSIG_TRY_GAIN_MUTATION, PROC_REF(on_mutation_gained))
 
 /datum/quirk/glowy/remove()
-    . = ..()
-    UnregisterSignal(quirk_holder, COMSIG_TRY_GAIN_MUTATION)
+	. = ..()
+	UnregisterSignal(quirk_holder, COMSIG_TRY_GAIN_MUTATION)
 
 /datum/quirk/glowy/proc/on_mutation_gained(datum/mutation/source, mob/living/carbon/human/acquirer)
-    if(istype(source, /datum/mutation/human/glow/anti))
-        return TRUE
+	if(istype(source, /datum/mutation/human/glow/anti))
+		return TRUE

--- a/modular_zubbers/modules/quirks/neutral.dm
+++ b/modular_zubbers/modules/quirks/neutral.dm
@@ -1,0 +1,67 @@
+// Bubber quirks
+
+/datum/quirk/glowy
+	name = "Glowy"
+	desc = "You emit a small amount of light. Geiger counters might hate you."
+	value = 0
+	medical_record_text = "Patient's body contains moderate levels of emissive radiation. This seems mostly harmless to the surroundings."
+	icon = FA_ICON_LIGHTBULB
+	var/glowy_color = null /// Holds player's selected color
+	var/glowy_power = 1
+	var/glowy_range = 1
+	var/obj/effect/dummy/lighting_obj/moblight/glowy
+
+/datum/quirk/glowy/add_unique(client/client_source)
+	. = ..()
+
+	glowy_color = client_source?.prefs.read_preference(/datum/preference/color/glowy_color)
+
+/datum/quirk_constant_data/glowy
+	associated_typepath = /datum/quirk/glowy
+	customization_options = list(/datum/preference/color/glowy_color)
+
+/datum/quirk/glowy/add(mob/living/carbon/human/owner)
+	. = ..()
+	if(.)
+		return
+	glowy = owner.mob_light()
+	glowy.set_light_range_power_color(glowy_range, glowy_power, glowy_color)
+
+/datum/quirk/glowy/remove()
+	. = ..()
+
+	if(QDELETED(quirk_holder))
+		return
+	QDEL_NULL(glowy)
+
+// Client preference for glow color
+/datum/preference/color/glowy_color
+	savefile_key = "glowy_color"
+	savefile_identifier = PREFERENCE_CHARACTER
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+
+/datum/preference/color/glowy_color/is_accessible(datum/preferences/preferences)
+	if (!..(preferences))
+		return FALSE
+
+	return "Glowy" in preferences.all_quirks
+
+/datum/preference/color/glowy_color/apply_to_human(mob/living/carbon/human/target, value)
+	return
+
+/datum/preference/color/glowy_color/create_default_value()
+	return ("#[random_color()]")
+
+
+// Handles mutation conflicts
+/datum/quirk/glowy/add(client/client_source)
+    . = ..()
+    RegisterSignal(quirk_holder, COMSIG_TRY_GAIN_MUTATION, PROC_REF(on_mutation_gained))
+
+/datum/quirk/glowy/remove()
+    . = ..()
+    UnregisterSignal(quirk_holder, COMSIG_TRY_GAIN_MUTATION)
+
+/datum/quirk/glowy/proc/on_mutation_gained(datum/mutation/source, mob/living/carbon/human/acquirer)
+    if(istype(source, /datum/mutation/human/glow/anti))
+        return TRUE

--- a/modular_zubbers/modules/quirks/neutral.dm
+++ b/modular_zubbers/modules/quirks/neutral.dm
@@ -13,20 +13,18 @@
 	var/glowy_range = 1
 	var/obj/effect/dummy/lighting_obj/moblight/glowy_light
 
-/datum/quirk/glowy/add_unique(client/client_source)
+/datum/quirk/glowy/add(client/client_source)
 	. = ..()
+
+	var/mob/living/carbon/human/user = quirk_holder
 	glowy_color = client_source?.prefs.read_preference(/datum/preference/color/glowy_color)
 
 /datum/quirk_constant_data/glowy
 	associated_typepath = /datum/quirk/glowy
 	customization_options = list(/datum/preference/color/glowy_color)
 
-/datum/quirk/glowy/add(client/client_source)
-	. = ..()
-	if(.)
-		return
-	glowy_light = owner.mob_light(light_type = /obj/effect/dummy/lighting_obj/moblight)
-	refresh_light(owner)
+/datum/quirk/glowy/add_to_holder(mob/living/new_holder, quirk_transfer = FALSE, client/client_source)
+	glowy_light = new_holder.mob_light(light_type = /obj/effect/dummy/lighting_obj/moblight)
 
 /datum/quirk/glowy/remove()
 	. = ..()
@@ -34,18 +32,6 @@
 	if(QDELETED(quirk_holder))
 		return
 	QDEL_NULL(glowy_light)
-
-/datum/quirk/glowy/proc/refresh_light(mob/living/carbon/human/owner)
-	SIGNAL_HANDLER
-	if(isnull(glowy_light))
-		return
-	if(owner.stat != DEAD)
-		glowy_light.set_light_range_power_color(glowy_range, glowy_power, glowy_color)
-		glowy_light.set_light_on(TRUE)
-		owner.update_body()
-	else
-		glowy_light.set_light_on(FALSE)
-		owner.update_body()
 
 // Client preference for glow color
 /datum/preference/color/glowy_color

--- a/modular_zubbers/modules/quirks/neutral.dm
+++ b/modular_zubbers/modules/quirks/neutral.dm
@@ -16,9 +16,6 @@
 /datum/quirk/glowy/add_unique(client/client_source)
 	. = ..()
 	glowy_color = client_source?.prefs.read_preference(/datum/preference/color/glowy_color)
-	if (isnull(glowy_color))
-		var/mob/living/carbon/human/human_holder = quirk_holder
-		glowy_color = ("#[random_color()]")
 
 /datum/quirk_constant_data/glowy
 	associated_typepath = /datum/quirk/glowy

--- a/modular_zubbers/modules/quirks/neutral.dm
+++ b/modular_zubbers/modules/quirks/neutral.dm
@@ -25,7 +25,8 @@
 	. = ..()
 	if(.)
 		return
-	glowy_light = owner.mob_light()
+	glowy_light = owner.mob_light(light_type = /obj/effect/dummy/lighting_obj/moblight)
+	refresh_light(owner)
 
 /datum/quirk/glowy/remove()
 	. = ..()
@@ -33,6 +34,18 @@
 	if(QDELETED(quirk_holder))
 		return
 	QDEL_NULL(glowy_light)
+
+/datum/quirk/glowy/proc/refresh_light(mob/living/carbon/human/owner)
+	SIGNAL_HANDLER
+	if(isnull(glowy_light))
+		return
+	if(owner.stat != DEAD)
+		glowy_light.set_light_range_power_color(glowy_range, glowy_power, glowy_color)
+		glowy_light.set_light_on(TRUE)
+		owner.update_body()
+	else
+		glowy_light.set_light_on(FALSE)
+		owner.update_body()
 
 // Client preference for glow color
 /datum/preference/color/glowy_color

--- a/modular_zubbers/modules/quirks/neutral.dm
+++ b/modular_zubbers/modules/quirks/neutral.dm
@@ -24,7 +24,7 @@
 	. = ..()
 	if(.)
 		return
-	glowy_light = owner.mob_light(glowy_range, glowy_power, glowy_color)
+	glowy_light = owner.mob_light()
 
 /datum/quirk/glowy/remove()
 	. = ..()

--- a/modular_zubbers/modules/quirks/neutral.dm
+++ b/modular_zubbers/modules/quirks/neutral.dm
@@ -21,7 +21,7 @@
 	associated_typepath = /datum/quirk/glowy
 	customization_options = list(/datum/preference/color/glowy_color)
 
-/datum/quirk/glowy/add(mob/living/carbon/human/owner)
+/datum/quirk/glowy/add(client/client_source)
 	. = ..()
 	if(.)
 		return

--- a/modular_zubbers/modules/quirks/neutral.dm
+++ b/modular_zubbers/modules/quirks/neutral.dm
@@ -16,7 +16,6 @@
 /datum/quirk/glowy/add(client/client_source)
 	. = ..()
 
-	var/mob/living/carbon/human/user = quirk_holder
 	glowy_color = client_source?.prefs.read_preference(/datum/preference/color/glowy_color)
 
 /datum/quirk_constant_data/glowy
@@ -24,6 +23,7 @@
 	customization_options = list(/datum/preference/color/glowy_color)
 
 /datum/quirk/glowy/add_to_holder(mob/living/new_holder, quirk_transfer = FALSE, client/client_source)
+	. = ..()
 	glowy_light = new_holder.mob_light(light_type = /obj/effect/dummy/lighting_obj/moblight)
 
 /datum/quirk/glowy/remove()

--- a/modular_zubbers/modules/quirks/neutral.dm
+++ b/modular_zubbers/modules/quirks/neutral.dm
@@ -1,11 +1,13 @@
 // Bubber quirks
 
+/// 4/23 glowy_light value is null, failing to be assigned. dont know how to fix
+
 /datum/quirk/glowy
 	name = "Glowy"
 	desc = "You emit a small amount of light. Geiger counters might hate you."
 	value = 0
 	medical_record_text = "Patient's body contains moderate levels of emissive radiation. This seems mostly harmless to the surroundings."
-	icon = FA_ICON_LIGHTBULB
+	icon = FA_ICON_BOLT_LIGHTNING
 	var/glowy_color = null /// Holds player's selected color
 	var/glowy_power = 1
 	var/glowy_range = 1
@@ -13,8 +15,10 @@
 
 /datum/quirk/glowy/add_unique(client/client_source)
 	. = ..()
-
 	glowy_color = client_source?.prefs.read_preference(/datum/preference/color/glowy_color)
+	if (isnull(glowy_color))
+		var/mob/living/carbon/human/human_holder = quirk_holder
+		glowy_color = ("#[random_color()]")
 
 /datum/quirk_constant_data/glowy
 	associated_typepath = /datum/quirk/glowy

--- a/modular_zubbers/modules/quirks/positive.dm
+++ b/modular_zubbers/modules/quirks/positive.dm
@@ -1,0 +1,1 @@
+// Bubber quirks

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9700,6 +9700,9 @@
 #include "modular_zubbers\modules\plexagon_selfserve\code\sign.dm"
 #include "modular_zubbers\modules\plexagon_selfserve\code\time_clock.dm"
 #include "modular_zubbers\modules\primitive_cooking\code\cauldron.dm"
+#include "modular_zubbers\modules\quirks\negative.dm"
+#include "modular_zubbers\modules\quirks\neutral.dm"
+#include "modular_zubbers\modules\quirks\positive.dm"
 #include "modular_zubbers\modules\wood_walls\code\mineral_walls.dm"
 #include "modular_zubbers\modules\wood_walls\code\new_floors.dm"
 // END_INCLUDE

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/bubbers/glowy.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/bubbers/glowy.tsx
@@ -1,0 +1,6 @@
+import { Feature, FeatureColorInput } from '../../base';
+
+export const glowy_color: Feature<string> = {
+  name: 'Glowy Color',
+  component: FeatureColorInput,
+};


### PR DESCRIPTION
## About The Pull Request

Adds a new neutral quirk that replaces an old function of the high-luminosity eyes that was since lost with changes. This gives the user a weak glow effect on their tile, used to compliment emissives.

## Why It's Good For The Game

A neat way for emissive characters to really show off in dimly lit areas. It's weak and small enough as to not really be applicable in any mechanical scenarios.

## Proof Of Testing

Still testing

## Changelog

:cl:
add: Added new neutral quirk: Glowy
/:cl:
