### PR TITLE
Fix some runtimes related to null sprite accessory names

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences/mutant_parts.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/mutant_parts.dm
@@ -100,7 +100,7 @@
 	savefile_key = "feature_body_markings"
 	relevant_mutant_bodypart = "body_markings"
 	type_to_check = /datum/preference/toggle/mutant_toggle/body_markings
-	default_accessory_type = /datum/sprite_accessory/lizard_markings
+	default_accessory_type = /datum/sprite_accessory/lizard_markings/none
 
 /datum/preference/choiced/mutant_choice/body_markings/is_accessible(datum/preferences/preferences)
 	. = ..() // Got to do this because of linters.
@@ -213,7 +213,7 @@
 	savefile_key = "feature_horns"
 	relevant_mutant_bodypart = "horns"
 	type_to_check = /datum/preference/toggle/mutant_toggle/horns
-	default_accessory_type = /datum/sprite_accessory/horns
+	default_accessory_type = /datum/sprite_accessory/horns/none
 
 /datum/preference/tri_color/horns
 	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
@@ -291,7 +291,7 @@
 	savefile_key = "feature_frills"
 	relevant_mutant_bodypart = "frills"
 	type_to_check = /datum/preference/toggle/mutant_toggle/frills
-	default_accessory_type = /datum/sprite_accessory/frills
+	default_accessory_type = /datum/sprite_accessory/frills/none
 
 /datum/preference/tri_color/frills
 	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
@@ -317,7 +317,7 @@
 	savefile_key = "feature_spines"
 	relevant_mutant_bodypart = "spines"
 	type_to_check = /datum/preference/toggle/mutant_toggle/spines
-	default_accessory_type = /datum/sprite_accessory/spines
+	default_accessory_type = /datum/sprite_accessory/spines/none
 
 /datum/preference/tri_color/spines
 	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
@@ -399,7 +399,7 @@
 	savefile_key = "feature_moth_markings"
 	relevant_mutant_bodypart = "moth_markings"
 	type_to_check = /datum/preference/toggle/mutant_toggle/moth_markings
-	default_accessory_type = /datum/sprite_accessory/moth_markings
+	default_accessory_type = /datum/sprite_accessory/moth_markings/none
 
 /datum/preference/choiced/mutant_choice/moth_markings/is_accessible(datum/preferences/preferences)
 	. = ..() // Got to do this because of linters.


### PR DESCRIPTION

## About The Pull Request

Some of the mutant part prefs had their default sprite accessory set to the parent type which has a name of `null` instead of `None` which made the code "Big Mad"
## Why It's Good For The Game

Fix runtime spam about null accessory names

## Proof Of Testing

Tested it on a local with an affected save file

## Changelog

N/A