### PR TITLE
Fix runtimes in combat indicator

### DIFF
--- a/modular_skyrat/modules/indicators/code/combat_indicator.dm
+++ b/modular_skyrat/modules/indicators/code/combat_indicator.dm
@@ -47,10 +47,9 @@ GLOBAL_VAR_INIT(combat_indicator_overlay, GenerateCombatOverlay())
 	if(combat_indicator_vehicle)
 		. += GLOB.combat_indicator_overlay
 
-/mob/living/proc/combat_indicator_unconscious_signal()
+/mob/living/proc/combat_indicator_unconscious_signal(datum/source, amount, ignore_canstun)
 	SIGNAL_HANDLER
-	if(stat < UNCONSCIOUS) // sanity check because something is calling this signal improperly -- it may be due to adjustconciousness()
-		stack_trace("Improper COMSIG_LIVING_STATUS_UNCONSCIOUS sent; mob is not unconscious")
+	if(!IsUnconscious() && amount <= 0)
 		return
 	set_combat_indicator(FALSE)
 


### PR DESCRIPTION

## About The Pull Request

Combat indicator code incorrectly treats `COMSIG_LIVING_STATUS_UNCONSCIOUS` being sent when the mob isn't unconscious as a bug and throws a stack trace, in reality that signal is sent whenever the unconscious status of the mob is adjusted at all, like when a negative amount is applied to wake someone up. Change the logic to return if the mob isn't actually going unconscious

## Why It's Good For The Game

several dozen meaningless runtimes gone

## Proof Of Testing

Imagine an empty runtime list

## Changelog

Nothing player facing
