### PR TITLE
Fix bug with loadout items replacing properties of similar job items

### DIFF
--- a/code/modules/loadout/loadout_helpers.dm
+++ b/code/modules/loadout/loadout_helpers.dm
@@ -76,7 +76,7 @@
 	var/update = NONE
 	for(var/datum/loadout_item/item as anything in loadout_datums)
 		update |= item.on_equip_item(
-			equipped_item = locate(item.item_path) in new_contents,
+			equipped_item = loadout_placement_preference == LOADOUT_OVERRIDE_CASE ? locate(item.item_path) in travel_suitcase : locate(item.item_path) in new_contents, // BUBBER EDIT CHANGE - ORIGINAL: equipped_item = locate(item.item_path) in new_contents,
 			preference_source = preference_source,
 			preference_list = preference_list,
 			equipper = src,


### PR DESCRIPTION
## About The Pull Request

Loadout equipping code checks mob equipment when running `on_equip_item` which would normally be fine because it eventually loops to the items in the case but if a job has the same type path as something in the loadout, say `/obj/item/clothing/head/beret` in the loadout and `/obj/item/clothing/head/beret/blueshield` in the job, it'll apply the loadout prefs to the job item because that's earlier in the list and that can break shit

## Why It's Good For The Game

Fixes #3667 

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/da7df967-6cc6-463e-a2b1-ab5553e9bf0f)

</details>

## Changelog
:cl:
fix: fixed loadout item customization breaking job equipment under certain circumstances
/:cl:
