### PR TITLE
Fix winter woods ambience

### DIFF
--- a/modular_skyrat/modules/ghostcafe/code/hilbertshotel_ghost.dm
+++ b/modular_skyrat/modules/ghostcafe/code/hilbertshotel_ghost.dm
@@ -39,7 +39,7 @@
 
 /area/misc/hilbertshotel/winterwoods
 	name = "Winter Woods"
-	ambientsounds = AMBIENCE_ICEMOON
+	ambience_index = AMBIENCE_ICEMOON
 
 /datum/map_template/ghost_cafe_rooms/evacuationstation
 	name = "Evacuated Station"


### PR DESCRIPTION

## About The Pull Request

The `AMBIENCE_` defines are supposed to be used with `ambience_index` not `ambientsounds`

## Why It's Good For The Game

Bug fix

## Proof Of Testing

I didn't

## Changelog
:cl:
fix: fixed the winter woods not playing ambience
/:cl:
