### PR TITLE
Adds missing/additional genital sizes & sprites.

### DIFF
--- a/code/__DEFINES/~skyrat_defines/DNA.dm
+++ b/code/__DEFINES/~skyrat_defines/DNA.dm
@@ -76,7 +76,7 @@
 #define PENIS_DEFAULT_LENGTH 6 //still a lil long but not insane
 
 #define TESTICLES_MIN_SIZE 0
-#define TESTICLES_MAX_SIZE 6
+#define TESTICLES_MAX_SIZE 8
 
 #define SHEATH_NONE	"None"
 #define SHEATH_NORMAL "Sheath"

--- a/code/__DEFINES/~skyrat_defines/lewd_defines.dm
+++ b/code/__DEFINES/~skyrat_defines/lewd_defines.dm
@@ -29,6 +29,9 @@
 #define BREAST_SIZE_N "N"
 #define BREAST_SIZE_O "O"
 #define BREAST_SIZE_P "P"
+#define BREAST_SIZE_Q "Q"
+#define BREAST_SIZE_R "R"
+#define BREAST_SIZE_S "S"
 #define BREAST_SIZE_BEYOND_MEASUREMENT "beyond measurement"
 
 //ERP Size Areas

--- a/modular_skyrat/modules/customization/_globalvars/lists.dm
+++ b/modular_skyrat/modules/customization/_globalvars/lists.dm
@@ -48,7 +48,9 @@ GLOBAL_LIST_INIT(balls_size_translation, list(
 	"3" = "Very Big",
 	"4" = "Enormous",
 	"5" = "Immense",
-	"6" = "Gargantuan"
+	"6" = "Gargantuan",
+	"7" = "Monstrous",
+	"8" = "Colossal"
 	))
 
 GLOBAL_LIST_INIT(marking_zone_to_bitflag, list(
@@ -80,7 +82,9 @@ GLOBAL_LIST_INIT(preference_balls_sizes, list(
 	"Very Big",
 	"Enormous",
 	"Immense",
-	"Gargantuan"
+	"Gargantuan",
+	"Monstrous",
+	"Colossal"
 	))
 
 GLOBAL_LIST_INIT(robotic_styles_list, list(

--- a/modular_skyrat/modules/customization/_globalvars/lists.dm
+++ b/modular_skyrat/modules/customization/_globalvars/lists.dm
@@ -19,6 +19,9 @@ GLOBAL_LIST_INIT(breast_size_translation, list(
 	"14" = BREAST_SIZE_N,
 	"15" = BREAST_SIZE_O,
 	"16" = BREAST_SIZE_P,
+	"17" = BREAST_SIZE_Q,
+	"18" = BREAST_SIZE_R,
+	"19" = BREAST_SIZE_S
 	))
 
 GLOBAL_LIST_INIT(breast_size_to_number, list(
@@ -39,6 +42,9 @@ GLOBAL_LIST_INIT(breast_size_to_number, list(
 	BREAST_SIZE_N = 14,
 	BREAST_SIZE_O = 15,
 	BREAST_SIZE_P = 16,
+	BREAST_SIZE_Q = 17,
+	BREAST_SIZE_R = 18,
+	BREAST_SIZE_S = 19
 	))
 
 GLOBAL_LIST_INIT(balls_size_translation, list(

--- a/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
@@ -187,8 +187,14 @@
 			size_affix = "2"
 		if(16 to 24)
 			size_affix = "3"
-		else
+		if(25 to 37)
 			size_affix = "4"
+		if(38 to 47)
+			size_affix = "5"
+		if(48 to 59)
+			size_affix = "6"
+		else
+			size_affix = "7"
 	var/passed_string = "penis_[genital_type]_[size_affix]"
 	if(uses_skintones)
 		passed_string += "_s"
@@ -215,8 +221,14 @@
 			size_affix = "2"
 		if(16 to 24)
 			size_affix = "3"
-		else
+		if(25 to 37)
 			size_affix = "4"
+		if(38 to 47)
+			size_affix = "5"
+		if(48 to 59)
+			size_affix = "6"
+		else
+			size_affix = "7"
 	var/passed_string = "[genital_type]_[size_affix]_[is_erect]"
 	if(uses_skintones)
 		passed_string += "_s"

--- a/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
@@ -477,7 +477,7 @@
 /obj/item/organ/genital/breasts/get_sprite_size_string()
 	var/max_size = 5
 	if(genital_type == "pair")
-		max_size = 16
+		max_size = 19
 	var/current_size = FLOOR(genital_size, 1)
 	if(current_size < 0)
 		current_size = 0

--- a/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
@@ -479,6 +479,8 @@
 	if(genital_type == "pair")
 		max_size = 19
 	var/current_size = FLOOR(genital_size, 1)
+	if(genital_name == "Pair")
+		current_size = clamp(current_size, 0, 16)
 	if(current_size < 0)
 		current_size = 0
 	else if (current_size > max_size)

--- a/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
@@ -272,6 +272,8 @@
 
 /obj/item/organ/genital/testicles/update_genital_icon_state()
 	var/measured_size = clamp(genital_size, 1, TESTICLES_MAX_SIZE)
+	if(genital_name == "Pair")
+		measured_size = clamp(measured_size, 0, 6)
 	var/passed_string = "testicles_[genital_type]_[measured_size]"
 	if(uses_skintones)
 		passed_string += "_s"
@@ -295,6 +297,8 @@
 
 /obj/item/organ/genital/testicles/get_sprite_size_string()
 	var/measured_size = FLOOR(genital_size,1)
+	if(genital_name == "Pair")
+		measured_size = clamp(measured_size, 0, 6)
 	measured_size = clamp(measured_size, 0, TESTICLES_MAX_SIZE)
 	var/passed_string = "[genital_type]_[measured_size]"
 	if(uses_skintones)


### PR DESCRIPTION

## About The Pull Request

Like the title says. We found some unused sprites for genitals and decided it'd be neat to add them in along with their respective sizes. This includes cleanup to make sure the non-alt versions/older sprites that don't have up to those same sizes don't disappear and stay at the previous max size even if you choose the higher numbers. Sprite additions for penis, balls, and breast sizes are included.

## Why It's Good For The Game

More customization options don't hurt and we know a lot of people wanting these! Don't see why it'd be a bad thing, only thing we could foresee is the bigger sizes being questionable but pretty much all the risk factors of that is covered by our ERP policy/rules.
## Proof Of Testing

_Want us to post naughty bits for the world to see...?_
Yes tested numerous times on our localhost, we even accounted for the larger sizes making the older sprites disappear (for some reason), hopefully that doesn't break again somehow.
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl: AstrumLernaean
add: More genital size options, with sprites! For your viewing pleasure.
/:cl:
