### PR TITLE
Remove Skyrat lights off override

### DIFF
--- a/modular_skyrat/modules/aesthetics/lightswitch/code/lightswitch.dm
+++ b/modular_skyrat/modules/aesthetics/lightswitch/code/lightswitch.dm
@@ -5,13 +5,6 @@
 	. = ..()
 	playsound(src, 'modular_skyrat/modules/aesthetics/lightswitch/sound/lightswitch.ogg', 100, 1)
 
-#ifndef UNIT_TESTS
-/obj/machinery/light_switch/post_machine_initialize()
-	. = ..()
-	if(prob(50) && area.lightswitch) //50% chance for area to start with lights off.
-		set_lights(FALSE)
-#endif
-
 /obj/machinery/light_switch/default_on
 
 /obj/machinery/light_switch/default_on/post_machine_initialize()


### PR DESCRIPTION
## About The Pull Request

Removes a Skyrat add that turns off lights by default in rooms that have light switches

## Why It's Good For The Game

There's no reason to make you hunt for the lights shift start. It also means the janitor can't tell what rooms have broken lights at a glance unless someone hit the switch.

## Changelog

:cl: LT3
del: Removed lights being turned off by default in various locations
/:cl:
