### PR TITLE
Proteans can now be sacrificed by heretics

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -89,7 +89,11 @@
 		// Otherwise if it's neither a target nor a cultist, remove it
 		else if(!(sacrifice in heretic_datum.sac_targets) && !IS_CULTIST(sacrifice))
 			atoms -= sacrifice
-
+	//BUBBER EDIT, NO HIDING FROM THE DARK GODS!
+	for(var/obj/item/mod/control/pre_equipped/protean/protean_item in atoms)
+		for(var/mob/living/carbon/human/hiding_target in protean_item.contents)
+			atoms += hiding_target
+	//BUBBER EDIT END
 	// Finally, return TRUE if we have a target in the list
 	if(locate(/mob/living/carbon/human) in atoms)
 		return TRUE
@@ -337,7 +341,12 @@
 		CRASH("[type] - begin_sacrifice could not find a destination landmark OR default landmark to send the sacrifice! (Heretic's path: [our_heretic.heretic_path])")
 
 	var/turf/destination = get_turf(destination_landmark)
-
+	//BUBBERSTATION EDIT
+	if(is_species(sac_target, /datum/species/protean))
+		var/obj/item/organ/brain/protean/brain = sac_target.get_organ_slot(ORGAN_SLOT_BRAIN)
+		brain.revive()
+		brain.leave_modsuit()
+	//BUBBERSTATION EDIT END
 	sac_target.visible_message(span_danger("[sac_target] begins to shudder violenty as dark tendrils begin to drag them into thin air!"))
 	sac_target.set_handcuffed(new /obj/item/restraints/handcuffs/energy/cult(sac_target))
 	sac_target.update_handcuffed()


### PR DESCRIPTION
## About The Pull Request

Previously: Protean becomes modsuit on death. Is unsacrificable.

With the change: Protean in modsuit can be sacrificed, causing them to revive, reform, get cuffed and then sent as would be a typical carbon.

## Why It's Good For The Game

Not being able to be sacrificed is not an intended game mechanic, is a bug and unfairly robs heretics out of their hard work.

## Proof Of Testing

![obraz](https://github.com/user-attachments/assets/15e7d122-f5fb-4809-9ab8-db531c59a2f8)
I am not sure still if all is good and for whether 1 line is not that big of a deal to not have mondularized or if I should modularize it, too
## Changelog

fix: Proteans can now be sacrificed by heretics in modsuit form
/:cl:

