### PR TITLE
Fix being unable to hide moth antennae or wings

### DIFF
--- a/code/modules/surgery/organs/external/_visual_organs.dm
+++ b/code/modules/surgery/organs/external/_visual_organs.dm
@@ -285,6 +285,11 @@ Unlike normal organs, we're actually inside a persons limbs at all times
 	return burnt ? burn_datum.icon_state : sprite_datum.icon_state
 
 /datum/bodypart_overlay/mutant/antennae/can_draw_on_bodypart(obj/item/bodypart/bodypart_owner)
+	// BUBBER EDIT ADDITION BEGIN: Customization
+	. = ..()
+	if(!.)
+		return
+	// BUBBER EDIT ADDITION END: Customization
 	var/mob/living/carbon/human/human = bodypart_owner.owner
 	if(!istype(human))
 		return TRUE

--- a/code/modules/surgery/organs/external/wings/moth_wings.dm
+++ b/code/modules/surgery/organs/external/wings/moth_wings.dm
@@ -114,6 +114,11 @@
 	return ..()
 
 /datum/bodypart_overlay/mutant/wings/moth/can_draw_on_bodypart(obj/item/bodypart/bodypart_owner)
+	// BUBBER EDIT ADDITION BEGIN - Customization
+	. = ..()
+	if(!.)
+		return
+	// BUBBER EDIT ADDITION END - Customization
 	var/mob/living/carbon/human/human = bodypart_owner.owner
 	if(!istype(human))
 		return TRUE


### PR DESCRIPTION

## About The Pull Request

tg changed mutant part hiding logic some upstreams back and our override hiding logic stopped getting called

## Why It's Good For The Game

Fixes #2790 

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/bd7506f4-5560-4134-afa4-6721a59279a9)
I have hiding antennae and wings enabled in this pic

</details>

## Changelog
:cl:
fix: fixed moth antennae and wings not hiding properly
/:cl:
