### PR TITLE
Fix Box Station delam suppressor

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -55336,10 +55336,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "qKs" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/delam_scram/directional/east,
+/obj/machinery/atmospherics/components/unary/delam_scram/directional/south,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "qKx" = (
@@ -96711,7 +96708,7 @@ cqZ
 crt
 nfO
 cAm
-cMH
+qKs
 cMN
 cFO
 eIE
@@ -96966,7 +96963,7 @@ cqj
 cSG
 crb
 cru
-qKs
+cEx
 cEx
 cEx
 cAP


### PR DESCRIPTION
## About The Pull Request

Fixes Box delam suppressor being outside of the SM chamber

## Why It's Good For The Game

Fix good

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/3f78a337-54e8-4b16-9336-d9f7934c4914)

</details>

## Changelog

:cl: LT3
fix: Box Station's delam suppressor is now actually in the SM chamber
/:cl: