### PR TITLE
Reduces Syndicate Kidnapping time from 6 minutes to 3 minutes because I got kidnapped once.

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -45,7 +45,7 @@
 #define RESPONSE_MAX_TIME 2 MINUTES
 
 /// How long till a spessman should come back after being captured and sent to the holding facility (which some antags use)
-#define COME_BACK_FROM_CAPTURE_TIME 6 MINUTES
+#define COME_BACK_FROM_CAPTURE_TIME 3 MINUTES //BUBBERSTATION CHANGE: 6 MINUTES TO 3 MINUTES.
 
 //ERT Types
 #define ERT_BLUE "Blue"


### PR DESCRIPTION
## About The Pull Request

Reduces Syndicate Kidnapping time from 6 minutes to 3 minutes (getting kidnapped and teleported to the syndicate weeb area).

## Why It's Good For The Game

That damn griefer george mellons kidnapped me once and I had to sit in the giant youtube box for 6 whole minutes because I was baited with powergaming items.

## Proof Of Testing

Untested.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: BurgerBB
balance: Reduces Syndicate Kidnapping time from 6 minutes to 3 minutes because I got kidnapped once.
/:cl:
