### PR TITLE
Fix hairline and compound fractures being instantly healed with bone gel

### DIFF
--- a/modular_skyrat/modules/filtersandsetters/code/filtersandsetters.dm
+++ b/modular_skyrat/modules/filtersandsetters/code/filtersandsetters.dm
@@ -21,6 +21,9 @@
 	treatable_tools = list(TOOL_ALIEN_BONESET)
 
 /datum/wound/blunt/bone/severe/treat(obj/item/I, mob/user)
+	if(!(TOOL_ALIEN_BONESET in I.get_all_tool_behaviours()))
+		return ..()
+
 	var/scanned = HAS_TRAIT(src, TRAIT_WOUND_SCANNED)
 	var/self_penalty_mult = user == victim ? 1.5 : 1
 	var/scanned_mult = scanned ? 0.5 : 1
@@ -50,6 +53,9 @@
 	treatable_tools = list(TOOL_ALIEN_BONESET)
 
 /datum/wound/blunt/bone/critical/treat(obj/item/I, mob/user)
+	if(!(TOOL_ALIEN_BONESET in I.get_all_tool_behaviours()))
+		return ..()
+
 	var/scanned = HAS_TRAIT(src, TRAIT_WOUND_SCANNED)
 	var/self_penalty_mult = user == victim ? 1.5 : 1
 	var/scanned_mult = scanned ? 0.5 : 1


### PR DESCRIPTION
## About The Pull Request

This code is ugly as fuck because the base boneset proc is just a `treat` proc so it got copy pasted here but whats supposed to happen is you're able to heal hairline/compound fractures instantly with an alien bonesetter, otherwise you have to use bone gel and tape and wait. but due to a bug (this override blocks the base bone wound treat with gel/tape, and it doesnt check if its actually a bonesetter we're using) it would use this alien bonesetter treatment path with bone gel and tape.
## Why It's Good For The Game

Fixes #3658 

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/bdd7ff28-f4eb-4893-b10b-423c94a40a69)

</details>

## Changelog
:cl:
fix: hairline and compound fractures are no longer instantly healed with bone gel, sorry!
/:cl:
