### PR TITLE
Hide unobtainable ckey-locked loadout items again

### DIFF
--- a/code/modules/loadout/loadout_items.dm
+++ b/code/modules/loadout/loadout_items.dm
@@ -347,6 +347,7 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 	formatted_item["reskins"] = get_reskin_options()
 	formatted_item["icon"] = ui_icon
 	formatted_item["icon_state"] = ui_icon_state
+	formatted_item["ckey_whitelist"] = ckeywhitelist // BUBBER EDIT ADDITION: Filter ckey-locked items
 
 	return formatted_item
 

--- a/code/modules/loadout/loadout_menu.dm
+++ b/code/modules/loadout/loadout_menu.dm
@@ -113,6 +113,7 @@
 /datum/preference_middleware/loadout/get_ui_static_data(mob/user)
 	var/list/data = list()
 	data["loadout_preview_view"] = preferences.character_preview_view.assigned_map
+	data["ckey"] = user.ckey // BUBBER EDIT ADDITION: Filter ckey-locked items
 	return data
 
 /datum/preference_middleware/loadout/get_constant_data()

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/loadout/ItemDisplay.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/loadout/ItemDisplay.tsx
@@ -132,7 +132,7 @@ export function ItemListDisplay(props: ListProps) {
     data.character_preferences.misc.loadout_lists[
       data.character_preferences.misc.loadout_index
     ]; // BUBBER EDIT CHANGE: Multiple loadout presets: Original: data.character_preferences.misc;
-  const itemGroups = sortByGroup(props.items);
+  const itemGroups = sortByGroup(FilterItemList(props.items)); // BUBBER EDIT CHANGE: Filter ckey-locked items - ORIGINAL: const itemGroups = sortByGroup(props.items);
 
   return (
     <Stack vertical>
@@ -168,6 +168,20 @@ export function ItemListDisplay(props: ListProps) {
     </Stack>
   );
 }
+
+// BUBBER EDIT ADDITION BEGIN: Filter ckey-locked items
+const FilterItemList = (items: LoadoutItem[]) => {
+  const { data } = useBackend<LoadoutManagerData>();
+  const ckey = data.ckey;
+
+  return items.filter((item: LoadoutItem) => {
+    if (item.ckey_whitelist && item.ckey_whitelist.indexOf(ckey) === -1) {
+      return false;
+    }
+    return true;
+  });
+};
+// BUBBER EDIT ADDITION END: Filter ckey-locked items
 
 type TabProps = {
   category: LoadoutCategory | undefined;

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/loadout/base.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/loadout/base.ts
@@ -38,6 +38,7 @@ export type LoadoutItem = {
   buttons: LoadoutButton[];
   reskins: ReskinOption[] | null;
   information: LoadoutTooltip[];
+  ckey_whitelist: string[] | null; // BUBBER EDIT ADDITION: Filter ckey-locked items
 };
 
 // Category of items in the loadout

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/types.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/types.ts
@@ -236,6 +236,7 @@ export type PreferencesMenuData = {
   quirks_balance: number;
   positive_quirk_count: number;
   species_restricted_jobs?: string[];
+  ckey: string;
   // SKYRAT EDIT END
 
   keybindings: Record<string, string[]>;


### PR DESCRIPTION

## About The Pull Request

I unhid ckey-locked and donor-locked items in #3747, but it's been expressed that people don't want to see items they'll never be able to obtain, so this re-hides them (while still keeping donor-locked ones visible, so people can see what they'll be getting if they donate)

## Why It's Good For The Game

Hide items you'll never be able to use

## Proof Of Testing

Tested both with and without having a ckey-locked item for my ckey

## Changelog
:cl:
qol: ckey-locked loadout items that you can't obtain are hidden again
/:cl:
