### PR TITLE
Take the station trait, HoS-AI, out of rotation.

### DIFF
--- a/modular_zubbers/code/datums/station_traits/negative_traits.dm
+++ b/modular_zubbers/code/datums/station_traits/negative_traits.dm
@@ -2,7 +2,7 @@
 	name = "Head of Security AI"
 	trait_type = STATION_TRAIT_NEGATIVE
 	trait_flags = parent_type::trait_flags | STATION_TRAIT_REQUIRES_AI
-	weight = 3
+	weight = 0
 	show_in_report = TRUE
 	report_message = "For experimental purposes, this station AI has been put in charge of the security department, Security Cyborgs are enabled for the duration of the shift. \
 	Do not meddle with the silicon laws unless absolutely necessary, the AI is to be treated as a member of command, and your head of Security"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR keeps the trait, but removes it from rotation. This is due to popular demand and the widely perceived imbalance of this for our current game state. As much as the idea is fun, we cannot keep it due to the lack of enjoyment from borgs, Antags, and Sec alike.

## Why It's Good For The Game

A comprehensive list would be how EMPs, any sort of conversion, ions, immediately shut down Borgs, which take up security slots, making SeC less efficient if the antag takes any of those options -bordering on impossible to play against for Borgs against Ling or a traitor who has invested in a flashlight. But then, on the other side of things, if a traitor or whoever has no EMPs, they're facing off against a Borg, which cannot be shoved, it can be only flashed. The counterplay against a Sec Borg is very small, mostly in the form of EMPs, which are tough to access, and overall Sec Borgs are just extremely spammy, tough to play against and as. You cannot do much. And now that we have damage slowdown on Borgs, it's a bit better, but it's still very lacking. It's gonna be a curb stomp one way or another.

And then there's the issue of Borgs who just don't want to play Sec and there's an unfair expectation placed upon them to play Sec because they've taken the slots, they've become a Borg, now you're a Sec Borg. Not all of our Borg players want to play Sec Borg. I'm pretty sure a lot of them play Borg to play Borg and if they want to play Sec, they play Sec instead. So we've got a conflict of interest that even mechanic balancing of the Sec Borg itself cannot solve.

## Proof Of Testing


## Changelog

:cl:
config: takes the HOS AI trait out of rotation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
