### PR TITLE
Make Detective's Notice Board being craftable.

### DIFF
--- a/modular_zubbers/code/datums/components/crafting/furniture.dm
+++ b/modular_zubbers/code/datums/components/crafting/furniture.dm
@@ -45,3 +45,12 @@
 	)
 	result = /obj/item/sign/flag/pride/trans
 	category = CAT_FURNITURE
+
+/datum/crafting_recipe/detectiveboard
+	name = "Detective's Notice Board"
+	reqs = list(
+		/obj/item/stack/sheet/mineral/wood = 1,
+	)
+	result = /obj/structure/detectiveboard
+	time = 20 SECONDS
+	category = CAT_FURNITURE


### PR DESCRIPTION
## About The Pull Request

Added Detective's Notice board to craftable recipes.
## Why It's Good For The Game

Otherwise those boards cannot be crafted or acquired in any way. And it makes the Detective Job just so much more fun and engaging when you can present your cases in this way.
(Or just flex all the cool things you gathered despite everything already having been resolved, but yknow - just in case)
## Proof Of Testing

Tested it and the board showed up in the crafting menu and was able to be crafted just fine.
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
add: A way to craft the Detective's Notice Board with wooden planks.
/:cl:
