### PR TITLE
Fix blinking config

### DIFF
--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -517,7 +517,7 @@
 		addtimer(CALLBACK(src, PROC_REF(animate_eyelids), owner), blink_delay + duration)
 
 /obj/item/organ/eyes/proc/animate_eyelids(mob/living/carbon/human/parent)
-	if(!CONFIG_GET(flag/blinking)) return // BUBBER EDIT - CONFIG BLINKING
+	if(CONFIG_GET(flag/disable_blinking)) return // BUBBER EDIT - CONFIG BLINKING
 
 	var/sync_blinking = TRUE // synchronized_blinking && (parent.get_organ_loss(ORGAN_SLOT_BRAIN) < ASYNC_BLINKING_BRAIN_DAMAGE) // BUBBER EDIT - REMOVE ASYNC BLINKING UNTIL https://github.com/tgstation/tgstation/issues/90269 is fixed
 	// Randomize order for unsynched animations

--- a/config/bubbers/bubbers_config.txt
+++ b/config/bubbers/bubbers_config.txt
@@ -20,5 +20,5 @@ INTERN_THRESHOLD_COMMAND 20
 ## Respawn grace period (deciseconds), which allows to return to the lobby some amount of time after the world loads - default 30 minutes
 RESPAWN_GRACE_PERIOD 18000
 
-#If enabled, /human mobs will ocassionaly blink (somewhat expensive)
-BLINKING
+## If enabled, /human mobs will no longer blink (blinking is somewhat expensive)
+#DISABLE_BLINKING

--- a/modular_zubbers/code/controllers/configuration/entries/blinking.dm
+++ b/modular_zubbers/code/controllers/configuration/entries/blinking.dm
@@ -1,14 +1,14 @@
-/datum/config_entry/flag/blinking
-	default = TRUE
+/datum/config_entry/flag/disable_blinking
+	default = FALSE
 
 // blinking won't update without re-running the animate
-/datum/config_entry/flag/blinking/vv_edit_var(var_name, var_value)
+/datum/config_entry/flag/disable_blinking/vv_edit_var(var_name, var_value)
 	. = ..()
 	if(var_name == NAMEOF(src, config_entry_value))
 		INVOKE_ASYNC(src, PROC_REF(update_blinkers))
 
 
-/datum/config_entry/flag/blinking/proc/update_blinkers()
+/datum/config_entry/flag/disable_blinking/proc/update_blinkers()
 	for(var/mob/living/carbon/human/blinker in GLOB.alive_mob_list)
 		var/obj/item/organ/eyes/eyes = blinker.get_organ_slot(ORGAN_SLOT_EYES)
 		eyes?.blink()


### PR DESCRIPTION

## About The Pull Request

#3703 introduced a config value to enable blinking but it doesn't work because it defaults to true and config entries are disabled by commenting them out, but the lack of an entry will make it use its default value meaning you can never actually disable blinking. This switches it to be an option to disable blinking that defaults to false instead

## Why It's Good For The Game

we need to steal their eyelids

## Proof Of Testing

yeag

## Changelog
:cl:
config: fixed blinking config option
/:cl:
