### PR TITLE
Remove asynchronous blinking until TG fixes their code

### DIFF
--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -516,7 +516,7 @@
 		addtimer(CALLBACK(src, PROC_REF(animate_eyelids), owner), blink_delay + duration)
 
 /obj/item/organ/eyes/proc/animate_eyelids(mob/living/carbon/human/parent)
-	var/sync_blinking = synchronized_blinking && (parent.get_organ_loss(ORGAN_SLOT_BRAIN) < ASYNC_BLINKING_BRAIN_DAMAGE)
+	var/sync_blinking = TRUE // synchronized_blinking && (parent.get_organ_loss(ORGAN_SLOT_BRAIN) < ASYNC_BLINKING_BRAIN_DAMAGE) // BUBBER EDIT - REMOVE ASYNC BLINKING UNTIL https://github.com/tgstation/tgstation/issues/90269 is fixed
 	// Randomize order for unsynched animations
 	if (sync_blinking || prob(50))
 		var/list/anim_times = animate_eyelid(eyelid_left, parent, sync_blinking)
@@ -1090,7 +1090,7 @@
 	name = "reptile eyes"
 	desc = "A pair of reptile eyes with thin vertical slits for pupils."
 	icon_state = "lizard_eyes"
-	synchronized_blinking = FALSE
+	// synchronized_blinking = FALSE // BUBBER EDIT - REMOVE ASYNC BLINKING UNTIL https://github.com/tgstation/tgstation/issues/90269 is fixed
 
 /obj/item/organ/eyes/night_vision/maintenance_adapted
 	name = "adapted eyes"


### PR DESCRIPTION
## About The Pull Request
If you play a lizard or get brain damage, you'll notice your character's eyes getting stuck closed.
https://github.com/tgstation/tgstation/issues/90269

## Why It's Good For The Game
It's very noticeable and offputting to be one-eyed.

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
del: Remove asynchronous blinking due to eyes getting stuck closed
/:cl:
