### PR TITLE
ethereal-revive-bugfix

### DIFF
--- a/code/modules/surgery/organs/internal/heart/heart_ethereal.dm
+++ b/code/modules/surgery/organs/internal/heart/heart_ethereal.dm
@@ -231,9 +231,9 @@
 	regenerating.revive(HEAL_ALL & ~HEAL_REFRESH_ORGANS)
 
 	if(prob(10)) //10% chance for a severe trauma
-		regenerating.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_ABSOLUTE)
+		regenerating.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_MAGIC)   //Bubber Edit was TRAUMA_RESILIENCE_ABSOLUTE
 	else
-		regenerating.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_ABSOLUTE)
+		regenerating.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_MAGIC)     //Bubber Edit was TRAUMA_RESILIENCE_ABSOLUTE
 
 	// revive calls fully heal -> deletes the crystal.
 	// this qdeleted check is just for sanity.

--- a/code/modules/unit_tests/ethereal_revival.dm
+++ b/code/modules/unit_tests/ethereal_revival.dm
@@ -42,7 +42,7 @@
 	TEST_ASSERT(length(current_traumas) == 1, "Ethereal failed to gain trauma when reviving.")
 
 	kill_and_revive(victim, respawn_heart)
-	TEST_ASSERT(length(victim.get_traumas()) == 2, "Ethereal failed to gain additional trauma on second revival.")
+	//TEST_ASSERT(length(victim.get_traumas()) == 2, "Ethereal failed to gain additional trauma on second revival.") //commenting out for now, to allow ethereals to gain a magical trauma instead of permanent one
 
 	instant_crystallise(victim, respawn_heart)
 	victim.heal_and_revive()

--- a/code/modules/unit_tests/ethereal_revival.dm
+++ b/code/modules/unit_tests/ethereal_revival.dm
@@ -42,7 +42,7 @@
 	TEST_ASSERT(length(current_traumas) == 1, "Ethereal failed to gain trauma when reviving.")
 
 	kill_and_revive(victim, respawn_heart)
-	//TEST_ASSERT(length(victim.get_traumas()) == 2, "Ethereal failed to gain additional trauma on second revival.") //commenting out for now, to allow ethereals to gain a magical trauma instead of permanent one
+	//TEST_ASSERT(length(victim.get_traumas()) == 2, "Ethereal failed to gain additional trauma on second revival.") //Bubber Edit - commenting out for now, to allow ethereals to gain a magical trauma instead of permanent one
 
 	instant_crystallise(victim, respawn_heart)
 	victim.heal_and_revive()


### PR DESCRIPTION
## About The Pull Request
Somehow Ethereals revives were changed back to TG's version. This fixes it back to bubbers version which gives them magical traumas instead of absolute traumas. Thus this is a bugfix, restoring how it originally was for bubber.

## Why It's Good For The Game

Getting a trauma that cannot be removed via any method is exceptionally annoying, and often just leads to the player immediately cryoing. Ethereals cannot control whether they revive via their passive. It is not something they can refuse without just flat out going DNR. A magical trauma is very difficult to remove, but not impossible, thus it is balanced.

## Proof Of Testing


## Changelog

:cl:
fix: ethereal revives gives magical trauma instead of permanent
/:cl:
