### PR TITLE
Fix flaky runtime related to ghoul limbs

### DIFF
--- a/modular_skyrat/modules/bodyparts/code/ghoul_bodyparts.dm
+++ b/modular_skyrat/modules/bodyparts/code/ghoul_bodyparts.dm
@@ -105,7 +105,8 @@
 
 		. = newMeat // Return MEAT
 
-	qdel(src)
+	if(!QDELETED(src))
+		qdel(src)
 
 /obj/item/bodypart/arm/left/mutant/ghoul/drop_limb(special, dismembered, move_to_floor = TRUE)
 	..() // Create Meat, Remove Limb
@@ -116,7 +117,8 @@
 
 		. = newMeat // Return MEAT
 
-	qdel(src)
+	if(!QDELETED(src))
+		qdel(src)
 
 /obj/item/bodypart/leg/right/mutant/ghoul/drop_limb(special, dismembered, move_to_floor = TRUE)
 	..() // Create Meat, Remove Limb
@@ -127,7 +129,8 @@
 
 		. = newMeat // Return MEAT
 
-	qdel(src)
+	if(!QDELETED(src))
+		qdel(src)
 
 /obj/item/bodypart/leg/left/mutant/ghoul/drop_limb(special, dismembered, move_to_floor = TRUE)
 	..() // Create Meat, Remove Limb
@@ -138,7 +141,8 @@
 
 		. = newMeat // Return MEAT
 
-	qdel(src)
+	if(!QDELETED(src))
+		qdel(src)
 
 #undef GHOUL_BRUTE_MODIFIER
 #undef GHOUL_BURN_MODIFIER


### PR DESCRIPTION

## About The Pull Request

Ghoul limbs drop meat instead of the limb when they come off and they do that by `qdel`ing in `drop_limb` but if `drop_limb` was originally called as part of `Destroy` they'll qdel twice and you can't do that and it runtimes

## Why It's Good For The Game

Fix flaky CI failure

## Proof Of Testing

Trust

## Changelog

N/A
