### PR TITLE
The current storyteller is displayed on Discord when the storyteller vote ends.

### DIFF
--- a/modular_zubbers/code/modules/storyteller/storyteller_vote.dm
+++ b/modular_zubbers/code/modules/storyteller/storyteller_vote.dm
@@ -40,6 +40,11 @@
 /datum/vote/storyteller/finalize_vote(winning_option)
 	SSgamemode.storyteller_vote_result(winning_option)
 	SSgamemode.storyteller_voted = TRUE
+	for(var/channel_tag in CONFIG_GET(str_list/channel_announce_new_game))
+		send2chat(
+			new /datum/tgs_message_content("The storyteller has been set to [winning_option]. Get ready!"),
+			channel_tag
+		)
 
 /*
 ### PERSISTENCE SUBSYSTEM TRACKING BELOW ###


### PR DESCRIPTION
## About The Pull Request

The current storyteller is displayed on Discord when the storyteller vote ends.

## Why It's Good For The Game

Useful to know what storyteller it is before joining.

## Proof Of Testing

I cannot test this.

## Changelog


:cl: BurgerBB
qol: The current storyteller is displayed on Discord when the storyteller vote ends.
/:cl:
