### PR TITLE
Fix loading screen messages not appearing

### DIFF
--- a/modular_skyrat/modules/title_screen/code/title_screen_html.dm
+++ b/modular_skyrat/modules/title_screen/code/title_screen_html.dm
@@ -170,11 +170,12 @@ GLOBAL_LIST_EMPTY(startup_messages)
 		"}
 
 	// Tell the server this page loaded.
-	dat += {"
-		<script>
-			location.href = "byond://?src=[text_ref(src)];title_is_ready=1";
-		</script>
-	"}
+	if(!title_screen_is_ready)
+		dat += {"
+			<script>
+				location.href = "byond://?src=[text_ref(src)];title_is_ready=1";
+			</script>
+		"}
 
 	dat += "</body></html>"
 


### PR DESCRIPTION
## About The Pull Request
516 fucked with href stuff and so this request never sends and the client is never marked ready so init loading messages don't get sent

## Why It's Good For The Game
Cool live loading messages

## Proof Of Testing
This is a web edit from bed that I tested earlier and it worked

## Changelog
:cl:
fix: fixed loading screen not updating as subsystems init
fix: fixed character name on title screen not updating when changing slots
/:cl:
