### PR TITLE
Reverts the tg change of making lizard blood green

### DIFF
--- a/code/modules/mob/living/blood_types.dm
+++ b/code/modules/mob/living/blood_types.dm
@@ -137,7 +137,7 @@
 
 /datum/blood_type/lizard
 	name = BLOOD_TYPE_LIZARD
-	color = BLOOD_COLOR_LIZARD
+	// color = BLOOD_COLOR_LIZARD //BUBBER EDIT REMOVAL
 	compatible_types = list(
 		/datum/blood_type/lizard,
 	)


### PR DESCRIPTION
## About The Pull Request

read title. it's red again.
## Why It's Good For The Game

![image](https://github.com/user-attachments/assets/62ad0533-3e6d-492a-813d-c39f6f2a4521)

Also we're getting the blood customization quirk soon and I know that'll also remove this but honestly I'm not waiting several weeks for that
## Proof Of Testing

I commented it out and added //BUBBER EDIT REMOVAL
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
remove: Lizard blood is no longer inherently green
/:cl:
