### PR TITLE
Add verb to send ping and message to online, de-adminned admins

### DIFF
--- a/modular_zubbers/code/modules/admin/verbs/admin.dm
+++ b/modular_zubbers/code/modules/admin/verbs/admin.dm
@@ -1,0 +1,24 @@
+ADMIN_VERB(ping_deadmins, R_ADMIN, "Ping De-adminned Admins", "Send a notification and message to all currently de-adminned admins.", ADMIN_CATEGORY_MAIN)
+	var/message = tgui_input_text(user, "Enter message to send with ping", "Notify Deadmins", "Need help with tickets...", max_length = 256)
+	if(!message)
+		return
+
+	var/list/admins_notified = list()
+	for(var/ckey as anything in GLOB.deadmins)
+		var/client/deadmin_client = GLOB.directory[ckey]
+		if(!deadmin_client)
+			continue
+		to_chat(
+			deadmin_client,
+			fieldset_block(
+				span_adminhelp("[user.key] is requesting help"),
+				span_adminsay(message),
+				"boxed_message red_box"),
+			type = MESSAGE_TYPE_SYSTEM,
+			confidential = TRUE,
+		)
+		SEND_SOUND(deadmin_client, sound('sound/effects/adminhelp.ogg'))
+		admins_notified += ckey
+
+	log_admin("[key_name_admin(user)] pinged [length(admins_notified)] ([admins_notified.Join(", ")]) de-adminned admin(s) with message: [message]")
+	message_admins("[key_name_admin(user)] pinged [length(admins_notified)] ([admins_notified.Join(", ")]) de-adminned admin(s) with message: [message]")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9063,6 +9063,7 @@
 #include "modular_zubbers\code\game\turfs\open\openspace.dm"
 #include "modular_zubbers\code\game\turfs\open\sand.dm"
 #include "modular_zubbers\code\modules\_defines.dm"
+#include "modular_zubbers\code\modules\admin\verbs\admin.dm"
 #include "modular_zubbers\code\modules\admin\verbs\debug.dm"
 #include "modular_zubbers\code\modules\alt_anomaly_refinery\anomaly_refinery.dm"
 #include "modular_zubbers\code\modules\alternative_job_titles\code\alt_job_titles.dm"


### PR DESCRIPTION

## About The Pull Request

Requested by another admin, adds a verb "Ping De-adminned Admins" in the main admin panel that lets you type in a message which it then sends to every admin that's online but currently deadminned, uses the ahelp sound and box to grab attention

## Why It's Good For The Game

Sometimes you need to call for help cause theres too many tickets or you can't do a certain ticket or whatever

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

https://github.com/user-attachments/assets/b11168c6-47d1-43fc-bf57-a0332d8cca6a

</details>

## Changelog
:cl:
admin: new verb, ping de-adminned admins, to send a message and ping to any currently deadminned admins
/:cl:
