### PR TITLE
lets the medical bandolier hold all 'hyposprays' and vials

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/storage/belts.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/storage/belts.dm
@@ -154,7 +154,7 @@
 		/obj/item/reagent_containers/medigel,
 		/obj/item/storage/pill_bottle,
 		/obj/item/implanter,
-		/obj/item/hypospray, //why was this only restricted to skyrat hypos in the first place?
+		/obj/item/hypospray,
 		/obj/item/reagent_containers/cup/vial,
 		/obj/item/weaponcell/medical,
 		/obj/item/reagent_containers/cup/tube

--- a/modular_skyrat/modules/customization/modules/clothing/storage/belts.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/storage/belts.dm
@@ -154,7 +154,8 @@
 		/obj/item/reagent_containers/medigel,
 		/obj/item/storage/pill_bottle,
 		/obj/item/implanter,
-		/obj/item/hypospray/mkii,
+		/obj/item/hypospray, //why was this only restricted to skyrat hypos in the first place?
 		/obj/item/reagent_containers/cup/vial,
-		/obj/item/weaponcell/medical
+		/obj/item/weaponcell/medical,
+		/obj/item/reagent_containers/cup/tube
 		))


### PR DESCRIPTION
## About The Pull Request

see title

## Why It's Good For The Game

its really arbitrary that it only lets you carry skyrat hypos and not medipens and such, especially because it lets you carry DNA injectors and syringes...

## Proof Of Testing

line change

## Changelog

:cl:
add: medical bandolier lets you carry all hyposprays/injectors and test tubes
/:cl: