### PR TITLE
Fix hundreds of divide by zero runtimes in death consequences perk

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences/quirks/death_consequences.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/quirks/death_consequences.dm
@@ -101,7 +101,7 @@
 /datum/preference/numeric/death_consequences/crit_threshold_reduction_percent_of_max
 	savefile_key = "dc_crit_threshold_reduction_percent_of_max"
 
-	minimum = 0
+	minimum = 1
 	maximum = 100
 
 /datum/preference/numeric/death_consequences/crit_threshold_reduction_percent_of_max/create_default_value()
@@ -128,7 +128,7 @@
 /datum/preference/numeric/death_consequences/stamina_damage_percent_of_max
 	savefile_key = "dc_stamina_damage_percent_of_max"
 
-	minimum = 0
+	minimum = 1
 	maximum = 100
 
 /datum/preference/numeric/death_consequences/stamina_damage_percent_of_max/create_default_value()

--- a/modular_skyrat/modules/death_consequences_perk/death_consequences_trauma.dm
+++ b/modular_skyrat/modules/death_consequences_perk/death_consequences_trauma.dm
@@ -324,6 +324,10 @@
 	if (victim_properly_resting())
 		return
 
+	// Should not run if this is zero,
+	if(!stamina_damage_max_degradation)
+		return
+
 	var/clamped_degradation = clamp((current_degradation - stamina_damage_minimum_degradation), 0, stamina_damage_max_degradation)
 	var/percent_to_max = min((clamped_degradation / stamina_damage_max_degradation), 1)
 	var/minimum_stamina_damage = max_stamina_damage * percent_to_max

--- a/modular_skyrat/modules/death_consequences_perk/death_consequences_trauma.dm
+++ b/modular_skyrat/modules/death_consequences_perk/death_consequences_trauma.dm
@@ -324,10 +324,6 @@
 	if (victim_properly_resting())
 		return
 
-	// Should not run if this is zero,
-	if(!stamina_damage_max_degradation)
-		return
-
 	var/clamped_degradation = clamp((current_degradation - stamina_damage_minimum_degradation), 0, stamina_damage_max_degradation)
 	var/percent_to_max = min((clamped_degradation / stamina_damage_max_degradation), 1)
 	var/minimum_stamina_damage = max_stamina_damage * percent_to_max


### PR DESCRIPTION

## About The Pull Request

Changes the minimum value for two death consequences related settings to be 1 instead of 0, because these are percentages that get divided and end up causing div by zero runtimes. Also it doesn't make sense to even let these be zero

## Why It's Good For The Game

![image](https://github.com/user-attachments/assets/42586d49-15b9-4c49-9540-601dcb6c46f3)


## Proof Of Testing

I didddd

## Changelog
:cl:
fix: the minimum values for "stamina damage end degradation percent" and "crit threshold end degradation percent" are now 1 instead of 0
/:cl: