### PR TITLE
Sanguirite allergy removal

### DIFF
--- a/code/datums/quirks/negative_quirks/allergic.dm
+++ b/code/datums/quirks/negative_quirks/allergic.dm
@@ -21,6 +21,8 @@
 		/datum/reagent/medicine/synaphydramine,
 		/datum/reagent/medicine/diphenhydramine,
 		/datum/reagent/medicine/sansufentanyl
+		/datum/reagent/medicine/coagulant       //Bubber edit: adds coagulant
+		/datum/reagent/toxin/formaldehyde       //Bubber edit: adds formaldehyde
 		)
 	var/allergy_string
 

--- a/code/datums/quirks/negative_quirks/allergic.dm
+++ b/code/datums/quirks/negative_quirks/allergic.dm
@@ -22,7 +22,6 @@
 		/datum/reagent/medicine/diphenhydramine,
 		/datum/reagent/medicine/sansufentanyl
 		/datum/reagent/medicine/coagulant       //Bubber edit: adds coagulant
-		/datum/reagent/toxin/formaldehyde       //Bubber edit: adds formaldehyde
 		)
 	var/allergy_string
 


### PR DESCRIPTION
## About The Pull Request

Adds sanguirite to the blacklist for the medicine allergies quirk.

## Why It's Good For The Game

The emergency epinephrine autoinjector contains 3 chems in it: Epinephrine, sanguirite, and formaldehyde. It is intended to combat allergies, and is even in the mail goodies for people who take this quirk, and yet for some dumb reason you can be allergic to the medicine that is in the tool that is intended to stop your allergic reaction! It is remarkable how often this allergy comes up, and when people go to treat someone's allergic reaction by using the very tool designed to help treat it, only to make it worse causes immense frustration and confusion.  So I am adding it to the blacklist of chems.

## Proof Of Testing

## Changelog

:cl:
add: No more sanguirite allergies
/:cl:
