### PR TITLE
Fix screen color not cleaning up and add erroring on invalid usage

### DIFF
--- a/modular_skyrat/modules/exp_corps/code/clothing.dm
+++ b/modular_skyrat/modules/exp_corps/code/clothing.dm
@@ -229,7 +229,7 @@
 		if(my_eyes)
 			my_eyes.color_cutoffs = list(10, 30, 10)
 			my_eyes.flash_protect = FLASH_PROTECTION_SENSITIVE
-		current_user.add_client_colour(/datum/client_colour/glass_colour/lightgreen)
+		current_user.add_client_colour(/datum/client_colour/glass_colour/lightgreen, REF(src))
 
 /obj/item/clothing/head/helmet/expeditionary_corps/proc/disable_nv()
 	if(current_user)
@@ -237,7 +237,7 @@
 		if(my_eyes)
 			my_eyes.color_cutoffs = initial(my_eyes.color_cutoffs)
 			my_eyes.flash_protect = initial(my_eyes.flash_protect)
-		current_user.remove_client_colour(/datum/client_colour/glass_colour/lightgreen)
+		current_user.remove_client_colour(REF(src))
 		current_user.update_sight()
 
 /obj/item/clothing/head/helmet/expeditionary_corps/click_alt(mob/user)

--- a/modular_skyrat/modules/quirks/echolocation/echolocation.dm
+++ b/modular_skyrat/modules/quirks/echolocation/echolocation.dm
@@ -43,8 +43,8 @@
 	)
 	esp = human_holder.GetComponent(/datum/component/echolocation)
 
-	human_holder.remove_client_colour(/datum/client_colour/monochrome)
-	esp_color = human_holder.add_client_colour(/datum/client_colour/echolocation_custom)
+	human_holder.remove_client_colour(REF(src))
+	esp_color = human_holder.add_client_colour(/datum/client_colour/echolocation_custom, REF(src))
 	esp_color.update_color(col)
 
 	// add an action/spell to allow the player to toggle echolocation off for a bit (eyestrain on longer rounds, or just roleplay)
@@ -57,7 +57,7 @@
 	QDEL_NULL(esp) // echolocation component removal handles graceful disposal of everything above
 	QDEL_NULL(added_action) // remove the stall action, too
 	var/mob/living/carbon/human/human_holder = quirk_holder
-	human_holder.remove_client_colour(/datum/client_colour/echolocation_custom) // clean up the custom colour override we added
+	human_holder.remove_client_colour(REF(src)) // clean up the custom colour override we added
 	UnregisterSignal(human_holder, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine_text))
 
 /datum/quirk/echolocation/proc/on_examine_text(client/client_source, mob/user, list/examine_list)

--- a/modular_zubbers/code/modules/client/client_color.dm
+++ b/modular_zubbers/code/modules/client/client_color.dm
@@ -5,6 +5,6 @@
 	. = ..()
 
 /mob/remove_client_colour(source)
-	if(!ispath(source))
+	if(ispath(source))
 		stack_trace("[src] tried to remove a client colour with a path source.")
 	. = ..()

--- a/modular_zubbers/code/modules/client/client_color.dm
+++ b/modular_zubbers/code/modules/client/client_color.dm
@@ -1,0 +1,10 @@
+
+/mob/add_client_colour(datum/client_colour/new_color, source, force = FALSE)
+	if(!source)
+		stack_trace("[src] tried to add a client colour with no source.")
+	. = ..()
+
+/mob/remove_client_colour(source)
+	if(!ispath(source))
+		stack_trace("[src] tried to remove a client colour with a path source.")
+	. = ..()

--- a/modular_zubbers/code/modules/status_effects/buffs/frenzy.dm
+++ b/modular_zubbers/code/modules/status_effects/buffs/frenzy.dm
@@ -48,7 +48,7 @@
 		was_tooluser = TRUE
 		REMOVE_TRAIT(owner, TRAIT_ADVANCEDTOOLUSER, SPECIES_TRAIT)
 	owner.add_movespeed_modifier(/datum/movespeed_modifier/frenzy_speedup)
-	owner.add_client_colour(/datum/client_colour/manual_heart_blood)
+	owner.add_client_colour(/datum/client_colour/manual_heart_blood, REF(src))
 	var/obj/cuffs = user.get_item_by_slot(ITEM_SLOT_HANDCUFFED)
 	var/obj/legcuffs = user.get_item_by_slot(ITEM_SLOT_LEGCUFFED)
 	if((user.handcuffed && cuffs) || (user.legcuffed && legcuffs))
@@ -64,7 +64,7 @@
 		ADD_TRAIT(owner, TRAIT_ADVANCEDTOOLUSER, SPECIES_TRAIT)
 		was_tooluser = FALSE
 	owner.remove_movespeed_modifier(/datum/movespeed_modifier/frenzy_speedup)
-	owner.remove_client_colour(/datum/client_colour/manual_heart_blood)
+	owner.remove_client_colour(REF(src))
 
 	SEND_SIGNAL(bloodsuckerdatum, COMSIG_BLOODSUCKER_EXITS_FRENZY)
 	bloodsuckerdatum.frenzied = FALSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9137,6 +9137,7 @@
 #include "modular_zubbers\code\modules\changeling_zombies\reagent.dm"
 #include "modular_zubbers\code\modules\changeling_zombies\virus.dm"
 #include "modular_zubbers\code\modules\character_preview_background\character_preview_background.dm"
+#include "modular_zubbers\code\modules\client\client_color.dm"
 #include "modular_zubbers\code\modules\client\examine_tgui.dm"
 #include "modular_zubbers\code\modules\client\preferences.dm"
 #include "modular_zubbers\code\modules\client\ssd.dm"


### PR DESCRIPTION
## About The Pull Request
Fix screen color not cleaning up and add erroring on invalid usage, this includes the echolocation quirk, NV helmet, frenzy.
https://github.com/tgstation/tgstation/pull/89843 refactored the procs and we didn't update our usage of it

## Why It's Good For The Game
Bug fixes

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>
:blushes: umm
</details>

## Changelog

:cl:
fix: Fixes NV helmets, frenzy, echolocation quirk leaving screen colors permanently on
/:cl:

