### PR TITLE
Makes the server (more) gay

### DIFF
--- a/code/__DEFINES/time.dm
+++ b/code/__DEFINES/time.dm
@@ -36,7 +36,7 @@
 #define FESTIVE_SEASON "Festive Season"
 #define GARBAGEDAY "Garbage Day"
 #define MONKEYDAY "Monkey Day"
-#define PRIDE_WEEK "Pride Week"
+#define PRIDE_WEEK "Pride Month" // BUBBER EDIT CHANGE - Pride Month
 #define MOTH_WEEK "Moth Week"
 #define IAN_HOLIDAY "Ian's Birthday"
 #define HOTDOG_DAY "National Hot Dog Day"

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -103,13 +103,18 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 		if(PATTERN_RAINBOW)
 			var/datum/holiday/pride_week/rainbow_datum = new()
 			return rainbow_datum.get_holiday_colors(thing_to_color, PATTERN_DEFAULT)
-	if(!length(GLOB.holidays))
-		return
+	//if(!length(GLOB.holidays)) // BUBBER EDIT REMOVAL - Pride Flag Colors
+	//	return // BUBBER EDIT REMOVAL - Pride Flag Colors
 	for(var/holiday_key in GLOB.holidays)
 		var/datum/holiday/holiday_real = GLOB.holidays[holiday_key]
 		if(!holiday_real.holiday_colors)
 			continue
 		return holiday_real.get_holiday_colors(thing_to_color, pattern || holiday_real.holiday_pattern)
+	// BUBBER EDIT ADDITION BEGIN - Pride Flag Colors
+	if(prob(25))
+		var/datum/holiday/pride_week/rainbow_datum = new()
+		return rainbow_datum.get_holiday_colors(thing_to_color, pattern)
+	// BUBBER EDIT ADDITION END - Pride Flag Colors
 
 // The actual holidays
 

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -111,7 +111,7 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 			continue
 		return holiday_real.get_holiday_colors(thing_to_color, pattern || holiday_real.holiday_pattern)
 	// BUBBER EDIT ADDITION BEGIN - Pride Flag Colors
-	if(prob(25))
+	if(prob(20))
 		var/datum/holiday/pride_week/rainbow_datum = new()
 		return rainbow_datum.get_holiday_colors(thing_to_color, pattern)
 	// BUBBER EDIT ADDITION END - Pride Flag Colors

--- a/modular_zubbers/master_files/code/modules/holiday/holiday.dm
+++ b/modular_zubbers/master_files/code/modules/holiday/holiday.dm
@@ -1,9 +1,31 @@
-#define PURPLE_LIGHT "#9F79F2"
-#define PURPLE_DARK "#6141A6"
-#define ORANGE_LIGHT "#F27F1B"
-#define ORANGE_DARK "#F24F13"
-#define GREY_LIGHT "#FFFFFF"
-#define GREY_DARK "#292929"
+#define COLOR_PURPLE_LIGHT "#9F79F2"
+#define COLOR_PURPLE_DARK "#6141A6"
+#define COLOR_ORANGE_LIGHT "#F27F1B"
+#define COLOR_ORANGE_DARK "#F24F13"
+#define COLOR_GREY_LIGHT "#FFFFFF"
+#define COLOR_GREY_DARK "#292929"
+
+#define COLOR_PRIDE_WHITE "#FFFFFF"
+
+#define COLOR_TRANS_BLUE "#5BCEFA"
+#define COLOR_TRANS_PINK "#F5A9B8"
+
+#define COLOR_ACE_BLACK "#292929"
+#define COLOR_ACE_GREY "#888888"
+#define COLOR_ACE_PURPLE "#800080"
+
+#define COLOR_BI_PINK "#D60270"
+#define COLOR_BI_PURPLE "#9B4F96"
+#define COLOR_BI_BLUE "#0038A8"
+
+#define COLOR_LESBIAN_RED "#D62800"
+#define COLOR_LESBIAN_ORANGE "#FF9B56"
+#define COLOR_LESBIAN_PINK "#D452A6"
+#define COLOR_LESBIAN_MAGENTA "#A40062"
+
+#define COLOR_PAN_MAGENTA "#FF218C"
+#define COLOR_PAN_YELLOW "#FFE45E"
+#define COLOR_PAN_CYAN "#2CCAFF"
 
 /datum/holiday/proc/queue_storyteller_celebration(datum/round_event/event, datum/round_event_control/control)
 	if(isnull(event) || isnull(control))
@@ -38,50 +60,50 @@
 	switch(palette)
 		if(1, 2)
 			holiday_colors += list(
-				PURPLE_LIGHT,
-				PURPLE_DARK,
-				GREY_DARK,
-				ORANGE_DARK,
-				ORANGE_LIGHT,
-				GREY_LIGHT,
+				COLOR_PURPLE_LIGHT,
+				COLOR_PURPLE_DARK,
+				COLOR_GREY_DARK,
+				COLOR_ORANGE_DARK,
+				COLOR_ORANGE_LIGHT,
+				COLOR_GREY_LIGHT,
 			)
 		if(3)
 			holiday_colors += list(
-				PURPLE_LIGHT,
-				ORANGE_LIGHT,
-				GREY_LIGHT,
+				COLOR_PURPLE_LIGHT,
+				COLOR_ORANGE_LIGHT,
+				COLOR_GREY_LIGHT,
 			)
 		if(4)
 			holiday_colors += list(
-				PURPLE_DARK,
-				ORANGE_DARK,
-				GREY_DARK,
+				COLOR_PURPLE_DARK,
+				COLOR_ORANGE_DARK,
+				COLOR_GREY_DARK,
 			)
 		if(5)
 			holiday_colors += list(
-				pick(GREY_LIGHT, GREY_DARK),
-				pick(PURPLE_LIGHT, PURPLE_DARK),
-				pick(ORANGE_LIGHT, ORANGE_DARK),
+				pick(COLOR_GREY_LIGHT, COLOR_GREY_DARK),
+				pick(COLOR_PURPLE_LIGHT, COLOR_PURPLE_DARK),
+				pick(COLOR_ORANGE_LIGHT, COLOR_ORANGE_DARK),
 			)
 		if(6)
 			holiday_colors += list(
-				pick(GREY_LIGHT, GREY_DARK),
-				pick(PURPLE_LIGHT, PURPLE_DARK),
+				pick(COLOR_GREY_LIGHT, COLOR_GREY_DARK),
+				pick(COLOR_PURPLE_LIGHT, COLOR_PURPLE_DARK),
 			)
 		if(7)
 			holiday_colors += list(
-				pick(GREY_LIGHT, GREY_DARK),
-				pick(ORANGE_LIGHT, ORANGE_DARK),
+				pick(COLOR_GREY_LIGHT, COLOR_GREY_DARK),
+				pick(COLOR_ORANGE_LIGHT, COLOR_ORANGE_DARK),
 			)
 		if(8)
 			holiday_colors += list(
-				pick(PURPLE_LIGHT, PURPLE_DARK),
-				pick(ORANGE_LIGHT, ORANGE_DARK),
+				pick(COLOR_PURPLE_LIGHT, COLOR_PURPLE_DARK),
+				pick(COLOR_ORANGE_LIGHT, COLOR_ORANGE_DARK),
 			)
 		if(9)
-			holiday_colors += list(PURPLE_LIGHT, ORANGE_LIGHT)
+			holiday_colors += list(COLOR_PURPLE_LIGHT, COLOR_ORANGE_LIGHT)
 		if(10)
-			holiday_colors += list(PURPLE_DARK, ORANGE_DARK)
+			holiday_colors += list(COLOR_PURPLE_DARK, COLOR_ORANGE_DARK)
 		if(11)
 			holiday_colors = list(
 				COLOR_PRIDE_PURPLE,
@@ -92,13 +114,13 @@
 				COLOR_PRIDE_RED,
 			)
 		if(12)
-			holiday_colors += PURPLE_LIGHT
+			holiday_colors += COLOR_PURPLE_LIGHT
 		if(13)
-			holiday_colors += ORANGE_LIGHT
+			holiday_colors += COLOR_ORANGE_LIGHT
 		if(14)
-			holiday_colors += PURPLE_DARK
+			holiday_colors += COLOR_PURPLE_DARK
 		if(15)
-			holiday_colors += ORANGE_DARK
+			holiday_colors += COLOR_ORANGE_DARK
 
 /datum/holiday/halloween/celebrate()
 	. = ..()
@@ -123,17 +145,17 @@
 			holiday_colors += list(
 				COLOR_CHRISTMAS_GREEN,
 				COLOR_CHRISTMAS_RED,
-				GREY_LIGHT,
+				COLOR_GREY_LIGHT,
 			)
 		if(7, 8)
 			holiday_colors += list(
 				COLOR_CHRISTMAS_GREEN,
-				GREY_LIGHT,
+				COLOR_GREY_LIGHT,
 			)
 		if(9, 10)
 			holiday_colors += list(
 				COLOR_CHRISTMAS_RED,
-				GREY_LIGHT,
+				COLOR_GREY_LIGHT,
 			)
 		if(11)
 			holiday_colors += list(
@@ -145,9 +167,107 @@
 				COLOR_PRIDE_RED,
 			)
 
-#undef PURPLE_LIGHT
-#undef PURPLE_DARK
-#undef ORANGE_LIGHT
-#undef ORANGE_DARK
-#undef GREY_LIGHT
-#undef GREY_DARK
+/datum/holiday/pride_week
+	begin_day = 1
+	holiday_colors = list()
+
+/datum/holiday/pride_week/New()
+	. = ..()
+	var/palette = rand(1, 7)
+	switch(palette)
+		if(1)
+			holiday_colors += list(
+				COLOR_PRIDE_PURPLE,
+				COLOR_PRIDE_BLUE,
+				COLOR_PRIDE_GREEN,
+				COLOR_PRIDE_YELLOW,
+				COLOR_PRIDE_ORANGE,
+				COLOR_PRIDE_RED,
+			)
+		if(2)
+			holiday_colors += list(
+				COLOR_TRANS_BLUE,
+				COLOR_TRANS_PINK,
+				COLOR_PRIDE_WHITE,
+			)
+		if(3)
+			holiday_colors += list(
+				COLOR_ACE_BLACK,
+				COLOR_ACE_GREY,
+				COLOR_PRIDE_WHITE,
+				COLOR_ACE_PURPLE,
+			)
+		if(4)
+			holiday_colors += list(
+				COLOR_PAN_MAGENTA,
+				COLOR_PAN_YELLOW,
+				COLOR_PAN_CYAN,
+			)
+		if(5)
+			holiday_colors += list(
+				COLOR_BI_PINK,
+				COLOR_BI_PURPLE,
+				COLOR_BI_BLUE,
+			)
+		if(6)
+			holiday_colors += list(
+				COLOR_LESBIAN_RED,
+				COLOR_LESBIAN_ORANGE,
+				COLOR_LESBIAN_PINK,
+				COLOR_LESBIAN_MAGENTA,
+			)
+		if(7)
+			holiday_colors += list(
+				COLOR_LESBIAN_RED,
+				COLOR_LESBIAN_ORANGE,
+				COLOR_LESBIAN_PINK,
+				COLOR_LESBIAN_MAGENTA,
+				COLOR_PRIDE_PURPLE,
+				COLOR_PRIDE_BLUE,
+				COLOR_PRIDE_GREEN,
+				COLOR_PRIDE_YELLOW,
+				COLOR_PRIDE_ORANGE,
+				COLOR_PRIDE_RED,
+				COLOR_TRANS_BLUE,
+				COLOR_TRANS_PINK,
+				COLOR_PRIDE_WHITE,
+				COLOR_PAN_MAGENTA,
+				COLOR_PAN_YELLOW,
+				COLOR_PAN_CYAN,
+				COLOR_ACE_BLACK,
+				COLOR_ACE_GREY,
+				COLOR_PRIDE_WHITE,
+				COLOR_ACE_PURPLE,
+				COLOR_BI_PINK,
+				COLOR_BI_PURPLE,
+				COLOR_BI_BLUE,
+			)
+
+#undef COLOR_PURPLE_LIGHT
+#undef COLOR_PURPLE_DARK
+#undef COLOR_ORANGE_LIGHT
+#undef COLOR_ORANGE_DARK
+#undef COLOR_GREY_LIGHT
+#undef COLOR_GREY_DARK
+
+#undef COLOR_PRIDE_WHITE
+
+#undef COLOR_TRANS_BLUE
+#undef COLOR_TRANS_PINK
+
+#undef COLOR_ACE_BLACK
+#undef COLOR_ACE_GREY
+#undef COLOR_ACE_PURPLE
+
+#undef COLOR_BI_PINK
+#undef COLOR_BI_PURPLE
+#undef COLOR_BI_BLUE
+
+#undef COLOR_LESBIAN_RED
+#undef COLOR_LESBIAN_ORANGE
+#undef COLOR_LESBIAN_PINK
+#undef COLOR_LESBIAN_MAGENTA
+
+#undef COLOR_PAN_MAGENTA
+#undef COLOR_PAN_YELLOW
+#undef COLOR_PAN_CYAN


### PR DESCRIPTION
## About The Pull Request

Adds the other five in game pride flags to the tile colouring system. Also adds a 20% chance of pride tiles on non-holiday days.

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/360405e9-40ca-4830-833d-abd5535503da)

</details>

## Changelog
:cl: LT3
add: The station tiles may now be gay, bi, trans, lesbian, pan, or ace if they want to
/:cl: