### PR TITLE
Fixes ghouls wearing hats wrong

### DIFF
--- a/modular_skyrat/modules/bodyparts/code/ghoul_bodyparts.dm
+++ b/modular_skyrat/modules/bodyparts/code/ghoul_bodyparts.dm
@@ -19,7 +19,7 @@
 	worn_head_offset = new(
 		attached_part = src,
 		feature_key = OFFSET_HEAD,
-		offset_x = list("north" = 1, "south" = 1, "east" = 1, "west" = 1),
+		offset_x = list("north" = 0, "south" = 0, "east" = 1, "west" = -1),
 	)
 	worn_mask_offset = new(
 		attached_part = src,


### PR DESCRIPTION

## About The Pull Request
It does as the title says, fixes the ghoul headwear offset by updating `worn_head_offset` in `modular_skyrat/modules/bodyparts/code/ghoul_bodyparts.dm`. This will also fix https://github.com/Bubberstation/Bubberstation/issues/3517. Glasses get covered a little bit, but that is due to the offset needed to fully cover ghouls eyes, so there is not much that can be done about that without changing the sprite entirely.
## Why It's Good For The Game
Bugs are bad and despite the fact that ghouls are goofy creatures, it is about time they learned how to properly wear headwear.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/c6609c19-db26-400b-8bec-2a7dc88ea02e)

</details>

## Changelog
:cl:
fix: fixed the offsets for ghoul headwear, hats will now look right on them
/:cl:
