### PR TITLE
Changes and fixes some ninja cyborg issues

### DIFF
--- a/code/modules/antagonists/ninja/ninjaDrainAct.dm
+++ b/code/modules/antagonists/ninja/ninjaDrainAct.dm
@@ -325,6 +325,8 @@
 	//BUBBER ADDITION BEGIN - Role Selection
 	//model.transform_to(pick(/obj/item/robot_model/syndicate, /obj/item/robot_model/syndicate_medical, /obj/item/robot_model/saboteur)) - SKYRAT EDIT - ORIGINAL
 	var/choice = tgui_input_list(src, "What role do you wish to become?","Select Role", modelselected)
+	if(!choice)
+		choice = pick(modelselected)
 	model.transform_to(modelselected[choice])
 	//BUBBER ADDITION END
 


### PR DESCRIPTION

## About The Pull Request
Updates the role selection menu for when a borg is hacked by a ninja to use the tgui input instead.

Shells now get reset when hacked by a ninja instead of getting a free ninja shell.

Borgs now Scramble codes and get set to an emagged status when hacked by ninja.

## Why It's Good For The Game
Turns out the role selection code is not TG it's was a skyrat feature meaning it never got updated to a tgui selection menu

Shells should not be a free ninja shell otherwise I'd suppose emags should be allowed to emag an AI shell.
This also fixes some scenarios of when an AI shell was hacked and then turned around and just killed the ninja right then and there with the now ninja shell.

Borgs not being scrambled and not having an emagged status when hacked by a ninja always confused me, since game play wise you could just see they got hacked go strait to the robotics console lock them down (I may be wrong about that) or kill them and slap a law board in them and send them to just kill the ninja.

## Proof Of Testing
Tested locally selection menu functions along with the other two mentioned things
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
balance: AI shells can no longer get a free ninja shell from a ninja.
balance: Cyborgs hacked by a ninja now set scrambled codes and are emagged.
fix: When a ninja hacks a cyborg it now uses Tgui instead of the byond selection.
/:cl:
