### PR TITLE
Revert "Nerf printable medipen volume from 25 to 12"

### DIFF
--- a/modular_zubbers/code/modules/pen_medipens/pen_medipens.dm
+++ b/modular_zubbers/code/modules/pen_medipens/pen_medipens.dm
@@ -5,7 +5,7 @@
 	icon = 'modular_zubbers/icons/obj/medical/pen_medipens/pen_medipens.dmi'
 	icon_state = "default"
 	base_icon_state = "default"
-	volume = 12
+	volume = 25
 	fill_icon = 'modular_zubbers/icons/obj/medical/pen_medipens/fill_overlay.dmi'
 	fill_icon_state = "tank"
 	fill_icon_thresholds = list(0,1)


### PR DESCRIPTION

## About The Pull Request

After thinking about it and learning from people just how insanely strong pills are, I decided it was a knee jerk nerf and wasn't necessary

## Why It's Good For The Game

the chemical

## Proof Of Testing

yeah

## Changelog
:cl:
balance: revert medipen volume back to 25u
/:cl:
