### PR TITLE
SAD and VV load prefs overrides quirks

### DIFF
--- a/modular_skyrat/modules/extra_vv/code/extra_vv.dm
+++ b/modular_skyrat/modules/extra_vv/code/extra_vv.dm
@@ -56,6 +56,7 @@
 		return
 
 	client?.prefs?.apply_prefs_to(src)
+	SSquirks.OverrideQuirks(src, client)
 	var/msg = span_notice("[key_name_admin(usr)] has loaded [key_name(src)]'s preferences onto their current mob [ADMIN_VERBOSEJMP(src)].")
 	message_admins(msg)
 	admin_ticket_log(src, msg)

--- a/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
+++ b/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
@@ -215,7 +215,6 @@
 
 	patient.client?.prefs?.safe_transfer_prefs_to_with_damage(patient, visuals_only = TRUE)
 	patient.dna.update_dna_identity()
-	SSquirks.AssignQuirks(patient, patient.client)
 	if(patient.dna.real_name != original_name)
 		log_game("[key_name(patient)] has used the Self-Actualization Device at [loc_name(src)], changed the name of their character. \
 		Original Name: [original_name], New Name: [patient.dna.real_name].")
@@ -226,6 +225,7 @@
 	say("Procedure complete! Enjoy your life being a new you!")
 
 	open_machine()
+	SSquirks.OverrideQuirks(patient, patient.client)
 
 /// Ejection and shut down of the machine, used before the preferences have been applied to the player. Damage optional.
 /obj/machinery/self_actualization_device/proc/eject_old_you(damaged_goods = FALSE)

--- a/modular_zubbers/code/controllers/subsystem/processing/quirks.dm
+++ b/modular_zubbers/code/controllers/subsystem/processing/quirks.dm
@@ -1,0 +1,8 @@
+
+/// Remove any quirks that the client's prefs do not have, and apply any new ones
+/datum/controller/subsystem/processing/quirks/proc/OverrideQuirks(mob/living/user, client/applied_client)
+	var/list/required_quirks = applied_client.prefs.all_quirks
+	for(var/datum/quirk/quirk in user.quirks)
+		if(!(quirk.name in required_quirks))
+			user.remove_quirk(quirk.type)
+	AssignQuirks(user, applied_client)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8852,6 +8852,7 @@
 #include "modular_zubbers\code\controllers\subsystem\security_level.dm"
 #include "modular_zubbers\code\controllers\subsystem\vote.dm"
 #include "modular_zubbers\code\controllers\subsystem\processing\nanites.dm"
+#include "modular_zubbers\code\controllers\subsystem\processing\quirks.dm"
 #include "modular_zubbers\code\controllers\subsystem\processing\sol_subsystem.dm"
 #include "modular_zubbers\code\datums\action.dm"
 #include "modular_zubbers\code\datums\akula_overrides.dm"


### PR DESCRIPTION

## About The Pull Request
SAD and VV load prefs overrides quirks, instead of simply adding if missing

## Why It's Good For The Game
This is me trying to get people to pester admins less about quirks

## Proof Of Testing
Tested, seems to work

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
add: SAD will now remove any quirks you don't have set in prefs, please don't abuse it.
admin: VV load prefs now loads and overrides quirks as well.
/:cl:

