### PR TITLE
Move soulcatcher verb to IC tab

### DIFF
--- a/modular_skyrat/modules/modular_implants/code/soulcatcher/ghost.dm
+++ b/modular_skyrat/modules/modular_implants/code/soulcatcher/ghost.dm
@@ -15,7 +15,7 @@
 
 /mob/dead/observer/verb/join_soulcatcher()
 	set name = "Enter Soulcatcher"
-	set category = "Ghost"
+	set category = "IC"
 
 	var/list/joinable_soulcatchers = list()
 	var/list/rooms_to_join = list()


### PR DESCRIPTION
## About The Pull Request

Moves the 'Enter soulcatcher' verb to the IC tab, because TG eliminated the Ghost tab

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/ec700274-c335-4134-9f5e-f80bf4b8f610)

</details>

## Changelog

:cl: LT3
fix: Enter soulcatcher is now on the IC stat panel tab
/:cl: