### PR TITLE
Fix tarkon bounty pad being broken

### DIFF
--- a/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
+++ b/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
@@ -224,6 +224,8 @@
 	var/interface_type = "CargoHoldTerminal"
 	///Typecache of things that shouldn't be sold and shouldn't have their contents sold.
 	var/static/list/nosell_typecache
+	///Market this terminal sells to, defaults to pirate
+	var/export_market = EXPORT_MARKET_PIRACY // BUBBER EDIT ADDITION
 
 /obj/machinery/computer/piratepad_control/Initialize(mapload)
 	..()
@@ -363,11 +365,11 @@
 			continue
 		for(var/mob/living/hidden as anything in hidden_mobs)
 			///Sell mobs, but leave their contents intact.
-			export_single_item(hidden, apply_elastic = FALSE, dry_run = dry_run, external_report = report)
+			export_single_item(hidden, apply_elastic = FALSE, dry_run = dry_run, external_report = report, export_market = export_market) // BUBBER EDIT CHANGE - ORIGINAL: export_single_item(hidden, apply_elastic = FALSE, dry_run = dry_run, external_report = report)
 		///there are still licing mobs inside that item. Stop, don't sell it ffs.
 		if(locate(/mob/living) in item_on_pad.get_all_contents())
 			continue
-		export_item_and_contents(item_on_pad, apply_elastic = FALSE, dry_run = dry_run, delete_unsold = FALSE, external_report = report, ignore_typecache = nosell_typecache, export_market = EXPORT_MARKET_PIRACY)
+		export_item_and_contents(item_on_pad, apply_elastic = FALSE, dry_run = dry_run, delete_unsold = FALSE, external_report = report, ignore_typecache = nosell_typecache, export_market = export_market) // BUBBER EDIT CHANGE - ORIGINAL: export_item_and_contents(item_on_pad, apply_elastic = FALSE, dry_run = dry_run, delete_unsold = FALSE, external_report = report, ignore_typecache = nosell_typecache, export_market = EXPORT_MARKET_PIRACY)
 	return report
 
 /// Prepares to sell the items on the pad

--- a/modular_zubbers/code/game/machinery/syndiepad.dm
+++ b/modular_zubbers/code/game/machinery/syndiepad.dm
@@ -63,6 +63,7 @@
 	icon_keyboard = "syndie_key"
 	warmup_time = SYN_BOUNTY_PAD_WARM_TIME
 	circuit = /obj/item/circuitboard/computer/syndiepad
+	export_market = EXPORT_MARKET_STATION
 
 	/// The account to add balance
 	var/credits_account = ACCOUNT_INT


### PR DESCRIPTION

## About The Pull Request

TG added it so the pirate pad exports to a separate market that has like 3 things in it (hostages, parrots, cash) and so I added a var on the computer to determine which market it sells to and overrode it to station for interdyne/tarkon pads

## Why It's Good For The Game

Fixes #3661 

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/024a375f-79e8-4196-8937-53dc7a94118f)

</details>

## Changelog
:cl:
fix: fixed port tarkon bounty pad returning 0 for all sales
/:cl:
