### PR TITLE
combat surgeon medkit no longer fits normal sized items

### DIFF
--- a/modular_skyrat/modules/deforest_medical_items/code/storage_items.dm
+++ b/modular_skyrat/modules/deforest_medical_items/code/storage_items.dm
@@ -140,12 +140,6 @@
 	pickup_sound = SFX_CLOTH_PICKUP
 	drop_sound = SFX_CLOTH_DROP
 
-/obj/item/storage/medkit/combat_surgeon/Initialize(mapload)
-	. = ..()
-	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
-
-/obj/item/storage/medkit/combat_surgeon/stocked
-
 /obj/item/storage/medkit/combat_surgeon/stocked/PopulateContents()
 	var/static/items_inside = list(
 		/obj/item/bonesetter = 1,


### PR DESCRIPTION

## About The Pull Request
combat surgeon medkit no longer fits normal sized items

## Why It's Good For The Game
Normal sized items should be able to hold normal sized items

## Proof Of Testing
nop

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
balance: combat surgeon medkit no longer fits normal sized items
/:cl:

