### PR TITLE
Change required perms for player ranks management to R_ADMIN

### DIFF
--- a/modular_skyrat/modules/admin/code/player_ranks.dm
+++ b/modular_skyrat/modules/admin/code/player_ranks.dm
@@ -1,8 +1,8 @@
 /// The list of the available special player ranks
 #define SKYRAT_PLAYER_RANKS list("Donator", "Mentor")
 
-ADMIN_VERB(manage_player_ranks, R_PERMISSIONS, "Manage Player Ranks", "Manage who has the special player ranks while the server is running.", ADMIN_CATEGORY_MAIN)
-	if(!check_rights(R_PERMISSIONS))
+ADMIN_VERB(manage_player_ranks, R_ADMIN, "Manage Player Ranks", "Manage who has the special player ranks while the server is running.", ADMIN_CATEGORY_MAIN)
+	if(!check_rights(R_ADMIN))
 		return
 
 	usr.client?.holder.manage_player_ranks()
@@ -12,7 +12,7 @@ ADMIN_VERB(manage_player_ranks, R_PERMISSIONS, "Manage Player Ranks", "Manage wh
 	if(IsAdminAdvancedProcCall())
 		return
 
-	if(!check_rights(R_PERMISSIONS))
+	if(!check_rights(R_ADMIN))
 		return
 
 	var/choice = tgui_alert(usr, "Which rank would you like to manage?", "Manage Player Ranks", SKYRAT_PLAYER_RANKS)
@@ -82,14 +82,14 @@ ADMIN_VERB(manage_player_ranks, R_PERMISSIONS, "Manage Player Ranks", "Manage wh
 
 
 
-ADMIN_VERB(migrate_player_ranks, R_PERMISSIONS|R_DEBUG|R_SERVER, "Migrate Player Ranks", "Individually migrate the various player ranks from their legacy system to the SQL-based one.", ADMIN_CATEGORY_DEBUG)
+ADMIN_VERB(migrate_player_ranks, R_ADMIN|R_DEBUG|R_SERVER, "Migrate Player Ranks", "Individually migrate the various player ranks from their legacy system to the SQL-based one.", ADMIN_CATEGORY_DEBUG)
 	user.mob.client?.holder.migrate_player_ranks()
 
 /datum/admins/proc/migrate_player_ranks()
 	if(IsAdminAdvancedProcCall())
 		return
 
-	if(!check_rights(R_PERMISSIONS | R_DEBUG | R_SERVER))
+	if(!check_rights(R_ADMIN | R_DEBUG | R_SERVER))
 		return
 
 	if(!CONFIG_GET(flag/sql_enabled))

--- a/modular_skyrat/modules/player_ranks/code/subsystem/player_ranks.dm
+++ b/modular_skyrat/modules/player_ranks/code/subsystem/player_ranks.dm
@@ -225,7 +225,7 @@ SUBSYSTEM_DEF(player_ranks)
 	if(!admin_holder)
 		return FALSE
 
-	if(!admin_holder.check_for_rights(R_PERMISSIONS))
+	if(!admin_holder.check_for_rights(R_ADMIN))
 		if(is_admin_client)
 			to_chat(admin, span_warning("You do not possess the permissions to do this."))
 
@@ -314,7 +314,7 @@ SUBSYSTEM_DEF(player_ranks)
 	if(!admin_holder)
 		return FALSE
 
-	if(!admin_holder.check_for_rights(R_PERMISSIONS))
+	if(!admin_holder.check_for_rights(R_ADMIN))
 		if(is_admin_client)
 			to_chat(admin, span_warning("You do not possess the permissions to do this."))
 
@@ -377,7 +377,7 @@ SUBSYSTEM_DEF(player_ranks)
 	if(IsAdminAdvancedProcCall())
 		return
 
-	if(!check_rights_for(admin, R_PERMISSIONS | R_DEBUG | R_SERVER))
+	if(!check_rights_for(admin, R_ADMIN | R_DEBUG | R_SERVER))
 		to_chat(admin, span_warning("You do not possess the permissions to do this."))
 		return
 

--- a/modular_skyrat/modules/player_ranks/code/world_topic.dm
+++ b/modular_skyrat/modules/player_ranks/code/world_topic.dm
@@ -34,7 +34,7 @@
 		.["message"] = "No valid admin datum was found associated with the ckey associated to your Discord account."
 		return
 
-	if(!linked_admin_holder.check_for_rights(R_PERMISSIONS))
+	if(!linked_admin_holder.check_for_rights(R_ADMIN))
 		.["success"] = FALSE
 		.["message"] = "You do not possess the permissions to execute this command."
 		return


### PR DESCRIPTION

## About The Pull Request

Changes verbs for managing player ranks (donator and mentor rank) to only require `R_ADMIN` instead of `R_PERMISSIONS`

## Why It's Good For The Game

`R_PERMISSIONS` is the flag for managing admin ranks, like changing an admin's rank, which is only given to senior staff. This is overkill, donator and mentor ranks should be changeable by regular admins

## Proof Of Testing

Hehehe I didn't

## Changelog
:cl:
admin: manage player ranks only needs R_ADMIN now
/:cl:
