### PR TITLE
Fix non-station SM crystals from activating the delam suppression system

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -579,7 +579,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 
 	final_countdown = TRUE
 
-	SEND_GLOBAL_SIGNAL(COMSIG_MAIN_SM_DELAMINATING, final_countdown) // SKYRAT EDIT ADDITION - DELAM_SCRAM
+	if(is_main_engine) // BUBBER EDIT ADDITION - DELAM_SCRAM
+		SEND_GLOBAL_SIGNAL(COMSIG_MAIN_SM_DELAMINATING, final_countdown) // BUBBER EDIT ADDITION - DELAM_SCRAM
 	notify_ghosts(
 		"[src] has begun the delamination process!",
 		source = src,


### PR DESCRIPTION
## About The Pull Request

lol

![image](https://github.com/user-attachments/assets/fba330da-5a66-43c0-b6af-b73a9b851718)

## Changelog

:cl: LT3
fix: Those jerks over at Cybersun can no longer trigger your station's supermatter delam suppression system
/:cl:
