### PR TITLE
Add default to arrivals shuttle auto return config

### DIFF
--- a/modular_skyrat/master_files/code/_globalvars/configuration.dm
+++ b/modular_skyrat/master_files/code/_globalvars/configuration.dm
@@ -67,5 +67,7 @@ GLOBAL_VAR_INIT(looc_allowed, TRUE)
 /// Split the threat budget between roundstart and midrounds
 /datum/config_entry/flag/split_threat_budget
 
-// How much time arrivals shuttle should stay at station after its engines recharged before returning to interlink. In deciseconds. 150 - 15 seconds. 0 - disables autoreturn
+// How much time arrivals shuttle should stay at station after its engines recharged before returning to interlink, in deciseconds. 0 - disables autoreturn
 /datum/config_entry/number/arrivals_wait
+	default = 150
+	min_val = 0

--- a/modular_skyrat/modules/advanced_shuttles/code/shuttles.dm
+++ b/modular_skyrat/modules/advanced_shuttles/code/shuttles.dm
@@ -16,7 +16,7 @@
 
 	///Our shuttle's control console
 	var/obj/machinery/computer/shuttle/arrivals/console
-	///How much time are we waiting before returning to interlink. Sets itself automatically from config file
+	///How much time are we waiting before returning to interlink. Sets itself automatically from config file. 0 = no auto return
 	var/wait_time
 	///State variable. True when our shuttle is waiting before autoreturn
 	var/waiting = FALSE // would've been better to use shuttle's mode variable, but check() resets it to SHUTTLE_IDLE so it's more sane way to make this fully modular


### PR DESCRIPTION

## About The Pull Request

Yeah

## Why It's Good For The Game

Fixes #3680 

## Proof Of Testing

Yeag

## Changelog

:cl:
config: the arrivals shuttle should automatically return to the interlink again
/:cl:
