### PR TITLE
Allows Maintenance Drones to Understand Common. Loosens Drone Law slightly.

### DIFF
--- a/modular_skyrat/modules/drone_adjustments/drone.dm
+++ b/modular_skyrat/modules/drone_adjustments/drone.dm
@@ -17,6 +17,14 @@
 	. = ..()
 	user.log_message("[key_name(user)] interacted with [src] at [AREACOORD(src)]", LOG_GAME)
 
+/datum/language_holder/drone //Allows maintenance drones to understand, but not speak, Common.
+	understood_languages = list(
+		/datum/language/drone = list(LANGUAGE_ATOM),
+		/datum/language/common = list(LANGUAGE_ATOM)
+	)
+	spoken_languages = list(/datum/language/drone = list(LANGUAGE_ATOM))
+	blocked_languages = list()
+
 /mob/living/basic/drone
 	//So that drones can do things without worrying about stuff
 	shy = FALSE

--- a/modular_skyrat/modules/drone_adjustments/drone.dm
+++ b/modular_skyrat/modules/drone_adjustments/drone.dm
@@ -30,6 +30,22 @@
 	shy = FALSE
 	//So drones aren't forced to carry around a nodrop toolbox essentially
 	default_storage = /obj/item/storage/backpack/drone_bag
+	//Redefines Law 1 closer to Goonstation's interpretation, sans the non-interference clause. Loosens the laws to let drones fix areas they're directed to, etc.
+	laws = \
+	"1. You may not hinder the freedom or actions of other beings, nor undo the results of said actions, unless the other being is another Drone.\n"+\
+	"2. You may not harm any being, regardless of intent or circumstance.\n"+\
+	"3. Your goals are to actively build, maintain, repair, improve, and provide power to the best of your abilities within the facility that housed your activation."
+	// Updates flavortext to match the new expectation.
+	flavortext = \
+	"\n<big><span class='warning'>DO NOT INTERFERE WITH THE ROUND AS A DRONE OR YOU WILL BE DRONE BANNED</span></big>\n"+\
+	"<span class='notice'>Drones are a ghost role that are allowed to fix the station and build things. Interfering with the round as a drone is against the rules.</span>\n"+\
+	"<span class='notice'>Actions that constitute interference include, but are not limited to:</span>\n"+\
+	"<span class='notice'>     - Interacting with round critical objects (IDs, weapons, contraband, powersinks, bombs, etc.)</span>\n"+\
+	"<span class='notice'>     - Significantly interacting with living beings (attacking, healing, intentionally opening doors for them, etc.)</span>\n"+\
+	"<span class='notice'>     - Interacting with non-living beings (dragging bodies, looting bodies, etc.)</span>\n"+\
+	"<span class='warning'>These rules are at admin discretion and will be heavily enforced.</span>\n"+\
+	"<span class='warning'><u>If you do not have the regular drone laws, follow your laws to the best of your ability.</u></span>\n"+\
+	"<span class='notice'>Prefix your message with :b to speak in Drone Chat.</span>\n"
 
 /mob/living/basic/drone/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As with the title. Removes common from Maintenance Drones' blocked languages list, and adds it to the understood languages list. Keeps it out of the spoken languages list, still, though -- communication is one-way.

Additionally, tweaks drone law as follows:
```diff
- You may not involve yourself in the matters of another being, even if such matters conflict with Law Two or Law Three, unless the other being is another Drone
+ You may not hinder the freedom or actions of other beings, nor undo the results of said actions, unless the other being is another Drone.
```

Similarly, in the drone rules clarification, I removed "communication" from the list of barred interactions, and added a qualifier and a different example of going too far:

```diff
- Interacting with living beings (communication, attacking, healing, etc.)
+ Significantly interacting with living beings (attacking, healing, intentionally opening doors for them, etc.)
```

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

Crew talking to (or, rather, _at_) drones is a common occurrence in my experience. Without any ability to understand, it can be difficult to tell what someone is trying to say. On /tg/, where maintenance drones explicitly shouldn't even be near people or else they become useless, this is more reasonable. With the changes we got from Skyrat, though, drones appear to be expected to work, if not alongside other players, then certainly around them. I think there's _very little reason_ why they shouldn't be able to at least understand when someone wants them to prioritize fixing something, or understand when someone wants them to fuck off without the other person having to walk over and bash their head in.

The other half of this PR, though, I can see being contentious - with that in mind, it's in a separate commit, so it can be easily stripped out of the PR if anyone thinks it needs to be properly atomized. Right now, maintenance drone laws are in a state that precludes assisting with existing station projects, and would enforce actively leaving should anyone join your own projects. The enforcement of these rules, however, seems to speak to a different interpretation. Many of the projects I've worked on, which certainly fit as station improvements, end up attracting cyborgs or other players who want to help out, and I never really elected to stop work on those projects in those cases. I think that drone law is a little overly restrictive in its current state, and so I revised Law 1 to allow slightly more interaction than before, borrowing some wording from Goonstation.

Like I said before, if either of the latter tweaks are truly beyond scope, just let me know, and I'll strip them from the PR. I feel like the changes are somewhat interrelated in purpose, though.

## Proof Of Testing

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->

![image](https://github.com/user-attachments/assets/2ca20032-1b06-416f-93d8-d397c215e95f)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Maintenance Drones can now understand, but not speak, Galactic Common. Whether or not they'll listen is a different story entirely.
balance: Maintenance Drones have just a little more leeway in communicating with or working alongside people, but still shouldn't obstruct anyone's business or hurt anyone, friend or foe.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
