### PR TITLE
Normalized speedloader price between cargo goodies and imports

### DIFF
--- a/modular_skyrat/modules/company_imports/code/armament_datums/vitezstvi_ammo.dm
+++ b/modular_skyrat/modules/company_imports/code/armament_datums/vitezstvi_ammo.dm
@@ -64,7 +64,7 @@
 
 /datum/armament_entry/company_import/vitezstvi/speedloader
 	subcategory = "Speedloaders"
-	cost = PAYCHECK_CREW
+	cost = PAYCHECK_CREW * 2
 
 /datum/armament_entry/company_import/vitezstvi/speedloader/detective_lethal
 	item_type = /obj/item/ammo_box/c38


### PR DESCRIPTION

## About The Pull Request
speedloaders were 50 on imports and 100 on goodies before. now it's 100 on both
## Why It's Good For The Game
Normalizing numbers is probably good, also fixes https://github.com/Bubberstation/Bubberstation/issues/3385
## Proof Of Testing

trust me bro it's a one line change
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: Speedloaders now cost the same between cargo goodies, and company imports.
/:cl:
