### PR TITLE
Fixes the Cigarette Vendor Contraband lists

### DIFF
--- a/modular_skyrat/modules/modular_vending/code/cigarette.dm
+++ b/modular_skyrat/modules/modular_vending/code/cigarette.dm
@@ -1,5 +1,4 @@
 /obj/machinery/vending/cigarette/
-	contraband = list()
 	skyrat_products = list(
 		/obj/item/vape = 5,
 		/obj/item/reagent_containers/vapecart = 10,


### PR DESCRIPTION

## About The Pull Request

There was a bug that was preventing the base contraband list from being added to the cigarette vendor
## Why It's Good For The Game

Modularity fix - the baseline contraband lists was just not appearing at all for the cigarette vendors. I confirmed that none of the other modular vending machines have this issue, (they don't have a base `contraband()` list in them.)

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/9dbf3ed1-5e9e-4af7-a9a0-e5a277884809)

This shows it contains both:
https://github.com/Bubberstation/Bubberstation/blob/dfb11b4f7171ec4aec141fbe5db047af9cfde769/code/modules/vending/cigarette.dm#L19-L22
https://github.com/Bubberstation/Bubberstation/blob/dfb11b4f7171ec4aec141fbe5db047af9cfde769/modular_skyrat/modules/modular_vending/code/cigarette.dm#L7-L14
</details>

## Changelog
:cl:
fix: Fixed a small bug with combining contraband lists between baseline and modular cigarette vending machines
/:cl:
