### PR TITLE
Makes Blind quirks (slightly) less blind

### DIFF
--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -128,6 +128,13 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/fullscreen)
 	layer = BLIND_LAYER
 	plane = FULLSCREEN_PLANE
 
+//BUBBER EDIT START
+/atom/movable/screen/fullscreen/blind_special
+	icon_state = "impairedoverlay3"
+	layer = BLIND_LAYER
+	plane = FULLSCREEN_PLANE
+//BUBBER EDIT END
+
 /atom/movable/screen/fullscreen/curse
 	icon_state = "curse"
 	layer = CURSE_LAYER

--- a/code/datums/status_effects/debuffs/vision/blindness.dm
+++ b/code/datums/status_effects/debuffs/vision/blindness.dm
@@ -52,7 +52,16 @@
 	make_unblind()
 
 /datum/status_effect/grouped/blindness/proc/make_blind()
-	owner.overlay_fullscreen(id, /atom/movable/screen/fullscreen/blind)
+	//BUBBER EDIT START
+	if (!owner)
+		return
+
+	var/overlay_type = /atom/movable/screen/fullscreen/blind
+	if (owner.is_blind_from(ECHOLOCATION_TRAIT) || owner.is_blind_from(QUIRK_TRAIT))
+		overlay_type = /atom/movable/screen/fullscreen/blind_special
+
+	owner.overlay_fullscreen(id, overlay_type) //BUBBER EDIT - Changed from just setting fullscreen/blind to the var/overlay_type.
+	//BUBBER EDIT END
 	// You are blind - at most, able to make out shapes near you
 	owner.add_client_colour(/datum/client_colour/monochrome, REF(src))
 

--- a/modular_skyrat/modules/carriers/code/overlay_system.dm
+++ b/modular_skyrat/modules/carriers/code/overlay_system.dm
@@ -84,6 +84,12 @@ There are downstream SFW servers using this code and I'd rather them not be expo
 	name = "Blind"
 	icon_state = "blackimageoverlay"
 
+//BUBBER EDIT START
+/atom/movable/screen/fullscreen/carrier/blind_special
+	name = "Blind"
+	icon_state = "impairedoverlay3"
+//BUBBER EDIT END
+
 /atom/movable/screen/fullscreen/carrier/colorable
 	name = "Recolorable"
 	icon = 'icons/hud/screen_gen.dmi'

--- a/modular_skyrat/modules/carriers/code/overlay_system.dm
+++ b/modular_skyrat/modules/carriers/code/overlay_system.dm
@@ -84,11 +84,9 @@ There are downstream SFW servers using this code and I'd rather them not be expo
 	name = "Blind"
 	icon_state = "blackimageoverlay"
 
-//BUBBER EDIT START
 /atom/movable/screen/fullscreen/carrier/blind_special
 	name = "Blind"
 	icon_state = "impairedoverlay3"
-//BUBBER EDIT END
 
 /atom/movable/screen/fullscreen/carrier/colorable
 	name = "Recolorable"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR makes it so that players with quirks that give permanent, incurable blindless (Blind, Echolocation) have an overlay that is _slighty_ less blind than the current one, for quality of life for the user.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game
I've put in _a lot_ of hours on characters that use the blind quirk. Echolocation is a functional must if you're planning to do anything that isn't just sit around as an assistant. Echolocation is a balanced trade off, however, it's incredibly irritating for the eyes when having to stare at the flashing overlay for a round(s). After a while, I find myself having to take a break or cryo early. I have to keep echolocation on because the current blind overlay is really good at it's job, making you completely blind. There have been many moments personally where if I just had a little more vision with the quirk, I wouldn't have to rely so heavily on eye searing echolocation.

This PR is a balance change that replaces the current overlay with a slightly more forgiving one. The idea behind this is to allow blind players fulfilling roles that stay in the same place fairly often (service, medical, robotics, etc.) to turn off echolocation for a while and instead rely on the vision provided by the overlay. The overlay is visible enough to where you should be able to operate your job with only a slight amount of eye-squinting difficulty, but restrictive enough to where you're still blind.

This change only affects characters that have the blindness/echolocation quirk, and doesn't effect characters that become blind from any other source.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Proof Of Testing

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->
<details>
<summary>Screenshots/Videos</summary>
Before:

The before image doesn't want to upload no matter what I do. It's just the current blindness overlay. Sorry.


After:
![dreamseeker_R4IBo3pEba](https://github.com/user-attachments/assets/0cfb8591-83dc-410a-b092-ca5cb513df02)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: made the blindness quirk slightly less restrictive

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
