### PR TITLE
Fixes express grocery pricing

### DIFF
--- a/code/game/machinery/computer/orders/order_computer/cook_order.dm
+++ b/code/game/machinery/computer/orders/order_computer/cook_order.dm
@@ -11,7 +11,6 @@
 	announcement_line = "The kitchen has ordered groceries which will arrive on the cargo shuttle! Please make sure it gets to them as soon as possible!"
 	// Discount for items in the chefs category like mining/bitrunning consoles
 	cargo_cost_multiplier =  0.65
-	express_cost_multiplier = 1 //BUBBERSTATION EDIT
 
 /obj/machinery/computer/order_console/cook/order_groceries(mob/living/purchaser, obj/item/card/id/card, list/groceries)
 	say("Thank you for your purchase! It will arrive on the next cargo shuttle!")

--- a/code/game/machinery/computer/orders/order_computer/cook_order.dm
+++ b/code/game/machinery/computer/orders/order_computer/cook_order.dm
@@ -11,6 +11,7 @@
 	announcement_line = "The kitchen has ordered groceries which will arrive on the cargo shuttle! Please make sure it gets to them as soon as possible!"
 	// Discount for items in the chefs category like mining/bitrunning consoles
 	cargo_cost_multiplier =  0.65
+	express_cost_multiplier = 1 //BUBBERSTATION EDIT
 
 /obj/machinery/computer/order_console/cook/order_groceries(mob/living/purchaser, obj/item/card/id/card, list/groceries)
 	say("Thank you for your purchase! It will arrive on the next cargo shuttle!")

--- a/modular_zubbers/code/game/machinery/computer/orders/order_computer/cook_order.dm
+++ b/modular_zubbers/code/game/machinery/computer/orders/order_computer/cook_order.dm
@@ -1,0 +1,2 @@
+/obj/machinery/computer/order_console/cook
+	express_cost_multiplier = 1

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8950,6 +8950,7 @@
 #include "modular_zubbers\code\game\machinery\camera\camera.dm"
 #include "modular_zubbers\code\game\machinery\computer\crew.dm"
 #include "modular_zubbers\code\game\machinery\computer\operating_computer.dm"
+#include "modular_zubbers\code\game\machinery\computer\orders\order_computer\cook_order.dm"
 #include "modular_zubbers\code\game\machinery\computer\orders\order_computer\cook_order_interdyne.dm"
 #include "modular_zubbers\code\game\machinery\computer\orders\order_computer\cook_order_tarkon.dm"
 #include "modular_zubbers\code\game\machinery\computer\orders\order_items\mining\order_pka.dm"


### PR DESCRIPTION
## About The Pull Request

As it turns out, despite the console having lowered prices for ordering normally - it had the original ones for express consoles. 
This means, that instead of paying, say, 5 credits for an item, you pay 15 credits for an item, as the actual gap between them is not double, but TRIPLE the price.

Now, instead of making it a 2x gap, I have decided that it's not entirely a bad idea to make it a 1.5x practical gap with the modifier = 1. 
## Why It's Good For The Game

Since cooks make large orders, I do not think the option of getting express orders and ignoring cargo is always convenient. 

We shouldn't punish cooks for trying to quickly make a meal. What is the crime? Trying to cook? To cook a succulent meal?
![fak](https://github.com/user-attachments/assets/22959f40-c0c8-4e7a-a17b-4033c715cc5f)

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
qol:  Ordering groceries from the service produce console is now much cheaper for the express option. 
/:cl:
