### PR TITLE
Provide hookers to all moonstation players

### DIFF
--- a/_maps/moonstation.json
+++ b/_maps/moonstation.json
@@ -3,6 +3,7 @@
 	"map_name": "Moon Station",
 	"map_path": "map_files/moonstation",
 	"map_file": "moonstation.dmm",
+	"give_players_hooks": 1,
 	"space_ruin_levels": 0,
 	"space_empty_levels": 0,
 	"planetary": 1,


### PR DESCRIPTION
## About The Pull Request

Give Moonstation players a little something extra for their shifts.

:cl: LT3
fix: Moonstation players are now begrudgingly given emergency hooks in their survival boxes
/:cl: