### PR TITLE
Craftable Wall Mounted Torches

### DIFF
--- a/modular_skyrat/modules/primitive_structures/code/wall_torch.dm
+++ b/modular_skyrat/modules/primitive_structures/code/wall_torch.dm
@@ -50,14 +50,23 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/wall_torch, 28)
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/wall_torch/spawns_lit, 28)
 
-// Crafting recipe for the wall torch
+// Crafting recipe for the wall torch mount
 /datum/crafting_recipe/wall_torch
 	name = "Wall Torch"
-	result = /obj/structure/wall_torch
+	result = /obj/item/wallframe/torch
 	reqs = list(
 		/obj/item/stack/sheet/mineral/wood = 2,
 		/obj/item/stack/sheet/iron = 1,
 		/obj/item/stack/sheet/cloth = 1,
 	)
-	time = 10 SECONDS
+	time = 5 SECONDS
 	category = CAT_STRUCTURE
+
+// The wall torch mount item
+/obj/item/wallframe/torch
+	name = "wall mounted torch"
+	desc = "A simple torch ready to be mounted to the wall, for lighting and such. Apply to wall to use."
+	icon = 'modular_skyrat/modules/primitive_structures/icons/lighting.dmi'
+	icon_state = "walltorch"
+	result_path = /obj/structure/wall_torch
+	pixel_shift = 28

--- a/modular_skyrat/modules/primitive_structures/code/wall_torch.dm
+++ b/modular_skyrat/modules/primitive_structures/code/wall_torch.dm
@@ -50,7 +50,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/wall_torch, 28)
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/wall_torch/spawns_lit, 28)
 
-// Crafting recipe for the wall torch mount
 /datum/crafting_recipe/wall_torch
 	name = "Wall Torch"
 	result = /obj/item/wallframe/torch
@@ -62,7 +61,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/wall_torch/spawns_lit, 28)
 	time = 5 SECONDS
 	category = CAT_STRUCTURE
 
-// The wall torch mount item
 /obj/item/wallframe/torch
 	name = "wall mounted torch"
 	desc = "A simple torch ready to be mounted to the wall, for lighting and such. Apply to wall to use."

--- a/modular_skyrat/modules/primitive_structures/code/wall_torch.dm
+++ b/modular_skyrat/modules/primitive_structures/code/wall_torch.dm
@@ -49,3 +49,15 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/wall_torch, 28)
 	spawns_lit = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/wall_torch/spawns_lit, 28)
+
+// Crafting recipe for the wall torch
+/datum/crafting_recipe/wall_torch
+	name = "Wall Torch"
+	result = /obj/structure/wall_torch
+	reqs = list(
+		/obj/item/stack/sheet/mineral/wood = 2,
+		/obj/item/stack/sheet/iron = 1,
+		/obj/item/stack/sheet/cloth = 1,
+	)
+	time = 10 SECONDS
+	category = CAT_STRUCTURE


### PR DESCRIPTION

## About The Pull Request
Does as the title says and makes it so you can actually *craft* the wall-mounted torches.
## Why It's Good For The Game
It makes it possible to actually light your rooms if you want to try to make a low-tech base on Lavaland or something along those lines.
## Proof Of Testing
I tested it and it was working as intended.
## Changelog
:cl:
qol: wall-mounted torches can now be crafted
/:cl:
