### PR TITLE
Fix export gate runtime

### DIFF
--- a/modular_skyrat/modules/cargo/code/export_gate.dm
+++ b/modular_skyrat/modules/cargo/code/export_gate.dm
@@ -1,13 +1,3 @@
-/// Returns a list of minds of staff in a particular job
-/datum/controller/subsystem/job/proc/get_job_staff_records(job_trim)
-	if(isnull(job_trim))
-		CRASH("get_job_staff_records called without a job argument")
-
-	. = list()
-	for(var/datum/record/locked/target in GLOB.manifest.locked)
-		if(target.trim == job_trim)
-			. += target
-
 /obj/item/circuitboard/machine/export_gate
 	name = "Export Gate"
 	greyscale_colors = CIRCUIT_COLOR_SUPPLY
@@ -193,19 +183,11 @@
 
 /obj/machinery/export_gate/proc/refresh_payment_accounts()
 	var/list/manifest_accounts = list()
-	var/list/cargo_techs = SSjob.get_job_staff_records(JOB_CARGO_TECHNICIAN)
-	if(isnull(cargo_techs))
+	var/list/cargo_tech_accounts = SSeconomy.bank_accounts_by_job[/datum/job/cargo_technician]
+	if(isnull(cargo_tech_accounts))
 		return
 
-	for(var/datum/record/locked/cargo_tech as anything in cargo_techs)
-		var/datum/mind/cargo_mind = cargo_tech.mind_ref.resolve()
-		if(isnull(cargo_mind))
-			continue
-
-		var/datum/bank_account/tech_account = cargo_mind.current.get_bank_account()
-		if(isnull(tech_account))
-			continue
-
+	for(var/datum/bank_account/tech_account as anything in cargo_tech_accounts)
 		if(tech_account.off_duty_check())
 			continue
 


### PR DESCRIPTION

## About The Pull Request

The export gate would runtime whenever someone cryoed that was a cargo tech because it looped through the locked manifest to get a mind reference and then a current mob (which wouldn't always exist) for some godawful reason, changed the logic to just use the `bank_accounts_by_job` list on `SSeconomy`

## Why It's Good For The Game

Fixes #3663 

## Proof Of Testing

Trust

## Changelog

N/A
