### PR TITLE
Fix ammo workbench crash on changing materials amount

### DIFF
--- a/tgui/packages/tgui/interfaces/AmmoWorkbench.jsx
+++ b/tgui/packages/tgui/interfaces/AmmoWorkbench.jsx
@@ -266,7 +266,7 @@ const MaterialRow = (props) => {
           minValue={1}
           maxValue={50}
           value={amount}
-          onChange={(e, value) => setAmount(value)}
+          onChange={setAmount}
         />
         <Button
           disabled={amountAvailable < 1}


### PR DESCRIPTION

## About The Pull Request
Same rationale as #3631, I'll probably do a pass through all our TGUI to look for these later but this is the other one I know 100% is broken

## Why It's Good For The Game
Buggg

## Proof Of Testing

I didn't but I just fixed something else caused by the same issue so if this breaks feel free to kill me

## Changelog
:cl:
fix: fixed ammo workbench crashing on changing amount of materials to release
/:cl:
