### PR TITLE
HOP lockers now contain a "granted" and "denied" stamp

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -47,6 +47,8 @@
 	new /obj/item/storage/photo_album/hop(src)
 	new /obj/item/storage/lockbox/medal/hop(src)
 	new /obj/item/card/id/departmental_budget/srv(src) //SKYRAT EDIT ADDITION
+	new /obj/item/stamp/granted(src) //BUBBERSTATION EDIT ADDITIONS
+	new /obj/item/stamp/denied(src)
 
 /obj/structure/closet/secure_closet/hop/populate_contents_immediate()
 	new /obj/item/gun/energy/e_gun(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -50,8 +50,6 @@
 
 /obj/structure/closet/secure_closet/hop/populate_contents_immediate()
 	new /obj/item/gun/energy/e_gun(src)
-	new /obj/item/stamp/granted(src) //BUBBERSTATION EDIT ADDITIONS
-	new /obj/item/stamp/denied(src)
 
 /obj/structure/closet/secure_closet/hos
 	name = "head of security's locker"

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -47,11 +47,11 @@
 	new /obj/item/storage/photo_album/hop(src)
 	new /obj/item/storage/lockbox/medal/hop(src)
 	new /obj/item/card/id/departmental_budget/srv(src) //SKYRAT EDIT ADDITION
-	new /obj/item/stamp/granted(src) //BUBBERSTATION EDIT ADDITIONS
-	new /obj/item/stamp/denied(src)
 
 /obj/structure/closet/secure_closet/hop/populate_contents_immediate()
 	new /obj/item/gun/energy/e_gun(src)
+	new /obj/item/stamp/granted(src) //BUBBERSTATION EDIT ADDITIONS
+	new /obj/item/stamp/denied(src)
 
 /obj/structure/closet/secure_closet/hos
 	name = "head of security's locker"

--- a/modular_zubbers/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/modular_zubbers/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -1,3 +1,8 @@
 /obj/structure/closet/secure_closet/warden/PopulateContents()
 	. = ..()
 	new /obj/item/stamp/warden(src)
+
+/obj/structure/closet/secure_closet/hop/populate_contents_immediate()
+	. = ..()
+	new /obj/item/stamp/granted(src)
+	new /obj/item/stamp/denied(src)


### PR DESCRIPTION

## About The Pull Request

The HOP locker structure has had the two items, 
/obj/item/stamp/granted
 /obj/item/stamp/denied
added to them. Meaning this affects every map with a hop office. 

## Why It's Good For The Game

Community supported, lets people larp as their favourite Arstrotzkan booth-man without stealing cargo's stamps (which are objectives already to make it funnier, just pointing out the humor).
![thepower](https://github.com/user-attachments/assets/a6d7b735-8f25-4808-b1f6-f623a3e7857f)


## Proof Of Testing
No way this fails... There is no way. Worst case scenario? My comments are bad, but the code compiles.

:cl:
qol: Heads of Personnel have been given a bonus by Nanotrasen for their hard work, they now are provided big "granted" and "denied" stamps to assert dominance on any requesters in their line.
/:cl:
