### PR TITLE
Fix persistence walls being error

### DIFF
--- a/code/game/turfs/closed/wall/reinf_walls.dm
+++ b/code/game/turfs/closed/wall/reinf_walls.dm
@@ -205,7 +205,7 @@
 		icon = 'modular_skyrat/modules/aesthetics/walls/icons/reinforced_wall.dmi' // SKYRAT EDIT CHANGE - ORIGINAL: icon = 'icons/turf/walls/reinforced_states.dmi'
 		icon_state = "[base_decon_state]-[d_state]"
 	else
-		icon = 'modular_skyrat/modules/aesthetics/walls/icons/reinforced_wall.dmi' // SKYRAT EDIT CHANGE - ORIGINAL: icon = 'icons/turf/walls/reinforced_wall.dmi'
+		icon = initial(icon) // SKYRAT EDIT CHANGE - ORIGINAL: icon = 'icons/turf/walls/reinforced_wall.dmi'
 		icon_state = "[base_icon_state]-[smoothing_junction]"
 	return ..()
 


### PR DESCRIPTION

## About The Pull Request

`/turf/closed/wall/r_wall/update_icon_state` had a hard-coded icon file in it that the `syndicate` subtype doesn't use so it was getting changed to that

## Why It's Good For The Game

Fixes #3717 

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/b9fbed56-3ce6-46fd-9afa-0f88af4e0698)

</details>

## Changelog
:cl:
fix: fixed persistence walls being error on some maps
/:cl:
