### PR TITLE
Liquid solder now heals organs on top of brain damage.

### DIFF
--- a/modular_skyrat/modules/synths/code/reagents/reagents.dm
+++ b/modular_skyrat/modules/synths/code/reagents/reagents.dm
@@ -37,13 +37,14 @@
 
 /datum/reagent/medicine/liquid_solder
 	name = "Liquid Solder"
-	description = "Repairs brain damage in synthetics."
+	description = "Repairs organ damage in synthetics."
 	color = "#727272"
 	taste_description = "metal"
 	process_flags = REAGENT_SYNTHETIC
 
 /datum/reagent/medicine/liquid_solder/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick)
-	affected_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, -3 * REM * seconds_per_tick)
+	for(var/obj/item/organ/organ in affected_mob.organs)
+		affected_mob.adjustOrganLoss(organ.slot, -3 * REM * seconds_per_tick)
 	if(prob(10))
 		affected_mob.cure_trauma_type(resilience = TRAUMA_RESILIENCE_BASIC)
 	return ..()


### PR DESCRIPTION
This isnt really my original idea.
Original PR: https://github.com/Bubberstation/Bubberstation/pull/1040/files
## About The Pull Request
This is part of a PR that was testmerged but wasnt maintained due to various amount of changes it had, hence why im only doin it partly one at a time if i were to do more from it.
Title is self explanator.
## Why It's Good For The Game
It should help synthetic humanoids with repair of their organs that doesnt exactly equal with overdosing themselfs on nanite slurry that even on lowest overdose, barely doesnt crit you and it barely heals.
## Proof Of Testing
Tested if its working in the first place aka healing organs and if it still heals brain damage and even traumas.
Everything seems to be working on my side as far as I have seen it.
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
balance: Liquid solder now also heals organs.
/:cl:
