### PR TITLE
Teshari/Tajara now start with cold-adapted lungs + adds default lungs to the augment menu

### DIFF
--- a/modular_skyrat/modules/customization/modules/client/augment/organs.dm
+++ b/modular_skyrat/modules/customization/modules/client/augment/organs.dm
@@ -55,6 +55,12 @@
 /datum/augment_item/organ/lungs
 	slot = AUGMENT_SLOT_LUNGS
 
+/datum/augment_item/organ/lungs/normal
+	name = "Normal Lungs"
+	slot = AUGMENT_SLOT_LUNGS
+	path = /obj/item/organ/lungs
+	cost = 1 // if you dont have normal lungs, still an investment to switch it out
+
 /datum/augment_item/organ/lungs/hot
 	name = "Heat-Adapted Lungs"
 	slot = AUGMENT_SLOT_LUNGS

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/tajaran.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/tajaran.dm
@@ -9,6 +9,7 @@
 		TRAIT_MUTANT_COLORS,
 	)
 	mutanttongue = /obj/item/organ/tongue/cat/tajaran
+	mutantlungs = /obj/item/organ/lungs/adaptive/cold
 	inherent_biotypes = MOB_ORGANIC|MOB_HUMANOID
 	mutant_bodyparts = list()
 	payday_modifier = 1.0

--- a/modular_skyrat/modules/teshari/code/_teshari.dm
+++ b/modular_skyrat/modules/teshari/code/_teshari.dm
@@ -39,6 +39,7 @@
 	bodytemp_cold_damage_limit = (BODYTEMP_COLD_DAMAGE_LIMIT + TESHARI_TEMP_OFFSET)
 	species_language_holder = /datum/language_holder/teshari
 	mutantears = /obj/item/organ/ears/teshari
+	mutantlungs = /obj/item/organ/lungs/adaptive/cold
 	body_size_restricted = TRUE
 	bodypart_overrides = list(
 		BODY_ZONE_HEAD = /obj/item/bodypart/head/mutant/teshari,
@@ -56,7 +57,6 @@
 		"ears" = list("Teshari Regular", TRUE),
 		"legs" = list("Normal Legs", FALSE),
 	)
-
 
 /obj/item/organ/tongue/teshari
 	liked_foodtypes = MEAT | GORE | RAW
@@ -79,3 +79,15 @@
 /datum/species/teshari/on_species_loss(mob/living/carbon/C, datum/species/new_species, pref_load)
 	. = ..()
 	passtable_off(C, SPECIES_TRAIT)
+
+/datum/species/teshari/create_pref_unique_perks()
+	var/list/perk_descriptions = list()
+
+	perk_descriptions += list(list(
+		SPECIES_PERK_TYPE = SPECIES_POSITIVE_PERK,
+		SPECIES_PERK_ICON = FA_ICON_RUNNING,
+		SPECIES_PERK_NAME = "Tablerunning",
+		SPECIES_PERK_DESC = "A being of extreme agility, you can jump on tables just by running into them!"
+	))
+
+	return perk_descriptions

--- a/modular_skyrat/modules/teshari/code/_teshari.dm
+++ b/modular_skyrat/modules/teshari/code/_teshari.dm
@@ -80,14 +80,3 @@
 	. = ..()
 	passtable_off(C, SPECIES_TRAIT)
 
-/datum/species/teshari/create_pref_unique_perks()
-	var/list/perk_descriptions = list()
-
-	perk_descriptions += list(list(
-		SPECIES_PERK_TYPE = SPECIES_POSITIVE_PERK,
-		SPECIES_PERK_ICON = FA_ICON_RUNNING,
-		SPECIES_PERK_NAME = "Tablerunning",
-		SPECIES_PERK_DESC = "A being of extreme agility, you can jump on tables just by running into them!"
-	))
-
-	return perk_descriptions


### PR DESCRIPTION
## About The Pull Request

Title.
## Why It's Good For The Game

Allows Teshari/Tajara to breathe on icemoon by default. Sure, you could just take the lungs, but teshari are a frigid species, and should be adaptive to the cold out-of-the-box.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

lol i forgot to record. trust me tho the lungs get applied and the birds can breathe icebox air

</details>

## Changelog
:cl:
add: Teshari spawn with cold-adapted lungs
add: Default lungs to the augment menu
/:cl:
