### PR TITLE
[no GBP] Fixing the arrow display when using the multitool (#91047)

### DIFF
--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -94,7 +94,7 @@
 	user.balloon_alert(user, balloon_message)
 
 	var/datum/hud/user_hud = user.hud_used
-	if(!user_hud)
+	if(!user_hud || !istype(user_hud, /datum/hud) || !islist(user_hud.infodisplay))
 		return
 
 	var/atom/movable/screen/multitool_arrow/arrow = new(null, user_hud)


### PR DESCRIPTION
PS, quickpull of https://github.com/tgstation/tgstation/pull/91047
## About The Pull Request


![dreamseeker_aOB3rxXxs2](https://github.com/user-attachments/assets/cd50c412-88b2-4795-afcf-3aaf239af70f)
On multi-level maps, if you have mesons, the multitool arrow broke the
entire game screen (in the picture) when climbing and descending stairs.
(I saw the same thing on heretic's local server, but I reproduced it 2
times and didn't fully understand the reason for this, so I'm only
fixing the multitool)


https://github.com/user-attachments/assets/c8ff1382-da46-485c-ae71-1f9041591cde


## Why It's Good For The Game

Well, I made this mistake, it's my duty to fix it, and I hope it's
working correctly now.
## Changelog
:cl:

fix: Fixing the arrow display when using the multitool

/:cl:

## About The Pull Request

## Why It's Good For The Game

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

</details>
