### PR TITLE
Fix admin heal making you drop to the deck and flop like a fish

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -925,7 +925,7 @@
 	if(full_heal_flags)
 		fully_heal(full_heal_flags)
 
-	if(stat == DEAD && can_be_revived() || (full_heal_flags & HEAL_ADMIN)) //in some cases you can't revive (e.g. no brain) //SKYRAT EDIT ADDITION - DNR TRAIT - Added: " || (full_heal_flags & HEAL_ADMIN)"
+	if(stat == DEAD && (can_be_revived() || (full_heal_flags & HEAL_ADMIN))) //in some cases you can't revive (e.g. no brain) //SKYRAT EDIT ADDITION - DNR TRAIT - Original: if(stat == DEAD && can_be_revived())
 		set_suicide(FALSE)
 		set_stat(UNCONSCIOUS) //the mob starts unconscious,
 		updatehealth() //then we check if the mob should wake up.


### PR DESCRIPTION

## About The Pull Request

Skyrat added a condition so that people who didn't pass `can_be_revived()` (DNR people) could still be admin healed, but they didn't put brackets so the branch is taken every aheal, and it's only supposed to be used for dead people so it does things like makes them unconscious and lie down for a second

## Why It's Good For The Game

It's dumb as fuck

## Proof Of Testing

Imagine

## Changelog
:cl:
fix: getting admin healed no longer makes you drop to the floor and then get up
/:cl:
