### PR TITLE
Fixes a hat offset in the Dullahan cyborg model

### DIFF
--- a/code/__DEFINES/~~bubber_defines/robot_defines.dm
+++ b/code/__DEFINES/~~bubber_defines/robot_defines.dm
@@ -209,7 +209,7 @@
 	SKIN_HAT_REST_OFFSET = list("north" = list(0, 1), "south" = list(0, 1), "east" = list(2, 1), "west" = list(-2, 1))
 #define DULLAHAN_TAUR_HAT_OFFSET \
 	SKIN_HAT_OFFSET = list("north" = list(1, 15), "south" = list(1, 15), "east" = list(7, 15), "west" = list(-7, 15)), \
-	SKIN_HAT_REST_OFFSET = list("north" = list(1, 1), "south" = list(1, 1), "east" = list(7, 1), "west" = list(-2, 1))
+	SKIN_HAT_REST_OFFSET = list("north" = list(1, 1), "south" = list(1, 1), "east" = list(7, 1), "west" = list(-7, 1))
 #define CORRUPT_HAT_OFFSET \
 	SKIN_HAT_OFFSET = list("north" = list(16, -4), "south" = list(16, -15), "east" = list(35, -7), "west" = list(-3, -7)), \
 	SKIN_HAT_REST_OFFSET = list("north" = list(16, -6), "south" = list(16, -17), "east" = list(35, -14), "west" = list(-3, -14))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I forgot to adjust the laying position offset

## Why It's Good For The Game

Hats MUST be worn correctly for safety reasons

## Proof Of Testing

![image](https://github.com/user-attachments/assets/c8aae665-e9ec-4869-aae3-dd706c61eff8)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Dullahan (Taurs) now have correct had positions when resting in all directions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
