### PR TITLE
Fix donator loadout items being removed

### DIFF
--- a/code/modules/loadout/loadout_helpers.dm
+++ b/code/modules/loadout/loadout_helpers.dm
@@ -51,6 +51,10 @@
 				to_chat(preference_source.parent, span_warning("You were unable to get a loadout item ([initial(item.item_path.name)]) due to species restrictions!"))
 			continue
 
+		if(item.donator_only && !SSplayer_ranks.is_donator(preference_source?.parent))
+			if(preference_source.parent)
+				to_chat(preference_source.parent, span_warning("You were unable to get a loadout item ([initial(item.item_path.name)]) due to donator restrictions!"))
+
 		if(item.ckeywhitelist && !(preference_source?.parent?.ckey in item.ckeywhitelist)) // Sanity checking
 			if(preference_source.parent)
 				to_chat(preference_source.parent, span_warning("You were unable to get a loadout item ([initial(item.item_path.name)]) due to CKEY restrictions!"))

--- a/code/modules/loadout/loadout_helpers.dm
+++ b/code/modules/loadout/loadout_helpers.dm
@@ -54,6 +54,7 @@
 		if(item.donator_only && !SSplayer_ranks.is_donator(preference_source?.parent))
 			if(preference_source.parent)
 				to_chat(preference_source.parent, span_warning("You were unable to get a loadout item ([initial(item.item_path.name)]) due to donator restrictions!"))
+			continue
 
 		if(item.ckeywhitelist && !(preference_source?.parent?.ckey in item.ckeywhitelist)) // Sanity checking
 			if(preference_source.parent)

--- a/code/modules/loadout/loadout_menu.dm
+++ b/code/modules/loadout/loadout_menu.dm
@@ -113,11 +113,6 @@
 /datum/preference_middleware/loadout/get_ui_static_data(mob/user)
 	var/list/data = list()
 	data["loadout_preview_view"] = preferences.character_preview_view.assigned_map
-	// SKYRAT EDIT START - EXPANDED LOADOUT
-	data["ckey"] = user.ckey
-	if(SSplayer_ranks.is_donator(user.client))
-		data["is_donator"] = TRUE
-	// SKYRAT EDIT END
 	return data
 
 /datum/preference_middleware/loadout/get_constant_data()

--- a/code/modules/loadout/loadout_menu.dm
+++ b/code/modules/loadout/loadout_menu.dm
@@ -80,7 +80,7 @@
 		to_chat(preferences.parent, span_warning("You cannot select this item!"))
 		return
 
-	if(selected_item.donator_only && !GLOB.donator_list[preferences?.parent?.ckey])
+	if(selected_item.donator_only && !SSplayer_ranks.is_donator(preferences.parent))
 		to_chat(preferences.parent, span_warning("This item is for donators only."))
 		return
 	// SKYRAT EDIT END

--- a/code/modules/loadout/loadout_preference.dm
+++ b/code/modules/loadout/loadout_preference.dm
@@ -58,8 +58,6 @@
 			var/datum/loadout_item/loadout_item = GLOB.all_loadout_datums[real_path]
 			if(loadout_item?.ckeywhitelist && !(owner_client?.ckey in loadout_item.ckeywhitelist))
 				continue
-			if(loadout_item?.donator_only && !GLOB.donator_list[owner_client?.ckey])
-				continue
 		// SKYRAT EDIT END
 
 		// Set into sanitize list using converted path key

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/types.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/types.ts
@@ -236,8 +236,6 @@ export type PreferencesMenuData = {
   quirks_balance: number;
   positive_quirk_count: number;
   species_restricted_jobs?: string[];
-  ckey: string;
-  is_donator: BooleanLike;
   // SKYRAT EDIT END
 
   keybindings: Record<string, string[]>;


### PR DESCRIPTION

## About The Pull Request

Is this user a donator validation was being done in the `deserialize` proc for the pref which is bad because if someone was auto reconnected to the server after restart and joins right as it restarts it'll be run before the ranks system has loaded meaning this check will always fail and remove the item from their loadout. Moved the validation to when the player spawns in, so ranks is guaranteed to be loaded. Also changed something that was checking the donator list directly to use the proc for it. Also removed two unused variables that got deprecated in #3747 

## Why It's Good For The Game

Fixes #3773 

## Proof Of Testing

Tested it on a local before and after

## Changelog
:cl:
fix: fixed donator-only loadout items disappearing from donator's loadouts
/:cl:
