### PR TITLE
Synth now require a heart and lungs to function.

### DIFF
--- a/modular_skyrat/modules/synths/code/species/synthetic.dm
+++ b/modular_skyrat/modules/synths/code/species/synthetic.dm
@@ -79,7 +79,7 @@
 			do_sparks(3, TRUE, human)
 
 	var/obj/item/organ/lungs/lungs = human.get_organ_slot(ORGAN_SLOT_LUNGS)
-	if(!lungs)
+	if(!lungs || (liver.organ_flags & ORGAN_FAILING))
 		// No lungs present, apply overheating
 		human.adjust_bodytemperature(50)
 		human.adjustFireLoss(1)
@@ -88,7 +88,7 @@
 			do_sparks(3, TRUE, human)
 
 	var/obj/item/organ/heart/heart = human.get_organ_slot(ORGAN_SLOT_HEART)
-	if(!heart)
+	if(!heart || (liver.organ_flags & ORGAN_FAILING))
 		// No heart present, apply paralysis
 		human.adjust_staggered_up_to(STAGGERED_SLOWDOWN_LENGTH, 10 SECONDS)
 		if(prob(10))

--- a/modular_skyrat/modules/synths/code/species/synthetic.dm
+++ b/modular_skyrat/modules/synths/code/species/synthetic.dm
@@ -90,7 +90,7 @@
 	var/obj/item/organ/heart/heart = human.get_organ_slot(ORGAN_SLOT_HEART)
 	if(!heart)
 		// No heart present, apply paralysis
-		human.Paralyze(15) // Paralyze for 10 ticks (adjust as needed)
+		human.Paralyze(15) // Paralyze for 15 ticks (adjust as needed)
 		if(prob(10))
 			to_chat(human, span_warning("Alert: Missing oil pump. Unable to use hydraulics for movement."))
 

--- a/modular_skyrat/modules/synths/code/species/synthetic.dm
+++ b/modular_skyrat/modules/synths/code/species/synthetic.dm
@@ -81,11 +81,18 @@
 	var/obj/item/organ/lungs/lungs = human.get_organ_slot(ORGAN_SLOT_LUNGS)
 	if(!lungs)
 		// No lungs present, apply overheating
-		human.adjust_bodytemperature(50) // We're overheating!!
+		human.adjust_bodytemperature(50)
 		human.adjustFireLoss(1)
 		if(prob(10))
-			to_chat(human, span_warning("Alert: Cooling system missing, overheating imminent!"))
+			to_chat(human, span_warning("Alert: Cooling system missing, OVERHEATING!"))
 			do_sparks(3, TRUE, human)
+
+	var/obj/item/organ/heart/heart = human.get_organ_slot(ORGAN_SLOT_HEART)
+	if(!heart)
+		// No heart present, apply paralysis
+		human.Paralyze(15) // Paralyze for 10 ticks (adjust as needed)
+		if(prob(10))
+			to_chat(human, span_warning("Alert: Missing oil pump. Unable to use hydraulics for movement."))
 
 /datum/species/synthetic/spec_revival(mob/living/carbon/human/transformer)
 	switch_to_screen(transformer, "Console")

--- a/modular_skyrat/modules/synths/code/species/synthetic.dm
+++ b/modular_skyrat/modules/synths/code/species/synthetic.dm
@@ -80,7 +80,7 @@
 
 	var/obj/item/organ/lungs/lungs = human.get_organ_slot(ORGAN_SLOT_LUNGS)
 	if(!lungs || (lungs.organ_flags & ORGAN_FAILING))
-		// No lungs present, apply overheating
+		// No lungs or failing lungs present, apply overheating
 		human.adjust_bodytemperature(50)
 		human.adjustFireLoss(1)
 		if(prob(10))
@@ -89,8 +89,8 @@
 
 	var/obj/item/organ/heart/heart = human.get_organ_slot(ORGAN_SLOT_HEART)
 	if(!heart || (heart.organ_flags & ORGAN_FAILING))
-		// No heart present, apply paralysis
-		human.adjust_staggered_up_to(STAGGERED_SLOWDOWN_LENGTH, 10 SECONDS)
+		// No heart or failing heart present, apply slowdown
+		human.adjust_staggered_up_to(STAGGERED_SLOWDOWN_LENGTH, 5 SECONDS)
 		if(prob(10))
 			to_chat(human, span_warning("Alert: Oil pump is non-functional or missing. Hydraulics efficiency reduced."))
 

--- a/modular_skyrat/modules/synths/code/species/synthetic.dm
+++ b/modular_skyrat/modules/synths/code/species/synthetic.dm
@@ -95,8 +95,8 @@
 			to_chat(human, span_warning("Alert: Oil pump is non-functional or missing. Hydraulics efficiency reduced."))
 
 	var/obj/item/organ/liver/liver = human.get_organ_slot(ORGAN_SLOT_LIVER)
-	if(!liver)
-		// No liver present, apply message informing of the missing liver
+	if(!liver || (liver.organ_flags & ORGAN_FAILING))
+		// No liver or failing liver present, apply message informing of the missing liver
 		if(prob(10))
 			to_chat(human, span_warning("Alert: Reagent processing unit is non-functional or missing. Systems clogging."))
 

--- a/modular_skyrat/modules/synths/code/species/synthetic.dm
+++ b/modular_skyrat/modules/synths/code/species/synthetic.dm
@@ -90,9 +90,9 @@
 	var/obj/item/organ/heart/heart = human.get_organ_slot(ORGAN_SLOT_HEART)
 	if(!heart)
 		// No heart present, apply paralysis
-		human.Paralyze(15) // Paralyze for 15 ticks (adjust as needed)
+		human.adjust_staggered_up_to(STAGGERED_SLOWDOWN_LENGTH, 10 SECONDS)
 		if(prob(10))
