### PR TITLE
[DNM] Fixes dept radio custom say emotes

### DIFF
--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -122,7 +122,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	var/original_message = message
 	message = get_message_mods(message, message_mods)
 	saymode = SSradio.saymodes[message_mods[RADIO_KEY]]
-	if (!forced && !saymode)
+	if (!forced && (!saymode || message_mods[RADIO_EXTENSION] == MODE_DEPARTMENT)) // BUBBER EDIT - Makes dept. custom emotes work.
 		message = check_for_custom_say_emote(message, message_mods)
 
 	if(!message)


### PR DESCRIPTION

## About The Pull Request
You can now custom emote over the dept radio key, `.h` (or `:h` for heathens)
## Why It's Good For The Game

emote :]

## Proof Of Testing

I tested both as a BST and an AI using a holopad.
Holopad works fine, but does drop the emote part of the message, which, whatever. It didn't work like that before anyways (I think.)

## Changelog
:cl:
fix: You can now do a custom say emote over the dept radio key 'h'
/:cl:
