### PR TITLE
Some active turfs fixes

### DIFF
--- a/_maps/RandomRuins/IceRuins/bubberstation/icemoon_persistence.dmm
+++ b/_maps/RandomRuins/IceRuins/bubberstation/icemoon_persistence.dmm
@@ -104,8 +104,7 @@
 	},
 /obj/structure/bed/dogbed,
 /mob/living/basic/pet/syndifox{
-	faction = list("neutral","Syndicate");
-	dir = 2
+	faction = list("neutral","Syndicate")
 	},
 /turf/open/floor/stone,
 /area/ruin/space/has_grav/bubbers/persistance/command/admiral)
@@ -122,7 +121,6 @@
 	},
 /obj/structure/decorative{
 	icon_state = "tile_half";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	base_icon_state = "tile_half";
 	color = "#303030";
@@ -133,7 +131,6 @@
 	},
 /obj/structure/decorative{
 	icon_state = "siding_plain";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	dir = 8;
 	color = "#878787";
@@ -747,7 +744,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/effect/turf_decal/siding/wideplating_new/dark/end,
 /obj/effect/turf_decal/siding/dark{
-	dir = 2;
 	icon_state = "siding_plain_end"
 	},
 /turf/open/floor/mineral/plastitanium/red,
@@ -1109,7 +1105,6 @@
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/purple/end{
@@ -1128,8 +1123,7 @@
 	dir = 6
 	},
 /obj/structure/bed/dogbed{
-	pixel_x = -16;
-	pixel_y = 0
+	pixel_x = -16
 	},
 /obj/item/kirbyplants/organic/plant22{
 	pixel_x = 8;
@@ -1269,7 +1263,6 @@
 /area/ruin/space/has_grav/bubbers/persistance/engineering)
 "cE" = (
 /obj/machinery/button/door/directional/east{
-	pixel_x = 24;
 	pixel_y = -12;
 	id = "syndisci_windows";
 	name = "science dorms windows shutters";
@@ -1291,7 +1284,6 @@
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/item/modular_computer/laptop/preset/syndicate{
-	pixel_x = 0;
 	pixel_y = 9
 	},
 /obj/item/reagent_containers/cup/glass/waterbottle/tea{
@@ -1384,8 +1376,7 @@
 	pixel_x = 4
 	},
 /obj/item/radio/headset/syndicateciv/staff{
-	pixel_x = 2;
-	pixel_y = 0
+	pixel_x = 2
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bubbers/persistance/command/bridge)
@@ -1485,7 +1476,6 @@
 /area/ruin/space/has_grav/bubbers/persistance/med)
 "db" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 2;
 	external_pressure_bound = 140;
 	name = "server vent";
 	pressure_checks = 0
@@ -1542,19 +1532,16 @@
 	},
 /obj/structure/closet/generic/wall/empty{
 	pixel_x = 30;
-	pixel_y = 0;
 	name = "hazmat suit closet"
 	},
 /obj/item/clothing/suit/bio_suit/virology{
 	name = "Interdyne bio suit";
 	desc = "A suit that protects against biological contamination. It's Interdyne branded.";
-	pixel_x = 0;
 	pixel_y = -2
 	},
 /obj/item/clothing/head/bio_hood/virology{
 	desc = "A hood that protects the head and face from biological contaminants. It's Interdyne branded.";
 	name = "Interdyne bio hood";
-	pixel_x = 0;
 	pixel_y = 7
 	},
 /turf/open/floor/iron/dark/smooth_half{
@@ -1593,8 +1580,7 @@
 /area/ruin/space/has_grav/bubbers/persistance/service/sauna)
 "dj" = (
 /obj/machinery/light/floor{
-	pixel_x = -16;
-	pixel_y = 0
+	pixel_x = -16
 	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -1663,8 +1649,7 @@
 "dr" = (
 /obj/effect/turf_decal/tile/neutral/half{
 	alpha = 255;
-	color = "#5d341f";
-	dir = 2
+	color = "#5d341f"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
@@ -1819,19 +1804,16 @@
 /obj/item/forging/billow,
 /obj/item/stack/sheet/mineral/wood{
 	amount = 10;
-	pixel_x = 7;
-	pixel_y = 0
+	pixel_x = 7
 	},
 /obj/item/stack/sheet/iron/ten{
 	pixel_x = -6;
 	pixel_y = 3
 	},
 /obj/item/forging/tongs{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/item/forging/hammer{
-	pixel_x = 0;
 	pixel_y = -3
 	},
 /turf/open/floor/mineral/plastitanium,
@@ -1913,7 +1895,6 @@
 /obj/item/modular_computer/pda/syndicate,
 /obj/item/clothing/suit/jacket/runner/syndicate,
 /obj/item/modular_computer/laptop/preset/syndicate{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /turf/open/floor/mineral/plastitanium,
@@ -1988,7 +1969,6 @@
 	req_access = list("syndicate_leader")
 	},
 /obj/item/bouquet{
-	pixel_x = 0;
 	pixel_y = -8
 	},
 /turf/open/floor/mineral/plastitanium/red,
@@ -2016,10 +1996,8 @@
 	base_icon_state = "stairs-old";
 	icon_state = "stairs-l";
 	anchored = 1;
-	pixel_y = 0;
 	name = "staircase";
 	desc = "A small step for the humanity, and so is for you.";
-	dir = 2;
 	color = "#474747"
 	},
 /obj/structure/railing{
@@ -2047,8 +2025,7 @@
 	pixel_y = 6
 	},
 /obj/item/lipstick/syndie{
-	pixel_x = -20;
-	pixel_y = 0
+	pixel_x = -20
 	},
 /obj/item/tattoo_kit{
 	pixel_y = 2;
@@ -2093,7 +2070,6 @@
 	icon = 'icons/obj/machines/wallmounts.dmi';
 	base_icon_state = "tile_half";
 	dir = 8;
-	pixel_x = 0;
 	name = "old radio";
 	anchored = 1
 	},
@@ -2230,7 +2206,6 @@
 	},
 /obj/structure/rack/wooden,
 /obj/item/construction/plumbing{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /obj/machinery/light_switch/directional/south,
@@ -2353,7 +2328,6 @@
 /area/ruin/space/has_grav/bubbers/persistance/service/hydro)
 "eP" = (
 /obj/structure/marker_beacon/burgundy{
-	pixel_x = 0;
 	pixel_y = 16
 	},
 /obj/structure/chair/sofa/corp/right{
@@ -2590,7 +2564,6 @@
 "fx" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/clothing/suit/apron/chef{
-	pixel_x = 0;
 	pixel_y = 8
 	},
 /obj/item/clothing/head/utility/chefhat{
@@ -2677,8 +2650,7 @@
 	frequency = 1241;
 	canhear_range = 1;
 	desc = "Surely no one is listening in!";
-	pixel_x = 0;
-	pixel_y = 0
+	pixel_x = 0
 	},
 /obj/machinery/button/polarizer{
 	pixel_x = -5;
@@ -2712,16 +2684,13 @@
 	pixel_y = 18
 	},
 /obj/item/stamp/chameleon{
-	pixel_x = 0;
 	pixel_y = 7
 	},
 /obj/item/stamp/persistence{
-	pixel_x = 5;
-	pixel_y = 0
+	pixel_x = 5
 	},
 /obj/item/stamp/denied{
-	pixel_x = -5;
-	pixel_y = 0
+	pixel_x = -5
 	},
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark/textured_large,
@@ -2809,7 +2778,6 @@
 /area/ruin/space/has_grav/bubbers/persistance/service/sauna)
 "fS" = (
 /obj/structure/chair/comfy/shuttle{
-	pixel_y = 0;
 	dir = 4;
 	name = "adjustable office seat";
 	desc = "A comfortable, secure seat. It has a more sturdy looking buckling system, for smoother working sessions."
@@ -2887,7 +2855,6 @@
 	base_icon_state = "stairs-old";
 	icon_state = "stairs-l";
 	anchored = 1;
-	pixel_y = 0;
 	name = "staircase";
 	desc = "A small step for the humanity, and so is for you.";
 	dir = 1;
@@ -2913,11 +2880,9 @@
 	},
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/serviette/colonial{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/sign/flag/syndicate{
-	pixel_x = 0;
 	pixel_y = 11
 	},
 /turf/open/floor/carpet/purple,
@@ -3066,10 +3031,8 @@
 	base_icon_state = "stairs-old";
 	icon_state = "stairs-m";
 	anchored = 1;
-	pixel_y = 0;
 	name = "staircase";
 	desc = "A small step for the humanity, and so is for you.";
-	dir = 2;
 	color = "#474747"
 	},
 /turf/open/floor/iron/stairs/medium,
@@ -3249,7 +3212,6 @@
 	pixel_y = 3
 	},
 /obj/item/restraints/handcuffs/cable/zipties{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /turf/open/floor/iron/dark/smooth_corner{
@@ -3357,7 +3319,6 @@
 	},
 /obj/structure/flora/rock/pile/jungle/style_2,
 /obj/structure/flora/bush/large/style_3{
-	pixel_x = -16;
 	pixel_y = 2
 	},
 /turf/open/floor/grass,
@@ -3467,7 +3428,6 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
@@ -3551,8 +3511,7 @@
 /obj/structure/chair/pew/left,
 /obj/effect/turf_decal/tile/neutral/half{
 	alpha = 255;
-	color = "#5d341f";
-	dir = 2
+	color = "#5d341f"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/iron/dark/smooth_large,
@@ -3724,8 +3683,7 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/dark/filled/corner{
-	alpha = 160;
-	dir = 2
+	alpha = 160
 	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 9
@@ -3758,8 +3716,7 @@
 	dir = 8
 	},
 /obj/structure/marker_beacon/cerulean{
-	pixel_x = -7;
-	pixel_y = 0
+	pixel_x = -7
 	},
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 6
@@ -3780,8 +3737,7 @@
 	},
 /obj/effect/turf_decal/weather/snow,
 /turf/open/floor/iron/shuttle/evac{
-	icon_state = "5,13";
-	dir = 2
+	icon_state = "5,13"
 	},
 /area/icemoon/underground/explored)
 "hX" = (
@@ -3790,7 +3746,6 @@
 /area/ruin/space/has_grav/bubbers/persistance/med)
 "hY" = (
 /obj/structure/flora/bush/large/style_3{
-	pixel_x = -16;
 	pixel_y = -7
 	},
 /turf/open/floor/grass,
@@ -3822,8 +3777,7 @@
 	desc = "STAY WINNING"
 	},
 /obj/item/toy/figure/syndie{
-	pixel_x = -5;
-	pixel_y = 0
+	pixel_x = -5
 	},
 /obj/item/toy/figure/syndie{
 	pixel_x = 4;
@@ -3854,8 +3808,7 @@
 /obj/structure/hedge,
 /obj/machinery/door/poddoor/shutters/preopen{
 	name = "Bar Shutters";
-	id = "dauntbar_s";
-	dir = 2
+	id = "dauntbar_s"
 	},
 /obj/structure/aquarium/donkfish,
 /obj/structure/window/reinforced/spawner/directional/north{
@@ -4185,7 +4138,6 @@
 	base_icon_state = "stairs-old";
 	icon_state = "stairs-old";
 	anchored = 1;
-	pixel_y = 0;
 	name = "staircase";
 	desc = "A small step for the humanity, and so is for you.";
 	dir = 1;
@@ -4214,8 +4166,7 @@
 	name = "Admiral Quarters Bolt Switch";
 	id = "syndishipmanager";
 	req_access = list("syndicate");
-	normaldoorcontrol = 1;
-	pixel_x = -24
+	normaldoorcontrol = 1
 	},
 /turf/open/floor/wood/tile,
 /area/ruin/space/has_grav/bubbers/persistance/command/admiral)
@@ -4358,7 +4309,6 @@
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/neutral/line{
@@ -4404,11 +4354,9 @@
 	dir = 8
 	},
 /obj/structure/flora/bush/sparsegrass/style_2{
-	pixel_x = 0;
 	pixel_y = 11
 	},
 /obj/structure/flora/bush/flowers_yw/style_random{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /turf/open/floor/grass,
@@ -4574,7 +4522,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/warning{
-	dir = 2;
 	alpha = 200;
 	color = "#1dc251"
 	},
@@ -4647,7 +4594,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/siding/wideplating_new/dark/end,
 /obj/effect/turf_decal/siding/dark{
-	dir = 2;
 	icon_state = "siding_plain_end"
 	},
 /turf/open/floor/mineral/plastitanium/red,
@@ -4692,8 +4638,7 @@
 /obj/item/reagent_containers/cup/glass/trophy/gold_cup{
 	pixel_y = 11;
 	desc = "To the loss of a beloved sister ship. May you rest peacefully beneath the ice.";
-	name = "DS-2 Memorial Trophy";
-	pixel_x = 0
+	name = "DS-2 Memorial Trophy"
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/mineral/plastitanium/red,
@@ -4826,7 +4771,6 @@
 	},
 /obj/machinery/plumbing/input,
 /obj/machinery/light/small/directional/east{
-	pixel_x = 0;
 	pixel_y = -16
 	},
 /turf/open/floor/iron/shuttle/exploration/corner{
@@ -5000,8 +4944,7 @@
 	pixel_y = -1
 	},
 /obj/structure/sign/painting/library{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/mineral/plasma,
 /area/ruin/space/has_grav/bubbers/persistance/service/dorms/janitor)
@@ -5250,7 +5193,6 @@
 	pixel_y = 4
 	},
 /obj/item/paper{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/folder/red{
@@ -5266,7 +5208,6 @@
 	pixel_y = 18
 	},
 /obj/structure/marker_beacon/burgundy{
-	pixel_x = 0;
 	pixel_y = 16
 	},
 /obj/effect/turf_decal/siding/wideplating_new/corner{
@@ -5374,7 +5315,6 @@
 	pixel_y = 4
 	},
 /obj/item/storage/bag/xeno{
-	pixel_x = 0;
 	pixel_y = -6
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -5473,8 +5413,7 @@
 /obj/structure/aquarium/donkfish,
 /obj/machinery/door/poddoor/shutters/preopen{
 	name = "Bar Shutters";
-	id = "dauntbar_s";
-	dir = 2
+	id = "dauntbar_s"
 	},
 /turf/open/floor/plating/reinforced,
 /area/ruin/space/has_grav/bubbers/persistance/service/diner)
@@ -5845,7 +5784,6 @@
 	icon = 'modular_skyrat/modules/wargame_projectors/icons/projectors_and_holograms.dmi';
 	base_icon_state = "projector";
 	dir = 8;
-	pixel_x = 0;
 	anchored = 1;
 	name = "hologram projector"
 	},
@@ -6097,7 +6035,6 @@
 /obj/machinery/light_switch/directional/south,
 /obj/structure/table/wood/fancy,
 /obj/item/sign/flag/syndicate{
-	pixel_x = 0;
 	pixel_y = 15
 	},
 /obj/item/pen/fourcolor{
@@ -6130,10 +6067,8 @@
 	base_icon_state = "stairs-old";
 	icon_state = "stairs-r";
 	anchored = 1;
-	pixel_y = 0;
 	name = "staircase";
 	desc = "A small step for the humanity, and so is for you.";
-	dir = 2;
 	color = "#474747"
 	},
 /obj/structure/railing{
@@ -6209,19 +6144,15 @@
 	},
 /obj/effect/turf_decal/siding/dark/end,
 /obj/structure/bed/pillow_large{
-	pixel_x = 0;
 	pixel_y = 21
 	},
 /obj/structure/chair/pillow_small{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/fancy_pillow{
-	pixel_x = 6;
-	pixel_y = 0
+	pixel_x = 6
 	},
 /obj/structure/marker_beacon/purple{
-	pixel_x = 0;
 	pixel_y = 16
 	},
 /turf/open/floor/mineral/plasma,
@@ -6586,7 +6517,6 @@
 	pixel_y = 7
 	},
 /obj/structure/flora/bush/sparsegrass{
-	pixel_x = 0;
 	pixel_y = 7
 	},
 /turf/open/floor/grass,
@@ -6818,8 +6748,7 @@
 	pixel_y = -3
 	},
 /obj/item/ammo_box/magazine/sniper_rounds/marksman{
-	pixel_x = 1;
-	pixel_y = 0
+	pixel_x = 1
 	},
 /obj/item/ammo_box/magazine/sniper_rounds/marksman{
 	pixel_x = -2;
@@ -6843,15 +6772,12 @@
 	icon_state = "siding_plain_end"
 	},
 /obj/structure/closet/generic/wall{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/item/bodybag/environmental/prisoner/syndicate{
-	pixel_y = 0;
 	pixel_x = -8
 	},
 /obj/item/bodybag/environmental/prisoner/syndicate{
-	pixel_y = 0;
 	pixel_x = 8
 	},
 /obj/item/bodybag/environmental/prisoner/syndicate{
@@ -7216,7 +7142,6 @@
 "oI" = (
 /obj/structure/decorative{
 	icon_state = "siding_plain";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	dir = 4;
 	color = "#474747";
@@ -7618,7 +7543,6 @@
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/neutral/line{
@@ -7645,7 +7569,6 @@
 "pB" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/integrated_circuit/loaded/hello_world{
-	pixel_x = 0;
 	pixel_y = 7
 	},
 /obj/item/integrated_circuit/loaded/speech_relay{
@@ -7799,14 +7722,12 @@
 /area/ruin/space/has_grav/bubbers/persistance/sec/prison/rec)
 "pP" = (
 /obj/machinery/dryer{
-	pixel_y = -26;
-	pixel_x = 0
+	pixel_y = -26
 	},
 /obj/effect/turf_decal/siding/white{
 	dir = 10
 	},
 /obj/structure/toilet{
-	pixel_y = 0;
 	dir = 4
 	},
 /turf/open/floor/iron/freezer,
@@ -7923,8 +7844,7 @@
 /area/ruin/space/has_grav/bubbers/persistance/cargo)
 "pZ" = (
 /obj/structure/sign/painting/library{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/structure/chair/comfy/black,
 /turf/open/floor/glass/reinforced/plasma,
@@ -7973,7 +7893,7 @@
 "qg" = (
 /obj/machinery/gibber,
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/iron/kitchen_coldroom/white/smooth_large,
 /area/ruin/space/has_grav/bubbers/persistance/service/freezer)
 "qh" = (
 /obj/structure/cable,
@@ -8027,8 +7947,7 @@
 	},
 /obj/effect/turf_decal/trimline/purple/corner{
 	color = "#2cbf9d";
-	alpha = 200;
-	dir = 2
+	alpha = 200
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -8044,17 +7963,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark/filled/line{
-	alpha = 160;
-	dir = 2
+	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/purple/line{
 	color = "#2cbf9d";
-	alpha = 200;
-	dir = 2
+	alpha = 200
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8213,8 +8129,7 @@
 	pixel_y = 2
 	},
 /obj/item/lighter/skull{
-	pixel_x = 7;
-	pixel_y = 0
+	pixel_x = 7
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/ruin/space/has_grav/bubbers/persistance/service/lounge)
@@ -8268,7 +8183,6 @@
 /obj/effect/spawner/random/entertainment/plushie,
 /obj/effect/turf_decal/siding/wideplating_new/dark/end,
 /obj/effect/turf_decal/siding/dark{
-	dir = 2;
 	icon_state = "siding_plain_end"
 	},
 /turf/open/floor/mineral/plastitanium/red,
@@ -8504,10 +8418,8 @@
 	base_icon_state = "stairs-old";
 	icon_state = "stairs-r";
 	anchored = 1;
-	pixel_y = 0;
 	name = "staircase";
 	desc = "A small step for the humanity, and so is for you.";
-	dir = 2;
 	color = "#474747"
 	},
 /obj/structure/railing{
@@ -8602,11 +8514,9 @@
 	dir = 4
 	},
 /obj/structure/closet/generic/wall{
-	pixel_y = -30;
-	pixel_x = 0
+	pixel_y = -30
 	},
 /obj/machinery/dryer{
-	pixel_y = 0;
 	pixel_x = -28
 	},
 /turf/open/floor/wood/tile,
@@ -8728,8 +8638,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/dark/filled/corner{
-	alpha = 160;
-	dir = 2
+	alpha = 160
 	},
 /obj/effect/turf_decal/siding/dark/corner,
 /obj/effect/turf_decal/siding/dark/corner{
@@ -8851,7 +8760,6 @@
 	pixel_y = 3
 	},
 /obj/item/storage/box/hecu_rations{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/item/storage/box/hecu_rations{
@@ -8882,7 +8790,6 @@
 "rY" = (
 /obj/structure/decorative{
 	icon_state = "siding_plain";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	dir = 4;
 	color = "#474747";
@@ -9016,7 +8923,6 @@
 /obj/effect/turf_decal/siding/dark,
 /obj/structure/railing{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -10
 	},
 /obj/structure/fireplace,
@@ -9025,7 +8931,6 @@
 	alpha = 160
 	},
 /obj/structure/marker_beacon/bronze{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /turf/open/floor/iron/dark/herringbone,
@@ -9069,7 +8974,6 @@
 	pixel_y = 5
 	},
 /obj/item/toy/plush/lizard_plushie/green{
-	pixel_x = 0;
 	pixel_y = 21;
 	name = "Cells-The-Cook"
 	},
@@ -9118,11 +9022,9 @@
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/siding/dark{
-	dir = 2;
 	icon_state = "siding_plain_end"
 	},
 /obj/structure/marker_beacon/purple,
@@ -9195,7 +9097,6 @@
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/machinery/vending/clothing{
 	density = 0;
-	pixel_y = 0;
 	all_products_free = 1
 	},
 /turf/open/floor/iron/dark/textured_large,
@@ -9244,8 +9145,7 @@
 "sF" = (
 /obj/structure/flora/bush/jungle/b/style_2,
 /obj/structure/marker_beacon/lime{
-	pixel_x = -16;
-	pixel_y = 0
+	pixel_x = -16
 	},
 /turf/open/misc/grass/jungle/station,
 /area/ruin/space/has_grav/bubbers/persistance/med)
@@ -9256,10 +9156,7 @@
 /obj/structure/emergency_shield/cult/weak{
 	name = "Energy Shield"
 	},
-/obj/machinery/porta_turret/syndicate{
-	dir = 2;
-	pixel_y = 0
-	},
+/obj/machinery/porta_turret/syndicate,
 /obj/machinery/camera/autoname/directional/north{
 	name = "Persistence Exterior North";
 	network = list("persistence_ext")
@@ -9470,8 +9367,7 @@
 /obj/structure/chair/pew/left,
 /obj/effect/turf_decal/tile/neutral/half{
 	alpha = 255;
-	color = "#5d341f";
-	dir = 2
+	color = "#5d341f"
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/bubbers/persistance/service/sauna)
@@ -9487,7 +9383,6 @@
 	dir = 1
 	},
 /obj/structure/marker_beacon/burgundy{
-	pixel_x = 0;
 	pixel_y = -16
 	},
 /obj/item/plate{
@@ -9915,8 +9810,7 @@
 	},
 /obj/effect/turf_decal/trimline/purple/corner{
 	color = "#2cbf9d";
-	alpha = 200;
-	dir = 2
+	alpha = 200
 	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
@@ -9944,7 +9838,6 @@
 	},
 /obj/structure/decorative{
 	icon_state = "pwindow";
-	pixel_y = 0;
 	icon = 'icons/obj/mining_zones/survival_pod.dmi';
 	dir = 6;
 	anchored = 1;
@@ -9952,8 +9845,7 @@
 	},
 /obj/structure/marker_beacon/fuchsia,
 /obj/item/ai_module/reset/purge{
-	pixel_y = 8;
-	pixel_x = 0
+	pixel_y = 8
 	},
 /obj/item/ai_module/core/full/persistence{
 	pixel_y = 4;
@@ -10063,8 +9955,7 @@
 	dir = 1
 	},
 /obj/structure/marker_beacon/burgundy{
-	pixel_x = 16;
-	pixel_y = 0
+	pixel_x = 16
 	},
 /turf/open/floor/plating/elevatorshaft,
 /area/ruin/space/has_grav/bubbers/persistance/command/bridge)
@@ -10188,9 +10079,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/structure/railing/wooden_fencing/gate{
-	dir = 2
-	},
+/obj/structure/railing/wooden_fencing/gate,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/bubbers/persistance/service/hydro)
 "uE" = (
@@ -10208,7 +10097,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/duct,
 /obj/machinery/vending/boozeomat{
-	pixel_y = 0;
 	all_products_free = 1
 	},
 /obj/item/reagent_containers/cup/glass/bottle/small{
@@ -10220,7 +10108,6 @@
 	pixel_y = 16
 	},
 /obj/item/reagent_containers/cup/glass{
-	pixel_x = 0;
 	pixel_y = 18
 	},
 /turf/open/floor/wood/tile,
@@ -10351,8 +10238,7 @@
 	},
 /obj/structure/stone_tile/surrounding_tile/cracked{
 	dir = 8;
-	pixel_x = -3;
-	pixel_y = 0
+	pixel_x = -3
 	},
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/grass,
@@ -10655,7 +10541,6 @@
 /obj/structure/window/reinforced/plasma/spawner/directional/north,
 /obj/machinery/byteforge,
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "Syndibitrunningconveyor"
 	},
 /turf/open/floor/mineral/plastitanium/red,
@@ -10773,8 +10658,7 @@
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/digital_clock/directional/north,
 /obj/item/canvas/drawingtablet{
-	pixel_x = 2;
-	pixel_y = 0
+	pixel_x = 2
 	},
 /turf/open/floor/iron/shuttle/exploration/blanktile,
 /area/ruin/space/has_grav/bubbers/persistance/service/dorms/science)
@@ -10784,8 +10668,7 @@
 /obj/structure/marker_beacon/bronze,
 /obj/effect/turf_decal/tile/neutral/half{
 	alpha = 255;
-	color = "#5d341f";
-	dir = 2
+	color = "#5d341f"
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/bubbers/persistance/service/sauna)
@@ -10822,10 +10705,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bubbers/persistance/service)
 "vU" = (
-/obj/machinery/vending/donksofttoyvendor{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/machinery/vending/donksofttoyvendor,
 /turf/open/floor/carpet/black,
 /area/ruin/space/has_grav/bubbers/persistance/service/lounge)
 "vV" = (
@@ -10848,7 +10728,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/machinery/defibrillator_mount/charging{
 	pixel_y = 30;
-	pixel_x = 0;
 	icon_state = "defib"
 	},
 /obj/structure/marker_beacon/cerulean,
@@ -10915,32 +10794,25 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/decorative{
 	icon_state = "warningline";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
-	dir = 2;
 	anchored = 1;
 	name = "decorative panel"
 	},
 /obj/structure/decorative{
 	icon_state = "warningline_white";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
-	dir = 2;
 	anchored = 1;
 	name = "decorative panel"
 	},
 /obj/structure/decorative{
 	icon_state = "siding_wideplating_new_corner";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
-	dir = 2;
 	anchored = 1;
 	name = "decorative panel";
 	color = "#949494"
 	},
 /obj/structure/decorative{
 	icon_state = "siding_plain";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	dir = 4;
 	color = "#474747";
@@ -11060,16 +10932,13 @@
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/item/storage/backpack/duffelbag/syndie/surgery{
-	pixel_x = 0;
 	pixel_y = 12
 	},
 /obj/item/storage/backpack/duffelbag/synth_treatment_kit/trauma/advanced{
-	pixel_x = 0;
 	pixel_y = 1
 	},
 /obj/item/clothing/gloves/latex/nitrile{
-	pixel_x = 21;
-	pixel_y = 0
+	pixel_x = 21
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/bubbers/persistance/med/treatment)
@@ -11097,7 +10966,6 @@
 	pixel_y = 13
 	},
 /obj/item/stock_parts/power_store/cell/high{
-	pixel_x = 0;
 	pixel_y = 9
 	},
 /obj/item/stock_parts/power_store/cell/high{
@@ -11123,11 +10991,9 @@
 	},
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/structure/sign/painting/library{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/item/kirbyplants/organic/plant21{
-	pixel_x = 0;
 	pixel_y = 11
 	},
 /obj/item/clothing/head/costume/maidheadband/tactical_maid{
@@ -11570,7 +11436,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/vending/wardrobe/syndie_wardrobe{
-	pixel_y = 0;
 	all_products_free = 1
 	},
 /obj/effect/turf_decal/bot_red,
@@ -12252,12 +12117,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/storage/fancy/donut_box{
-	pixel_x = 0;
 	pixel_y = 7
 	},
 /obj/item/toy/figure/hos{
 	pixel_x = -6;
-	pixel_y = 0;
 	name = "\improper Badass Head of Security action figure";
 	desc = "If God wanted you to live he wouldn't have created me!"
 	},
@@ -12266,8 +12129,7 @@
 	},
 /obj/machinery/light/directional/east,
 /obj/item/toy/toy_xeno{
-	pixel_x = 7;
-	pixel_y = 0
+	pixel_x = 7
 	},
 /turf/open/floor/carpet/red,
 /area/ruin/space/has_grav/bubbers/persistance/service/dorms/maa)
@@ -12304,8 +12166,7 @@
 "yR" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/storage/toolbox/syndicate{
-	pixel_y = 2;
-	pixel_x = 0
+	pixel_y = 2
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bubbers/persistance/sci/rnd)
@@ -12316,11 +12177,9 @@
 	pixel_y = 36
 	},
 /obj/item/plate{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/plate{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /turf/open/floor/iron/dark/textured_large,
@@ -12360,7 +12219,6 @@
 	dir = 1
 	},
 /obj/structure/flora/bush/sparsegrass/style_3{
-	pixel_x = 0;
 	pixel_y = -11
 	},
 /turf/open/floor/grass,
@@ -12469,7 +12327,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/item/storage/briefcase/secure{
-	pixel_x = 0;
 	pixel_y = 17
 	},
 /turf/open/floor/mineral/plastitanium,
@@ -12631,7 +12488,6 @@
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
@@ -12693,7 +12549,6 @@
 /area/ruin/space/has_grav/bubbers/persistance/service/gym)
 "zx" = (
 /obj/machinery/light/floor{
-	pixel_x = 0;
 	pixel_y = 16;
 	brightness = 7.5
 	},
@@ -12800,8 +12655,7 @@
 "zD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/sign/painting/library{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/turf_decal/siding/wideplating_new/dark/end{
 	dir = 4
@@ -13194,7 +13048,6 @@
 	pixel_y = 22
 	},
 /obj/item/reagent_containers/cup/glass/bottle/small{
-	pixel_x = 0;
 	pixel_y = 19
 	},
 /obj/item/toy/figure/prisoner{
@@ -13205,8 +13058,7 @@
 /area/ruin/space/has_grav/bubbers/persistance/sec/prison)
 "Az" = (
 /obj/machinery/porta_turret/syndicate{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/camera/autoname/directional/west{
 	name = "Persistence Exterior West";
@@ -13337,14 +13189,10 @@
 	pixel_y = -15
 	},
 /obj/item/gun/energy/floragun{
-	pixel_x = 0;
 	pixel_y = 11
 	},
 /obj/structure/marker_beacon/teal,
-/obj/item/plant_analyzer{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/plant_analyzer,
 /turf/open/floor/iron/dark/herringbone,
 /area/ruin/space/has_grav/bubbers/persistance/service/hydro)
 "AU" = (
@@ -13470,7 +13318,6 @@
 "Bh" = (
 /obj/structure/decorative{
 	icon_state = "siding_plain";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	dir = 4;
 	color = "#474747";
@@ -13726,12 +13573,10 @@
 "BG" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/effect/spawner/random/food_or_drink/donkpockets{
-	pixel_x = 0;
 	pixel_y = 7
 	},
 /obj/structure/marker_beacon/bronze{
-	pixel_x = 16;
-	pixel_y = 0
+	pixel_x = 16
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bubbers/persistance/service/kitchen)
@@ -14277,11 +14122,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark/filled/line{
-	alpha = 160;
-	dir = 2
+	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
@@ -14290,8 +14133,7 @@
 	},
 /obj/effect/turf_decal/trimline/purple/line{
 	color = "#2cbf9d";
-	alpha = 200;
-	dir = 2
+	alpha = 200
 	},
 /obj/effect/turf_decal/trimline/purple/line{
 	color = "#2cbf9d";
@@ -14369,8 +14211,7 @@
 /obj/structure/marker_beacon/bronze,
 /obj/effect/turf_decal/tile/neutral/half{
 	alpha = 255;
-	color = "#5d341f";
-	dir = 2
+	color = "#5d341f"
 	},
 /obj/item/thermometer{
 	pixel_x = -6;
@@ -14416,7 +14257,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/decorative{
 	icon_state = "warningline";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	dir = 1;
 	anchored = 1;
@@ -14424,7 +14264,6 @@
 	},
 /obj/structure/decorative{
 	icon_state = "warningline_white";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	dir = 1;
 	anchored = 1;
@@ -14432,7 +14271,6 @@
 	},
 /obj/structure/decorative{
 	icon_state = "siding_wideplating_new_corner";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	dir = 4;
 	anchored = 1;
@@ -14441,7 +14279,6 @@
 	},
 /obj/structure/decorative{
 	icon_state = "siding_plain";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	dir = 4;
 	color = "#474747";
@@ -14541,7 +14378,6 @@
 "Dh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/structure/closet/generic/wall{
-	pixel_y = 0;
 	pixel_x = 30
 	},
 /obj/item/storage/wallet/random,
@@ -14649,8 +14485,7 @@
 "Dt" = (
 /obj/structure/railing/corner/end{
 	dir = 4;
-	pixel_y = -4;
-	pixel_x = 0
+	pixel_y = -4
 	},
 /obj/structure/railing/corner{
 	dir = 1;
@@ -14658,7 +14493,6 @@
 	pixel_y = -32
 	},
 /obj/structure/flora/bush/large{
-	pixel_x = -16;
 	pixel_y = -3
 	},
 /obj/structure/flora/bush/jungle/a{
@@ -14878,7 +14712,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
@@ -14937,17 +14770,14 @@
 /area/ruin/space/has_grav/bubbers/persistance/sec/brigentrance)
 "DT" = (
 /obj/effect/turf_decal/trimline/dark/filled/line{
-	alpha = 160;
-	dir = 2
+	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/purple/line{
 	color = "#2cbf9d";
-	alpha = 200;
-	dir = 2
+	alpha = 200
 	},
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/white/smooth_edge,
@@ -15002,8 +14832,7 @@
 	},
 /obj/structure/flora/rock/pile/jungle/style_3,
 /obj/structure/flora/bush/jungle/c/style_2{
-	pixel_x = -16;
-	pixel_y = 0
+	pixel_x = -16
 	},
 /obj/structure/flora/bush/large/style_2{
 	pixel_x = -15;
@@ -15083,7 +14912,6 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/item/toy/nuke{
-	pixel_x = 0;
 	pixel_y = 13
 	},
 /obj/structure/marker_beacon/burgundy,
@@ -15094,12 +14922,10 @@
 /obj/machinery/airalarm/directional/south,
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/filingcabinet{
-	pixel_x = -9;
-	pixel_y = 0
+	pixel_x = -9
 	},
 /obj/structure/filingcabinet/chestdrawer{
-	pixel_x = 6;
-	pixel_y = 0
+	pixel_x = 6
 	},
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/item/toy/figure/syndie{
@@ -15202,11 +15028,9 @@
 "Eq" = (
 /obj/effect/turf_decal/tile/neutral/half{
 	alpha = 255;
-	color = "#5d341f";
-	dir = 2
+	color = "#5d341f"
 	},
 /obj/structure/closet/generic/wall{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -15239,7 +15063,6 @@
 	dir = 1
 	},
 /obj/structure/flora/bush/sparsegrass{
-	pixel_x = 0;
 	pixel_y = -9
 	},
 /turf/open/floor/grass,
@@ -15491,8 +15314,7 @@
 	dir = 5
 	},
 /obj/structure/marker_beacon/cerulean{
-	pixel_x = -7;
-	pixel_y = 0
+	pixel_x = -7
 	},
 /turf/open/floor/iron/diagonal,
 /area/ruin/space/has_grav/bubbers/persistance/service/sauna)
@@ -15639,7 +15461,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/warning{
-	dir = 2;
 	alpha = 200;
 	color = "#1dc251"
 	},
@@ -15694,8 +15515,7 @@
 	dir = 1
 	},
 /obj/structure/sign/painting/library{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/light/directional/east,
 /turf/open/floor/wood/large,
@@ -15703,8 +15523,7 @@
 "Fm" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/mod/construction/broken_core{
-	pixel_x = -8;
-	pixel_y = 0
+	pixel_x = -8
 	},
 /obj/machinery/door/window/survival_pod/left/directional/east{
 	req_access = list("syndicate");
@@ -16215,9 +16034,7 @@
 "Gs" = (
 /obj/structure/decorative{
 	icon_state = "siding_plain_corner";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
-	dir = 2;
 	color = "#474747";
 	anchored = 1;
 	name = "decorative panel"
@@ -16297,7 +16114,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/decorative{
 	icon_state = "siding_plain_corner";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	dir = 4;
 	color = "#474747";
@@ -16453,8 +16269,7 @@
 "GV" = (
 /obj/machinery/newscaster/directional/south,
 /obj/structure/sign/painting/library{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -16485,8 +16300,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/dark/filled/corner{
-	alpha = 160;
-	dir = 2
+	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/warning{
 	alpha = 160;
@@ -16623,7 +16437,6 @@
 /area/ruin/space/has_grav/bubbers/persistance/sci/ordnance)
 "Hq" = (
 /obj/structure/flora/bush/large{
-	pixel_x = -16;
 	pixel_y = -3
 	},
 /obj/structure/flora/bush/jungle/a{
@@ -16637,7 +16450,6 @@
 /obj/structure/railing/corner/end{
 	dir = 4;
 	color = "#683d21";
-	pixel_x = 0;
 	pixel_y = -4
 	},
 /obj/structure/railing/corner{
@@ -16712,7 +16524,6 @@
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/neutral/line{
@@ -16729,7 +16540,6 @@
 "Hx" = (
 /obj/structure/decorative{
 	icon_state = "siding_plain";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	dir = 4;
 	color = "#474747";
@@ -16764,13 +16574,11 @@
 	pixel_y = 8
 	},
 /obj/item/crowbar/red{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/structure/sign/poster/contraband/revolver/directional/east,
 /obj/item/toy/figure/syndie{
 	pixel_x = 3;
-	pixel_y = 0;
 	desc = "SIR YES SIR OORAH"
 	},
 /turf/open/floor/iron/dark/textured_large,
@@ -16806,7 +16614,6 @@
 	},
 /obj/structure/flora/rock/pile/jungle/style_3,
 /obj/structure/flora/bush/large/style_3{
-	pixel_x = -16;
 	pixel_y = -3
 	},
 /turf/open/floor/grass,
@@ -16891,12 +16698,10 @@
 /area/ruin/space/has_grav/bubbers/persistance/sec/prison)
 "HQ" = (
 /obj/effect/turf_decal/siding/dark{
-	dir = 2;
 	icon_state = "siding_plain_end"
 	},
 /obj/structure/chair/pillow_small,
 /obj/structure/bed/pillow_large{
-	pixel_x = 0;
 	pixel_y = 20
 	},
 /obj/item/fancy_pillow{
@@ -16904,16 +16709,13 @@
 	pixel_y = 4
 	},
 /obj/structure/sign/painting/library{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/item/toy/plush/skyrat/jecca{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/machinery/newscaster/directional/south,
 /obj/structure/marker_beacon/purple{
-	pixel_x = 0;
 	pixel_y = 16
 	},
 /turf/open/floor/mineral/plasma,
@@ -17077,10 +16879,7 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced/plastitaniumglass,
-/obj/item/sequence_scanner{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/sequence_scanner,
 /obj/item/infuser_book{
 	pixel_x = -7;
 	pixel_y = 1
@@ -17134,7 +16933,6 @@
 	dir = 1
 	},
 /obj/structure/closet/shuttle/engivent{
-	pixel_x = 0;
 	pixel_y = -34
 	},
 /turf/open/floor/mineral/plastitanium,
@@ -17485,7 +17283,6 @@
 	},
 /obj/structure/weightmachine,
 /obj/effect/turf_decal/siding{
-	dir = 2;
 	icon_state = "siding_plain_end"
 	},
 /turf/open/floor/iron/white/small,
@@ -17802,7 +17599,6 @@
 	alpha = 200
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/neutral/warning{
@@ -17849,7 +17645,6 @@
 /area/ruin/space/has_grav/bubbers/persistance/service/freezer)
 "JN" = (
 /obj/effect/turf_decal/siding/dark{
-	dir = 2;
 	icon_state = "siding_plain_end"
 	},
 /obj/structure/reagent_dispensers/water_cooler,
@@ -17870,9 +17665,7 @@
 	pixel_x = -30
 	},
 /obj/machinery/vending/games{
-	pixel_x = 0;
-	all_products_free = 1;
-	pixel_y = 0
+	all_products_free = 1
 	},
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 8
@@ -17891,7 +17684,6 @@
 	dir = 9
 	},
 /obj/structure/window/reinforced/survival_pod/spawner/directional/north{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/structure/sink/directional/east,
@@ -18032,7 +17824,6 @@
 "Ko" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/plantgenes{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /turf/open/floor/iron/dark/herringbone,
@@ -18327,17 +18118,14 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark/filled/line{
-	alpha = 160;
-	dir = 2
+	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/purple/line{
 	color = "#2cbf9d";
-	alpha = 200;
-	dir = 2
+	alpha = 200
 	},
 /obj/effect/turf_decal/trimline/purple/corner{
 	color = "#2cbf9d";
@@ -18369,7 +18157,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/structure/chair/comfy/shuttle{
-	pixel_y = 0;
 	dir = 8;
 	name = "adjustable office seat";
 	desc = "A comfortable, secure seat. It has a more sturdy looking buckling system, for smoother working sessions."
@@ -18411,7 +18198,6 @@
 	alpha = 200
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/neutral/corner{
@@ -18461,7 +18247,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/effect/turf_decal/siding/dark,
 /obj/machinery/light/floor{
-	pixel_x = 0;
 	pixel_y = 16
 	},
 /turf/open/floor/carpet/black,
@@ -18594,11 +18379,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark/filled/line{
-	alpha = 160;
-	dir = 2
+	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
@@ -18607,8 +18390,7 @@
 	},
 /obj/effect/turf_decal/trimline/purple/line{
 	color = "#2cbf9d";
-	alpha = 200;
-	dir = 2
+	alpha = 200
 	},
 /obj/effect/turf_decal/trimline/purple/line{
 	color = "#2cbf9d";
@@ -18790,7 +18572,6 @@
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/end{
@@ -18840,7 +18621,6 @@
 	pixel_y = 14
 	},
 /obj/item/sign/flag/syndicate{
-	pixel_x = 0;
 	pixel_y = 12
 	},
 /obj/effect/turf_decal/box/red,
@@ -18952,7 +18732,6 @@
 	},
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/food/cake/birthday/energy{
-	pixel_x = 0;
 	pixel_y = 5
 	},
 /turf/open/floor/iron/dark/textured_large,
@@ -19183,7 +18962,6 @@
 /area/ruin/space/has_grav/bubbers/persistance/engineering)
 "MM" = (
 /obj/effect/turf_decal/siding/dark{
-	dir = 2;
 	icon_state = "siding_plain_end"
 	},
 /obj/structure/disposalpipe/trunk{
@@ -19365,8 +19143,7 @@
 	pixel_y = 7
 	},
 /obj/item/shovel/spade{
-	pixel_x = -5;
-	pixel_y = 0
+	pixel_x = -5
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/ruin/space/has_grav/bubbers/persistance/service/hydro)
@@ -19588,8 +19365,7 @@
 	},
 /obj/structure/railing{
 	color = "#5d341f";
-	name = "wooden railing";
-	dir = 2
+	name = "wooden railing"
 	},
 /turf/open/misc/dirt/station,
 /area/ruin/space/has_grav/bubbers/persistance/service)
@@ -19617,7 +19393,6 @@
 "ND" = (
 /obj/structure/decorative{
 	icon_state = "siding_plain";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	dir = 4;
 	color = "#474747";
@@ -19669,7 +19444,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable,
 /obj/item/storage/backpack/satchel/flat{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -19695,7 +19469,6 @@
 	dir = 9
 	},
 /obj/item/bounty_cube{
-	pixel_x = 0;
 	pixel_y = 15;
 	bounty_value = 500;
 	name = "outdated bounty cube of 6400 cr that lost its value";
@@ -19766,8 +19539,7 @@
 	name = "mentats pills"
 	},
 /obj/item/storage/box/stockparts/deluxe{
-	pixel_x = 6;
-	pixel_y = 0
+	pixel_x = 6
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -19793,8 +19565,7 @@
 /obj/structure/chair/pew/right,
 /obj/effect/turf_decal/tile/neutral/half{
 	alpha = 255;
-	color = "#5d341f";
-	dir = 2
+	color = "#5d341f"
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/bubbers/persistance/service/sauna)
@@ -19804,7 +19575,6 @@
 	base_icon_state = "stairs-old";
 	icon_state = "stairs-r";
 	anchored = 1;
-	pixel_y = 0;
 	name = "staircase";
 	desc = "A small step for the humanity, and so is for you.";
 	dir = 1;
@@ -19896,13 +19666,11 @@
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/light/directional/east,
 /obj/item/clothing/mask/chameleon{
-	pixel_x = 0;
 	pixel_y = 7
 	},
 /obj/machinery/status_display/department_balance{
 	credits_account = "INT";
 	name = "dauntless budget display";
-	pixel_y = 0;
 	default_logo = "synd";
 	pixel_x = 32
 	},
@@ -20080,7 +19848,6 @@
 	},
 /obj/item/storage/toolbox/guncase/c20r,
 /obj/item/storage/toolbox/guncase/c20r{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /turf/open/floor/iron/dark/smooth_large,
@@ -20124,7 +19891,6 @@
 "OG" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/storage/test_tube_rack{
-	pixel_x = 0;
 	pixel_y = 23;
 	name = "utencils rack"
 	},
@@ -20146,11 +19912,9 @@
 	pixel_y = 3
 	},
 /obj/item/reagent_containers/condiment/peppermill{
-	pixel_y = 0;
 	pixel_x = -10
 	},
 /obj/item/reagent_containers/condiment/saltshaker{
-	pixel_y = 0;
 	pixel_x = -4
 	},
 /turf/open/floor/iron/dark/textured_large,
@@ -20243,7 +20007,6 @@
 "OP" = (
 /obj/effect/spawner/random/food_or_drink/pizzaparty{
 	loot = list(/obj/item/pizzabox/margherita = 2, /obj/item/pizzabox/meat = 2, /obj/item/pizzabox/mushroom = 2, /obj/item/pizzabox/pineapple = 2, /obj/item/pizzabox/vegetable = 2);
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/structure/table/wood/fancy/green,
@@ -20359,8 +20122,7 @@
 	},
 /obj/structure/table/greyscale,
 /obj/item/condom_pack{
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/towel_bin{
 	pixel_x = -5;
@@ -20512,11 +20274,9 @@
 /obj/effect/turf_decal/siding/dark/corner,
 /obj/item/storage/bag/bio,
 /obj/item/storage/box/beakers{
-	pixel_x = 0;
 	pixel_y = 1
 	},
 /obj/item/storage/box/syringes{
-	pixel_x = 0;
 	pixel_y = 8
 	},
 /turf/open/floor/iron/dark/smooth_corner,
@@ -20608,7 +20368,6 @@
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/purple/end{
@@ -20639,10 +20398,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/fans/tiny,
-/obj/machinery/smartfridge/extract/preloaded{
-	pixel_y = 0;
-	pixel_x = 0
-	},
+/obj/machinery/smartfridge/extract/preloaded,
 /obj/structure/marker_beacon/indigo,
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west{
 	pixel_x = -8
@@ -20672,7 +20428,6 @@
 	pixel_y = -13
 	},
 /obj/item/pen/fountain/captain{
-	pixel_x = 0;
 	pixel_y = -12
 	},
 /obj/item/pen/survival{
@@ -20876,8 +20631,7 @@
 /obj/effect/mapping_helpers/apc/full_charge,
 /obj/effect/mapping_helpers/apc/syndicate_access,
 /obj/machinery/light/small/red/dim/directional/south{
-	pixel_x = -16;
-	pixel_y = 0
+	pixel_x = -16
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -21184,8 +20938,7 @@
 	},
 /obj/structure/railing{
 	color = "#5d341f";
-	name = "wooden railing";
-	dir = 2
+	name = "wooden railing"
 	},
 /turf/open/misc/dirt/station,
 /area/ruin/space/has_grav/bubbers/persistance/service)
@@ -21261,11 +21014,9 @@
 	all_products_free = 1
 	},
 /obj/effect/turf_decal/trimline/dark/filled/end{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/siding/dark{
-	dir = 2;
 	icon_state = "siding_plain_end"
 	},
 /obj/effect/turf_decal/trimline/neutral/end{
@@ -21507,11 +21258,9 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/safe/abovetilefloor,
 /obj/item/aicard/syndie{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/item/sign/flag/syndicate{
-	pixel_x = 0;
 	pixel_y = -3
 	},
 /obj/item/mod/module/stealth/wraith,
@@ -21581,9 +21330,7 @@
 /obj/effect/turf_decal/siding{
 	dir = 9
 	},
-/obj/machinery/cryopod{
-	dir = 2
-	},
+/obj/machinery/cryopod,
 /obj/machinery/computer/cryopod/cybersun/directional/north,
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/bubbers/persistance/sec/prison)
@@ -21661,7 +21408,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
@@ -21699,7 +21445,6 @@
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
@@ -21719,7 +21464,6 @@
 /obj/machinery/door/window/survival_pod/left/directional/west{
 	req_access = list("syndicate");
 	name = "Slime Pacification Chamber";
-	pixel_y = 0;
 	pixel_x = -8
 	},
 /turf/open/floor/iron/white/smooth_large,
@@ -21890,8 +21634,7 @@
 	name = "two-way prisoner intercom";
 	freerange = 1;
 	freqlock = 1;
-	frequency = 1245;
-	pixel_y = 0
+	frequency = 1245
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bubbers/persistance/service/dorms/brig)
@@ -22165,7 +21908,7 @@
 /obj/machinery/computer/order_console/cook/interdyne{
 	dir = 1
 	},
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/iron/kitchen_coldroom/white/smooth_large,
 /area/ruin/space/has_grav/bubbers/persistance/service/freezer)
 "SQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
@@ -22263,12 +22006,10 @@
 	},
 /obj/structure/sink/kitchen/directional/west,
 /obj/item/construction/plumbing{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/item/storage/box/petridish,
 /obj/structure/closet/generic/wall/empty{
-	pixel_x = 0;
 	pixel_y = 32;
 	name = "cytology closet"
 	},
@@ -22423,8 +22164,7 @@
 	name = "Dorm Bolt Switch";
 	id = "syndishipjanidorm";
 	req_access = list("syndicate");
-	normaldoorcontrol = 1;
-	pixel_x = -24
+	normaldoorcontrol = 1
 	},
 /turf/open/floor/carpet/purple,
 /area/ruin/space/has_grav/bubbers/persistance/service/dorms/janitor)
@@ -22533,7 +22273,6 @@
 	dir = 4
 	},
 /obj/structure/flora/bush/flowers_pp/style_random{
-	pixel_x = 0;
 	pixel_y = -4
 	},
 /turf/open/floor/grass,
@@ -22705,7 +22444,6 @@
 	dir = 1
 	},
 /obj/machinery/door/window/survival_pod/left/directional/north{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/machinery/duct,
@@ -22759,8 +22497,7 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /obj/item/storage/toolbox/syndicate{
-	pixel_y = 1;
-	pixel_x = 0
+	pixel_y = 1
 	},
 /obj/structure/marker_beacon/burgundy,
 /turf/open/floor/iron/dark/textured_large,
@@ -22890,12 +22627,10 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/multitool/circuit{
-	pixel_x = 3;
-	pixel_y = 0
+	pixel_x = 3
 	},
 /obj/item/multitool/circuit{
-	pixel_x = -7;
-	pixel_y = 0
+	pixel_x = -7
 	},
 /obj/structure/window/reinforced/survival_pod/spawner/directional/east{
 	pixel_x = 4
@@ -22956,8 +22691,7 @@
 	name = "Energy Shield"
 	},
 /obj/machinery/porta_turret/syndicate{
-	dir = 5;
-	pixel_y = 0
+	dir = 5
 	},
 /obj/machinery/camera/autoname/directional/south{
 	name = "Persistence Exterior South";
@@ -22965,8 +22699,7 @@
 	},
 /obj/effect/turf_decal/weather/snow,
 /turf/open/floor/iron/shuttle/evac{
-	icon_state = "7,2";
-	dir = 2
+	icon_state = "7,2"
 	},
 /area/ruin/space/has_grav/bubbers/dauntless/command/vault)
 "UH" = (
@@ -23125,7 +22858,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/clothing/glasses/sunglasses/reagent{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /obj/item/rag{
@@ -23234,17 +22966,14 @@
 /area/ruin/space/has_grav/bubbers/persistance/service)
 "Vg" = (
 /obj/effect/turf_decal/trimline/dark/filled/line{
-	alpha = 160;
-	dir = 2
+	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/purple/line{
 	color = "#2cbf9d";
-	alpha = 200;
-	dir = 2
+	alpha = 200
 	},
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/turf_decal/trimline/purple/corner{
@@ -23327,7 +23056,6 @@
 /obj/machinery/airalarm/directional/south,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/item/storage/test_tube_rack{
-	pixel_x = 0;
 	pixel_y = 14
 	},
 /obj/item/reagent_containers/medigel{
@@ -23348,7 +23076,6 @@
 	},
 /obj/item/reagent_containers/medigel{
 	icon_state = "medigel_cyan";
-	pixel_x = 0;
 	pixel_y = 2;
 	desc = "A handy container bottle, designed for precision application, with an unscrewable cap.";
 	list_reagents = list(/datum/reagent/uranium/uraniumvirusfood/unstable = 60);
@@ -23363,7 +23090,6 @@
 	list_reagents = list(/datum/reagent/toxin/mutagen/mutagenvirusfood = 60)
 	},
 /obj/item/reagent_containers/dropper{
-	pixel_x = 0;
 	pixel_y = 17
 	},
 /turf/open/floor/iron/dark/smooth_half,
@@ -23371,7 +23097,6 @@
 "Vp" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/reagentgrinder{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /turf/open/floor/iron/dark/textured_large,
@@ -23421,7 +23146,6 @@
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/storage/box/shipping,
 /obj/item/clothing/head/soft{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /turf/open/floor/iron/shuttle/exploration/uside,
@@ -23437,8 +23161,7 @@
 	dir = 4
 	},
 /obj/structure/stone_tile/surrounding_tile{
-	pixel_x = 4;
-	pixel_y = 0
+	pixel_x = 4
 	},
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
@@ -23533,8 +23256,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral/half{
 	alpha = 255;
-	color = "#5d341f";
-	dir = 2
+	color = "#5d341f"
 	},
 /obj/item/book/granter/magazine,
 /obj/structure/noticeboard/directional/north,
@@ -23559,7 +23281,6 @@
 /obj/effect/mapping_helpers/apc/full_charge,
 /obj/effect/mapping_helpers/apc/cut_AI_wire,
 /obj/machinery/vending/cytopro{
-	pixel_y = 0;
 	all_products_free = 1
 	},
 /turf/open/floor/iron/dark/textured_large,
@@ -23593,9 +23314,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
 	dir = 1
 	},
-/turf/open/floor/engine{
-	initial_gas_mix = "LAVALAND_ATMOS"
-	},
+/turf/open/floor/engine,
 /area/ruin/space/has_grav/bubbers/persistance/engineering/atmospherics)
 "VO" = (
 /obj/structure/cable,
@@ -23658,9 +23377,7 @@
 	id = "synditrashgun";
 	pixel_y = -5
 	},
-/obj/structure/reagent_anvil{
-	pixel_y = 0
-	},
+/obj/structure/reagent_anvil,
 /obj/item/food/deadmouse{
 	pixel_x = -1;
 	pixel_y = 7;
@@ -23761,9 +23478,7 @@
 "Wj" = (
 /obj/machinery/light_switch/directional/east,
 /obj/machinery/vending/security/noaccess{
-	pixel_y = 0;
-	all_products_free = 1;
-	pixel_x = 0
+	all_products_free = 1
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/bubbers/persistance/sec/armory)
@@ -24032,7 +23747,6 @@
 /obj/machinery/digital_clock/directional/west,
 /obj/structure/dresser,
 /obj/item/clothing/accessory/dogtag{
-	pixel_x = 0;
 	pixel_y = 6;
 	desc = "It's a miracle you're still alive...";
 	name = "worn out dogtag"
@@ -24107,9 +23821,7 @@
 /area/ruin/space/has_grav/bubbers/persistance/service)
 "WZ" = (
 /obj/machinery/vending/dorms{
-	pixel_y = 0;
-	all_products_free = 1;
-	pixel_x = 0
+	all_products_free = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -24209,7 +23921,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/warning{
-	dir = 2;
 	alpha = 200;
 	color = "#1dc251"
 	},
@@ -24290,7 +24001,6 @@
 	pixel_y = 15
 	},
 /obj/effect/spawner/random/food_or_drink/three_course_meal{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/machinery/newscaster/directional/south,
@@ -24674,12 +24384,10 @@
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/structure/rack,
 /obj/item/tank/internals/anesthetic{
-	pixel_x = 4;
-	pixel_y = 0
+	pixel_x = 4
 	},
 /obj/item/tank/internals/anesthetic{
-	pixel_x = -3;
-	pixel_y = 0
+	pixel_x = -3
 	},
 /obj/item/clothing/mask/breath/medical{
 	pixel_y = -6;
@@ -24709,10 +24417,7 @@
 /obj/structure/emergency_shield/cult/weak{
 	name = "Energy Shield"
 	},
-/obj/machinery/porta_turret/syndicate{
-	dir = 2;
-	pixel_y = 0
-	},
+/obj/machinery/porta_turret/syndicate,
 /obj/effect/turf_decal/weather/snow,
 /turf/open/floor/iron/shuttle/evac{
 	icon_state = "7,2";
@@ -24783,10 +24488,8 @@
 	base_icon_state = "stairs-old";
 	icon_state = "stairs-old";
 	anchored = 1;
-	pixel_y = 0;
 	name = "staircase";
 	desc = "A small step for the humanity, and so is for you.";
-	dir = 2;
 	color = "#474747"
 	},
 /obj/structure/railing{
@@ -24853,7 +24556,6 @@
 	},
 /obj/structure/decorative{
 	icon_state = "drain";
-	pixel_y = 0;
 	icon = 'modular_skyrat/modules/liquids/icons/obj/structures/drains.dmi';
 	base_icon_state = "drain";
 	dir = 8;
@@ -24866,7 +24568,6 @@
 	},
 /obj/structure/decorative{
 	icon_state = "tile_half";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	base_icon_state = "tile_half";
 	color = "#303030";
@@ -24877,7 +24578,6 @@
 	},
 /obj/structure/decorative{
 	icon_state = "siding_plain";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	dir = 8;
 	color = "#878787";
@@ -24979,7 +24679,6 @@
 	},
 /obj/structure/decorative{
 	icon_state = "tile_half";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	base_icon_state = "tile_half";
 	color = "#303030";
@@ -24990,7 +24689,6 @@
 	},
 /obj/structure/decorative{
 	icon_state = "siding_plain";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	dir = 8;
 	color = "#878787";
@@ -25309,7 +25007,6 @@
 /area/ruin/space/has_grav/bubbers/persistance/service/lounge)
 "Zf" = (
 /obj/structure/flora/bush/large/style_2{
-	pixel_x = -16;
 	pixel_y = -8
 	},
 /turf/open/floor/grass,
@@ -25529,8 +25226,7 @@
 /obj/structure/hedge/opaque,
 /obj/structure/railing{
 	color = "#5d341f";
-	name = "wooden railing";
-	dir = 2
+	name = "wooden railing"
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bubbers/persistance/service/sauna)
@@ -25561,10 +25257,8 @@
 	base_icon_state = "stairs-old";
 	icon_state = "stairs-l";
 	anchored = 1;
-	pixel_y = 0;
 	name = "staircase";
 	desc = "A small step for the humanity, and so is for you.";
-	dir = 2;
 	color = "#474747"
 	},
 /obj/structure/railing{
@@ -25643,7 +25337,6 @@
 /area/ruin/space/has_grav/bubbers/persistance/med/chem)
 "ZI" = (
 /obj/structure/chair/comfy/shuttle{
-	pixel_y = 0;
 	dir = 4;
 	name = "adjustable office seat";
 	desc = "A comfortable, secure seat. It has a more sturdy looking buckling system, for smoother working sessions."

--- a/_maps/RandomRuins/IceRuins/bubberstation/icemoon_surface_gas_bubber.dmm
+++ b/_maps/RandomRuins/IceRuins/bubberstation/icemoon_surface_gas_bubber.dmm
@@ -24,8 +24,6 @@
 /area/ruin/powered/lizard_gas)
 "ap" = (
 /obj/machinery/door/airlock/external/ruin{
-	pixel_x = 0;
-	pixel_y = 0;
 	id_tag = "lizardgasbolt"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
@@ -72,7 +70,7 @@
 "cx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden,
 /obj/machinery/duct,
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/icemoon/outdoors,
 /area/ruin/powered/lizard_gas)
 "cI" = (
 /obj/structure/water_source/puddle,
@@ -124,7 +122,6 @@
 	},
 /obj/item/paper{
 	pixel_x = 7;
-	pixel_y = 0;
 	default_raw_text = "The gosh darn safe is on the fritz again! Do me a favor and count these bills for me, and stuff them in the stafe whe you're done. Thanks a bunch, and have a Lizardrific Day!<BR><BR>-General Manager, Ra'Tahul Rekinov";
 	name = "Manager Note"
 	},
@@ -229,7 +226,7 @@
 	dir = 4
 	},
 /obj/machinery/light/dim/directional/north,
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/icemoon/outdoors,
 /area/ruin/powered/lizard_gas)
 "fr" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -286,16 +283,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plating/lavaland_atmos{
-	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
-	},
+/turf/open/floor/plating/icemoon,
 /area/ruin/powered/lizard_gas)
 "gP" = (
 /obj/structure/mineral_door/wood{
 	name = "Old Storehouse"
 	},
 /obj/structure/barricade/wooden/crude,
-/turf/open/floor/wood/lavaland,
+/turf/open/floor/wood/icemoon,
 /area/icemoon/underground/unexplored)
 "gT" = (
 /obj/structure/chair/sofa/right/maroon{
@@ -320,9 +315,7 @@
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
 	},
-/turf/open/floor/plating/lavaland_atmos{
-	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
-	},
+/turf/open/floor/plating/icemoon,
 /area/ruin/powered/lizard_gas)
 "hj" = (
 /obj/machinery/dryer{
@@ -346,7 +339,7 @@
 	pixel_x = -9;
 	pixel_y = 6
 	},
-/turf/open/floor/wood/lavaland,
+/turf/open/floor/wood/icemoon,
 /area/icemoon/underground/unexplored)
 "hy" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -390,7 +383,6 @@
 	},
 /obj/item/paper{
 	pixel_x = 7;
-	pixel_y = 0;
 	name = "Manager Note";
 	default_raw_text = "Good news! That little decrepit hut out front is finally, <B>legally</B> ours! Feel free to snoop around it if you find the time, and remember, time to lean means time to clean!<BR><BR>-General Manager, Ra'Tahul Rekinov"
 	},
@@ -398,12 +390,8 @@
 	pixel_x = -6;
 	pixel_y = 6
 	},
-/obj/item/screwdriver{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/screwdriver,
 /obj/item/inducer{
-	pixel_x = 0;
 	pixel_y = 8
 	},
 /turf/open/floor/iron/smooth{
@@ -424,7 +412,7 @@
 	pixel_x = -4;
 	pixel_y = -8
 	},
-/turf/open/floor/wood/lavaland,
+/turf/open/floor/wood/icemoon,
 /area/icemoon/underground/unexplored)
 "iO" = (
 /obj/effect/turf_decal/bot,
@@ -435,8 +423,7 @@
 	pixel_y = 3
 	},
 /obj/item/stack/sheet/mineral/plasma/thirty{
-	pixel_x = -4;
-	pixel_y = 0
+	pixel_x = -4
 	},
 /obj/item/flatpacked_machine/fuel_generator,
 /obj/item/paper{
@@ -534,9 +521,7 @@
 	dir = 8;
 	target_pressure = 4100
 	},
-/turf/open/floor/plating/lavaland_atmos{
-	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
-	},
+/turf/open/floor/plating/icemoon,
 /area/ruin/powered/lizard_gas)
 "nA" = (
 /obj/structure/sign/warning/chem_diamond/directional/north,
@@ -585,7 +570,7 @@
 "pu" = (
 /obj/structure/sign/warning/fire/directional/north,
 /obj/structure/reagent_dispensers/fueltank/large{
-	anchored = 1;
+	anchored = 1
 	},
 /obj/structure/railing{
 	dir = 8
@@ -594,7 +579,7 @@
 	dir = 4
 	},
 /obj/machinery/light/dim/directional/south,
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/icemoon/outdoors,
 /area/ruin/powered/lizard_gas)
 "py" = (
 /obj/structure/table,
@@ -617,7 +602,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden,
 /obj/structure/girder/reinforced,
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/icemoon/outdoors,
 /area/ruin/powered/lizard_gas)
 "qQ" = (
 /obj/structure/cable,
@@ -652,9 +637,7 @@
 /obj/machinery/atmospherics/components/unary/passive_vent/layer4{
 	dir = 1
 	},
-/turf/open/floor/plating/lavaland_atmos{
-	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
-	},
+/turf/open/floor/plating/icemoon,
 /area/ruin/powered/lizard_gas)
 "sy" = (
 /obj/structure/sign/poster/official/pda_ad/directional/south,
@@ -692,12 +675,10 @@
 /obj/structure/cable,
 /obj/machinery/button/door/directional/east{
 	id = "lizardshutters";
-	pixel_x = 24;
 	pixel_y = 7;
 	name = "Privacy Shutters"
 	},
 /obj/machinery/button/door/directional/east{
-	pixel_x = 24;
 	pixel_y = -3;
 	name = "Entrance Doorbolts";
 	id = "lizardgasbolt";
@@ -729,7 +710,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/icemoon/outdoors,
 /area/ruin/powered/lizard_gas)
 "tJ" = (
 /obj/structure/cable,
@@ -746,7 +727,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden,
 /obj/structure/girder/reinforced,
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/icemoon/outdoors,
 /area/ruin/powered/lizard_gas)
 "um" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -803,7 +784,7 @@
 /obj/machinery/duct,
 /obj/machinery/light/directional/north,
 /obj/structure/sign/warning/chem_diamond/directional/north,
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/icemoon/outdoors,
 /area/ruin/powered/lizard_gas)
 "wB" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -877,7 +858,7 @@
 	dir = 4;
 	pixel_x = -14
 	},
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/icemoon/outdoors,
 /area/ruin/powered/lizard_gas)
 "yv" = (
 /obj/structure/cable,
@@ -885,9 +866,7 @@
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
 	},
-/turf/open/floor/plating/lavaland_atmos{
-	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
-	},
+/turf/open/floor/plating/icemoon,
 /area/ruin/powered/lizard_gas)
 "yL" = (
 /obj/structure/rack,
@@ -1066,7 +1045,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden,
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/icemoon/outdoors,
 /area/ruin/powered/lizard_gas)
 "CA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden,
@@ -1074,7 +1053,7 @@
 	name = "IMPORTANT NOTE!";
 	default_raw_text = "Hello traveller! If you are reading this and the Blastdoors/Shutters are currently active, that means we are <B>CLOSED!</B> Please do not disturb our Lizard Gas team members or their materials as they are currently Cyrosleeping inside.<BR><BR>-General Manager, Ra'Tahul Rekinov"
 	},
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/icemoon/outdoors,
 /area/ruin/powered/lizard_gas)
 "CM" = (
 /obj/structure/cable,
@@ -1084,9 +1063,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/lavaland_atmos{
-	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
-	},
+/turf/open/floor/plating/icemoon,
 /area/ruin/powered/lizard_gas)
 "Dc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
@@ -1155,7 +1132,7 @@
 /area/ruin/powered/lizard_gas)
 "DU" = (
 /obj/structure/barricade/wooden,
-/turf/open/floor/wood/lavaland,
+/turf/open/floor/wood/icemoon,
 /area/icemoon/underground/unexplored)
 "DX" = (
 /obj/structure/table,
@@ -1163,8 +1140,6 @@
 /area/icemoon/underground/unexplored)
 "Ec" = (
 /obj/machinery/door/airlock/external/ruin{
-	pixel_x = 0;
-	pixel_y = 0;
 	id_tag = "lizardgasbolt"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
@@ -1208,10 +1183,10 @@
 	pixel_x = 6;
 	pixel_y = -1
 	},
-/turf/open/floor/wood/lavaland,
+/turf/open/floor/wood/icemoon,
 /area/icemoon/underground/unexplored)
 "Ey" = (
-/turf/open/floor/wood/lavaland,
+/turf/open/floor/wood/icemoon,
 /area/icemoon/underground/unexplored)
 "Fd" = (
 /obj/structure/closet/crate/trashcart,
@@ -1281,9 +1256,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/lavaland_atmos{
-	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
-	},
+/turf/open/floor/plating/icemoon,
 /area/ruin/powered/lizard_gas)
 "FU" = (
 /obj/structure/sign/poster/official/plasma_effects/directional/east,
@@ -1317,7 +1290,7 @@
 /area/ruin/powered/lizard_gas)
 "Hb" = (
 /obj/machinery/door/window/brigdoor/left/directional/west,
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/icemoon/outdoors,
 /area/ruin/powered/lizard_gas)
 "Hq" = (
 /obj/machinery/duct,
@@ -1340,16 +1313,14 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/end,
-/turf/open/floor/plating/lavaland_atmos{
-	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
-	},
+/turf/open/floor/plating/icemoon,
 /area/ruin/powered/lizard_gas)
 "HV" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/icemoon/outdoors,
 /area/ruin/powered/lizard_gas)
 "Iv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -1382,9 +1353,7 @@
 /area/ruin/powered/lizard_gas)
 "Ja" = (
 /obj/machinery/door/airlock/external/ruin{
-	id_tag = "lizardgasbolt";
-	pixel_x = 0;
-	pixel_y = 0
+	id_tag = "lizardgasbolt"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "lizardgas_lavaland_entrance"
@@ -1448,7 +1417,7 @@
 	pixel_x = -7;
 	pixel_y = 5
 	},
-/turf/open/floor/wood/lavaland,
+/turf/open/floor/wood/icemoon,
 /area/icemoon/underground/unexplored)
 "Lm" = (
 /obj/machinery/door/airlock/grunge{
@@ -1484,7 +1453,7 @@
 /area/ruin/powered/lizard_gas)
 "MK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden,
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/icemoon/outdoors,
 /area/ruin/powered/lizard_gas)
 "MX" = (
 /obj/structure/table/reinforced,
@@ -1507,11 +1476,11 @@
 /obj/machinery/light/directional/south,
 /obj/structure/sign/warning/chem_diamond/directional/south,
 /obj/machinery/duct,
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/icemoon/outdoors,
 /area/ruin/powered/lizard_gas)
 "Op" = (
 /obj/machinery/duct,
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/icemoon/outdoors,
 /area/ruin/powered/lizard_gas)
 "Ox" = (
 /obj/structure/table/reinforced,
@@ -1545,7 +1514,7 @@
 	dir = 8;
 	pixel_x = 14
 	},
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/icemoon/outdoors,
 /area/ruin/powered/lizard_gas)
 "Pj" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1654,9 +1623,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/lavaland_atmos{
-	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
-	},
+/turf/open/floor/plating/icemoon,
 /area/ruin/powered/lizard_gas)
 "Rt" = (
 /obj/structure/railing{
@@ -1669,9 +1636,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/plating/lavaland_atmos{
-	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
-	},
+/turf/open/floor/plating/icemoon,
 /area/ruin/powered/lizard_gas)
 "Rv" = (
 /obj/structure/railing{
@@ -1686,9 +1651,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/lavaland_atmos{
-	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
-	},
+/turf/open/floor/plating/icemoon,
 /area/ruin/powered/lizard_gas)
 "RU" = (
 /obj/structure/chair/greyscale{
@@ -1704,7 +1667,7 @@
 	pixel_x = -3;
 	pixel_y = 10
 	},
-/turf/open/floor/wood/lavaland,
+/turf/open/floor/wood/icemoon,
 /area/icemoon/underground/unexplored)
 "SL" = (
 /obj/structure/secure_safe/directional/east,
@@ -1719,16 +1682,14 @@
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 1
 	},
-/turf/open/floor/plating/lavaland_atmos{
-	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
-	},
+/turf/open/floor/plating/icemoon,
 /area/ruin/powered/lizard_gas)
 "Tt" = (
 /obj/structure/railing{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden,
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/icemoon/outdoors,
 /area/ruin/powered/lizard_gas)
 "TM" = (
 /obj/structure/cable,
@@ -1747,9 +1708,7 @@
 "TO" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/structure/cable,
-/turf/open/floor/plating/lavaland_atmos{
-	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
-	},
+/turf/open/floor/plating/icemoon,
 /area/ruin/powered/lizard_gas)
 "Uo" = (
 /obj/structure/cable,
@@ -1836,8 +1795,6 @@
 /area/ruin/powered/lizard_gas)
 "Vb" = (
 /obj/machinery/door/airlock/external/ruin{
-	pixel_x = 0;
-	pixel_y = 0;
 	id_tag = "lizardgasbolt"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
@@ -1881,7 +1838,7 @@
 "VR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden,
 /obj/structure/sign/warning/no_smoking/directional/east,
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/icemoon/outdoors,
 /area/ruin/powered/lizard_gas)
 "Wq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer2,
@@ -1892,7 +1849,7 @@
 /area/ruin/powered/lizard_gas)
 "WX" = (
 /obj/machinery/door/window/brigdoor/left/directional/east,
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/icemoon/outdoors,
 /area/ruin/powered/lizard_gas)
 "WZ" = (
 /obj/structure/cable,
@@ -1915,7 +1872,7 @@
 "Yv" = (
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden,
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/icemoon/outdoors,
 /area/ruin/powered/lizard_gas)
 "Yy" = (
 /obj/structure/table,

--- a/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_surface_gas_bubber.dmm
+++ b/_maps/RandomRuins/LavaRuins/bubberstation/lavaland_surface_gas_bubber.dmm
@@ -33,7 +33,7 @@
 "bp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden,
 /obj/structure/sign/warning/no_smoking/directional/east,
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/lavaland/outdoors,
 /area/ruin/thelizardsgas_lavaland)
 "bG" = (
 /obj/structure/sink/directional/west,
@@ -114,7 +114,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden,
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/lavaland/outdoors,
 /area/ruin/thelizardsgas_lavaland)
 "cR" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -125,7 +125,7 @@
 /area/ruin/thelizardsgas_lavaland)
 "dC" = (
 /obj/machinery/duct,
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/lavaland/outdoors,
 /area/ruin/thelizardsgas_lavaland)
 "ef" = (
 /obj/structure/toilet,
@@ -191,7 +191,6 @@
 	},
 /obj/item/paper{
 	pixel_x = 7;
-	pixel_y = 0;
 	name = "Manager Note";
 	default_raw_text = "Good news! That little decrepit hut out front is finally, <B>legally</B> ours! Feel free to snoop around it if you find the time, and remember, time to lean means time to clean!<BR><BR>P.S, go into the backroom and set the nitrogen and oxygen pressure tanks to layer 3 with the multitool, the HVAC tech had no fucking clue what he was doing apparently!<BR><BR>-General Manager, Ra'Tahul Rekinov"
 	},
@@ -199,12 +198,8 @@
 	pixel_x = -6;
 	pixel_y = 6
 	},
-/obj/item/screwdriver{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/screwdriver,
 /obj/item/inducer{
-	pixel_x = 0;
 	pixel_y = 8
 	},
 /turf/open/floor/iron/smooth{
@@ -322,7 +317,7 @@
 	dir = 4
 	},
 /obj/machinery/light/dim/directional/south,
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/lavaland/outdoors,
 /area/ruin/thelizardsgas_lavaland)
 "il" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -377,7 +372,7 @@
 /area/lavaland/surface/outdoors)
 "jo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden,
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/lavaland/outdoors,
 /area/ruin/thelizardsgas_lavaland)
 "jG" = (
 /obj/structure/cable,
@@ -387,7 +382,7 @@
 /obj/effect/turf_decal/arrows{
 	dir = 1
 	},
-/turf/open/floor/asphalt/lavaland,
+/turf/open/floor/asphalt/lavaland/outdoors,
 /area/lavaland/surface/outdoors)
 "kT" = (
 /obj/effect/spawner/random/trash/hobo_squat,
@@ -417,7 +412,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden,
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/lavaland/outdoors,
 /area/ruin/thelizardsgas_lavaland)
 "lM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -566,7 +561,7 @@
 /obj/machinery/light/directional/south,
 /obj/structure/sign/warning/chem_diamond/directional/south,
 /obj/machinery/duct,
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/lavaland/outdoors,
 /area/ruin/thelizardsgas_lavaland)
 "qW" = (
 /obj/structure/railing{
@@ -621,7 +616,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden,
 /obj/structure/girder/reinforced,
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/lavaland/outdoors,
 /area/ruin/thelizardsgas_lavaland)
 "rL" = (
 /obj/structure/fence/corner,
@@ -757,12 +752,10 @@
 /obj/structure/cable,
 /obj/machinery/button/door/directional/east{
 	id = "lizardshutters";
-	pixel_x = 24;
 	pixel_y = 7;
 	name = "Privacy Shutters"
 	},
 /obj/machinery/button/door/directional/east{
-	pixel_x = 24;
 	pixel_y = -3;
 	name = "Entrance Doorbolts";
 	id = "lizardgasbolt";
@@ -959,7 +952,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden,
 /obj/structure/girder/reinforced,
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/lavaland/outdoors,
 /area/ruin/thelizardsgas_lavaland)
 "zo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
@@ -974,7 +967,7 @@
 "zP" = (
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden,
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/lavaland/outdoors,
 /area/ruin/thelizardsgas_lavaland)
 "Ab" = (
 /obj/structure/cable,
@@ -998,7 +991,7 @@
 /obj/machinery/duct,
 /obj/machinery/light/directional/north,
 /obj/structure/sign/warning/chem_diamond/directional/north,
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/lavaland/outdoors,
 /area/ruin/thelizardsgas_lavaland)
 "Bf" = (
 /obj/structure/cable,
@@ -1071,7 +1064,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/lavaland/outdoors,
 /area/ruin/thelizardsgas_lavaland)
 "DE" = (
 /obj/machinery/door/airlock/external/ruin{
@@ -1150,7 +1143,7 @@
 	},
 /area/ruin/thelizardsgas_lavaland)
 "Fs" = (
-/turf/open/floor/asphalt/lavaland,
+/turf/open/floor/asphalt/lavaland/outdoors,
 /area/lavaland/surface/outdoors)
 "Fy" = (
 /obj/structure/table/wood/shuttle_bar,
@@ -1422,7 +1415,7 @@
 /area/ruin/thelizardsgas_lavaland)
 "Ob" = (
 /obj/machinery/door/window/brigdoor/left/directional/west,
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/lavaland/outdoors,
 /area/ruin/thelizardsgas_lavaland)
 "Ov" = (
 /turf/open/floor/iron{
@@ -1448,7 +1441,7 @@
 "PH" = (
 /obj/structure/sign/warning/fire/directional/south,
 /obj/structure/reagent_dispensers/fueltank/large{
-	anchored = 1;
+	anchored = 1
 	},
 /obj/structure/railing{
 	dir = 8
@@ -1457,7 +1450,7 @@
 	dir = 4
 	},
 /obj/machinery/light/dim/directional/north,
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/lavaland/outdoors,
 /area/ruin/thelizardsgas_lavaland)
 "PJ" = (
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -1512,7 +1505,6 @@
 	},
 /obj/item/paper{
 	pixel_x = 7;
-	pixel_y = 0;
 	default_raw_text = "The gosh darn safe is on the fritz again! Do me a favor and count these bills for me, and stuff them in the stafe whe you're done. Thanks a bunch, and have a Lizardrific Day!<BR><BR>-General Manager, Ra'Tahul Rekinov";
 	name = "Manager Note"
 	},
@@ -1611,7 +1603,7 @@
 	name = "IMPORTANT NOTE!";
 	default_raw_text = "Hello traveller! If you are reading this and the Blastdoors/Shutters are currently active, that means we are <B>CLOSED!</B> Please do not disturb our Lizard Gas team members or their materials as they are currently Cyrosleeping inside.<BR><BR>-General Manager, Ra'Tahul Rekinov"
 	},
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/lavaland/outdoors,
 /area/ruin/thelizardsgas_lavaland)
 "Sq" = (
 /obj/structure/sign/poster/official/pda_ad/directional/south,
@@ -1697,7 +1689,7 @@
 /area/ruin/thelizardsgas_lavaland)
 "Vd" = (
 /obj/machinery/door/window/brigdoor/left/directional/east,
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/lavaland/outdoors,
 /area/ruin/thelizardsgas_lavaland)
 "Vn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer4,
@@ -1725,7 +1717,7 @@
 	dir = 4;
 	pixel_x = -14
 	},
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/lavaland/outdoors,
 /area/ruin/thelizardsgas_lavaland)
 "WI" = (
 /obj/machinery/door/airlock/grunge{
@@ -1740,7 +1732,7 @@
 	dir = 8;
 	pixel_x = 14
 	},
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/lavaland/outdoors,
 /area/ruin/thelizardsgas_lavaland)
 "WP" = (
 /obj/structure/chair/sofa/left/maroon{
@@ -1801,8 +1793,7 @@
 	pixel_y = 3
 	},
 /obj/item/stack/sheet/mineral/plasma/thirty{
-	pixel_x = -4;
-	pixel_y = 0
+	pixel_x = -4
 	},
 /obj/item/flatpacked_machine/fuel_generator,
 /obj/item/paper{
@@ -1868,7 +1859,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/turf/open/floor/asphalt,
+/turf/open/floor/asphalt/lavaland/outdoors,
 /area/ruin/thelizardsgas_lavaland)
 "Zo" = (
 /obj/structure/cable,

--- a/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon.dmm
@@ -1893,7 +1893,7 @@
 	pixel_x = -4;
 	pixel_y = -2
 	},
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/port_tarkon/kitchen)
 "gw" = (
 /obj/effect/spawner/structure/window{
@@ -3579,7 +3579,6 @@
 	dir = 4
 	},
 /obj/machinery/computer/order_console/mining{
-	express_cost_multiplier = 1;
 	forced_express = 1
 	},
 /turf/open/floor/iron,
@@ -6622,9 +6621,7 @@
 /area/ruin/space/has_grav/port_tarkon/aiante)
 "xv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/musician/piano{
-	icon_state = "piano"
-	},
+/obj/structure/musician/piano,
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/port_tarkon/lounge)
 "xw" = (
@@ -10925,7 +10922,7 @@
 "MN" = (
 /obj/structure/kitchenspike,
 /obj/item/knife/butcher,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/port_tarkon/kitchen)
 "MO" = (
 /obj/effect/turf_decal/tile/purple/half{
@@ -12785,7 +12782,7 @@
 /obj/item/food/meat/slab,
 /obj/item/food/meat/slab,
 /obj/item/food/meat/slab,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/port_tarkon/kitchen)
 "Th" = (
 /turf/open/floor/iron/airless,

--- a/_maps/bubber/automapper/templates/IceBoxStation/iceboxstation_icecats_lower.dmm
+++ b/_maps/bubber/automapper/templates/IceBoxStation/iceboxstation_icecats_lower.dmm
@@ -866,7 +866,7 @@
 /area/ruin/unpowered/primitive_catgirl_den)
 "tn" = (
 /obj/structure/chair/sofa/bamboo/left,
-/turf/open/water/hot_spring,
+/turf/open/water/hot_spring/icemoon_atmos,
 /area/ruin/unpowered/primitive_catgirl_den)
 "tw" = (
 /obj/structure/rack/wooden,
@@ -1285,7 +1285,7 @@
 /area/ruin/unpowered/primitive_catgirl_den)
 "Gc" = (
 /obj/structure/chair/sofa/bamboo,
-/turf/open/water/hot_spring,
+/turf/open/water/hot_spring/icemoon_atmos,
 /area/ruin/unpowered/primitive_catgirl_den)
 "GE" = (
 /obj/effect/turf_decal/siding/wood,
@@ -1465,7 +1465,7 @@
 /obj/structure/chair/sofa/bamboo/left{
 	dir = 1
 	},
-/turf/open/water/hot_spring,
+/turf/open/water/hot_spring/icemoon_atmos,
 /area/ruin/unpowered/primitive_catgirl_den)
 "Lj" = (
 /obj/effect/turf_decal/siding/wood{
@@ -1493,7 +1493,7 @@
 /turf/open/misc/dirt/icemoon,
 /area/ruin/unpowered/primitive_catgirl_den)
 "MP" = (
-/turf/open/water/hot_spring,
+/turf/open/water/hot_spring/icemoon_atmos,
 /area/ruin/unpowered/primitive_catgirl_den)
 "MU" = (
 /obj/effect/turf_decal/weather/snow/corner{
@@ -1601,7 +1601,7 @@
 /obj/structure/chair/sofa/bamboo/right{
 	dir = 1
 	},
-/turf/open/water/hot_spring,
+/turf/open/water/hot_spring/icemoon_atmos,
 /area/ruin/unpowered/primitive_catgirl_den)
 "Pm" = (
 /obj/effect/mob_spawn/ghost_role/human/primitive_catgirl,
@@ -1799,7 +1799,7 @@
 /area/ruin/unpowered/primitive_catgirl_den)
 "Tj" = (
 /obj/structure/chair/sofa/bamboo/right,
-/turf/open/water/hot_spring,
+/turf/open/water/hot_spring/icemoon_atmos,
 /area/ruin/unpowered/primitive_catgirl_den)
 "Ty" = (
 /obj/effect/turf_decal/weather/dirt{

--- a/_maps/bubber/automapper/templates/lavaland/lavaland_persistence.dmm
+++ b/_maps/bubber/automapper/templates/lavaland/lavaland_persistence.dmm
@@ -60,7 +60,6 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
@@ -262,8 +261,7 @@
 	name = "Admiral Quarters Bolt Switch";
 	id = "syndishipmanager";
 	req_access = list("syndicate");
-	normaldoorcontrol = 1;
-	pixel_x = -24
+	normaldoorcontrol = 1
 	},
 /turf/open/floor/wood/tile,
 /area/ruin/space/has_grav/bubbers/persistance/command/admiral)
@@ -371,10 +369,7 @@
 /obj/structure/emergency_shield/cult/weak{
 	name = "Energy Shield"
 	},
-/obj/machinery/porta_turret/syndicate{
-	dir = 2;
-	pixel_y = 0
-	},
+/obj/machinery/porta_turret/syndicate,
 /obj/effect/turf_decal/lunar_sand/plating,
 /obj/machinery/camera/autoname/directional/north{
 	name = "Persistence Exterior North";
@@ -410,7 +405,6 @@
 	pixel_y = 15
 	},
 /obj/effect/spawner/random/food_or_drink/three_course_meal{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/machinery/newscaster/directional/south,
@@ -457,7 +451,6 @@
 /area/ruin/space/has_grav/bubbers/persistance/engineering)
 "aY" = (
 /obj/structure/flora/bush/large/style_3{
-	pixel_x = -16;
 	pixel_y = -7
 	},
 /turf/open/floor/grass,
@@ -530,19 +523,16 @@
 /obj/item/forging/billow,
 /obj/item/stack/sheet/mineral/wood{
 	amount = 10;
-	pixel_x = 7;
-	pixel_y = 0
+	pixel_x = 7
 	},
 /obj/item/stack/sheet/iron/ten{
 	pixel_x = -6;
 	pixel_y = 3
 	},
 /obj/item/forging/tongs{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/item/forging/hammer{
-	pixel_x = 0;
 	pixel_y = -3
 	},
 /turf/open/floor/mineral/plastitanium,
@@ -580,7 +570,6 @@
 	dir = 4
 	},
 /obj/structure/flora/bush/flowers_pp/style_random{
-	pixel_x = 0;
 	pixel_y = -4
 	},
 /turf/open/floor/grass,
@@ -691,19 +680,16 @@
 	},
 /obj/structure/closet/generic/wall/empty{
 	pixel_x = 30;
-	pixel_y = 0;
 	name = "hazmat suit closet"
 	},
 /obj/item/clothing/suit/bio_suit/virology{
 	name = "Interdyne bio suit";
 	desc = "A suit that protects against biological contamination. It's Interdyne branded.";
-	pixel_x = 0;
 	pixel_y = -2
 	},
 /obj/item/clothing/head/bio_hood/virology{
 	desc = "A hood that protects the head and face from biological contaminants. It's Interdyne branded.";
 	name = "Interdyne bio hood";
-	pixel_x = 0;
 	pixel_y = 7
 	},
 /turf/open/floor/iron/dark/smooth_half{
@@ -790,7 +776,6 @@
 	pixel_y = -13
 	},
 /obj/item/pen/fountain/captain{
-	pixel_x = 0;
 	pixel_y = -12
 	},
 /obj/item/pen/survival{
@@ -941,7 +926,6 @@
 "bO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/structure/closet/generic/wall{
-	pixel_y = 0;
 	pixel_x = 30
 	},
 /obj/item/storage/wallet/random,
@@ -966,7 +950,6 @@
 	pixel_y = 13
 	},
 /obj/item/stock_parts/power_store/cell/high{
-	pixel_x = 0;
 	pixel_y = 9
 	},
 /obj/item/stock_parts/power_store/cell/high{
@@ -991,7 +974,6 @@
 	},
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/food/cake/birthday/energy{
-	pixel_x = 0;
 	pixel_y = 5
 	},
 /turf/open/floor/iron/dark/textured_large,
@@ -1143,7 +1125,6 @@
 "cs" = (
 /obj/structure/decorative{
 	icon_state = "siding_plain";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	dir = 4;
 	color = "#474747";
@@ -1221,7 +1202,6 @@
 	desc = "A marked patch of soil, showing signs of a burial long ago, circa 2565. There's something inscribed... 'Jade: rest in ramen', 'wow this tastes of nothing and my mouth is on fire', 'also ow my lips are chapped and i bit the dry skin off', 'only now realized this ramen is best before jan 10 2025, wish me luck'. Poor guy."
 	},
 /obj/item/clothing/accessory/dogtag{
-	pixel_x = 0;
 	pixel_y = -3;
 	name = "Cells' Dogtag";
 	desc = "Dogtag with an operative's codename inscribed. At least there was no meat in it..."
@@ -1302,8 +1282,7 @@
 	dir = 6
 	},
 /obj/structure/bed/dogbed{
-	pixel_x = -16;
-	pixel_y = 0
+	pixel_x = -16
 	},
 /obj/item/kirbyplants/organic/plant22{
 	pixel_x = 8;
@@ -1354,7 +1333,6 @@
 "cQ" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/integrated_circuit/loaded/hello_world{
-	pixel_x = 0;
 	pixel_y = 7
 	},
 /obj/item/integrated_circuit/loaded/speech_relay{
@@ -1582,7 +1560,6 @@
 /obj/effect/turf_decal/siding/dark,
 /obj/structure/railing{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -10
 	},
 /obj/structure/fireplace,
@@ -1591,7 +1568,6 @@
 	alpha = 160
 	},
 /obj/structure/marker_beacon/bronze{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /turf/open/floor/iron/dark/herringbone,
@@ -1682,7 +1658,6 @@
 	dir = 1
 	},
 /obj/structure/closet/shuttle/engivent{
-	pixel_x = 0;
 	pixel_y = -34
 	},
 /turf/open/floor/mineral/plastitanium,
@@ -1807,10 +1782,8 @@
 	base_icon_state = "stairs-old";
 	icon_state = "stairs-r";
 	anchored = 1;
-	pixel_y = 0;
 	name = "staircase";
 	desc = "A small step for the humanity, and so is for you.";
-	dir = 2;
 	color = "#474747"
 	},
 /obj/structure/railing{
@@ -1849,7 +1822,6 @@
 	pixel_y = 7
 	},
 /obj/structure/flora/bush/sparsegrass{
-	pixel_x = 0;
 	pixel_y = 7
 	},
 /turf/open/floor/grass,
@@ -2055,7 +2027,6 @@
 /obj/effect/spawner/random/entertainment/plushie,
 /obj/effect/turf_decal/siding/wideplating_new/dark/end,
 /obj/effect/turf_decal/siding/dark{
-	dir = 2;
 	icon_state = "siding_plain_end"
 	},
 /turf/open/floor/mineral/plastitanium/red,
@@ -2166,7 +2137,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/warning{
-	dir = 2;
 	alpha = 200;
 	color = "#1dc251"
 	},
@@ -2339,7 +2309,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/decorative{
 	icon_state = "warningline";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	dir = 1;
 	anchored = 1;
@@ -2347,7 +2316,6 @@
 	},
 /obj/structure/decorative{
 	icon_state = "warningline_white";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	dir = 1;
 	anchored = 1;
@@ -2355,7 +2323,6 @@
 	},
 /obj/structure/decorative{
 	icon_state = "siding_wideplating_new_corner";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	dir = 4;
 	anchored = 1;
@@ -2364,7 +2331,6 @@
 	},
 /obj/structure/decorative{
 	icon_state = "siding_plain";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	dir = 4;
 	color = "#474747";
@@ -2506,7 +2472,6 @@
 	alpha = 200
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/neutral/corner{
@@ -2702,7 +2667,6 @@
 	},
 /obj/structure/decorative{
 	icon_state = "drain";
-	pixel_y = 0;
 	icon = 'modular_skyrat/modules/liquids/icons/obj/structures/drains.dmi';
 	base_icon_state = "drain";
 	dir = 8;
@@ -2715,7 +2679,6 @@
 	},
 /obj/structure/decorative{
 	icon_state = "tile_half";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	base_icon_state = "tile_half";
 	color = "#303030";
@@ -2726,7 +2689,6 @@
 	},
 /obj/structure/decorative{
 	icon_state = "siding_plain";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	dir = 8;
 	color = "#878787";
@@ -2791,8 +2753,7 @@
 /obj/structure/chair/pew/left,
 /obj/effect/turf_decal/tile/neutral/half{
 	alpha = 255;
-	color = "#5d341f";
-	dir = 2
+	color = "#5d341f"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/iron/dark/smooth_large,
@@ -3022,8 +2983,7 @@
 /obj/structure/hedge/opaque,
 /obj/structure/railing{
 	color = "#5d341f";
-	name = "wooden railing";
-	dir = 2
+	name = "wooden railing"
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bubbers/persistance/service/sauna)
@@ -3031,8 +2991,7 @@
 /obj/structure/chair/pew/right,
 /obj/effect/turf_decal/tile/neutral/half{
 	alpha = 255;
-	color = "#5d341f";
-	dir = 2
+	color = "#5d341f"
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/bubbers/persistance/service/sauna)
@@ -3081,8 +3040,7 @@
 "gr" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/mod/construction/broken_core{
-	pixel_x = -8;
-	pixel_y = 0
+	pixel_x = -8
 	},
 /obj/machinery/door/window/survival_pod/left/directional/east{
 	req_access = list("syndicate");
@@ -3121,7 +3079,6 @@
 "gv" = (
 /obj/structure/decorative{
 	icon_state = "siding_plain";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	dir = 4;
 	color = "#474747";
@@ -3441,8 +3398,7 @@
 	dir = 1
 	},
 /obj/structure/sign/painting/library{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/light/directional/east,
 /turf/open/floor/wood/large,
@@ -3739,8 +3695,7 @@
 	desc = "STAY WINNING"
 	},
 /obj/item/toy/figure/syndie{
-	pixel_x = -5;
-	pixel_y = 0
+	pixel_x = -5
 	},
 /obj/item/toy/figure/syndie{
 	pixel_x = 4;
@@ -3842,8 +3797,7 @@
 	pixel_y = 6
 	},
 /obj/item/lipstick/syndie{
-	pixel_x = -20;
-	pixel_y = 0
+	pixel_x = -20
 	},
 /obj/item/tattoo_kit{
 	pixel_y = 2;
@@ -3971,7 +3925,6 @@
 	dir = 1
 	},
 /obj/structure/flora/bush/sparsegrass/style_3{
-	pixel_x = 0;
 	pixel_y = -11
 	},
 /turf/open/floor/grass,
@@ -4062,7 +4015,6 @@
 	},
 /obj/item/storage/toolbox/guncase/c20r,
 /obj/item/storage/toolbox/guncase/c20r{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /turf/open/floor/iron/dark/smooth_large,
@@ -4170,15 +4122,13 @@
 	pixel_x = 4
 	},
 /obj/item/radio/headset/syndicateciv/staff{
-	pixel_x = 2;
-	pixel_y = 0
+	pixel_x = 2
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bubbers/persistance/command/bridge)
 "iz" = (
 /obj/structure/decorative{
 	icon_state = "siding_plain";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	dir = 4;
 	color = "#474747";
@@ -4443,9 +4393,7 @@
 /area/ruin/space/has_grav/bubbers/persistance/sec/prison)
 "jd" = (
 /obj/machinery/vending/dorms{
-	pixel_y = 0;
-	all_products_free = 1;
-	pixel_x = 0
+	all_products_free = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -4701,7 +4649,6 @@
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/neutral/line{
@@ -4719,7 +4666,6 @@
 /obj/machinery/light_switch/directional/south,
 /obj/structure/table/wood/fancy,
 /obj/item/sign/flag/syndicate{
-	pixel_x = 0;
 	pixel_y = 15
 	},
 /obj/item/pen/fourcolor{
@@ -4929,9 +4875,7 @@
 "kb" = (
 /obj/structure/decorative{
 	icon_state = "siding_plain_corner";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
-	dir = 2;
 	color = "#474747";
 	anchored = 1;
 	name = "decorative panel"
@@ -5650,7 +5594,6 @@
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/purple/end{
@@ -5678,8 +5621,7 @@
 	pixel_y = -1
 	},
 /obj/structure/sign/painting/library{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/mineral/plasma,
 /area/ruin/space/has_grav/bubbers/persistance/service/dorms/janitor)
@@ -5741,11 +5683,9 @@
 /obj/effect/turf_decal/siding/dark/corner,
 /obj/item/storage/bag/bio,
 /obj/item/storage/box/beakers{
-	pixel_x = 0;
 	pixel_y = 1
 	},
 /obj/item/storage/box/syringes{
-	pixel_x = 0;
 	pixel_y = 8
 	},
 /turf/open/floor/iron/dark/smooth_corner,
@@ -6310,10 +6250,7 @@
 /obj/structure/emergency_shield/cult/weak{
 	name = "Energy Shield"
 	},
-/obj/machinery/porta_turret/syndicate{
-	dir = 2;
-	pixel_y = 0
-	},
+/obj/machinery/porta_turret/syndicate,
 /obj/effect/turf_decal/lunar_sand/plating,
 /turf/open/floor/iron/shuttle/evac{
 	icon_state = "7,2";
@@ -6379,7 +6316,6 @@
 	dir = 9
 	},
 /obj/item/bounty_cube{
-	pixel_x = 0;
 	pixel_y = 15;
 	bounty_value = 500;
 	name = "outdated bounty cube of 6400 cr that lost its value";
@@ -6408,12 +6344,10 @@
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/structure/rack,
 /obj/item/tank/internals/anesthetic{
-	pixel_x = 4;
-	pixel_y = 0
+	pixel_x = 4
 	},
 /obj/item/tank/internals/anesthetic{
-	pixel_x = -3;
-	pixel_y = 0
+	pixel_x = -3
 	},
 /obj/item/clothing/mask/breath/medical{
 	pixel_y = -6;
@@ -6469,7 +6403,6 @@
 	},
 /obj/structure/decorative{
 	icon_state = "tile_half";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	base_icon_state = "tile_half";
 	color = "#303030";
@@ -6480,7 +6413,6 @@
 	},
 /obj/structure/decorative{
 	icon_state = "siding_plain";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	dir = 8;
 	color = "#878787";
@@ -6558,8 +6490,7 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /obj/item/storage/toolbox/syndicate{
-	pixel_y = 1;
-	pixel_x = 0
+	pixel_y = 1
 	},
 /obj/structure/marker_beacon/burgundy,
 /turf/open/floor/iron/dark/textured_large,
@@ -6653,10 +6584,7 @@
 	},
 /area/ruin/space/has_grav/bubbers/persistance/cargo)
 "nG" = (
-/obj/machinery/vending/donksofttoyvendor{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/machinery/vending/donksofttoyvendor,
 /turf/open/floor/carpet/black,
 /area/ruin/space/has_grav/bubbers/persistance/service/lounge)
 "nH" = (
@@ -6713,7 +6641,6 @@
 	icon = 'modular_skyrat/modules/wargame_projectors/icons/projectors_and_holograms.dmi';
 	base_icon_state = "projector";
 	dir = 8;
-	pixel_x = 0;
 	anchored = 1;
 	name = "hologram projector"
 	},
@@ -6960,7 +6887,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/structure/chair/comfy/shuttle{
-	pixel_y = 0;
 	dir = 8;
 	name = "adjustable office seat";
 	desc = "A comfortable, secure seat. It has a more sturdy looking buckling system, for smoother working sessions."
@@ -7181,8 +7107,7 @@
 "oH" = (
 /obj/effect/turf_decal/tile/neutral/half{
 	alpha = 255;
-	color = "#5d341f";
-	dir = 2
+	color = "#5d341f"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
@@ -7297,8 +7222,7 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/dark/filled/corner{
-	alpha = 160;
-	dir = 2
+	alpha = 160
 	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 9
@@ -7426,8 +7350,7 @@
 "ph" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/sign/painting/library{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/turf_decal/siding/wideplating_new/dark/end{
 	dir = 4
@@ -7484,7 +7407,6 @@
 /area/ruin/space/has_grav/bubbers/persistance/sec/interrogation)
 "pp" = (
 /obj/structure/marker_beacon/burgundy{
-	pixel_x = 0;
 	pixel_y = 16
 	},
 /obj/structure/chair/sofa/corp/right{
@@ -7553,8 +7475,7 @@
 	name = "two-way prisoner intercom";
 	freerange = 1;
 	freqlock = 1;
-	frequency = 1245;
-	pixel_y = 0
+	frequency = 1245
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bubbers/persistance/service/dorms/brig)
@@ -7796,9 +7717,7 @@
 "pY" = (
 /obj/machinery/light_switch/directional/east,
 /obj/machinery/vending/security/noaccess{
-	pixel_y = 0;
-	all_products_free = 1;
-	pixel_x = 0
+	all_products_free = 1
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/bubbers/persistance/sec/armory)
@@ -7851,11 +7770,9 @@
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/siding/dark{
-	dir = 2;
 	icon_state = "siding_plain_end"
 	},
 /obj/structure/marker_beacon/purple,
@@ -7913,7 +7830,6 @@
 	base_icon_state = "stairs-old";
 	icon_state = "stairs-old";
 	anchored = 1;
-	pixel_y = 0;
 	name = "staircase";
 	desc = "A small step for the humanity, and so is for you.";
 	dir = 1;
@@ -8227,8 +8143,7 @@
 /area/ruin/space/has_grav/bubbers/persistance/sci/robotics)
 "rc" = (
 /obj/structure/sign/painting/library{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/structure/chair/comfy/black,
 /turf/open/floor/glass/reinforced/plasma,
@@ -8319,8 +8234,7 @@
 	frequency = 1241;
 	canhear_range = 1;
 	desc = "Surely no one is listening in!";
-	pixel_x = 0;
-	pixel_y = 0
+	pixel_x = 0
 	},
 /obj/machinery/button/polarizer{
 	pixel_x = -5;
@@ -8440,10 +8354,8 @@
 	base_icon_state = "stairs-old";
 	icon_state = "stairs-old";
 	anchored = 1;
-	pixel_y = 0;
 	name = "staircase";
 	desc = "A small step for the humanity, and so is for you.";
-	dir = 2;
 	color = "#474747"
 	},
 /obj/structure/railing{
@@ -8537,8 +8449,7 @@
 	pixel_y = 7
 	},
 /obj/item/shovel/spade{
-	pixel_x = -5;
-	pixel_y = 0
+	pixel_x = -5
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/ruin/space/has_grav/bubbers/persistance/service/hydro)
@@ -8566,7 +8477,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/clothing/glasses/sunglasses/reagent{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /obj/item/rag{
@@ -8625,7 +8535,6 @@
 /obj/machinery/digital_clock/directional/west,
 /obj/structure/dresser,
 /obj/item/clothing/accessory/dogtag{
-	pixel_x = 0;
 	pixel_y = 6;
 	desc = "It's a miracle you're still alive...";
 	name = "worn out dogtag"
@@ -8711,8 +8620,7 @@
 	dir = 5
 	},
 /obj/structure/marker_beacon/cerulean{
-	pixel_x = -7;
-	pixel_y = 0
+	pixel_x = -7
 	},
 /turf/open/floor/iron/diagonal,
 /area/ruin/space/has_grav/bubbers/persistance/service/sauna)
@@ -8815,17 +8723,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark/filled/line{
-	alpha = 160;
-	dir = 2
+	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/purple/line{
 	color = "#2cbf9d";
-	alpha = 200;
-	dir = 2
+	alpha = 200
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8881,10 +8786,7 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced/plastitaniumglass,
-/obj/item/sequence_scanner{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/sequence_scanner,
 /obj/item/infuser_book{
 	pixel_x = -7;
 	pixel_y = 1
@@ -8897,8 +8799,7 @@
 /obj/structure/marker_beacon/bronze,
 /obj/effect/turf_decal/tile/neutral/half{
 	alpha = 255;
-	color = "#5d341f";
-	dir = 2
+	color = "#5d341f"
 	},
 /obj/item/thermometer{
 	pixel_x = -6;
@@ -8927,12 +8828,10 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/multitool/circuit{
-	pixel_x = 3;
-	pixel_y = 0
+	pixel_x = 3
 	},
 /obj/item/multitool/circuit{
-	pixel_x = -7;
-	pixel_y = 0
+	pixel_x = -7
 	},
 /obj/structure/window/reinforced/survival_pod/spawner/directional/east{
 	pixel_x = 4
@@ -8975,9 +8874,7 @@
 	pixel_x = -30
 	},
 /obj/machinery/vending/games{
-	pixel_x = 0;
-	all_products_free = 1;
-	pixel_y = 0
+	all_products_free = 1
 	},
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 8
@@ -9053,7 +8950,6 @@
 	pixel_y = 3
 	},
 /obj/item/restraints/handcuffs/cable/zipties{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /turf/open/floor/iron/dark/smooth_corner{
@@ -9185,12 +9081,10 @@
 /obj/machinery/airalarm/directional/south,
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/filingcabinet{
-	pixel_x = -9;
-	pixel_y = 0
+	pixel_x = -9
 	},
 /obj/structure/filingcabinet/chestdrawer{
-	pixel_x = 6;
-	pixel_y = 0
+	pixel_x = 6
 	},
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/item/toy/figure/syndie{
@@ -9215,7 +9109,6 @@
 	req_access = list("syndicate_leader")
 	},
 /obj/item/bouquet{
-	pixel_x = 0;
 	pixel_y = -8
 	},
 /turf/open/floor/mineral/plastitanium/red,
@@ -9387,7 +9280,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/decorative{
 	icon_state = "siding_plain_corner";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	dir = 4;
 	color = "#474747";
@@ -9657,15 +9549,12 @@
 	icon_state = "siding_plain_end"
 	},
 /obj/structure/closet/generic/wall{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/item/bodybag/environmental/prisoner/syndicate{
-	pixel_y = 0;
 	pixel_x = -8
 	},
 /obj/item/bodybag/environmental/prisoner/syndicate{
-	pixel_y = 0;
 	pixel_x = 8
 	},
 /obj/item/bodybag/environmental/prisoner/syndicate{
@@ -9838,7 +9727,6 @@
 "tY" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/storage/test_tube_rack{
-	pixel_x = 0;
 	pixel_y = 23;
 	name = "utencils rack"
 	},
@@ -9860,11 +9748,9 @@
 	pixel_y = 3
 	},
 /obj/item/reagent_containers/condiment/peppermill{
-	pixel_y = 0;
 	pixel_x = -10
 	},
 /obj/item/reagent_containers/condiment/saltshaker{
-	pixel_y = 0;
 	pixel_x = -4
 	},
 /turf/open/floor/iron/dark/textured_large,
@@ -9874,7 +9760,6 @@
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/machinery/vending/clothing{
 	density = 0;
-	pixel_y = 0;
 	all_products_free = 1
 	},
 /turf/open/floor/iron/dark/textured_large,
@@ -9888,7 +9773,6 @@
 	dir = 1
 	},
 /obj/machinery/door/window/survival_pod/left/directional/north{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/machinery/duct,
@@ -9920,8 +9804,7 @@
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/digital_clock/directional/north,
 /obj/item/canvas/drawingtablet{
-	pixel_x = 2;
-	pixel_y = 0
+	pixel_x = 2
 	},
 /turf/open/floor/iron/shuttle/exploration/blanktile,
 /area/ruin/space/has_grav/bubbers/persistance/service/dorms/science)
@@ -10069,11 +9952,9 @@
 	},
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/serviette/colonial{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/sign/flag/syndicate{
-	pixel_x = 0;
 	pixel_y = 11
 	},
 /turf/open/floor/carpet/purple,
@@ -10606,7 +10487,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/duct,
 /obj/machinery/vending/boozeomat{
-	pixel_y = 0;
 	all_products_free = 1
 	},
 /obj/item/reagent_containers/cup/glass/bottle/small{
@@ -10618,7 +10498,6 @@
 	pixel_y = 16
 	},
 /obj/item/reagent_containers/cup/glass{
-	pixel_x = 0;
 	pixel_y = 18
 	},
 /turf/open/floor/wood/tile,
@@ -10706,12 +10585,10 @@
 	},
 /obj/structure/sink/kitchen/directional/west,
 /obj/item/construction/plumbing{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/item/storage/box/petridish,
 /obj/structure/closet/generic/wall/empty{
-	pixel_x = 0;
 	pixel_y = 32;
 	name = "cytology closet"
 	},
@@ -10728,11 +10605,9 @@
 	},
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/structure/sign/painting/library{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/item/kirbyplants/organic/plant21{
-	pixel_x = 0;
 	pixel_y = 11
 	},
 /obj/item/clothing/head/costume/maidheadband/tactical_maid{
@@ -10785,8 +10660,7 @@
 	dir = 1
 	},
 /obj/structure/marker_beacon/burgundy{
-	pixel_x = 16;
-	pixel_y = 0
+	pixel_x = 16
 	},
 /turf/open/floor/plating/elevatorshaft,
 /area/ruin/space/has_grav/bubbers/persistance/command/bridge)
@@ -10890,8 +10764,7 @@
 	},
 /obj/effect/turf_decal/trimline/purple/corner{
 	color = "#2cbf9d";
-	alpha = 200;
-	dir = 2
+	alpha = 200
 	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
@@ -11063,7 +10936,6 @@
 "wq" = (
 /obj/effect/spawner/random/food_or_drink/pizzaparty{
 	loot = list(/obj/item/pizzabox/margherita = 2, /obj/item/pizzabox/meat = 2, /obj/item/pizzabox/mushroom = 2, /obj/item/pizzabox/pineapple = 2, /obj/item/pizzabox/vegetable = 2);
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/structure/table/wood/fancy/green,
@@ -11126,7 +10998,6 @@
 /obj/machinery/airalarm/directional/south,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/item/storage/test_tube_rack{
-	pixel_x = 0;
 	pixel_y = 14
 	},
 /obj/item/reagent_containers/medigel{
@@ -11147,7 +11018,6 @@
 	},
 /obj/item/reagent_containers/medigel{
 	icon_state = "medigel_cyan";
-	pixel_x = 0;
 	pixel_y = 2;
 	desc = "A handy container bottle, designed for precision application, with an unscrewable cap.";
 	list_reagents = list(/datum/reagent/uranium/uraniumvirusfood/unstable = 60);
@@ -11162,7 +11032,6 @@
 	list_reagents = list(/datum/reagent/toxin/mutagen/mutagenvirusfood = 60)
 	},
 /obj/item/reagent_containers/dropper{
-	pixel_x = 0;
 	pixel_y = 17
 	},
 /turf/open/floor/iron/dark/smooth_half,
@@ -11320,7 +11189,6 @@
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
@@ -11340,7 +11208,6 @@
 /obj/machinery/door/window/survival_pod/left/directional/west{
 	req_access = list("syndicate");
 	name = "Slime Pacification Chamber";
-	pixel_y = 0;
 	pixel_x = -8
 	},
 /turf/open/floor/iron/white/smooth_large,
@@ -11436,7 +11303,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable,
 /obj/item/storage/backpack/satchel/flat{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -11555,8 +11421,7 @@
 	dir = 8
 	},
 /obj/structure/marker_beacon/cerulean{
-	pixel_x = -7;
-	pixel_y = 0
+	pixel_x = -7
 	},
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 6
@@ -11733,7 +11598,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/effect/turf_decal/siding/wideplating_new/dark/end,
 /obj/effect/turf_decal/siding/dark{
-	dir = 2;
 	icon_state = "siding_plain_end"
 	},
 /turf/open/floor/mineral/plastitanium/red,
@@ -11822,9 +11686,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/structure/railing/wooden_fencing/gate{
-	dir = 2
-	},
+/obj/structure/railing/wooden_fencing/gate,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/bubbers/persistance/service/hydro)
 "xT" = (
@@ -11975,7 +11837,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
@@ -12154,8 +12015,7 @@
 "yB" = (
 /obj/structure/railing/corner/end{
 	dir = 4;
-	pixel_y = -4;
-	pixel_x = 0
+	pixel_y = -4
 	},
 /obj/structure/railing/corner{
 	dir = 1;
@@ -12163,7 +12023,6 @@
 	pixel_y = -32
 	},
 /obj/structure/flora/bush/large{
-	pixel_x = -16;
 	pixel_y = -3
 	},
 /obj/structure/flora/bush/jungle/a{
@@ -12222,7 +12081,6 @@
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/end{
@@ -12313,8 +12171,7 @@
 	},
 /obj/structure/stone_tile/surrounding_tile/cracked{
 	dir = 8;
-	pixel_x = -3;
-	pixel_y = 0
+	pixel_x = -3
 	},
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/grass,
@@ -12380,7 +12237,6 @@
 "yO" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/reagentgrinder{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /turf/open/floor/iron/dark/textured_large,
@@ -12662,7 +12518,6 @@
 	dir = 1
 	},
 /obj/structure/marker_beacon/burgundy{
-	pixel_x = 0;
 	pixel_y = -16
 	},
 /obj/item/plate{
@@ -12692,10 +12547,8 @@
 	base_icon_state = "stairs-old";
 	icon_state = "stairs-r";
 	anchored = 1;
-	pixel_y = 0;
 	name = "staircase";
 	desc = "A small step for the humanity, and so is for you.";
-	dir = 2;
 	color = "#474747"
 	},
 /obj/structure/railing{
@@ -12828,7 +12681,6 @@
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/neutral/line{
@@ -12971,13 +12823,11 @@
 	pixel_y = 8
 	},
 /obj/item/crowbar/red{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/structure/sign/poster/contraband/revolver/directional/east,
 /obj/item/toy/figure/syndie{
 	pixel_x = 3;
-	pixel_y = 0;
 	desc = "SIR YES SIR OORAH"
 	},
 /turf/open/floor/iron/dark/textured_large,
@@ -13026,11 +12876,9 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/safe/abovetilefloor,
 /obj/item/aicard/syndie{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/item/sign/flag/syndicate{
-	pixel_x = 0;
 	pixel_y = -3
 	},
 /obj/item/mod/module/stealth/wraith,
@@ -13190,14 +13038,12 @@
 /area/ruin/space/has_grav/bubbers/persistance/med/chem)
 "Au" = (
 /obj/machinery/dryer{
-	pixel_y = -26;
-	pixel_x = 0
+	pixel_y = -26
 	},
 /obj/effect/turf_decal/siding/white{
 	dir = 10
 	},
 /obj/structure/toilet{
-	pixel_y = 0;
 	dir = 4
 	},
 /turf/open/floor/iron/freezer,
@@ -13224,7 +13070,6 @@
 	},
 /obj/structure/weightmachine,
 /obj/effect/turf_decal/siding{
-	dir = 2;
 	icon_state = "siding_plain_end"
 	},
 /turf/open/floor/iron/white/small,
@@ -13398,7 +13243,6 @@
 	},
 /obj/structure/rack/wooden,
 /obj/item/construction/plumbing{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /obj/machinery/light_switch/directional/south,
@@ -13488,7 +13332,6 @@
 "Bf" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/plantgenes{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /turf/open/floor/iron/dark/herringbone,
@@ -13581,7 +13424,6 @@
 /area/ruin/space/has_grav/bubbers/persistance/sci/xenobio)
 "Bu" = (
 /obj/machinery/button/door/directional/east{
-	pixel_x = 24;
 	pixel_y = -12;
 	id = "syndisci_windows";
 	name = "science dorms windows shutters";
@@ -13603,7 +13445,6 @@
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/item/modular_computer/laptop/preset/syndicate{
-	pixel_x = 0;
 	pixel_y = 9
 	},
 /obj/item/reagent_containers/cup/glass/waterbottle/tea{
@@ -13682,7 +13523,6 @@
 /area/ruin/space/has_grav/bubbers/persistance/med)
 "Bz" = (
 /obj/structure/chair/comfy/shuttle{
-	pixel_y = 0;
 	dir = 4;
 	name = "adjustable office seat";
 	desc = "A comfortable, secure seat. It has a more sturdy looking buckling system, for smoother working sessions."
@@ -13697,8 +13537,7 @@
 	},
 /obj/effect/turf_decal/trimline/purple/corner{
 	color = "#2cbf9d";
-	alpha = 200;
-	dir = 2
+	alpha = 200
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -13861,8 +13700,7 @@
 	},
 /obj/effect/turf_decal/lunar_sand/plating,
 /turf/open/floor/iron/shuttle/evac{
-	icon_state = "5,13";
-	dir = 2
+	icon_state = "5,13"
 	},
 /area/lavaland/surface/outdoors)
 "Cc" = (
@@ -13922,11 +13760,9 @@
 "Co" = (
 /obj/effect/turf_decal/tile/neutral/half{
 	alpha = 255;
-	color = "#5d341f";
-	dir = 2
+	color = "#5d341f"
 	},
 /obj/structure/closet/generic/wall{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -14019,11 +13855,9 @@
 	dir = 8
 	},
 /obj/structure/flora/bush/sparsegrass/style_2{
-	pixel_x = 0;
 	pixel_y = 11
 	},
 /obj/structure/flora/bush/flowers_yw/style_random{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /turf/open/floor/grass,
@@ -14038,13 +13872,11 @@
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/light/directional/east,
 /obj/item/clothing/mask/chameleon{
-	pixel_x = 0;
 	pixel_y = 7
 	},
 /obj/machinery/status_display/department_balance{
 	credits_account = "INT";
 	name = "dauntless budget display";
-	pixel_y = 0;
 	default_logo = "synd";
 	pixel_x = 32
 	},
@@ -14155,7 +13987,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
@@ -14386,16 +14217,13 @@
 	pixel_y = 18
 	},
 /obj/item/stamp/chameleon{
-	pixel_x = 0;
 	pixel_y = 7
 	},
 /obj/item/stamp/persistence{
-	pixel_x = 5;
-	pixel_y = 0
+	pixel_x = 5
 	},
 /obj/item/stamp/denied{
-	pixel_x = -5;
-	pixel_y = 0
+	pixel_x = -5
 	},
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark/textured_large,
@@ -14434,8 +14262,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/dark/filled/corner{
-	alpha = 160;
-	dir = 2
+	alpha = 160
 	},
 /obj/effect/turf_decal/siding/dark/corner,
 /obj/effect/turf_decal/siding/dark/corner{
@@ -14463,10 +14290,8 @@
 	base_icon_state = "stairs-old";
 	icon_state = "stairs-l";
 	anchored = 1;
-	pixel_y = 0;
 	name = "staircase";
 	desc = "A small step for the humanity, and so is for you.";
-	dir = 2;
 	color = "#474747"
 	},
 /obj/structure/railing{
@@ -14498,7 +14323,6 @@
 /area/ruin/space/has_grav/bubbers/persistance/med)
 "Dj" = (
 /obj/structure/flora/bush/large/style_2{
-	pixel_x = -16;
 	pixel_y = -8
 	},
 /turf/open/floor/grass,
@@ -15039,7 +14863,6 @@
 /obj/item/modular_computer/pda/syndicate,
 /obj/item/clothing/suit/jacket/runner/syndicate,
 /obj/item/modular_computer/laptop/preset/syndicate{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /turf/open/floor/mineral/plastitanium,
@@ -15341,7 +15164,6 @@
 /area/ruin/space/has_grav/bubbers/persistance/service/freezer)
 "ED" = (
 /obj/structure/flora/bush/large{
-	pixel_x = -16;
 	pixel_y = -3
 	},
 /obj/structure/flora/bush/jungle/a{
@@ -15355,7 +15177,6 @@
 /obj/structure/railing/corner/end{
 	dir = 4;
 	color = "#683d21";
-	pixel_x = 0;
 	pixel_y = -4
 	},
 /obj/structure/railing/corner{
@@ -15376,8 +15197,7 @@
 /area/ruin/space/has_grav/bubbers/persistance/command/bridge)
 "EF" = (
 /obj/machinery/light/floor{
-	pixel_x = -16;
-	pixel_y = 0
+	pixel_x = -16
 	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -15471,8 +15291,7 @@
 "EP" = (
 /obj/effect/turf_decal/lunar_sand/plating,
 /obj/machinery/porta_turret/syndicate{
-	dir = 4;
-	pixel_y = 0
+	dir = 4
 	},
 /obj/machinery/camera/autoname/directional/west{
 	name = "Persistence Exterior West";
@@ -15625,7 +15444,6 @@
 	},
 /obj/structure/decorative{
 	icon_state = "tile_half";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	base_icon_state = "tile_half";
 	color = "#303030";
@@ -15636,7 +15454,6 @@
 	},
 /obj/structure/decorative{
 	icon_state = "siding_plain";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	dir = 8;
 	color = "#878787";
@@ -15745,7 +15562,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/machinery/defibrillator_mount/charging{
 	pixel_y = 30;
-	pixel_x = 0;
 	icon_state = "defib"
 	},
 /obj/structure/marker_beacon/cerulean,
@@ -15824,11 +15640,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark/filled/line{
-	alpha = 160;
-	dir = 2
+	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
@@ -15837,8 +15651,7 @@
 	},
 /obj/effect/turf_decal/trimline/purple/line{
 	color = "#2cbf9d";
-	alpha = 200;
-	dir = 2
+	alpha = 200
 	},
 /obj/effect/turf_decal/trimline/purple/line{
 	color = "#2cbf9d";
@@ -16027,17 +15840,14 @@
 /area/ruin/space/has_grav/bubbers/persistance/sec/prison)
 "FH" = (
 /obj/effect/turf_decal/trimline/dark/filled/line{
-	alpha = 160;
-	dir = 2
+	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/purple/line{
 	color = "#2cbf9d";
-	alpha = 200;
-	dir = 2
+	alpha = 200
 	},
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/white/smooth_edge,
@@ -16094,7 +15904,6 @@
 	},
 /obj/structure/flora/rock/pile/jungle/style_2,
 /obj/structure/flora/bush/large/style_3{
-	pixel_x = -16;
 	pixel_y = 2
 	},
 /turf/open/floor/grass,
@@ -16143,7 +15952,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/warning{
-	dir = 2;
 	alpha = 200;
 	color = "#1dc251"
 	},
@@ -16292,9 +16100,7 @@
 	id = "synditrashgun";
 	pixel_y = -5
 	},
-/obj/structure/reagent_anvil{
-	pixel_y = 0
-	},
+/obj/structure/reagent_anvil,
 /obj/item/food/deadmouse{
 	pixel_x = -1;
 	pixel_y = 7;
@@ -16317,7 +16123,6 @@
 	pixel_y = 14
 	},
 /obj/item/sign/flag/syndicate{
-	pixel_x = 0;
 	pixel_y = 12
 	},
 /obj/effect/turf_decal/box/red,
@@ -16349,7 +16154,6 @@
 	base_icon_state = "stairs-old";
 	icon_state = "stairs-r";
 	anchored = 1;
-	pixel_y = 0;
 	name = "staircase";
 	desc = "A small step for the humanity, and so is for you.";
 	dir = 1;
@@ -16632,8 +16436,7 @@
 	},
 /obj/structure/flora/rock/pile/jungle/style_3,
 /obj/structure/flora/bush/jungle/c/style_2{
-	pixel_x = -16;
-	pixel_y = 0
+	pixel_x = -16
 	},
 /obj/structure/flora/bush/large/style_2{
 	pixel_x = -15;
@@ -16667,7 +16470,6 @@
 	},
 /obj/machinery/plumbing/input,
 /obj/machinery/light/small/directional/east{
-	pixel_x = 0;
 	pixel_y = -16
 	},
 /turf/open/floor/iron/shuttle/exploration/corner{
@@ -16741,11 +16543,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark/filled/line{
-	alpha = 160;
-	dir = 2
+	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
@@ -16754,8 +16554,7 @@
 	},
 /obj/effect/turf_decal/trimline/purple/line{
 	color = "#2cbf9d";
-	alpha = 200;
-	dir = 2
+	alpha = 200
 	},
 /obj/effect/turf_decal/trimline/purple/line{
 	color = "#2cbf9d";
@@ -16802,11 +16601,9 @@
 	pixel_y = 36
 	},
 /obj/item/plate{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/plate{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /turf/open/floor/iron/dark/textured_large,
@@ -16870,8 +16667,7 @@
 "HA" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/storage/toolbox/syndicate{
-	pixel_y = 2;
-	pixel_x = 0
+	pixel_y = 2
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bubbers/persistance/sci/rnd)
@@ -16928,8 +16724,7 @@
 "HG" = (
 /obj/structure/flora/bush/jungle/b/style_2,
 /obj/structure/marker_beacon/lime{
-	pixel_x = -16;
-	pixel_y = 0
+	pixel_x = -16
 	},
 /turf/open/misc/grass/jungle/station,
 /area/ruin/space/has_grav/bubbers/persistance/med)
@@ -16957,7 +16752,6 @@
 	},
 /obj/structure/decorative{
 	icon_state = "pwindow";
-	pixel_y = 0;
 	icon = 'icons/obj/mining_zones/survival_pod.dmi';
 	dir = 6;
 	anchored = 1;
@@ -16965,8 +16759,7 @@
 	},
 /obj/structure/marker_beacon/fuchsia,
 /obj/item/ai_module/reset/purge{
-	pixel_y = 8;
-	pixel_x = 0
+	pixel_y = 8
 	},
 /obj/item/ai_module/core/full/persistence{
 	pixel_y = 4;
@@ -17274,7 +17067,6 @@
 	pixel_y = 5
 	},
 /obj/item/toy/plush/lizard_plushie/green{
-	pixel_x = 0;
 	pixel_y = 21;
 	name = "Cells-The-Cook"
 	},
@@ -17297,7 +17089,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/siding/wideplating_new/dark/end,
 /obj/effect/turf_decal/siding/dark{
-	dir = 2;
 	icon_state = "siding_plain_end"
 	},
 /turf/open/floor/mineral/plastitanium/red,
@@ -17322,17 +17113,14 @@
 /area/ruin/space/has_grav/bubbers/persistance/service)
 "IG" = (
 /obj/effect/turf_decal/trimline/dark/filled/line{
-	alpha = 160;
-	dir = 2
+	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/purple/line{
 	color = "#2cbf9d";
-	alpha = 200;
-	dir = 2
+	alpha = 200
 	},
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/turf_decal/trimline/purple/corner{
@@ -17441,19 +17229,15 @@
 	},
 /obj/effect/turf_decal/siding/dark/end,
 /obj/structure/bed/pillow_large{
-	pixel_x = 0;
 	pixel_y = 21
 	},
 /obj/structure/chair/pillow_small{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/fancy_pillow{
-	pixel_x = 6;
-	pixel_y = 0
+	pixel_x = 6
 	},
 /obj/structure/marker_beacon/purple{
-	pixel_x = 0;
 	pixel_y = 16
 	},
 /turf/open/floor/mineral/plasma,
@@ -17468,7 +17252,6 @@
 	dir = 9
 	},
 /obj/structure/window/reinforced/survival_pod/spawner/directional/north{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/structure/sink/directional/east,
@@ -17668,32 +17451,25 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/decorative{
 	icon_state = "warningline";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
-	dir = 2;
 	anchored = 1;
 	name = "decorative panel"
 	},
 /obj/structure/decorative{
 	icon_state = "warningline_white";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
-	dir = 2;
 	anchored = 1;
 	name = "decorative panel"
 	},
 /obj/structure/decorative{
 	icon_state = "siding_wideplating_new_corner";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
-	dir = 2;
 	anchored = 1;
 	name = "decorative panel";
 	color = "#949494"
 	},
 /obj/structure/decorative{
 	icon_state = "siding_plain";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	dir = 4;
 	color = "#474747";
@@ -17808,7 +17584,6 @@
 /area/ruin/space/has_grav/bubbers/persistance/sec/interrogation)
 "Jy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 2;
 	external_pressure_bound = 140;
 	name = "server vent";
 	pressure_checks = 0
@@ -17857,8 +17632,7 @@
 	name = "mentats pills"
 	},
 /obj/item/storage/box/stockparts/deluxe{
-	pixel_x = 6;
-	pixel_y = 0
+	pixel_x = 6
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -18202,8 +17976,7 @@
 /obj/structure/hedge,
 /obj/machinery/door/poddoor/shutters/preopen{
 	name = "Bar Shutters";
-	id = "dauntbar_s";
-	dir = 2
+	id = "dauntbar_s"
 	},
 /obj/structure/aquarium/donkfish,
 /obj/structure/window/reinforced/spawner/directional/north{
@@ -18232,14 +18005,10 @@
 	pixel_y = -15
 	},
 /obj/item/gun/energy/floragun{
-	pixel_x = 0;
 	pixel_y = 11
 	},
 /obj/structure/marker_beacon/teal,
-/obj/item/plant_analyzer{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/plant_analyzer,
 /turf/open/floor/iron/dark/herringbone,
 /area/ruin/space/has_grav/bubbers/persistance/service/hydro)
 "Kz" = (
@@ -18292,7 +18061,6 @@
 	pixel_y = 4
 	},
 /obj/item/paper{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/folder/red{
@@ -18308,7 +18076,6 @@
 	pixel_y = 18
 	},
 /obj/structure/marker_beacon/burgundy{
-	pixel_x = 0;
 	pixel_y = 16
 	},
 /obj/effect/turf_decal/siding/wideplating_new/corner{
@@ -18608,8 +18375,7 @@
 	dir = 4
 	},
 /obj/structure/stone_tile/surrounding_tile{
-	pixel_x = 4;
-	pixel_y = 0
+	pixel_x = 4
 	},
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
@@ -18709,7 +18475,7 @@
 /obj/machinery/computer/order_console/cook/interdyne{
 	dir = 1
 	},
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/iron/kitchen_coldroom/white/smooth_large,
 /area/ruin/space/has_grav/bubbers/persistance/service/freezer)
 "LD" = (
 /obj/structure/emergency_shield/cult/weak{
@@ -18719,8 +18485,7 @@
 	name = "Energy Shield"
 	},
 /obj/machinery/porta_turret/syndicate{
-	dir = 5;
-	pixel_y = 0
+	dir = 5
 	},
 /obj/machinery/camera/autoname/directional/south{
 	name = "Persistence Exterior South";
@@ -18728,8 +18493,7 @@
 	},
 /obj/effect/turf_decal/lunar_sand/plating,
 /turf/open/floor/iron/shuttle/evac{
-	icon_state = "7,2";
-	dir = 2
+	icon_state = "7,2"
 	},
 /area/ruin/space/has_grav/bubbers/dauntless/command/vault)
 "LE" = (
@@ -18791,7 +18555,6 @@
 	base_icon_state = "stairs-old";
 	icon_state = "stairs-l";
 	anchored = 1;
-	pixel_y = 0;
 	name = "staircase";
 	desc = "A small step for the humanity, and so is for you.";
 	dir = 1;
@@ -18816,8 +18579,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/dark/filled/corner{
-	alpha = 160;
-	dir = 2
+	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/warning{
 	alpha = 160;
@@ -18853,11 +18615,9 @@
 	all_products_free = 1
 	},
 /obj/effect/turf_decal/trimline/dark/filled/end{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/siding/dark{
-	dir = 2;
 	icon_state = "siding_plain_end"
 	},
 /obj/effect/turf_decal/trimline/neutral/end{
@@ -18928,7 +18688,6 @@
 	pixel_y = 3
 	},
 /obj/item/storage/box/hecu_rations{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/item/storage/box/hecu_rations{
@@ -19040,8 +18799,7 @@
 /obj/effect/mapping_helpers/apc/full_charge,
 /obj/effect/mapping_helpers/apc/syndicate_access,
 /obj/machinery/light/small/red/dim/directional/south{
-	pixel_x = -16;
-	pixel_y = 0
+	pixel_x = -16
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -19232,8 +18990,7 @@
 	pixel_y = -3
 	},
 /obj/item/ammo_box/magazine/sniper_rounds/marksman{
-	pixel_x = 1;
-	pixel_y = 0
+	pixel_x = 1
 	},
 /obj/item/ammo_box/magazine/sniper_rounds/marksman{
 	pixel_x = -2;
@@ -19269,8 +19026,7 @@
 /obj/structure/aquarium/donkfish,
 /obj/machinery/door/poddoor/shutters/preopen{
 	name = "Bar Shutters";
-	id = "dauntbar_s";
-	dir = 2
+	id = "dauntbar_s"
 	},
 /turf/open/floor/plating/reinforced,
 /area/ruin/space/has_grav/bubbers/persistance/service/diner)
@@ -19316,16 +19072,13 @@
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/item/storage/backpack/duffelbag/syndie/surgery{
-	pixel_x = 0;
 	pixel_y = 12
 	},
 /obj/item/storage/backpack/duffelbag/synth_treatment_kit/trauma/advanced{
-	pixel_x = 0;
 	pixel_y = 1
 	},
 /obj/item/clothing/gloves/latex/nitrile{
-	pixel_x = 21;
-	pixel_y = 0
+	pixel_x = 21
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/bubbers/persistance/med/treatment)
@@ -19343,7 +19096,6 @@
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
@@ -19370,12 +19122,10 @@
 "MV" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/effect/spawner/random/food_or_drink/donkpockets{
-	pixel_x = 0;
 	pixel_y = 7
 	},
 /obj/structure/marker_beacon/bronze{
-	pixel_x = 16;
-	pixel_y = 0
+	pixel_x = 16
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/bubbers/persistance/service/kitchen)
@@ -19542,10 +19292,8 @@
 	base_icon_state = "stairs-old";
 	icon_state = "stairs-m";
 	anchored = 1;
-	pixel_y = 0;
 	name = "staircase";
 	desc = "A small step for the humanity, and so is for you.";
-	dir = 2;
 	color = "#474747"
 	},
 /turf/open/floor/iron/stairs/medium,
@@ -19569,7 +19317,6 @@
 	pixel_y = 4
 	},
 /obj/item/storage/bag/xeno{
-	pixel_x = 0;
 	pixel_y = -6
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -19620,10 +19367,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/fans/tiny,
-/obj/machinery/smartfridge/extract/preloaded{
-	pixel_y = 0;
-	pixel_x = 0
-	},
+/obj/machinery/smartfridge/extract/preloaded,
 /obj/structure/marker_beacon/indigo,
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west{
 	pixel_x = -8
@@ -19720,14 +19464,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/effect/turf_decal/siding/dark,
 /obj/machinery/light/floor{
-	pixel_x = 0;
 	pixel_y = 16
 	},
 /turf/open/floor/carpet/black,
 /area/ruin/space/has_grav/bubbers/persistance/cargo)
 "NA" = (
 /obj/effect/turf_decal/siding/dark{
-	dir = 2;
 	icon_state = "siding_plain_end"
 	},
 /obj/structure/reagent_dispensers/water_cooler,
@@ -19744,7 +19486,6 @@
 	},
 /obj/structure/flora/rock/pile/jungle/style_3,
 /obj/structure/flora/bush/large/style_3{
-	pixel_x = -16;
 	pixel_y = -3
 	},
 /turf/open/floor/grass,
@@ -19774,7 +19515,6 @@
 	alpha = 200
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/neutral/warning{
@@ -19965,7 +19705,6 @@
 "Ob" = (
 /obj/structure/decorative{
 	icon_state = "siding_plain";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	dir = 4;
 	color = "#474747";
@@ -20212,7 +19951,6 @@
 	pixel_y = 22
 	},
 /obj/item/reagent_containers/cup/glass/bottle/small{
-	pixel_x = 0;
 	pixel_y = 19
 	},
 /obj/item/toy/figure/prisoner{
@@ -20284,7 +20022,6 @@
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/purple/end{
@@ -20322,8 +20059,7 @@
 /obj/structure/chair/pew/left,
 /obj/effect/turf_decal/tile/neutral/half{
 	alpha = 255;
-	color = "#5d341f";
-	dir = 2
+	color = "#5d341f"
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/bubbers/persistance/service/sauna)
@@ -20381,9 +20117,7 @@
 /obj/effect/turf_decal/siding{
 	dir = 9
 	},
-/obj/machinery/cryopod{
-	dir = 2
-	},
+/obj/machinery/cryopod,
 /obj/machinery/computer/cryopod/cybersun/directional/north,
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/bubbers/persistance/sec/prison)
@@ -20550,8 +20284,7 @@
 	name = "Dorm Bolt Switch";
 	id = "syndishipjanidorm";
 	req_access = list("syndicate");
-	normaldoorcontrol = 1;
-	pixel_x = -24
+	normaldoorcontrol = 1
 	},
 /turf/open/floor/carpet/purple,
 /area/ruin/space/has_grav/bubbers/persistance/service/dorms/janitor)
@@ -20972,8 +20705,7 @@
 	},
 /obj/structure/railing{
 	color = "#5d341f";
-	name = "wooden railing";
-	dir = 2
+	name = "wooden railing"
 	},
 /turf/open/misc/dirt/station,
 /area/ruin/space/has_grav/bubbers/persistance/service)
@@ -21088,8 +20820,7 @@
 /obj/structure/marker_beacon/bronze,
 /obj/effect/turf_decal/tile/neutral/half{
 	alpha = 255;
-	color = "#5d341f";
-	dir = 2
+	color = "#5d341f"
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/bubbers/persistance/service/sauna)
@@ -21563,7 +21294,6 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/item/toy/nuke{
-	pixel_x = 0;
 	pixel_y = 13
 	},
 /obj/structure/marker_beacon/burgundy,
@@ -21646,7 +21376,6 @@
 /obj/structure/window/reinforced/plasma/spawner/directional/north,
 /obj/machinery/byteforge,
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "Syndibitrunningconveyor"
 	},
 /turf/open/floor/mineral/plastitanium/red,
@@ -21662,8 +21391,7 @@
 	},
 /obj/structure/railing{
 	color = "#5d341f";
-	name = "wooden railing";
-	dir = 2
+	name = "wooden railing"
 	},
 /turf/open/misc/dirt/station,
 /area/ruin/space/has_grav/bubbers/persistance/service)
@@ -21942,8 +21670,7 @@
 	pixel_y = 2
 	},
 /obj/item/lighter/skull{
-	pixel_x = 7;
-	pixel_y = 0
+	pixel_x = 7
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/ruin/space/has_grav/bubbers/persistance/service/lounge)
@@ -22031,7 +21758,7 @@
 "So" = (
 /obj/machinery/gibber,
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/iron/kitchen_coldroom/white/smooth_large,
 /area/ruin/space/has_grav/bubbers/persistance/service/freezer)
 "Sr" = (
 /obj/structure/table/reinforced/plastitaniumglass,
@@ -22089,7 +21816,6 @@
 	icon = 'icons/obj/machines/wallmounts.dmi';
 	base_icon_state = "tile_half";
 	dir = 8;
-	pixel_x = 0;
 	name = "old radio";
 	anchored = 1
 	},
@@ -22188,7 +21914,6 @@
 /area/ruin/space/has_grav/bubbers/persistance/engineering/utilities)
 "SG" = (
 /obj/effect/turf_decal/siding/dark{
-	dir = 2;
 	icon_state = "siding_plain_end"
 	},
 /obj/structure/disposalpipe/trunk{
@@ -22222,11 +21947,9 @@
 	dir = 4
 	},
 /obj/structure/closet/generic/wall{
-	pixel_y = -30;
-	pixel_x = 0
+	pixel_y = -30
 	},
 /obj/machinery/dryer{
-	pixel_y = 0;
 	pixel_x = -28
 	},
 /turf/open/floor/wood/tile,
@@ -22249,8 +21972,7 @@
 "SS" = (
 /obj/machinery/newscaster/directional/south,
 /obj/structure/sign/painting/library{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -22620,7 +22342,6 @@
 "TA" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/clothing/suit/apron/chef{
-	pixel_x = 0;
 	pixel_y = 8
 	},
 /obj/item/clothing/head/utility/chefhat{
@@ -22762,12 +22483,10 @@
 /area/ruin/space/has_grav/bubbers/persistance/service/hydro)
 "TN" = (
 /obj/effect/turf_decal/siding/dark{
-	dir = 2;
 	icon_state = "siding_plain_end"
 	},
 /obj/structure/chair/pillow_small,
 /obj/structure/bed/pillow_large{
-	pixel_x = 0;
 	pixel_y = 20
 	},
 /obj/item/fancy_pillow{
@@ -22775,16 +22494,13 @@
 	pixel_y = 4
 	},
 /obj/structure/sign/painting/library{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/item/toy/plush/skyrat/jecca{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/machinery/newscaster/directional/south,
 /obj/structure/marker_beacon/purple{
-	pixel_x = 0;
 	pixel_y = 16
 	},
 /turf/open/floor/mineral/plasma,
@@ -22811,7 +22527,6 @@
 "TR" = (
 /obj/structure/decorative{
 	icon_state = "siding_plain";
-	pixel_y = 0;
 	icon = 'icons/turf/decals.dmi';
 	dir = 4;
 	color = "#474747";
@@ -22849,8 +22564,7 @@
 	},
 /obj/structure/bed/dogbed,
 /mob/living/basic/pet/syndifox{
-	faction = list("neutral","Syndicate");
-	dir = 2
+	faction = list("neutral","Syndicate")
 	},
 /turf/open/floor/stone,
 /area/ruin/space/has_grav/bubbers/persistance/command/admiral)
@@ -22899,12 +22613,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/storage/fancy/donut_box{
-	pixel_x = 0;
 	pixel_y = 7
 	},
 /obj/item/toy/figure/hos{
 	pixel_x = -6;
-	pixel_y = 0;
 	name = "\improper Badass Head of Security action figure";
 	desc = "If God wanted you to live he wouldn't have created me!"
 	},
@@ -22913,8 +22625,7 @@
 	},
 /obj/machinery/light/directional/east,
 /obj/item/toy/toy_xeno{
-	pixel_x = 7;
-	pixel_y = 0
+	pixel_x = 7
 	},
 /turf/open/floor/carpet/red,
 /area/ruin/space/has_grav/bubbers/persistance/service/dorms/maa)
@@ -22963,8 +22674,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral/half{
 	alpha = 255;
-	color = "#5d341f";
-	dir = 2
+	color = "#5d341f"
 	},
 /obj/item/book/granter/magazine,
 /obj/structure/noticeboard/directional/north,
@@ -22993,7 +22703,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/warning{
-	dir = 2;
 	alpha = 200;
 	color = "#1dc251"
 	},
@@ -23483,17 +23192,14 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark/filled/line{
-	alpha = 160;
-	dir = 2
+	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/purple/line{
 	color = "#2cbf9d";
-	alpha = 200;
-	dir = 2
+	alpha = 200
 	},
 /obj/effect/turf_decal/trimline/purple/corner{
 	color = "#2cbf9d";
@@ -23700,7 +23406,6 @@
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/storage/box/shipping,
 /obj/item/clothing/head/soft{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /turf/open/floor/iron/shuttle/exploration/uside,
@@ -23848,7 +23553,6 @@
 /area/ruin/space/has_grav/bubbers/persistance/service/dorms/medical)
 "VW" = (
 /obj/structure/chair/comfy/shuttle{
-	pixel_y = 0;
 	dir = 4;
 	name = "adjustable office seat";
 	desc = "A comfortable, secure seat. It has a more sturdy looking buckling system, for smoother working sessions."
@@ -24391,7 +24095,6 @@
 /obj/effect/mapping_helpers/apc/full_charge,
 /obj/effect/mapping_helpers/apc/cut_AI_wire,
 /obj/machinery/vending/cytopro{
-	pixel_y = 0;
 	all_products_free = 1
 	},
 /turf/open/floor/iron/dark/textured_large,
@@ -24526,7 +24229,6 @@
 	dir = 1
 	},
 /obj/structure/flora/bush/sparsegrass{
-	pixel_x = 0;
 	pixel_y = -9
 	},
 /turf/open/floor/grass,
@@ -24683,7 +24385,6 @@
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/dark/filled/mid_joiner{
-	dir = 2;
 	alpha = 160
 	},
 /obj/effect/turf_decal/trimline/neutral/line{
@@ -24970,8 +24671,7 @@
 /obj/item/reagent_containers/cup/glass/trophy/gold_cup{
 	pixel_y = 11;
 	desc = "To the loss of a beloved sister ship. May you rest peacefully beneath the ice.";
-	name = "DS-2 Memorial Trophy";
-	pixel_x = 0
+	name = "DS-2 Memorial Trophy"
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/mineral/plastitanium/red,
@@ -24987,8 +24687,7 @@
 	},
 /obj/structure/table/greyscale,
 /obj/item/condom_pack{
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/towel_bin{
 	pixel_x = -5;
@@ -25342,7 +25041,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/vending/wardrobe/syndie_wardrobe{
-	pixel_y = 0;
 	all_products_free = 1
 	},
 /obj/effect/turf_decal/bot_red,
@@ -25371,7 +25069,6 @@
 /area/ruin/space/has_grav/bubbers/persistance/command/bridge)
 "Zi" = (
 /obj/machinery/light/floor{
-	pixel_x = 0;
 	pixel_y = 16;
 	brightness = 7.5
 	},
@@ -25483,7 +25180,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/item/storage/briefcase/secure{
-	pixel_x = 0;
 	pixel_y = 17
 	},
 /turf/open/floor/mineral/plastitanium,
@@ -25661,10 +25357,8 @@
 	base_icon_state = "stairs-old";
 	icon_state = "stairs-l";
 	anchored = 1;
-	pixel_y = 0;
 	name = "staircase";
 	desc = "A small step for the humanity, and so is for you.";
-	dir = 2;
 	color = "#474747"
 	},
 /obj/structure/railing{

--- a/_maps/bubber/automapper/templates/lavaland/lavaland_persistence.dmm
+++ b/_maps/bubber/automapper/templates/lavaland/lavaland_persistence.dmm
@@ -2581,9 +2581,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
 	dir = 1
 	},
-/turf/open/floor/engine{
-	initial_gas_mix = "LAVALAND_ATMOS"
-	},
+/turf/open/floor/engine,
 /area/ruin/space/has_grav/bubbers/persistance/engineering/atmospherics)
 "fu" = (
 /obj/structure/table/reinforced/plastitaniumglass,

--- a/modular_skyrat/modules/hotel_rooms/prisoninfdorm.dmm
+++ b/modular_skyrat/modules/hotel_rooms/prisoninfdorm.dmm
@@ -1,96 +1,752 @@
-"av" = (/obj/machinery/hydroponics/constructable/fullupgrade,/obj/machinery/hydroponics/constructable/fullupgrade,/obj/machinery/light/directional/west,/turf/open/floor/grass,/area/misc/hilbertshotel)
-"cm" = (/obj/machinery/oven/range,/obj/structure/window/reinforced{dir = 1},/turf/open/floor/iron/checker,/area/misc/hilbertshotel)
-"cP" = (/obj/structure/closet/generic,/turf/open/floor/iron,/area/misc/hilbertshotel)
-"di" = (/obj/structure/chair/stool/directional/south,/turf/open/floor/iron,/area/misc/hilbertshotel)
-"eP" = (/obj/item/wallframe/status_display,/turf/closed/indestructible/reinforced,/area/misc/hilbertshotel)
-"eV" = (/obj/item/storage/box/nif_ghost_box/ghost_role,/obj/structure/closet/crate/trashcart/laundry,/turf/open/floor/iron,/area/misc/hilbertshotel)
-"fH" = (/obj/item/reagent_containers/cup/bottle/hexacrocin{pixel_x = -9},/obj/machinery/light/very_dim/directional/north,/turf/open/floor/iron,/area/misc/hilbertshotel)
-"ga" = (/obj/machinery/door/airlock,/turf/open/floor/iron,/area/misc/hilbertshotel)
-"hz" = (/obj/item/stack/license_plates/empty/fifty,/obj/item/stack/license_plates/empty/fifty,/obj/item/stack/license_plates/empty/fifty,/obj/structure/closet/crate/preopen,/turf/open/floor/iron,/area/misc/hilbertshotel)
-"ik" = (/obj/structure/table/reinforced,/obj/machinery/reagentgrinder{pixel_y = 10; pixel_x = -5},/turf/open/floor/iron/checker,/area/misc/hilbertshotel)
-"kP" = (/obj/structure/closet/crate/hydroponics,/obj/item/reagent_containers/cup/beaker/large,/obj/item/reagent_containers/cup/beaker/large,/obj/item/reagent_containers/cup/beaker/large,/obj/item/storage/bag/plants,/turf/open/floor/grass,/area/misc/hilbertshotel)
-"kX" = (/obj/structure/hoop{dir = 8},/obj/effect/turf_decal/trimline/white/filled/line{dir = 4},/obj/machinery/light/directional/east,/turf/open/floor/iron,/area/misc/hilbertshotel)
-"lD" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/closet/secure_closet/freezer/kitchen/all_access,/turf/open/floor/iron/checker,/area/misc/hilbertshotel)
-"mk" = (/obj/machinery/vending/hydronutrients{default_price = 0; extra_price = 0; fair_market_price = 0},/turf/open/floor/grass,/area/misc/hilbertshotel)
-"mX" = (/obj/machinery/light/warm/dim/directional/east,/turf/open/floor/iron,/area/misc/hilbertshotel)
-"nG" = (/obj/machinery/prisongate,/turf/open/floor/iron,/area/misc/hilbertshotel)
-"og" = (/obj/machinery/grill,/obj/machinery/griddle,/obj/structure/window/reinforced{dir = 1},/turf/open/floor/iron/checker,/area/misc/hilbertshotel)
-"rT" = (/obj/structure/table/reinforced,/obj/item/storage/box/handcuffs{pixel_y = 2; pixel_x = 5},/turf/open/floor/iron,/area/misc/hilbertshotel)
-"rZ" = (/obj/structure/chair/greyscale{dir = 1},/turf/open/floor/iron,/area/misc/hilbertshotel)
-"sv" = (/obj/structure/table,/obj/machinery/light/floor,/turf/open/floor/iron,/area/misc/hilbertshotel)
-"ui" = (/obj/structure/window/reinforced/spawner/directional/north{dir = 4},/obj/item/shovel/spade{pixel_x = 4; pixel_y = 4},/obj/item/hatchet{pixel_x = 10; pixel_y = 5},/obj/item/secateurs{pixel_y = 5; pixel_x = -10},/obj/item/plant_analyzer{pixel_y = -2},/obj/structure/table/glass,/turf/open/floor/grass,/area/misc/hilbertshotel)
-"uk" = (/obj/effect/turf_decal/trimline/white/filled/line{dir = 6},/turf/open/floor/iron,/area/misc/hilbertshotel)
-"uC" = (/obj/structure/window/reinforced{dir = 1},/obj/machinery/vending/dinnerware{default_price = 0; extra_price = 0; fair_market_price = 0},/turf/open/floor/iron/checker,/area/misc/hilbertshotel)
-"vT" = (/obj/machinery/light/directional/south,/turf/open/floor/iron,/area/misc/hilbertshotel)
-"ws" = (/obj/machinery/vending/security/noaccess,/obj/item/toy/figure/secofficer{pixel_y = 16},/turf/open/floor/iron,/area/misc/hilbertshotel)
-"xh" = (/obj/structure/chair/greyscale,/turf/open/floor/iron,/area/misc/hilbertshotel)
-"xI" = (/obj/machinery/biogenerator,/obj/structure/window/reinforced/spawner/directional/north,/turf/open/floor/grass,/area/misc/hilbertshotel)
-"yi" = (/obj/structure/table,/obj/item/toy/cards/deck/cas{pixel_y = 10; pixel_x = 8},/obj/item/toy/cards/deck/cas/black,/turf/open/floor/iron,/area/misc/hilbertshotel)
-"yr" = (/obj/effect/decal/cleanable/cum/femcum,/turf/open/floor/iron,/area/misc/hilbertshotel)
-"yD" = (/obj/structure/sign/poster/official/walk,/turf/closed/indestructible/reinforced,/area/misc/hilbertshotel)
-"yV" = (/obj/effect/turf_decal/trimline/white/filled/line{dir = 10},/turf/open/floor/iron,/area/misc/hilbertshotel)
-"zo" = (/obj/structure/sink/kitchen/directional/east,/turf/open/floor/grass,/area/misc/hilbertshotel)
-"zx" = (/obj/structure/table/reinforced{pixel_y = 0},/obj/item/storage/box/prisoner{pixel_y = 4; pixel_x = -6},/turf/open/floor/iron,/area/misc/hilbertshotel)
-"zU" = (/obj/structure/hoop{dir = 4},/obj/effect/turf_decal/trimline/white/filled/line{dir = 8},/obj/machinery/light/directional/west,/turf/open/floor/iron,/area/misc/hilbertshotel)
-"Ab" = (/obj/item/toy/basketball{pixel_x = 0},/turf/open/floor/iron,/area/misc/hilbertshotel)
-"AP" = (/obj/structure/chair/comfy/black,/obj/item/clothing/glasses/hypno{pixel_y = 8; pixel_x = -3},/obj/item/toy/figure/hos,/turf/open/floor/iron,/area/misc/hilbertshotel)
-"BT" = (/obj/machinery/light/directional/south,/turf/open/floor/iron/checker,/area/misc/hilbertshotel)
-"Cf" = (/obj/machinery/hydroponics/constructable/fullupgrade,/turf/open/floor/grass,/area/misc/hilbertshotel)
-"Ck" = (/obj/structure/table/reinforced,/obj/item/clothing/suit/jacket/straight_jacket{pixel_y = -5},/obj/item/clothing/mask/muzzle{pixel_y = 5},/obj/item/clothing/glasses/blindfold{pixel_y = 7},/turf/open/floor/iron,/area/misc/hilbertshotel)
-"Cm" = (/obj/structure/window/reinforced{dir = 8},/turf/open/floor/iron/checker,/area/misc/hilbertshotel)
-"Cx" = (/obj/machinery/plate_press,/turf/open/floor/iron,/area/misc/hilbertshotel)
-"Cz" = (/turf/closed/indestructible/hoteldoor{icon_state = "door_closed"; icon = 'icons/obj/doors/puzzledoor/default.dmi'},/area/misc/hilbertshotel)
-"CD" = (/obj/structure/window/reinforced/spawner/directional/east,/turf/open/floor/grass,/area/misc/hilbertshotel)
-"CZ" = (/obj/structure/sign/poster/contraband/got_wood,/turf/closed/indestructible/reinforced,/area/misc/hilbertshotel)
-"El" = (/turf/open/floor/iron/checker,/area/misc/hilbertshotel)
-"Fa" = (/obj/structure/falsewall/reinforced,/turf/open/floor/iron,/area/misc/hilbertshotel)
-"Fp" = (/obj/structure/window/reinforced/spawner/directional/east,/obj/structure/window/reinforced/spawner/directional/north,/obj/machinery/seed_extractor,/turf/open/floor/grass,/area/misc/hilbertshotel)
-"FV" = (/turf/closed/indestructible/fakeglass,/area/misc/hilbertshotel)
-"Gw" = (/obj/machinery/washing_machine,/turf/open/floor/iron,/area/misc/hilbertshotel)
-"GA" = (/turf/open/floor/iron/edge{dir = 1},/area/misc/hilbertshotel)
-"Hq" = (/turf/open/floor/grass,/area/misc/hilbertshotel)
-"Io" = (/obj/machinery/door/airlock/security/glass,/turf/open/floor/iron,/area/misc/hilbertshotel)
-"Iu" = (/obj/structure/bed/double,/obj/effect/spawner/random/bedsheet/double,/turf/open/floor/iron/edge{dir = 1},/area/misc/hilbertshotel)
-"Jq" = (/obj/machinery/washing_machine,/obj/item/toy/figure/prisoner{pixel_y = 10},/turf/open/floor/iron,/area/misc/hilbertshotel)
-"La" = (/obj/machinery/door/airlock/hatch,/turf/open/floor/iron,/area/misc/hilbertshotel)
-"Lw" = (/obj/structure/sign/poster/official/boombox,/turf/closed/indestructible/reinforced,/area/misc/hilbertshotel)
-"LF" = (/obj/structure/table,/turf/open/floor/iron,/area/misc/hilbertshotel)
-"LV" = (/turf/closed/indestructible/reinforced,/area/misc/hilbertshotel)
-"Md" = (/obj/structure/table/reinforced,/obj/item/kitchen/rollingpin{pixel_x = -10; pixel_y = 5},/obj/item/knife/kitchen{pixel_y = 5; pixel_x = 10},/turf/open/floor/iron/checker,/area/misc/hilbertshotel)
-"MR" = (/obj/machinery/vending/dorms/prison,/obj/item/toy/figure/assistant{pixel_y = 16},/turf/open/floor/iron,/area/misc/hilbertshotel)
-"Nt" = (/obj/machinery/door/window{dir = 8},/turf/open/floor/iron/checker,/area/misc/hilbertshotel)
-"NN" = (/turf/open/floor/iron,/area/misc/hilbertshotel)
-"Od" = (/obj/machinery/door/window/brigdoor/left/directional/east,/turf/open/floor/grass,/area/misc/hilbertshotel)
-"Oj" = (/obj/effect/turf_decal/trimline/white/filled/line{dir = 9},/turf/open/floor/iron,/area/misc/hilbertshotel)
-"OY" = (/obj/structure/window/reinforced/spawner/directional/north,/turf/open/floor/grass,/area/misc/hilbertshotel)
-"PR" = (/obj/machinery/light/directional/north,/turf/open/floor/iron,/area/misc/hilbertshotel)
-"QG" = (/obj/effect/turf_decal/trimline/white/filled/line{dir = 1},/turf/open/floor/iron,/area/misc/hilbertshotel)
-"QJ" = (/obj/machinery/vending/hydroseeds{default_price = 0; extra_price = 0; fair_market_price = 0},/obj/structure/window/reinforced/spawner/directional/east,/obj/item/toy/figure/botanist{pixel_y = 16},/turf/open/floor/grass,/area/misc/hilbertshotel)
-"Si" = (/obj/structure/table/reinforced,/obj/structure/table/reinforced,/obj/machinery/processor,/turf/open/floor/iron/checker,/area/misc/hilbertshotel)
-"SZ" = (/obj/structure/table,/obj/item/toy/figure/ian{pixel_x = 8},/obj/item/toy/figure/hop{pixel_y = 2},/obj/item/toy/figure/ian{pixel_x = -4; pixel_y = 2},/obj/item/toy/figure/ian{pixel_x = 0},/obj/item/toy/figure/ian{pixel_x = 4; pixel_y = 2},/obj/item/toy/figure/ian{pixel_x = -8},/turf/open/floor/iron,/area/misc/hilbertshotel)
-"TT" = (/obj/structure/closet,/obj/item/market_uplink,/obj/effect/spawner/random/entertainment/coin,/obj/effect/spawner/random/entertainment/coin,/obj/item/gun/ballistic/automatic/l6_saw/toy,/obj/effect/spawner/random/entertainment/toy_figure,/obj/item/pen/sleepy,/turf/open/floor/iron,/area/misc/hilbertshotel)
-"Vt" = (/obj/machinery/deepfryer,/obj/structure/window/reinforced{dir = 1},/turf/open/floor/iron/checker,/area/misc/hilbertshotel)
-"VM" = (/obj/machinery/vending/sustenance,/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 1; pixel_y = 1},/obj/item/toy/figure/chef{pixel_y = 15},/turf/open/floor/iron/checker,/area/misc/hilbertshotel)
-"XN" = (/obj/structure/bed,/turf/open/floor/iron,/area/misc/hilbertshotel)
-"YN" = (/obj/effect/turf_decal/trimline/white/filled/line,/turf/open/floor/iron,/area/misc/hilbertshotel)
-"YR" = (/obj/machinery/smartfridge,/turf/open/floor/iron/checker,/area/misc/hilbertshotel)
-"Za" = (/obj/item/clothing/mask/leatherwhip{pixel_x = -9; pixel_y = 4},/turf/open/floor/iron,/area/misc/hilbertshotel)
-"Zj" = (/obj/effect/turf_decal/trimline/white/filled/line{dir = 5},/turf/open/floor/iron,/area/misc/hilbertshotel)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"av" = (
+/obj/machinery/hydroponics/constructable/fullupgrade,
+/obj/machinery/hydroponics/constructable/fullupgrade,
+/obj/machinery/light/directional/west,
+/turf/open/floor/grass,
+/area/misc/hilbertshotel)
+"cm" = (
+/obj/machinery/oven/range,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/iron/checker,
+/area/misc/hilbertshotel)
+"cP" = (
+/obj/structure/closet/generic,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"di" = (
+/obj/structure/chair/stool/directional/south,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"eP" = (
+/obj/item/wallframe/status_display,
+/turf/closed/indestructible/reinforced,
+/area/misc/hilbertshotel)
+"eV" = (
+/obj/item/storage/box/nif_ghost_box/ghost_role,
+/obj/structure/closet/crate/trashcart/laundry,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"fH" = (
+/obj/item/reagent_containers/cup/bottle/hexacrocin{
+	pixel_x = -9
+	},
+/obj/machinery/light/very_dim/directional/north,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"ga" = (
+/obj/machinery/door/airlock,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"hz" = (
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/structure/closet/crate/preopen,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"ik" = (
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder{
+	pixel_y = 10;
+	pixel_x = -5
+	},
+/turf/open/floor/iron/checker,
+/area/misc/hilbertshotel)
+"kP" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/reagent_containers/cup/beaker/large,
+/obj/item/reagent_containers/cup/beaker/large,
+/obj/item/reagent_containers/cup/beaker/large,
+/obj/item/storage/bag/plants,
+/turf/open/floor/grass,
+/area/misc/hilbertshotel)
+"kX" = (
+/obj/structure/hoop{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"lD" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/freezer/kitchen/all_access,
+/turf/open/floor/iron/checker,
+/area/misc/hilbertshotel)
+"mk" = (
+/obj/machinery/vending/hydronutrients{
+	default_price = 0;
+	extra_price = 0;
+	fair_market_price = 0
+	},
+/turf/open/floor/grass,
+/area/misc/hilbertshotel)
+"mX" = (
+/obj/machinery/light/warm/dim/directional/east,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"nG" = (
+/obj/machinery/prisongate,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"og" = (
+/obj/machinery/grill,
+/obj/machinery/griddle,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/iron/checker,
+/area/misc/hilbertshotel)
+"rT" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/handcuffs{
+	pixel_y = 2;
+	pixel_x = 5
+	},
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"rZ" = (
+/obj/structure/chair/greyscale{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"sv" = (
+/obj/structure/table,
+/obj/machinery/light/floor,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"ui" = (
+/obj/structure/window/reinforced/spawner/directional/north{
+	dir = 4
+	},
+/obj/item/shovel/spade{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/hatchet{
+	pixel_x = 10;
+	pixel_y = 5
+	},
+/obj/item/secateurs{
+	pixel_y = 5;
+	pixel_x = -10
+	},
+/obj/item/plant_analyzer{
+	pixel_y = -2
+	},
+/obj/structure/table/glass,
+/turf/open/floor/grass,
+/area/misc/hilbertshotel)
+"uk" = (
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"uC" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/vending/dinnerware{
+	default_price = 0;
+	extra_price = 0;
+	fair_market_price = 0
+	},
+/turf/open/floor/iron/checker,
+/area/misc/hilbertshotel)
+"vT" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"ws" = (
+/obj/machinery/vending/security/noaccess,
+/obj/item/toy/figure/secofficer{
+	pixel_y = 16
+	},
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"xh" = (
+/obj/structure/chair/greyscale,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"xI" = (
+/obj/machinery/biogenerator,
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/grass,
+/area/misc/hilbertshotel)
+"yi" = (
+/obj/structure/table,
+/obj/item/toy/cards/deck/cas{
+	pixel_y = 10;
+	pixel_x = 8
+	},
+/obj/item/toy/cards/deck/cas/black,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"yr" = (
+/obj/effect/decal/cleanable/cum/femcum,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"yD" = (
+/obj/structure/sign/poster/official/walk,
+/turf/closed/indestructible/reinforced,
+/area/misc/hilbertshotel)
+"yV" = (
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"zo" = (
+/obj/structure/sink/kitchen/directional/east,
+/turf/open/floor/grass,
+/area/misc/hilbertshotel)
+"zx" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/prisoner{
+	pixel_y = 4;
+	pixel_x = -6
+	},
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"zU" = (
+/obj/structure/hoop{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"Ab" = (
+/obj/item/toy/basketball,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"AP" = (
+/obj/structure/chair/comfy/black,
+/obj/item/clothing/glasses/hypno{
+	pixel_y = 8;
+	pixel_x = -3
+	},
+/obj/item/toy/figure/hos,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"BT" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/checker,
+/area/misc/hilbertshotel)
+"Cf" = (
+/obj/machinery/hydroponics/constructable/fullupgrade,
+/turf/open/floor/grass,
+/area/misc/hilbertshotel)
+"Ck" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/jacket/straight_jacket{
+	pixel_y = -5
+	},
+/obj/item/clothing/mask/muzzle{
+	pixel_y = 5
+	},
+/obj/item/clothing/glasses/blindfold{
+	pixel_y = 7
+	},
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"Cm" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/iron/checker,
+/area/misc/hilbertshotel)
+"Cx" = (
+/obj/machinery/plate_press,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"Cz" = (
+/turf/closed/indestructible/hoteldoor{
+	icon_state = "door_closed";
+	icon = 'icons/obj/doors/puzzledoor/default.dmi'
+	},
+/area/misc/hilbertshotel)
+"CD" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/floor/grass,
+/area/misc/hilbertshotel)
+"CZ" = (
+/obj/structure/sign/poster/contraband/got_wood,
+/turf/closed/indestructible/reinforced,
+/area/misc/hilbertshotel)
+"El" = (
+/turf/open/floor/iron/checker,
+/area/misc/hilbertshotel)
+"Fa" = (
+/obj/structure/falsewall/reinforced,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"Fp" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/machinery/seed_extractor,
+/turf/open/floor/grass,
+/area/misc/hilbertshotel)
+"FV" = (
+/turf/closed/indestructible/fakeglass,
+/area/misc/hilbertshotel)
+"Gw" = (
+/obj/machinery/washing_machine,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"GA" = (
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/misc/hilbertshotel)
+"Hq" = (
+/turf/open/floor/grass,
+/area/misc/hilbertshotel)
+"Io" = (
+/obj/machinery/door/airlock/security/glass,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"Iu" = (
+/obj/structure/bed/double,
+/obj/effect/spawner/random/bedsheet/double,
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/misc/hilbertshotel)
+"Jq" = (
+/obj/machinery/washing_machine,
+/obj/item/toy/figure/prisoner{
+	pixel_y = 10
+	},
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"La" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"Lw" = (
+/obj/structure/sign/poster/official/boombox,
+/turf/closed/indestructible/reinforced,
+/area/misc/hilbertshotel)
+"LF" = (
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"LV" = (
+/turf/closed/indestructible/reinforced,
+/area/misc/hilbertshotel)
+"Md" = (
+/obj/structure/table/reinforced,
+/obj/item/kitchen/rollingpin{
+	pixel_x = -10;
+	pixel_y = 5
+	},
+/obj/item/knife/kitchen{
+	pixel_y = 5;
+	pixel_x = 10
+	},
+/turf/open/floor/iron/checker,
+/area/misc/hilbertshotel)
+"MR" = (
+/obj/machinery/vending/dorms/prison,
+/obj/item/toy/figure/assistant{
+	pixel_y = 16
+	},
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"Nt" = (
+/obj/machinery/door/window{
+	dir = 8
+	},
+/turf/open/floor/iron/checker,
+/area/misc/hilbertshotel)
+"NN" = (
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"Od" = (
+/obj/machinery/door/window/brigdoor/left/directional/east,
+/turf/open/floor/grass,
+/area/misc/hilbertshotel)
+"Oj" = (
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"OY" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/grass,
+/area/misc/hilbertshotel)
+"PR" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"QG" = (
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"QJ" = (
+/obj/machinery/vending/hydroseeds{
+	default_price = 0;
+	extra_price = 0;
+	fair_market_price = 0
+	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/item/toy/figure/botanist{
+	pixel_y = 16
+	},
+/turf/open/floor/grass,
+/area/misc/hilbertshotel)
+"Si" = (
+/obj/structure/table/reinforced,
+/obj/structure/table/reinforced,
+/obj/machinery/processor,
+/turf/open/floor/iron/checker,
+/area/misc/hilbertshotel)
+"SZ" = (
+/obj/structure/table,
+/obj/item/toy/figure/ian{
+	pixel_x = 8
+	},
+/obj/item/toy/figure/hop{
+	pixel_y = 2
+	},
+/obj/item/toy/figure/ian{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/toy/figure/ian,
+/obj/item/toy/figure/ian{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/toy/figure/ian{
+	pixel_x = -8
+	},
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"TT" = (
+/obj/structure/closet,
+/obj/item/market_uplink,
+/obj/effect/spawner/random/entertainment/coin,
+/obj/effect/spawner/random/entertainment/coin,
+/obj/item/gun/ballistic/automatic/l6_saw/toy,
+/obj/effect/spawner/random/entertainment/toy_figure,
+/obj/item/pen/sleepy,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"Vt" = (
+/obj/machinery/deepfryer,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/iron/checker,
+/area/misc/hilbertshotel)
+"VM" = (
+/obj/machinery/vending/sustenance,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/item/toy/figure/chef{
+	pixel_y = 15
+	},
+/turf/open/floor/iron/checker,
+/area/misc/hilbertshotel)
+"XN" = (
+/obj/structure/bed,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"YN" = (
+/obj/effect/turf_decal/trimline/white/filled/line,
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"YR" = (
+/obj/machinery/smartfridge,
+/turf/open/floor/iron/checker,
+/area/misc/hilbertshotel)
+"Za" = (
+/obj/item/clothing/mask/leatherwhip{
+	pixel_x = -9;
+	pixel_y = 4
+	},
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
+"Zj" = (
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/misc/hilbertshotel)
 
 (1,1,1) = {"
-LVLVLVLVLVFVFVFVFVFVFVLVLVLVLV
-LVGAPRIuLVOjQGQGQGQGZjLVAPfHLV
-LVNNNNNNLVzUNNAbNNNNkXLVyrZaLV
-LVgaePCZCZyVYNYNYNYNukLVFaLVLV
-LVNNMRPRNNNNNNNNNNNNNNPReVJqLV
-LVNNNNNNNNNNNNNNNNdiNNdiNNGwLV
-LVxIOYFpNNxhxhNNsvCxhzCxsvNNLV
-LVCfHquiNNyiSZNNVMuCogcmVtlDLV
-LVavHqOdNNLFLFNNCmElElElElElLV
-LVzoHqCDNNrZrZNNNtElikSiMdElLV
-LVkPmkQJNNvTNNNNYRElElBTElElLV
-LVLVyDFVFVLwIonGLVLVLVLVLVLVLV
-LVcPrTzxwsPRNNNNNNNNPRLaNNmXLV
-CzNNNNNNNNNNNNNNNNTTCkLVNNXNLV
-LVLVLVLVLVLVLVLVLVLVLVLVLVLVLV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+Cz
+LV
+"}
+(2,1,1) = {"
+LV
+GA
+NN
+ga
+NN
+NN
+xI
+Cf
+av
+zo
+kP
+LV
+cP
+NN
+LV
+"}
+(3,1,1) = {"
+LV
+PR
+NN
+eP
+MR
+NN
+OY
+Hq
+Hq
+Hq
+mk
+yD
+rT
+NN
+LV
+"}
+(4,1,1) = {"
+LV
+Iu
+NN
+CZ
+PR
+NN
+Fp
+ui
+Od
+CD
+QJ
+FV
+zx
+NN
+LV
+"}
+(5,1,1) = {"
+LV
+LV
+LV
+CZ
+NN
+NN
+NN
+NN
+NN
+NN
+NN
+FV
+ws
+NN
+LV
+"}
+(6,1,1) = {"
+FV
+Oj
+zU
+yV
+NN
+NN
+xh
+yi
+LF
+rZ
+vT
+Lw
+PR
+NN
+LV
+"}
+(7,1,1) = {"
+FV
+QG
+NN
+YN
+NN
+NN
+xh
+SZ
+LF
+rZ
+NN
+Io
+NN
+NN
+LV
+"}
+(8,1,1) = {"
+FV
+QG
+Ab
+YN
+NN
+NN
+NN
+NN
+NN
+NN
+NN
+nG
+NN
+NN
+LV
+"}
+(9,1,1) = {"
+FV
+QG
+NN
+YN
+NN
+NN
+sv
+VM
+Cm
+Nt
+YR
+LV
+NN
+NN
+LV
+"}
+(10,1,1) = {"
+FV
+QG
+NN
+YN
+NN
+di
+Cx
+uC
+El
+El
+El
+LV
+NN
+TT
+LV
+"}
+(11,1,1) = {"
+FV
+Zj
+kX
+uk
+NN
+NN
+hz
+og
+El
+ik
+El
+LV
+PR
+Ck
+LV
+"}
+(12,1,1) = {"
+LV
+LV
+LV
+LV
+PR
+di
+Cx
+cm
+El
+Si
+BT
+LV
+La
+LV
+LV
+"}
+(13,1,1) = {"
+LV
+AP
+yr
+Fa
+eV
+NN
+sv
+Vt
+El
+Md
+El
+LV
+NN
+NN
+LV
+"}
+(14,1,1) = {"
+LV
+fH
+Za
+LV
+Jq
+Gw
+NN
+lD
+El
+El
+El
+LV
+mX
+XN
+LV
+"}
+(15,1,1) = {"
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
 "}

--- a/modular_skyrat/modules/primitive_catgirls/code/map_items.dm
+++ b/modular_skyrat/modules/primitive_catgirls/code/map_items.dm
@@ -12,11 +12,14 @@
 
 /turf/open/misc/dirt/icemoon
 	baseturfs = /turf/open/openspace/icemoon
-	initial_gas_mix = "ICEMOON_ATMOS"
+	initial_gas_mix = ICEMOON_DEFAULT_ATMOS
 
 /turf/open/misc/dirt/icemoon/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/simple_farm, set_plant = TRUE)
+
+/turf/open/water/hot_spring/icemoon_atmos
+	initial_gas_mix = ICEMOON_DEFAULT_ATMOS
 
 // The area
 

--- a/modular_zubbers/maps/offstation/lizard_gas.dm
+++ b/modular_zubbers/maps/offstation/lizard_gas.dm
@@ -3,3 +3,10 @@
 	assignment = "Lizard Gas Employee"
 	access = list(ACCESS_FACTION_PUBLIC)
 	big_pointer = TRUE
+
+/turf/open/floor/asphalt/icemoon
+	initial_gas_mix = ICEMOON_DEFAULT_ATMOS
+	baseturfs = /turf/open/floor/plating/snowed/icemoon
+
+/turf/open/floor/asphalt/icemoon/outdoors
+	planetary_atmos = TRUE

--- a/modular_zubbers/maps/offstation/persistence/turf.dm
+++ b/modular_zubbers/maps/offstation/persistence/turf.dm
@@ -1,0 +1,10 @@
+// Used in Persistence freezer
+/turf/open/floor/iron/kitchen_coldroom/white
+	icon_state = "white"
+	base_icon_state = "white"
+	floor_tile = /obj/item/stack/tile/iron/white
+
+/turf/open/floor/iron/kitchen_coldroom/white/smooth_large
+	icon_state = "white_large"
+	base_icon_state = "white_large"
+	floor_tile = /obj/item/stack/tile/iron/white/smooth_large

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9739,6 +9739,7 @@
 #include "modular_zubbers\maps\offstation\persistence\mob_spawns.dm"
 #include "modular_zubbers\maps\offstation\persistence\robot_upgrade.dm"
 #include "modular_zubbers\maps\offstation\persistence\ruins.dm"
+#include "modular_zubbers\maps\offstation\persistence\turf.dm"
 #include "modular_zubbers\master_files\code\controllers\subsystem\id_access.dm"
 #include "modular_zubbers\master_files\code\datums\announcers\default_announcer.dm"
 #include "modular_zubbers\master_files\code\datums\diseases\chronic_ilness.dm"


### PR DESCRIPTION

## About The Pull Request

Cleans up active turfs in the lizard gas ruin (lavaland and icemoon), the ice cats camp, port tarkon, and some but not all in persistence (lavaland and icemoon)

## Why It's Good For The Game

Less roundstart active turfs

## Proof Of Testing

I tested it 

## Changelog

No player facing changes