### PR TITLE
Adds 3 new alt job titles, removes one.

### DIFF
--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -153,6 +153,7 @@
 		"Postwoman",
 		"Receiving Clerk",
 		"Union Associate",
+		"Crate Pusher",
 	)
 
 /datum/job/chaplain
@@ -210,6 +211,7 @@
 		"Comedian",
 		"Jester",
 		"Joker",
+		"Prankster",
 	)
 
 /datum/job/cook
@@ -273,6 +275,7 @@
 		"Forensic Technician",
 		"Private Investigator",
 		"CID Officer",
+		"Gumshoe",
 	)
 
 /datum/job/doctor
@@ -330,7 +333,6 @@
 		"Custodian",
 		"Groundskeeper",
 		"Maid",
-		"Maintenance Technician",
 		"Sanitation Technician",
 	)
 
@@ -399,6 +401,7 @@
 		"Counsellor",
 		"Psychiatrist",
 		"Therapist",
+		"Shrink",
 	)
 
 /datum/job/quartermaster


### PR DESCRIPTION
## About The Pull Request
Adds the following job titles
Clown - Prankster
Detective - Gumshoe
Psych - Shrink
Cargo Technian - Crate Pusher

Removes Janitor's "Maintenance Technician" alternate title.
## Why It's Good For The Game

More alt titles are fun.

Maintenance Technician sounds more like an alternate job title for engineering, and I swear to god half the time I see someone with that alt job title my brain goes "oh, engineering!"
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
hehehehohoohoehehehe
</details>

## Changelog
:cl:
add: Adds four new job titles! Prankster, Gumshoe, Shrink, and Crate Pusher.
del: Removes Janitor's "Maintenance Technician" job title.
/:cl:
