### PR TITLE
Minor Protean Adjustments & Fixes

### DIFF
--- a/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
@@ -26,9 +26,11 @@
 	return ..()
 
 /obj/item/mod/control/pre_equipped/protean/wrench_act(mob/living/user, obj/item/wrench)
+	to_chat(user, span_warning("The core cannot be removed from the control unit."))
 	return FALSE // Can't remove the core.
 
 /obj/item/mod/control/pre_equipped/protean/emag_act(mob/user, obj/item/card/emag/emag_card)
+	to_chat(user, span_warning("The control unit does not respond."))
 	return FALSE // Nope
 
 /obj/item/mod/control/pre_equipped/protean/canStrip(mob/who)
@@ -223,7 +225,7 @@
 		. += span_notice("<b>Control Shift Click</b> to open Protean strip menu.")
 		if(brain.dead)
 			if(!open)
-				. += isnull(refactory) ? span_warning("This Protean requires critical repairs! <b>Screwdriver them open</b>") : span_notice("<b>Repairing systems...</b>")
+				. += isnull(refactory) ? span_warning("This Protean requires critical repairs! <b>Screwdriver them open</b>") : span_notice("<b>d systems...</b>")
 			else
 				. += isnull(refactory) ? span_warning("<b>Insert a new refactory</b>") : span_notice("<b>Refactory Installed! Repairing systems...</b>")
 
@@ -265,6 +267,7 @@
 	if (!isnull(should_strip_proc_path) && !call(species.owner, should_strip_proc_path)(user))
 		return
 	suit.balloon_alert_to_viewers("stripping")
+	suit.wearer.visible_message(span_warning("[source] begins to dump the contents of [suit.wearer]'s control unit!"))
 	ASYNC
 		var/datum/strip_menu/protean/strip_menu = LAZYACCESS(strip_menus, species.owner)
 		if (isnull(strip_menu))

--- a/modular_zubbers/code/modules/customization/species/proteans/protean_organs.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/protean_organs.dm
@@ -7,7 +7,7 @@
 
 /obj/item/organ/eyes/robotic/protean
 	name = "imaging nanites"
-	desc = "Nanites designed to collect visual data from the surrounding world"
+	desc = "Nanites designed to collect visual data from the surrounding world."
 	organ_flags = ORGAN_ROBOTIC
 	flash_protect = FLASH_PROTECTION_WELDER
 
@@ -22,7 +22,7 @@
 
 /obj/item/organ/ears/cybernetic/protean
 	name = "sensory nanites"
-	desc = "Nanites designed to collect audio feedback from the surrounding world"
+	desc = "Nanites designed to collect audio feedback from the surrounding world."
 	organ_flags = ORGAN_ROBOTIC
 
 /obj/item/organ/ears/cybernetic/protean/Insert(mob/living/carbon/receiver, special, movement_flags)

--- a/modular_zubbers/code/modules/customization/species/proteans/protean_stomach.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/protean_stomach.dm
@@ -1,6 +1,6 @@
 /obj/item/organ/stomach/protean
 	name = "refactory"
-	desc = "An extremely fragile factory used to rescyle materials and create more nanite mass"
+	desc = "An extremely fragile factory used to recycle materials and create more nanite mass in Proteans. Can either be inserted into the hardsuit rig as a mod suit 'module', or into the Protean's body directly."
 	icon = PROTEAN_ORGAN_SPRITE
 	icon_state = "refactory"
 	organ_flags = ORGAN_ROBOTIC | ORGAN_NANOMACHINE
@@ -44,8 +44,11 @@
 			metal -= clamp(((PROTEAN_STOMACH_FULL / PROTEAN_METABOLISM_RATE) * seconds_per_tick * 20), 0, 10) // Healing needs metal. 0.2 sheets per tick
 			owner.adjustBruteLoss(-2, forced = TRUE)
 			owner.adjustFireLoss(-2, forced = TRUE)
+		if(owner.blood_volume < BLOOD_VOLUME_NORMAL && metal > PROTEAN_STOMACH_FULL * 0.3) // Because blood loss doesn't actually register as health loss for us. We also bypass standard handle_blood because we do not use standard nutrition
+			metal -= clamp(((PROTEAN_STOMACH_FULL / PROTEAN_METABOLISM_RATE) * seconds_per_tick * 100), 0, 10) // Our blood is nanite slurry - a useful healing chem for others - we're going to make it cost a premium 1 sheets per tick
+			owner.blood_volume = min(owner.blood_volume + (((BLOOD_REGEN_FACTOR * PROTEAN_METABOLISM_RATE) * 0.05) * seconds_per_tick), BLOOD_VOLUME_NORMAL) // 1 Sheets = 25u of slurry
 		else
-			metal -= clamp(((PROTEAN_STOMACH_FULL / PROTEAN_METABOLISM_RATE) * seconds_per_tick), 0, 10)
+			metal -= clamp(((PROTEAN_STOMACH_FULL / PROTEAN_METABOLISM_RATE) * seconds_per_tick), 0, 5) // If we have no needed repairs, our consumption is minimal.
 		return
 	owner.adjustBruteLoss(2, forced = TRUE)
 	if(COOLDOWN_FINISHED(src, starving_message))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Making a few things more obvious/readable with Proteans, as well as making some small adjustments here and there:

- Proteans can now regenerate their nanite slurry blood, but this makes them very resource hungry to do so
- Visible messages for protean repairs, retreating/emerging
- Proteans that are in mod suit form are now immune to pressure/hot/cold to prevent death/damage from the vacuum of space.

## Why It's Good For The Game

Regarding new visible messages: The readability of repairing/helping a new race for both the roboticists/doctors healing them, as well as the players playing them.

Regarding the blood changes: Currently, although Proteans have nanite slurry for blood, they have no way to actually create more. This allows them to create more, at an exchange rate slightly better than a chemists making it (1 Iron sheet + 1 Gold bar = 20u of Slurry). **I'm definitely open to adjustments in numbers here**, but I'm trying to balance the fact they can only store 10 sheets of metal at a time, and blood volume is 560u. So although having a harsher exchange rate might be good in terms of keeping chemists relevant for nanite slurry, it would really suck to have to eat 40 iron to regenerate blood.

Regarding idle iron consumption adjustment: Proteans are very hungry for material if they need repairs, and I think tuning that dial back just a bit for if they're idle/not needing repairs makes downtime less punishing.

Suit_traits: this is a bug fix to prevent proteans from dying when retracted into their suit, in space. Seemed a bit silly for a space-capable suit to be harmed by space.


## Proof Of Testing

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->
<details>
<summary>Screenshots/Videos</summary>
WIP. Still trying to get a few things to work. Namely, the spans on a reviving/revived Protean. I'd also really like to solve the issue where a protean never fully "die" dies releasing them to the ghost realm, but I'm still spinning on that.
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Proteans can now regenerate their nanite slurry blood by eating materials.
add: Proteans have had a few helpful messages added to their revival mechanics and objects.
balance: Protean idle material consumption has been decreased
fix: Proteans in suit form no longer take pressure or temperature damage.
spellcheck: Cleaned up a few things related to Proteans
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
