### PR TITLE
Fix opfor crashing when changing equipment number

### DIFF
--- a/tgui/packages/tgui/interfaces/OpposingForcePanel.jsx
+++ b/tgui/packages/tgui/interfaces/OpposingForcePanel.jsx
@@ -503,7 +503,7 @@ export const EquipmentTab = (props) => {
                           value={equipment.count}
                           minValue={1}
                           maxValue={5}
-                          onChange={(e, value) =>
+                          onChange={(value) =>
                             act('set_equipment_count', {
                               selected_equipment_ref: equipment.ref,
                               new_equipment_count: value,


### PR DESCRIPTION

## About The Pull Request

`NumberInput` `onChange` doesn't pass an event, meaning this code was storing the new number in `e` and `value` was null

## Why It's Good For The Game

Fixes #3628 

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![4zWp4BIiBx](https://github.com/user-attachments/assets/b190d6d0-40cf-4271-a2b9-71df5a0d4bd4)

</details>

## Changelog
:cl:
fix: fixed opfor menu crashing when changing requested equipment amount
/:cl:
