### PR TITLE
Robotic cavity implant

### DIFF
--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -58,7 +58,7 @@ GLOBAL_LIST_INIT(heavy_cavity_implants, typecacheof(list(/obj/item/transfer_valv
 	var/obj/item/item_for_cavity
 
 /datum/surgery_step/handle_cavity/tool_check(mob/user, obj/item/tool)
-	if(tool.tool_behaviour == TOOL_CAUTERY || istype(tool, /obj/item/gun/energy/laser)) //Bubber edit: adds TOOL_WRENCH and TOOL_RETRACTOR to the list of excluded items so that the robotic surgery functions
+	if(tool.tool_behaviour == TOOL_CAUTERY || istype(tool, /obj/item/gun/energy/laser)) // BUBBER EDIT: adds TOOL_WRENCH and TOOL_RETRACTOR to the list of excluded items so that the robotic surgery functions
 		return FALSE
 	return !tool.get_temperature()
 

--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -9,7 +9,7 @@
 		/datum/surgery_step/handle_cavity,
 		/datum/surgery_step/close)
 
-/datum/surgery/cavity_implant/mechanic
+/datum/surgery/cavity_implant/mechanic //Bubber edit: new surgery path for augments and synths so they can have cavity implants.
 	name = "Robotic cavity implant"
 	requires_bodypart_type = BODYTYPE_ROBOTIC
 	possible_locs = list(BODY_ZONE_CHEST)
@@ -36,7 +36,7 @@ GLOBAL_LIST_INIT(heavy_cavity_implants, typecacheof(list(/obj/item/transfer_valv
 	var/obj/item/item_for_cavity
 
 /datum/surgery_step/handle_cavity/tool_check(mob/user, obj/item/tool)
-	if(tool.tool_behaviour == TOOL_CAUTERY || istype(tool, /obj/item/gun/energy/laser))
+	if(tool.tool_behaviour == TOOL_CAUTERY || istype(tool, /obj/item/gun/energy/laser) || TOOL_WRENCH || TOOL_RETRACTOR) //Bubber edit: adds TOOL_WRENCH and TOOL_RETRACTOR to the list of excluded items so that the robotic surgery functions
 		return FALSE
 	return !tool.get_temperature()
 

--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -9,42 +9,7 @@
 		/datum/surgery_step/handle_cavity,
 		/datum/surgery_step/close)
 
-/datum/surgery/cavity_implant/mechanic //Bubber edit: new surgery path for augments and synths so they can have cavity implants.
-	name = "Robotic cavity implant"
-	requires_bodypart_type = BODYTYPE_ROBOTIC
-	possible_locs = list(BODY_ZONE_CHEST)
-	steps = list(
-		/datum/surgery_step/mechanic_open,
-		/datum/surgery_step/mechanic_unwrench,
-		/datum/surgery_step/prepare_electronics,
-		/datum/surgery_step/open_hatch,
-		/datum/surgery_step/handle_cavity,
-		/datum/surgery_step/close_cavity,
-		/datum/surgery_step/mechanic_wrench,
-		/datum/surgery_step/mechanic_close)
-
 GLOBAL_LIST_INIT(heavy_cavity_implants, typecacheof(list(/obj/item/transfer_valve)))
-
-/datum/surgery_step/close_cavity  //Bubber edit: new surgery step used solely for the mechanical variant. Used to seal the cavity so the surgery can progress to the proper surgery end point for synthetics.
-	name = "solder  cavity (cautery or welder)"
-	implements = list(
-		TOOL_CAUTERY = 100,
-		/obj/item/gun/energy/laser = 90,
-		TOOL_WELDER = 100,
-		/obj/item = 30) // 30% success with any hot item.
-	time = 24
-	preop_sound = 'sound/items/handling/surgery/cautery1.ogg'
-	success_sound = 'sound/items/handling/surgery/cautery2.ogg'
-
-/datum/surgery_step/close_cavity/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	display_results(
-		user,
-		target,
-		span_notice("You begin to solder the electronics around [target]'s cavity..."),
-		span_notice("[user] begins to solder [target]'s internal cavity with [tool]!"),
-		span_notice("[user] begins to solder [target]'s internal cavity!"),
-	)
-	display_pain(target, "The pain in your chest is unbearable! You can barely take it anymore!")
 
 //handle cavity
 /datum/surgery_step/handle_cavity

--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -36,7 +36,9 @@ GLOBAL_LIST_INIT(heavy_cavity_implants, typecacheof(list(/obj/item/transfer_valv
 	var/obj/item/item_for_cavity
 
 /datum/surgery_step/handle_cavity/tool_check(mob/user, obj/item/tool)
-	if(tool.tool_behaviour == TOOL_CAUTERY || istype(tool, /obj/item/gun/energy/laser) || TOOL_WRENCH || TOOL_RETRACTOR) //Bubber edit: adds TOOL_WRENCH and TOOL_RETRACTOR to the list of excluded items so that the robotic surgery functions
+	if(tool.tool_behaviour == TOOL_CAUTERY || istype(tool, /obj/item/gun/energy/laser)) //Bubber edit: adds TOOL_WRENCH and TOOL_RETRACTOR to the list of excluded items so that the robotic surgery functions
+		return FALSE
+	if(tool.tool_behaviour == TOOL_WRENCH || TOOL_RETRACTOR) //Bubber edit: adds TOOL_WRENCH and TOOL_RETRACTOR to the list of excluded items so that the robotic surgery functions
 		return FALSE
 	return !tool.get_temperature()
 

--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -19,10 +19,23 @@
 		/datum/surgery_step/prepare_electronics,
 		/datum/surgery_step/open_hatch,
 		/datum/surgery_step/handle_cavity,
+		/datum/surgery_step/close_cavity,
 		/datum/surgery_step/mechanic_wrench,
 		/datum/surgery_step/mechanic_close)
 
 GLOBAL_LIST_INIT(heavy_cavity_implants, typecacheof(list(/obj/item/transfer_valve)))
+
+/datum/surgery_step/close_cavity
+	name = "solder  cavity (cautery)"
+	implements = list(
+		TOOL_CAUTERY = 100,
+		/obj/item/gun/energy/laser = 90,
+		TOOL_WELDER = 70,
+		/obj/item = 30) // 30% success with any hot item.
+	time = 24
+	preop_sound = 'sound/items/handling/surgery/cautery1.ogg'
+	success_sound = 'sound/items/handling/surgery/cautery2.ogg'
+
 
 //handle cavity
 /datum/surgery_step/handle_cavity
@@ -37,8 +50,6 @@ GLOBAL_LIST_INIT(heavy_cavity_implants, typecacheof(list(/obj/item/transfer_valv
 
 /datum/surgery_step/handle_cavity/tool_check(mob/user, obj/item/tool)
 	if(tool.tool_behaviour == TOOL_CAUTERY || istype(tool, /obj/item/gun/energy/laser)) //Bubber edit: adds TOOL_WRENCH and TOOL_RETRACTOR to the list of excluded items so that the robotic surgery functions
-		return FALSE
-	if(tool.tool_behaviour == TOOL_WRENCH || TOOL_RETRACTOR) //Bubber edit: adds TOOL_WRENCH and TOOL_RETRACTOR to the list of excluded items so that the robotic surgery functions
 		return FALSE
 	return !tool.get_temperature()
 

--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -25,17 +25,26 @@
 
 GLOBAL_LIST_INIT(heavy_cavity_implants, typecacheof(list(/obj/item/transfer_valve)))
 
-/datum/surgery_step/close_cavity
-	name = "solder  cavity (cautery)"
+/datum/surgery_step/close_cavity  //Bubber edit: new surgery step used solely for the mechanical variant. Used to seal the cavity so the surgery can progress to the proper surgery end point for synthetics.
+	name = "solder  cavity (cautery or welder)"
 	implements = list(
 		TOOL_CAUTERY = 100,
 		/obj/item/gun/energy/laser = 90,
-		TOOL_WELDER = 70,
+		TOOL_WELDER = 100,
 		/obj/item = 30) // 30% success with any hot item.
 	time = 24
 	preop_sound = 'sound/items/handling/surgery/cautery1.ogg'
 	success_sound = 'sound/items/handling/surgery/cautery2.ogg'
 
+/datum/surgery_step/close_cavity/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	display_results(
+		user,
+		target,
+		span_notice("You begin to solder the electronics around [target]'s cavity..."),
+		span_notice("[user] begins to solder [target]'s internal cavity with [tool]!"),
+		span_notice("[user] begins to solder [target]'s internal cavity!"),
+	)
+	display_pain(target, "The pain in your chest is unbearable! You can barely take it anymore!")
 
 //handle cavity
 /datum/surgery_step/handle_cavity

--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -9,6 +9,19 @@
 		/datum/surgery_step/handle_cavity,
 		/datum/surgery_step/close)
 
+/datum/surgery/cavity_implant/mechanic
+	name = "Robotic cavity implant"
+	requires_bodypart_type = BODYTYPE_ROBOTIC
+	possible_locs = list(BODY_ZONE_CHEST)
+	steps = list(
+		/datum/surgery_step/mechanic_open,
+		/datum/surgery_step/mechanic_unwrench,
+		/datum/surgery_step/prepare_electronics,
+		/datum/surgery_step/open_hatch,
+		/datum/surgery_step/handle_cavity,
+		/datum/surgery_step/mechanic_wrench,
+		/datum/surgery_step/mechanic_close)
+
 GLOBAL_LIST_INIT(heavy_cavity_implants, typecacheof(list(/obj/item/transfer_valve)))
 
 //handle cavity

--- a/modular_zubbers/code/modules/surgery/robotic_cavity_implant.dm
+++ b/modular_zubbers/code/modules/surgery/robotic_cavity_implant.dm
@@ -1,0 +1,34 @@
+/datum/surgery/cavity_implant/mechanic //Bubber edit: new surgery path for augments and synths so they can have cavity implants.
+	name = "Robotic cavity implant"
+	requires_bodypart_type = BODYTYPE_ROBOTIC
+	possible_locs = list(BODY_ZONE_CHEST)
+	steps = list(
+		/datum/surgery_step/mechanic_open,
+		/datum/surgery_step/mechanic_unwrench,
+		/datum/surgery_step/prepare_electronics,
+		/datum/surgery_step/open_hatch,
+		/datum/surgery_step/handle_cavity,
+		/datum/surgery_step/close_cavity,
+		/datum/surgery_step/mechanic_wrench,
+		/datum/surgery_step/mechanic_close)
+
+/datum/surgery_step/close_cavity  //Bubber edit: new surgery step used solely for the mechanical variant. Used to seal the cavity so the surgery can progress to the proper surgery end point for synthetics.
+	name = "solder  cavity (cautery or welder)"
+	implements = list(
+		TOOL_CAUTERY = 100,
+		/obj/item/gun/energy/laser = 90,
+		TOOL_WELDER = 100,
+		/obj/item = 30) // 30% success with any hot item.
+	time = 24
+	preop_sound = 'sound/items/handling/surgery/cautery1.ogg'
+	success_sound = 'sound/items/handling/surgery/cautery2.ogg'
+
+/datum/surgery_step/close_cavity/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	display_results(
+		user,
+		target,
+		span_notice("You begin to solder the electronics around [target]'s cavity..."),
+		span_notice("[user] begins to solder [target]'s internal cavity with [tool]!"),
+		span_notice("[user] begins to solder [target]'s internal cavity!"),
+	)
+	display_pain(target, "The pain in your chest is unbearable! You can barely take it anymore!")

--- a/modular_zubbers/code/modules/surgery/robotic_cavity_implant.dm
+++ b/modular_zubbers/code/modules/surgery/robotic_cavity_implant.dm
@@ -1,4 +1,4 @@
-/datum/surgery/cavity_implant/mechanic //Bubber edit: new surgery path for augments and synths so they can have cavity implants.
+/datum/surgery/cavity_implant/mechanic //new surgery path for augments and synths so they can have cavity implants.
 	name = "Robotic cavity implant"
 	requires_bodypart_type = BODYTYPE_ROBOTIC
 	possible_locs = list(BODY_ZONE_CHEST)
@@ -12,7 +12,7 @@
 		/datum/surgery_step/mechanic_wrench,
 		/datum/surgery_step/mechanic_close)
 
-/datum/surgery_step/close_cavity  //Bubber edit: new surgery step used solely for the mechanical variant. Used to seal the cavity so the surgery can progress to the proper surgery end point for synthetics.
+/datum/surgery_step/close_cavity  //new surgery step used solely for the mechanical variant. Used to seal the cavity so the surgery can progress to the proper surgery end point for synthetics.
 	name = "solder  cavity (cautery or welder)"
 	implements = list(
 		TOOL_CAUTERY = 100,

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9596,6 +9596,7 @@
 #include "modular_zubbers\code\modules\storyteller\storytellers\tellers\storyteller_6_house.dm"
 #include "modular_zubbers\code\modules\storyteller\storytellers\tellers\storyteller_7_enemy.dm"
 #include "modular_zubbers\code\modules\surgery\healing.dm"
+#include "modular_zubbers\code\modules\surgery\robotic_cavity_implant.dm"
 #include "modular_zubbers\code\modules\surgery\surgery_step.dm"
 #include "modular_zubbers\code\modules\surgery\tools.dm"
 #include "modular_zubbers\code\modules\surgery\advanced\trauma_surgery.dm"


### PR DESCRIPTION
## About The Pull Request

A simple PR that adds a new surgery for augmented/synthetic characters, allowing them to have cavity implants like organics.

## Why It's Good For The Game

More options for characters and it always felt silly to me that synthetics/augmented characters could not have cavity implants.

## Proof Of Testing

Tested locally on synthetic and augmented character, worked flawlessly.

## Changelog

:cl:
add: Adds cavity implantation surgery for synthetic/augmented/robotic characters
/:cl: