### PR TITLE
Fix gun safeties disabling when you click anywhere at all

### DIFF
--- a/modular_skyrat/modules/gun_safety/code/safety_component.dm
+++ b/modular_skyrat/modules/gun_safety/code/safety_component.dm
@@ -39,11 +39,19 @@
 /// Checks if the safety is currently on, if it is then stops the gun from firing
 /datum/component/gun_safety/proc/check_if_we_can_actually_shooty(obj/item/gun/source, mob/living/user, atom/target, flag, params)
 	SIGNAL_HANDLER
+	if(!safety_currently_on)
+		return // safety's off, we don't care
 
-	if(safety_currently_on)
-		user.balloon_alert(user, "the safety disengages!")
-		toggle_safeties(user)
-		return COMPONENT_CANCEL_GUN_FIRE
+	if(flag) // user clicked adjacent target
+		if(target in user.contents) // clicking something in inventory
+			return
+		if(!ismob(target)) // trying to place the gun somewhere/melee attack
+			return
+
+	// they are actually trying to shoot something
+	user.balloon_alert(user, "the safety disengages!")
+	toggle_safeties(user)
+	return COMPONENT_CANCEL_GUN_FIRE
 
 /// Calls toggle_safeties if the action type for doing so is used
 /datum/component/gun_safety/proc/we_may_be_toggling_safeties(source, user, datum/actiontype)


### PR DESCRIPTION

## About The Pull Request

Gun safety component registers `COMSIG_GUN_TRY_FIRE` but that signal firing doesn't necessarily mean the gun is going to shoot, it fires before it checks things like whether the user is putting the item in inventory or placing it on a table. Fixes the logic in the signal handler to account for this

## Why It's Good For The Game

Safety should only turn off when actually trying to fire

## Proof Of Testing

Trust

## Changelog
:cl:
fix: fixed gun safeties disabling when you tried to put it in your inventory or put it on a table
/:cl:
