### PR TITLE
Add option to search loadout item tooltip text

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/loadout/ItemDisplay.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/loadout/ItemDisplay.tsx
@@ -7,6 +7,7 @@ import {
   Stack,
   Tooltip,
 } from 'tgui-core/components';
+import { BooleanLike } from 'tgui-core/react';
 import { createSearch } from 'tgui-core/string';
 
 import type { LoadoutCategory, LoadoutItem, LoadoutManagerData } from './base';
@@ -203,14 +204,20 @@ export function LoadoutTabDisplay(props: TabProps) {
 type SearchProps = {
   loadout_tabs: LoadoutCategory[];
   currentSearch: string;
+  searchingTooltips: BooleanLike; // BUBBER EDIT ADDITION: Search in tooltips
 };
 
 export function SearchDisplay(props: SearchProps) {
-  const { loadout_tabs, currentSearch } = props;
+  const { loadout_tabs, currentSearch, searchingTooltips } = props; // BUBBER EDIT CHANGE: Search in tooltips: ORIGINAL: const { loadout_tabs, currentSearch } = props;
 
   const search = createSearch(
     currentSearch,
-    (loadout_item: LoadoutItem) => loadout_item.name,
+    (loadout_item: LoadoutItem) =>
+      loadout_item.name +
+      // BUBBER EDIT ADDITION BEGIN: Search in tooltips
+      (searchingTooltips &&
+        loadout_item.information.map((entry) => entry.tooltip)),
+    // BUBBER EDIT ADDITION END: Search in tooltips
   );
 
   const validLoadoutItems = loadout_tabs

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/loadout/index.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/loadout/index.tsx
@@ -14,6 +14,7 @@ import {
   Stack,
   Tabs,
 } from 'tgui-core/components';
+import { BooleanLike } from 'tgui-core/react';
 
 import { removeAllSkiplines } from '../../../TextInputModal';
 import { PreferencesMenuData } from '../../types';
@@ -38,6 +39,7 @@ export function LoadoutPage(props) {
   const [modifyItemDimmer, setModifyItemDimmer] = useState<LoadoutItem | null>(
     null,
   );
+  const [searchingTooltips, setSearchingTooltips] = useState<BooleanLike>(0); // BUBBER EDIT ADDITION: Search in tooltips
   // BUBBER EDIT ADDITION START: Multiple loadout presets
   const [managingPreset, _setManagingPreset] = useState<string | null>(null);
   const { act, data } = useBackend<PreferencesMenuData>();
@@ -144,12 +146,23 @@ export function LoadoutPage(props) {
           fitted
           title="&nbsp;"
           buttons={
-            <Input
-              width="200px"
-              onChange={setSearchLoadout}
-              placeholder="Search for an item..."
-              value={searchLoadout}
-            />
+            <>
+              {/* BUBBER EDIT ADDITION BEGIN: Search in tooltips */}
+              <Button.Checkbox
+                checked={searchingTooltips}
+                onClick={() => setSearchingTooltips(!searchingTooltips)}
+                tooltip="Include matches from item tooltip information e.g. Job Whitelist"
+              >
+                Search Tooltips
+              </Button.Checkbox>
+              {/* BUBBER EDIT ADDITION END: Search in tooltips */}
+              <Input
+                width="200px"
+                onChange={setSearchLoadout}
+                placeholder="Search for an item..."
+                value={searchLoadout}
+              />
+            </>
           }
         >
           <Tabs fluid align="center">
@@ -181,6 +194,7 @@ export function LoadoutPage(props) {
           currentTab={selectedTabName}
           currentSearch={searchLoadout}
           modifyItemDimmer={modifyItemDimmer}
+          searchingTooltips={searchingTooltips} // BUBBER EDIT ADDITION: Search in tooltips
           setModifyItemDimmer={setModifyItemDimmer}
           setManagingPreset={setManagingPreset}
         />
@@ -194,6 +208,7 @@ type LoadoutTabsProps = {
   currentTab: string;
   currentSearch: string;
   modifyItemDimmer: LoadoutItem | null;
+  searchingTooltips: BooleanLike; // BUBBER EDIT ADDITION: Search in tooltips
   setModifyItemDimmer: (dimmer: LoadoutItem | null) => void;
   setManagingPreset: (string) => void;
 };
@@ -204,6 +219,7 @@ function LoadoutTabs(props: LoadoutTabsProps) {
     currentTab,
     currentSearch,
     modifyItemDimmer,
+    searchingTooltips, // BUBBER EDIT ADDITION: Search in tooltips
     setModifyItemDimmer,
     setManagingPreset,
   } = props;
@@ -306,6 +322,7 @@ function LoadoutTabs(props: LoadoutTabsProps) {
                   <SearchDisplay
                     loadout_tabs={loadout_tabs}
                     currentSearch={currentSearch}
+                    searchingTooltips={searchingTooltips} // BUBBER EDIT ADDITION: Search in tooltips
                   />
                 ) : (
                   <LoadoutTabDisplay category={activeCategory} />


### PR DESCRIPTION

## About The Pull Request

Adds the ability to search loadout menu items by the things in their tooltips (job whitelist/blacklist, donor-only, recolorable, etc.) 

## Why It's Good For The Game

Sometimes you wanna see just items your job can equip

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/7b81a74d-6637-4335-aaec-110f34093158)

</details>

## Changelog
:cl:
qol: added an option to the loadout menu search that lets you also search in tooltip text
/:cl:
