### PR TITLE
Syndicate/United Surplus Crates now give the TC amount in loot that they do upstream

### DIFF
--- a/modular_skyrat/modules/skyrat-uplinks/code/categories/bundles.dm
+++ b/modular_skyrat/modules/skyrat-uplinks/code/categories/bundles.dm
@@ -1,10 +1,10 @@
 /datum/uplink_item/bundles_tc/surplus
 	desc = "A dusty crate from the back of the Syndicate warehouse delivered directly to you via Supply Pod. \
-			Contents are sorted to always be worth 50 TC. The Syndicate will only provide one surplus item per agent."
+			Contents are sorted to always be worth 30 TC. The Syndicate will only provide one surplus item per agent."
 	crate_tc_value = 30
 
 /datum/uplink_item/bundles_tc/surplus/united
 	desc = "A shiny and large crate to be delivered directly to you via Supply Pod. It has an advanced locking mechanism with an anti-tampering protocol. \
 			It is recommended that you only attempt to open it by having another agent purchase a Surplus Crate Key. Unite and fight. \
-			Contents are sorted to always be worth 125 TC. The Syndicate will only provide one surplus item per agent."
+			Contents are sorted to always be worth 80 TC. The Syndicate will only provide one surplus item per agent."
 	crate_tc_value = 80

--- a/modular_skyrat/modules/skyrat-uplinks/code/categories/bundles.dm
+++ b/modular_skyrat/modules/skyrat-uplinks/code/categories/bundles.dm
@@ -1,10 +1,10 @@
 /datum/uplink_item/bundles_tc/surplus
 	desc = "A dusty crate from the back of the Syndicate warehouse delivered directly to you via Supply Pod. \
 			Contents are sorted to always be worth 50 TC. The Syndicate will only provide one surplus item per agent."
-	crate_tc_value = 50
+	crate_tc_value = 30
 
 /datum/uplink_item/bundles_tc/surplus/united
 	desc = "A shiny and large crate to be delivered directly to you via Supply Pod. It has an advanced locking mechanism with an anti-tampering protocol. \
 			It is recommended that you only attempt to open it by having another agent purchase a Surplus Crate Key. Unite and fight. \
 			Contents are sorted to always be worth 125 TC. The Syndicate will only provide one surplus item per agent."
-	crate_tc_value = 125
+	crate_tc_value = 80


### PR DESCRIPTION

## About The Pull Request
Syndicate Surplus Crate loot amount from 50TC to 30TC
United Surplus Crate loot amount from 125TC to 80TC
These are the values /tg/ uses.
## Why It's Good For The Game

Gambling is fun, but being able to get double the TC you start with in random (potentially very powerful) junk AND having some left over is a bit much.

Having 5tc after buying either box to spend on whatever you want is reasonable and lets you adjust for strategies after you get the rngbox still. Getting 35tc worth of stuff is less excessive than 55tc total.

This sets it to the quite reasonable values upstream uses.
## Proof Of Testing
![image](https://github.com/user-attachments/assets/165b6b06-68a2-4eea-8a64-655482cb640d)



## Changelog
:cl:
balance: Syndicate Surplus Crate now contains 30TC worth of loot as opposed to 50TC
balance: United Surplus Crate now contains 80TC worth of loot as opposed to 125TC
/:cl:
