### PR TITLE
Fix departmental stun batons missing inhand icon

### DIFF
--- a/modular_skyrat/modules/goofsec/code/department_guards.dm
+++ b/modular_skyrat/modules/goofsec/code/department_guards.dm
@@ -663,6 +663,7 @@
 	desc = "A stun baton fitted with a departmental area-lock, based off the station's blueprint layout - outside of its department, it only has three uses."
 	icon = 'modular_skyrat/modules/goofsec/icons/departmental_batons.dmi'
 	icon_state = "prison_baton" // We're abstract anyhow
+	base_inhand_state = "stunbaton"
 	var/list/valid_areas = list()
 	var/emagged = FALSE
 	var/non_departmental_uses_left = 4


### PR DESCRIPTION
## About The Pull Request

Upstream introduced `base_inhand_state` for batons that needs to be set or it'll default to `base_icon_state`

## Why It's Good For The Game

Fixes #3760

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/41664135-4fdd-488b-ae73-94ac79ebb973)

</details>

## Changelog
:cl:
image: departmental stun batons have an inhand icon again
/:cl:
