### PR TITLE
Borgs can use IV drips again

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -23,7 +23,7 @@
 	anchored = FALSE
 	mouse_drag_pointer = MOUSE_ACTIVE_POINTER
 	use_power = NO_POWER_USE
-	//interaction_flags_mouse_drop = NEED_HANDS //Bubber Edit Remove: This reverts the change restricting borgs from using an iv drip
+	interaction_flags_mouse_drop = NEED_HANDS
 
 	/// Information and effects about where the IV drip is attached to
 	var/datum/iv_drip_attachment/attachment

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -23,7 +23,7 @@
 	anchored = FALSE
 	mouse_drag_pointer = MOUSE_ACTIVE_POINTER
 	use_power = NO_POWER_USE
-	interaction_flags_mouse_drop = NEED_HANDS
+	//interaction_flags_mouse_drop = NEED_HANDS //Bubber Edit Remove: This reverts the change restricting borgs from using an iv drip
 
 	/// Information and effects about where the IV drip is attached to
 	var/datum/iv_drip_attachment/attachment

--- a/modular_zubbers/code/game/machinery/iv_drip.dm
+++ b/modular_zubbers/code/game/machinery/iv_drip.dm
@@ -1,0 +1,2 @@
+/obj/machinery/iv_drip
+	interaction_flags_mouse_drop = NONE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8927,6 +8927,7 @@
 #include "modular_zubbers\code\game\machinery\crew_monitor.dm"
 #include "modular_zubbers\code\game\machinery\department_balance.dm"
 #include "modular_zubbers\code\game\machinery\incident_display.dm"
+#include "modular_zubbers\code\game\machinery\iv_drip.dm"
 #include "modular_zubbers\code\game\machinery\medipen_refiller.dm"
 #include "modular_zubbers\code\game\machinery\morgue.dm"
 #include "modular_zubbers\code\game\machinery\syndiepad.dm"


### PR DESCRIPTION

## About The Pull Request

Restores the ability for borgs to attach IV drips to people again which was removed in an upstream PR refactoring mouse drag interactions.

## Why It's Good For The Game

This should have never been restricted from borgs. Medical borgs can actually restore blood to patients efficiently again.

## Proof Of Testing

IV drips and Automated IV drips are able to be used by both silicons and crew.

## Changelog
:cl:
fix: Silicons can attach IV drips again
/:cl:
