### PR TITLE
Fix set internals button missing in strip menu

### DIFF
--- a/modular_zubbers/master_files/code/modules/entombed_quirk/code/entombed_alt_actions.dm
+++ b/modular_zubbers/master_files/code/modules/entombed_quirk/code/entombed_alt_actions.dm
@@ -4,7 +4,7 @@
 	. = ..()
 	var/obj/item/mod/control/pre_equipped/entombed/entombed_suit = get_item(source)
 	if (!istype(entombed_suit))
-		return null
+		return
 
 	if (!entombed_suit.active)
 		return list("entombed_emergency_reactivate")
@@ -13,7 +13,7 @@
 	. = ..()
 	var/obj/item/mod/control/pre_equipped/entombed/entombed_suit = get_item(source)
 	if (!istype(entombed_suit))
-		return null
+		return
 
 	switch (action_key)
 		if ("entombed_emergency_reactivate")

--- a/tgui/packages/tgui/interfaces/StripMenu.tsx
+++ b/tgui/packages/tgui/interfaces/StripMenu.tsx
@@ -60,12 +60,12 @@ const ALTERNATE_ACTIONS: Record<string, AlternateAction> = {
   },
 
   enable_internals: {
-    icon: 'lungs', // SKYRAT EDIT - TGFONT IS FUCKED AND I DUNNO WHY SO HERE'S A BANDAID - original "tg-air-tank"
+    icon: 'tg-air-tank',
     text: 'Enable internals',
   },
 
   disable_internals: {
-    icon: 'lungs-virus', // SKYRAT EDIT - TGFONT IS FUCKED AND I DUNNO WHY SO HERE'S A BANDAID - original "tg-air-tank-slash"
+    icon: 'tg-air-tank-slash',
     text: 'Disable internals',
   },
 


### PR DESCRIPTION

## About The Pull Request

Override for back slot strip alt actions was written wrong

## Why It's Good For The Game

Bug

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/cf984832-8b9a-4bf2-8dc8-70d0052dd44e)

</details>

## Changelog
:cl:
fix: fixed set internals button missing in the strip menu for tanks worn on the back
/:cl:
