### PR TITLE
Fix GAGS loadout item recolors not showing in char preview with place all in case pref

### DIFF
--- a/code/modules/loadout/loadout_helpers.dm
+++ b/code/modules/loadout/loadout_helpers.dm
@@ -81,7 +81,7 @@
 	var/update = NONE
 	for(var/datum/loadout_item/item as anything in loadout_datums)
 		update |= item.on_equip_item(
-			equipped_item = loadout_placement_preference == LOADOUT_OVERRIDE_CASE ? locate(item.item_path) in travel_suitcase : locate(item.item_path) in new_contents, // BUBBER EDIT CHANGE - ORIGINAL: equipped_item = locate(item.item_path) in new_contents,
+			equipped_item = (loadout_placement_preference == LOADOUT_OVERRIDE_CASE && !visuals_only) ? locate(item.item_path) in travel_suitcase : locate(item.item_path) in new_contents, // BUBBER EDIT CHANGE - ORIGINAL: equipped_item = locate(item.item_path) in new_contents,
 			preference_source = preference_source,
 			preference_list = preference_list,
 			equipper = src,


### PR DESCRIPTION

## About The Pull Request

Since when previewing your character it doesn't actually put the loadout items in a case it needs to be searching in the mob like normal

## Why It's Good For The Game

Fixes #3860 

## Proof Of Testing

Tested it before and after with all 3 loadout pref options

## Changelog
:cl:
fix: fixed GAGS modifications to loadout items not showing in preview when using place all in case pref
/:cl:
