### PR TITLE
Add code to migrate old invalid NIF paths in save files

### DIFF
--- a/modular_skyrat/modules/modular_implants/code/nif_persistence.dm
+++ b/modular_skyrat/modules/modular_implants/code/nif_persistence.dm
@@ -75,6 +75,10 @@
 	if(!persistence.nif_path)
 		return
 
+	// if nif_path exists but isn't a valid path it probably needs to be migrated post-organ refactor
+	if(!text2path(persistence.nif_path))
+		persistence.nif_path = replacetext(persistence.nif_path, "/obj/item/organ/internal", "/obj/item/organ")
+
 	var/obj/item/organ/cyberimp/brain/nif/new_nif = new persistence.nif_path
 
 	new_nif.durability = persistence.nif_durability

--- a/modular_skyrat/modules/modular_persistence/code/modular_persistence.dm
+++ b/modular_skyrat/modules/modular_persistence/code/modular_persistence.dm
@@ -60,6 +60,10 @@ GLOBAL_LIST_INIT(modular_persistence_ignored_vars, list(
 	if(!persistence_data)
 		return
 
+	// This will update the paths of saved NIFs because /obj/item/organ/internal was refactored away
+	if(persistence_data["nif_path"] && findtext(persistence_data["nif_path"], "/obj/item/organ/internal"))
+		persistence_data["nif_path"] = replacetext(persistence_data["nif_path"], "/obj/item/organ/internal", "/obj/item/organ")
+
 	for(var/var_name in vars)
 		var/var_entry = persistence_data[var_name]
 

--- a/modular_skyrat/modules/modular_persistence/code/modular_persistence.dm
+++ b/modular_skyrat/modules/modular_persistence/code/modular_persistence.dm
@@ -60,10 +60,6 @@ GLOBAL_LIST_INIT(modular_persistence_ignored_vars, list(
 	if(!persistence_data)
 		return
 
-	// This will update the paths of saved NIFs because /obj/item/organ/internal was refactored away
-	if(persistence_data["nif_path"] && findtext(persistence_data["nif_path"], "/obj/item/organ/internal"))
-		persistence_data["nif_path"] = replacetext(persistence_data["nif_path"], "/obj/item/organ/internal", "/obj/item/organ")
-
 	for(var/var_name in vars)
 		var/var_entry = persistence_data[var_name]
 


### PR DESCRIPTION
## About The Pull Request

`modular_persistence.json` on player saves holds the path of any NIFs they have installed and ended the round with, but when we refactored `/obj/item/organ/internal` to just be `/obj/item/organ` these save files weren't updated, meaning people lost their NIFs and now we get runtime errors when an affected person joins the game. This code will check their save on load and update the path appropriately (which will then be written to the file at round end)

## Why It's Good For The Game

They lost NIFs due to a bug

## Proof Of Testing

I can't really do pictures for this but I got a save file that had invalid NIFs installed and used it to test locally and it worked, also tested save files without NIFs and clients that don't have a `modular_persistence.json` at all, no runtimes

## Changelog
:cl:
fix: characters who had their NIFs disappear a few months ago should have them back now
/:cl:
