### PR TITLE
Cleans mentions of 'spinwarder' in code

### DIFF
--- a/code/modules/antagonists/fugitive/hunters/hunter.dm
+++ b/code/modules/antagonists/fugitive/hunters/hunter.dm
@@ -73,12 +73,16 @@
 	add_team_hud(mob_override || owner.current)
 	if(backstory == HUNTER_PACK_RUSSIAN)
 		var/mob/living/owner_mob = mob_override || owner.current
-		owner_mob.grant_language(/datum/language/spinwarder, source = LANGUAGE_BOUNTYHUNTER)
-		owner_mob.set_active_language(/datum/language/spinwarder)
+		//bubber edit; spinwarder removed
+		owner_mob.grant_language(/datum/language/panslavic, source = LANGUAGE_BOUNTYHUNTER)
+		owner_mob.set_active_language(/datum/language/panslavic)
+		//edit end
 
 /datum/antagonist/fugitive_hunter/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/owner_mob = mob_override || owner.current
-	owner_mob.remove_language(/datum/language/spinwarder, source = LANGUAGE_BOUNTYHUNTER)
+	//bubber edit; spinwarder removed
+	owner_mob.remove_language(/datum/language/panslavic, source = LANGUAGE_BOUNTYHUNTER)
+	//edit end
 	return ..()
 
 /datum/team/fugitive_hunters

--- a/code/modules/mob/living/basic/trooper/russian.dm
+++ b/code/modules/mob/living/basic/trooper/russian.dm
@@ -12,7 +12,7 @@
 	attack_verb_simple = "slash"
 	attack_sound = 'sound/items/weapons/bladeslice.ogg'
 	attack_vis_effect = ATTACK_EFFECT_SLASH
-	initial_language_holder = /datum/language_holder/panslavic_exclusive //bubber edit; spinwarder -> panslavic
+	initial_language_holder = /datum/language_holder/panslavic_exclusive //bubber edit; spinwarder to panslavic
 
 	mob_spawner = /obj/effect/mob_spawn/corpse/human/russian
 	r_hand = /obj/item/knife/kitchen

--- a/code/modules/mob/living/basic/trooper/russian.dm
+++ b/code/modules/mob/living/basic/trooper/russian.dm
@@ -12,7 +12,7 @@
 	attack_verb_simple = "slash"
 	attack_sound = 'sound/items/weapons/bladeslice.ogg'
 	attack_vis_effect = ATTACK_EFFECT_SLASH
-	initial_language_holder = /datum/language_holder/spinwarder_exclusive
+	initial_language_holder = /datum/language_holder/panslavic_exclusive //bubber edit; spinwarder -> panslavic
 
 	mob_spawner = /obj/effect/mob_spawn/corpse/human/russian
 	r_hand = /obj/item/knife/kitchen

--- a/code/modules/surgery/organs/internal/tongue/_tongue.dm
+++ b/code/modules/surgery/organs/internal/tongue/_tongue.dm
@@ -77,7 +77,7 @@
 	return list(
 		/datum/language/common,
 		/datum/language/uncommon,
-		/datum/language/spinwarder,
+		/datum/language/panslavic, //bubber edit; spinwarder removed
 		/datum/language/draconic,
 		/datum/language/codespeak,
 		/datum/language/monkey,

--- a/code/modules/vending/sovietsoda.dm
+++ b/code/modules/vending/sovietsoda.dm
@@ -17,7 +17,7 @@
 	extra_price = PAYCHECK_CREW //One credit for every state of FREEDOM
 	payment_department = NO_FREEBIES
 	light_color = COLOR_PALE_ORANGE
-	initial_language_holder = /datum/language_holder/panslavic //bubber edit; spinwarder -> panslavic
+	initial_language_holder = /datum/language_holder/panslavic //bubber edit; spinwarder to panslavic
 
 /obj/item/vending_refill/sovietsoda
 	machine_name = "BODA"

--- a/code/modules/vending/sovietsoda.dm
+++ b/code/modules/vending/sovietsoda.dm
@@ -17,7 +17,7 @@
 	extra_price = PAYCHECK_CREW //One credit for every state of FREEDOM
 	payment_department = NO_FREEBIES
 	light_color = COLOR_PALE_ORANGE
-	initial_language_holder = /datum/language_holder/spinwarder
+	initial_language_holder = /datum/language_holder/panslavic //bubber edit; spinwarder -> panslavic
 
 /obj/item/vending_refill/sovietsoda
 	machine_name = "BODA"

--- a/modular_zubbers/code/modules/languages/_language_holder.dm
+++ b/modular_zubbers/code/modules/languages/_language_holder.dm
@@ -8,3 +8,23 @@
 		/datum/language/common = list(LANGUAGE_ATOM),
 		/datum/language/piratespeak = list(LANGUAGE_ATOM)
 	)
+
+/datum/language_holder/panslavic
+	understood_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/panslavic = list(LANGUAGE_ATOM),
+	)
+	spoken_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/panslavic = list(LANGUAGE_ATOM),
+	)
+	selected_language = /datum/language/panslavic
+
+/datum/language_holder/panslavic_exclusive
+	understood_languages = list(
+		/datum/language/panslavic = list(LANGUAGE_ATOM),
+	)
+	spoken_languages = list(
+		/datum/language/panslavic = list(LANGUAGE_ATOM),
+	)
+	selected_language = /datum/language/panslavic


### PR DESCRIPTION
## Why It's Good For The Game

resolves https://github.com/Bubberstation/Bubberstation/issues/3716

## Proof Of Testing

idk man i didnt change anything

## Changelog

:cl:
refactor: changed bounty hunter and tongue default languages from spinwarder to panslavic
/:cl:
