### PR TITLE
Change a RegisterSignal to RegisterSignals

### DIFF
--- a/modular_skyrat/modules/borgs/code/robot_items.dm
+++ b/modular_skyrat/modules/borgs/code/robot_items.dm
@@ -734,7 +734,7 @@
 		return
 	if(listeningTo)
 		UnregisterSignal(listeningTo, signalCache)
-	RegisterSignal(user, signalCache, PROC_REF(disrupt))
+	RegisterSignals(user, signalCache, PROC_REF(disrupt))
 	listeningTo = user
 
 /obj/item/borg_shapeshifter/proc/deactivate(mob/living/silicon/robot/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Not supposed to pass lists of signals into `RegisterSignal` anymore

## Why It's Good For The Game

![image](https://github.com/user-attachments/assets/03b51ef0-d6f6-4bc1-819d-daf90bb93458)

## Proof Of Testing

You know I'm good for it...

## Changelog

N/A