### PR TITLE
Fixes the MetaStation Sec Locker Room Light switch.

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -35806,8 +35806,8 @@
 	pixel_y = 4
 	},
 /obj/structure/cable,
-/obj/machinery/light_switch/directional/west,
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "mMl" = (
@@ -43406,6 +43406,7 @@
 "pti" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "pts" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -35807,7 +35807,6 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "mMl" = (


### PR DESCRIPTION
## About The Pull Request

In another instance of blatant sec power creep, I have moved the light switch in MetaStation's security gear room from under the APC to a wall two tiles over. 
## Why It's Good For The Game

Seeing stuff = good

## Proof Of Testing

It is one change in a map file. I don't think compiling even does anything in regards to map files.

## Changelog
:cl:
map: moved MetaStation's Securty Equipment Room lightswitch from under the APC