-			to_chat(human, span_warning("Alert: Missing oil pump. Unable to use hydraulics for movement."))
+			to_chat(human, span_warning("Alert: Missing oil pump. Hydraulics efficiency reduced."))
 
 /datum/species/synthetic/spec_revival(mob/living/carbon/human/transformer)
 	switch_to_screen(transformer, "Console")

--- a/modular_skyrat/modules/synths/code/species/synthetic.dm
+++ b/modular_skyrat/modules/synths/code/species/synthetic.dm
@@ -78,6 +78,15 @@
 			to_chat(human, span_warning("Alert: Critical damage taken! Cooling systems failing!"))
 			do_sparks(3, TRUE, human)
 
+	var/obj/item/organ/lungs/lungs = human.get_organ_slot(ORGAN_SLOT_LUNGS)
+	if(!lungs)
+		// No lungs present, apply overheating
+		human.adjust_bodytemperature(50) // We're overheating!!
+		human.adjustFireLoss(1)
+		if(prob(10))
+			to_chat(human, span_warning("Alert: Cooling system missing, overheating imminent!"))
+			do_sparks(3, TRUE, human)
+
 /datum/species/synthetic/spec_revival(mob/living/carbon/human/transformer)
 	switch_to_screen(transformer, "Console")
 	addtimer(CALLBACK(src, PROC_REF(switch_to_screen), transformer, saved_screen), 5 SECONDS)

--- a/modular_skyrat/modules/synths/code/species/synthetic.dm
+++ b/modular_skyrat/modules/synths/code/species/synthetic.dm
@@ -79,7 +79,7 @@
 			do_sparks(3, TRUE, human)
 
 	var/obj/item/organ/lungs/lungs = human.get_organ_slot(ORGAN_SLOT_LUNGS)
-	if(!lungs || (liver.organ_flags & ORGAN_FAILING))
+	if(!lungs || (lungs.organ_flags & ORGAN_FAILING))
 		// No lungs present, apply overheating
 		human.adjust_bodytemperature(50)
 		human.adjustFireLoss(1)
@@ -88,7 +88,7 @@
 			do_sparks(3, TRUE, human)
 
 	var/obj/item/organ/heart/heart = human.get_organ_slot(ORGAN_SLOT_HEART)
-	if(!heart || (liver.organ_flags & ORGAN_FAILING))
+	if(!heart || (heart.organ_flags & ORGAN_FAILING))
 		// No heart present, apply paralysis
 		human.adjust_staggered_up_to(STAGGERED_SLOWDOWN_LENGTH, 10 SECONDS)
 		if(prob(10))

--- a/modular_skyrat/modules/synths/code/species/synthetic.dm
+++ b/modular_skyrat/modules/synths/code/species/synthetic.dm
@@ -75,7 +75,7 @@
 		human.adjustFireLoss(1) //Still deal some damage in case a cold environment would be preventing us from the sweet release to robot heaven
 		human.adjust_bodytemperature(13) //We're overheating!!
 		if(prob(10))
-			to_chat(human, span_warning("Alert: Critical damage taken! Cooling systems failing!"))
+			to_chat(human, span_warning("Alert: Critical damage taken, all systems failing."))
 			do_sparks(3, TRUE, human)
 
 	var/obj/item/organ/lungs/lungs = human.get_organ_slot(ORGAN_SLOT_LUNGS)
@@ -84,7 +84,7 @@
 		human.adjust_bodytemperature(50)
 		human.adjustFireLoss(1)
 		if(prob(10))
-			to_chat(human, span_warning("Alert: Cooling system missing, OVERHEATING!"))
+			to_chat(human, span_warning("Alert: Cooling system is non-functional or missing, OVERHEATING is imminent."))
 			do_sparks(3, TRUE, human)
 
 	var/obj/item/organ/heart/heart = human.get_organ_slot(ORGAN_SLOT_HEART)
@@ -92,7 +92,13 @@
 		// No heart present, apply paralysis
 		human.adjust_staggered_up_to(STAGGERED_SLOWDOWN_LENGTH, 10 SECONDS)
 		if(prob(10))
-			to_chat(human, span_warning("Alert: Missing oil pump. Hydraulics efficiency reduced."))
+			to_chat(human, span_warning("Alert: Oil pump is non-functional or missing. Hydraulics efficiency reduced."))
+
+	var/obj/item/organ/liver/liver = human.get_organ_slot(ORGAN_SLOT_LIVER)
+	if(!liver)
+		// No liver present, apply message informing of the missing liver
+		if(prob(10))
+			to_chat(human, span_warning("Alert: Reagent processing unit is non-functional or missing. Systems clogging."))
 
 /datum/species/synthetic/spec_revival(mob/living/carbon/human/transformer)
 	switch_to_screen(transformer, "Console")


### PR DESCRIPTION
## About The Pull Request
This PR does two things (three things)
Lack of/non-functional lungs causes you to overheat.
Lack of/non-functional heart will cause you to be slowed down. (edited from paralysis to slowdown)
Add additional messages to indicate lack of liver equivelant.

CURRENT ISSUE: (RESOLVED)
Removing it does the effects.
Having non functional organs doesnt apply it.
## Why It's Good For The Game
The fact that you didnt needed half of your organs is just dumb.
## Proof Of Testing
Lungs definitely work when you remove them and EMP them to death
Heart works when you remove them and EMP. (Again with new effect) 
Replacing it with any other organ also works as long as its in the heart/lungs slot.
Liver messaging workin when missing or non-functional
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
add: Synths now require their lungs. Lack of it/non-functional causes you to overheat.
add: Synths now require their heart. Lack of it/non-functional causes you to be slowed down.
/:cl:
