### PR TITLE
Adds AI-Uplink brain to the techweb as a late game technology

### DIFF
--- a/modular_zubbers/code/__DEFINES/techweb_nodes.dm
+++ b/modular_zubbers/code/__DEFINES/techweb_nodes.dm
@@ -1,5 +1,6 @@
 //Onstation Tech
 #define TECHWEB_NODE_EMPATHY_IMPLANT "empathy_implant"
+#define TECHWEB_NODE_AI_UPLINK_BRAIN "ai_uplink_brain"
 
 //Offstation Syndicate Tech
 #define TECHWEB_NODE_INTERDYNE "interdyne_tech"

--- a/modular_zubbers/code/modules/research/designs/mechfab_designs.dm
+++ b/modular_zubbers/code/modules/research/designs/mechfab_designs.dm
@@ -18,12 +18,13 @@
 	id = "ai_uplink_brain"
 	build_type = MECHFAB
 	construction_time = 60 SECONDS
-	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 25,
-					/datum/material/glass = SHEET_MATERIAL_AMOUNT * 25,
-					/datum/material/silver = SHEET_MATERIAL_AMOUNT * 25,
-					/datum/material/plasma = SHEET_MATERIAL_AMOUNT * 25,
-					/datum/material/bluespace = SHEET_MATERIAL_AMOUNT * 25,
-					/datum/material/titanium  = SHEET_MATERIAL_AMOUNT * 25,
+	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 10,
+					/datum/material/glass = SHEET_MATERIAL_AMOUNT * 20,
+					/datum/material/silver = SHEET_MATERIAL_AMOUNT * 10,
+					/datum/material/plasma = SHEET_MATERIAL_AMOUNT * 10,
+					/datum/material/bluespace = SHEET_MATERIAL_AMOUNT * 30,
+					/datum/material/titanium  = SHEET_MATERIAL_AMOUNT * 10,
+					/datum/material/bananium  = SHEET_MATERIAL_AMOUNT * 2,
 					/datum/material/gold = SHEET_MATERIAL_AMOUNT * 25)
 	category = list(RND_CATEGORY_MECHFAB_SYNTH + RND_SUBCATEGORY_MECHFAB_SYNTH_PARTS)
 

--- a/modular_zubbers/code/modules/research/designs/mechfab_designs.dm
+++ b/modular_zubbers/code/modules/research/designs/mechfab_designs.dm
@@ -17,7 +17,7 @@
 	name = "AI-uplink brain"
 	id = "ai_uplink_brain"
 	build_type = MECHFAB
-	construction_time = 30 SECONDS
+	construction_time = 60 SECONDS
 	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 25,
 					/datum/material/glass = SHEET_MATERIAL_AMOUNT * 25,
 					/datum/material/silver = SHEET_MATERIAL_AMOUNT * 25,

--- a/modular_zubbers/code/modules/research/designs/mechfab_designs.dm
+++ b/modular_zubbers/code/modules/research/designs/mechfab_designs.dm
@@ -13,6 +13,22 @@
 
 	build_path = /mob/living/carbon/human/species/synth/empty
 
+/datum/design/ai_uplink_brain
+	name = "AI-uplink brain"
+	id = "ai_uplink_brain"
+	build_type = MECHFAB
+	construction_time = 30 SECONDS
+	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 25,
+					/datum/material/glass = SHEET_MATERIAL_AMOUNT * 25,
+					/datum/material/silver = SHEET_MATERIAL_AMOUNT * 25,
+					/datum/material/plasma = SHEET_MATERIAL_AMOUNT * 25,
+					/datum/material/bluespace = SHEET_MATERIAL_AMOUNT * 25,
+					/datum/material/titanium  = SHEET_MATERIAL_AMOUNT * 25,
+					/datum/material/gold = SHEET_MATERIAL_AMOUNT * 25)
+	category = list(RND_CATEGORY_MECHFAB_SYNTH + RND_SUBCATEGORY_MECHFAB_SYNTH_PARTS)
+
+	build_path = /obj/item/organ/brain/cybernetic/ai
+
 /datum/design/borg_upgrade_advcutter
 	name = "Advanced Plasma Cutter"
 	id = "borg_upgrade_advcutter"

--- a/modular_zubbers/code/modules/research/designs/mechfab_designs.dm
+++ b/modular_zubbers/code/modules/research/designs/mechfab_designs.dm
@@ -24,7 +24,7 @@
 					/datum/material/plasma = SHEET_MATERIAL_AMOUNT * 10,
 					/datum/material/bluespace = SHEET_MATERIAL_AMOUNT * 30,
 					/datum/material/titanium  = SHEET_MATERIAL_AMOUNT * 10,
-					/datum/material/bananium  = SHEET_MATERIAL_AMOUNT * 2,
+					/datum/material/bananium  = SHEET_MATERIAL_AMOUNT * 5,
 					/datum/material/gold = SHEET_MATERIAL_AMOUNT * 25)
 	category = list(RND_CATEGORY_MECHFAB_SYNTH + RND_SUBCATEGORY_MECHFAB_SYNTH_PARTS)
 

--- a/modular_zubbers/code/modules/research/techweb/all_nodes.dm
+++ b/modular_zubbers/code/modules/research/techweb/all_nodes.dm
@@ -109,6 +109,17 @@
 		"adv_xenoarchbag_cyborg"
 	)
 
+/datum/techweb_node/ai_uplink_brain
+	id = TECHWEB_NODE_AI_UPLINK_BRAIN
+	display_name = "AI-uplink brain"
+	description = "This bleeding edge 'organ' can be inserted into the head of completely synthic humanoids, granting AIs that which they want most: hands."
+	prereq_ids = list(TECHWEB_NODE_ALIEN_SURGERY, TECHWEB_NODE_ALIEN_ENGI, TECHWEB_NODE_SYNDICATE_BASIC, TECHWEB_NODE_PARTS_BLUESPACE)
+	design_ids = list(
+		"ai_uplink_brain",
+	)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_4_POINTS)
+	announce_channels = list(RADIO_CHANNEL_SCIENCE)
+
 // Computer Tech
 /datum/techweb_node/gaming/New()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

This adds the AI-Uplink brain to the techweb for a steep cost, and high pre-reqs.

## Why It's Good For The Game

This is a very fun and interesting piece of tech, but having it currently locked to only appear on one ruin on one map (Out of 13!) behind a megafauna feels like it makes it **too** rare. Adding it to the techweb, but requiring both alien techs, and illegal research, as well as bananaium (obtainable through space ruins, or very expensive through cargo) should still limit it and keep it uncommon.

## Proof Of Testing

Went through and spun up a test and actually went through the research steps to get it to make sure it's accessible. Illegal tech, alien tech, ordinance, etc. (but I forgot to take a screenshot after I finished all the research, but it does work!)

![image](https://github.com/user-attachments/assets/7ecf7624-8122-4be3-ba3d-7be36f65f94c)


## Changelog
:cl:
balance: The AI uplink has been added to the tech web as a difficult-to-get research.
/:cl:
