### PR TITLE
Unifies coco powder to one reagent instead of two

### DIFF
--- a/modular_skyrat/modules/colony_fabricator/code/appliances/chem_machines.dm
+++ b/modular_skyrat/modules/colony_fabricator/code/appliances/chem_machines.dm
@@ -96,12 +96,13 @@
 	show_ph = FALSE
 	base_reagent_purity = 0.5
 	// God's strongest coffee machine
+	//bubber edit: Coco instead of powdered chocolate
 	dispensable_reagents = list(
 		/datum/reagent/water,
 		/datum/reagent/consumable/powdered_milk,
 		/datum/reagent/consumable/sugar,
 		/datum/reagent/consumable/powdered_lemonade,
-		/datum/reagent/consumable/powdered_coco,
+		/datum/reagent/consumable/coco,
 		/datum/reagent/consumable/powdered_coffee,
 		/datum/reagent/consumable/powdered_tea,
 		/datum/reagent/consumable/vanilla,
@@ -114,6 +115,7 @@
 		/datum/reagent/consumable/nutraslop,
 		/datum/reagent/consumable/enzyme,
 	)
+	//bubber edit end
 
 	/// Since we don't have a board to take from, we use this to give the dispenser a cell on spawning
 	var/cell_we_spawn_with = /obj/item/stock_parts/power_store/cell/high

--- a/modular_skyrat/modules/colony_fabricator/code/appliances/chem_machines.dm
+++ b/modular_skyrat/modules/colony_fabricator/code/appliances/chem_machines.dm
@@ -96,7 +96,6 @@
 	show_ph = FALSE
 	base_reagent_purity = 0.5
 	// God's strongest coffee machine
-	//bubber edit: Coco instead of powdered chocolate
 	dispensable_reagents = list(
 		/datum/reagent/water,
 		/datum/reagent/consumable/powdered_milk,
@@ -115,7 +114,6 @@
 		/datum/reagent/consumable/nutraslop,
 		/datum/reagent/consumable/enzyme,
 	)
-	//bubber edit end
 
 	/// Since we don't have a board to take from, we use this to give the dispenser a cell on spawning
 	var/cell_we_spawn_with = /obj/item/stock_parts/power_store/cell/high

--- a/modular_skyrat/modules/food_replicator/code/reagents.dm
+++ b/modular_skyrat/modules/food_replicator/code/reagents.dm
@@ -34,23 +34,8 @@
 	mix_message = "The mixture instantly heats up."
 	reaction_flags = REACTION_INSTANT
 
-/datum/reagent/consumable/powdered_coco
-	name = "Powdered Coco"
-	description = "Made with love (citation needed), and reclaimed biomass."
-	nutriment_factor = 0
-	color = "#403010"
-	taste_description = "dry chocolate"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
-	default_container = /obj/item/reagent_containers/cup/glass/mug/coco
-
-/datum/chemical_reaction/food/unpowdered_coco
-	required_reagents = list(
-		/datum/reagent/consumable/milk = 1,
-		/datum/reagent/consumable/powdered_coco = 1,
-	)
-	results = list(/datum/reagent/consumable/hot_coco = 2)
-	mix_message = "The mixture instantly heats up."
-	reaction_flags = REACTION_INSTANT
+//bubber removal start
+//bubber removal end
 
 /datum/reagent/consumable/powdered_lemonade
 	name = "Powdered Lemonade"

--- a/modular_skyrat/modules/food_replicator/code/reagents.dm
+++ b/modular_skyrat/modules/food_replicator/code/reagents.dm
@@ -34,9 +34,6 @@
 	mix_message = "The mixture instantly heats up."
 	reaction_flags = REACTION_INSTANT
 
-//bubber removal start
-//bubber removal end
-
 /datum/reagent/consumable/powdered_lemonade
 	name = "Powdered Lemonade"
 	description = "Sweet, tangy base of a lemonade. Would be good if you'd mix it with water."

--- a/modular_skyrat/modules/food_replicator/code/replicator_designs/replicator_food.dm
+++ b/modular_skyrat/modules/food_replicator/code/replicator_designs/replicator_food.dm
@@ -108,18 +108,18 @@
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_NRI_FOOD,
 	)
-
+//bubber edit - unify chocolate
 /datum/design/cocoa
 	name = "Powdered Hot Chocolate"
-	id = "slavic_coco"
+	id = "cocoa"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass = 4)
-	make_reagent = /datum/reagent/consumable/powdered_coco
+	make_reagent = /datum/reagent/consumable/coco
 	category = list(
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_NRI_FOOD,
 	)
-
+//bubber edit end
 /datum/design/lemonade
 	name = "Powdered Lemonade"
 	id = "slavic_lemon"

--- a/modular_skyrat/modules/food_replicator/code/replicator_designs/replicator_food.dm
+++ b/modular_skyrat/modules/food_replicator/code/replicator_designs/replicator_food.dm
@@ -108,7 +108,7 @@
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_NRI_FOOD,
 	)
-//bubber edit - unify chocolate
+
 /datum/design/cocoa
 	name = "Powdered Hot Chocolate"
 	id = "cocoa"
@@ -119,7 +119,7 @@
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_NRI_FOOD,
 	)
-//bubber edit end
+
 /datum/design/lemonade
 	name = "Powdered Lemonade"
 	id = "slavic_lemon"


### PR DESCRIPTION

## About The Pull Request

This PR aims to solve this issue by making any ways to obtain the non-crafting-friendly hot chocolate powder give the regular hot chocolate powder instead
![yeahs](https://github.com/user-attachments/assets/87184d3d-f416-4b29-8cc9-3717ccc62d1a)
## Why It's Good For The Game
Unintuitive, now with less hassle, now with more ease, harms noone, makes people happy. 

I swear if hot chocolate causes the destruction of the server or controversy on merge I will eat a sheet of paper. 
## Proof Of Testing
Basic replacement, trust me bro
## Changelog
:cl:
qol: unifies the two existing coco powder related reagents into one


/:cl: