### PR TITLE
Let ashwalkers make arrows

### DIFF
--- a/code/modules/antagonists/ashwalker/ashwalker.dm
+++ b/code/modules/antagonists/ashwalker/ashwalker.dm
@@ -28,6 +28,7 @@
 	. = ..()
 	RegisterSignal(owner.current, COMSIG_MOB_EXAMINATE, PROC_REF(on_examinate))
 	//owner.teach_crafting_recipe(/datum/crafting_recipe/skeleton_key) //SKYRAT EDIT REMOVAL - ASH RITUALS
+	owner.teach_crafting_recipe(/datum/crafting_recipe/arrow) //BUBBER EDIT - ASH WALKER SHOULD KNOW HOW TO FLETCH
 	if(FACTION_NEUTRAL in owner.current.faction)
 		owner.current.faction.Remove(FACTION_NEUTRAL) // ashwalkers aren't neutral; they're ashwalker-aligned
 


### PR DESCRIPTION

## About The Pull Request

It seems as of https://github.com/Bubberstation/Bubberstation/commit/224b8362c7a7117cba6682904fefbc9c28badf87 ashwalkers can't make arrows anymore. Arrow quivers and bows in the camp are useless.

## Why It's Good For The Game

Ashwalkers need arrows to hunt legions, which is currently extremely difficult. The arrow quivers in the ashwalker camp are also useless now.

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: Ashwalkers unable to craft arrows
/:cl:
