### PR TITLE
ERT gun balance adjustments

### DIFF
--- a/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/saibasan/mode_datums.dm
+++ b/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/saibasan/mode_datums.dm
@@ -140,7 +140,7 @@
 	applied_gun.force = 20
 	applied_gun.sharpness = SHARP_EDGED
 	applied_gun.bare_wound_bonus = 15
-	applied_gun.wound_bonus = 15
+	applied_gun.wound_bonus = 5
 	applied_gun.disabled_for_other_reasons = TRUE
 	applied_gun.attack_verb_continuous = list("slashes", "cuts")
 	applied_gun.attack_verb_simple = list("slash", "cut")

--- a/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/saibasan/mode_datums.dm
+++ b/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/saibasan/mode_datums.dm
@@ -137,9 +137,10 @@
 
 /datum/laser_weapon_mode/sword/apply_to_weapon(obj/item/gun/energy/modular_laser_rifle/applied_gun)
 	playsound(src, 'sound/items/unsheath.ogg', 25, TRUE)
-	applied_gun.force = 18
+	applied_gun.force = 20
 	applied_gun.sharpness = SHARP_EDGED
-	applied_gun.bare_wound_bonus = 10
+	applied_gun.bare_wound_bonus = 15
+	applied_gun.wound_bonus = 15
 	applied_gun.disabled_for_other_reasons = TRUE
 	applied_gun.attack_verb_continuous = list("slashes", "cuts")
 	applied_gun.attack_verb_simple = list("slash", "cut")
@@ -149,6 +150,7 @@
 	playsound(src, 'sound/items/sheath.ogg', 25, TRUE)
 	applied_gun.force = initial(applied_gun.force)
 	applied_gun.sharpness = initial(applied_gun.sharpness)
+	applied_gun.wound_bonus = initial(applied_gun.wound_bonus)
 	applied_gun.bare_wound_bonus = initial(applied_gun.bare_wound_bonus)
 	applied_gun.disabled_for_other_reasons = FALSE
 	applied_gun.attack_verb_continuous = initial(applied_gun.attack_verb_continuous)

--- a/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/saibasan/projectiles.dm
+++ b/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/saibasan/projectiles.dm
@@ -113,12 +113,13 @@
 
 /obj/projectile/beam/cybersun_laser/granata_shrapnel/shotgun_pellet
 	icon_state = "because_it_doesnt_miss"
-	damage = 22
+	damage = 15
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/purple_laser
 	speed = 1.25
 	light_color = COLOR_SCIENCE_PINK
 	range = 9
 	damage_falloff_tile = -3
+	weak_against_armour = FALSE
 // Hellfire lasers for the little guy
 
 /obj/item/ammo_casing/energy/cybersun_small_hellfire

--- a/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/saibasan/projectiles.dm
+++ b/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/saibasan/projectiles.dm
@@ -24,12 +24,13 @@
 
 /obj/projectile/beam/cybersun_laser/marksman
 	icon_state = "sniper"
-	damage = 50
+	damage = 40
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/yellow_laser
-	speed = 2.5
+	speed = 2
 	light_range = 2
 	light_color = COLOR_VERY_SOFT_YELLOW
 	wound_falloff_tile = -0.1
+	armour_penetration = 15
 
 // Disabler machinegun for the big gun
 
@@ -105,20 +106,19 @@
 /obj/item/ammo_casing/energy/cybersun_big_shotgun
 	projectile_type = /obj/projectile/beam/cybersun_laser/granata_shrapnel/shotgun_pellet
 	e_cost = LASER_SHOTS(10, STANDARD_CELL_CHARGE * 2)
-	pellets = 5
+	pellets = 4
 	variance = 30
 	select_name = "Shotgun"
 	fire_sound = 'modular_skyrat/modules/modular_weapons/sounds/laser_firing/melt.ogg'
 
 /obj/projectile/beam/cybersun_laser/granata_shrapnel/shotgun_pellet
 	icon_state = "because_it_doesnt_miss"
-	damage = 10
+	damage = 22
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/purple_laser
 	speed = 1.25
 	light_color = COLOR_SCIENCE_PINK
 	range = 9
-	damage_falloff_tile = -0.5
-
+	damage_falloff_tile = -3
 // Hellfire lasers for the little guy
 
 /obj/item/ammo_casing/energy/cybersun_small_hellfire
@@ -221,7 +221,7 @@
 	projectile_type = /obj/projectile/beam/cybersun_laser/granata_shrapnel/shotgun_pellet
 	e_cost = LASER_SHOTS(10, STANDARD_CELL_CHARGE)
 	pellets = 3
-	variance = 15
+	variance = 20
 	select_name = "Shotgun"
 	fire_sound = 'modular_skyrat/modules/modular_weapons/sounds/laser_firing/melt.ogg'
 


### PR DESCRIPTION
## About The Pull Request

**Sniper module:**
damage: 50 -> 40
Proj. Velocity: 2.5 -> 2
AP: 0->15

**Blade:**
Force: 18 -> 20
Wound bonus 0 -> 5
Bare wound bonus 10 -> 15

**Big Shotgun:**
Pellets: 5 -> 4

**Small Shotgun:**
Variance: 15 ->20

**Shotgun Pellets:**
Damage falloff: -0.5 -> -3
Damage: 10 -> 15
No longer weak against armour

## Abstract

The PR's goals are:
- Making the ERT modular shotguns stronger than lasers at their designated ranges
- Prevent shotguns from dominating over other modules in return 
- Allow the blade module to be a reliable fallback melee weapon in comparison to the modern arsenal
- Decrease the killing power of the sniper module

- It's goal is **not** to create an unfairly high TTK for the ERT
- It's goal is **not** to modify the overall power level of the ERT squads, rather making them consistent at all ranges
- The PR is made taking the ERT's damage resistance into account. The numbers would have been significantly lower if they had less armour.

## Blade
The blade previous to these changes was disturbingly lackluster for something made with intent to be a fallback weapon. 
Most heavy-duty improvised melee weapons (cleaver, saw) have 15 wound bonus and 15 bare wound bonus. Standard kitchen knives have 5 wound and 15 wound bonus. And shivs made of glass and some cloth have the same values as a knife. Weapons equipped by a combat-focused role should not have their statistics lower than improvised weaponry when it comes to combat, unless they are counterbalanced by something else. In this case they are not.

The damage does not offset the low wound chance, on the contrary, it makes the old blade feel even more useless. 

The damage raise aims to help the weapon cross a multitude of damage thresholds, especially structural ones related to things such as blob (5->4) , humans (8 -> 7) etc, as most healthbars are a multitude of 20, 10, 5, but not 18. 
The extra wound chance will help the weapon perform overall as wounds are an integral part of combat against most antagonists who aren't a changeling or a bloodsucker or simplemob. 

With ERT being a militaristic role, the combat knife's statistics fit what they should have as a *backup* weapon perfectly, and as such this is what they will have thanks to this PR going forwards.

## Sniper

Sniper rifles are a contentious element of videogames and are by far one of the more frustrating parts of them, as well. The gun's design revolves around ambushing, firing from ranges where one cannot be seen and dealing massive damage in small blows. 

This however is problematic furthermore in SS13 for many reasons:
Damage slowdown's mechanics cause burstier weapons to be more effective, no matter their factual DPS, as landing a single hit of a high damage low dps weapon will slow the target enough to provide an absurd advantage. Fights being decided by the first blow aren't healthy for game balance in regards to a team of 4 players using such weapons against a single, or few targets. Weapons such as this overall shouldn't have a place in regular combat in general when there is no drawback or risk, firing from afar and whittling down at targets. 

Balancing these mechanics through chargeups and the likes has failed dramatically in the case of weapons such as the beam rifle. 

In conclusion sniper rifles should be in general avoided unless reserved for very nichce cases, and considering the rest of the arsenal that this ERT packs I conclude that this weapon outshines it's siblings by far and should share it's spotlight with things such as the grenade launcher. The main reasons are:
- Initial burst damage
- Hard-to-dodge projectile
- Damage comparable to the grenade, which is slower, twice as expensive and also pays with the risk of collateral
- A zoom to hit from off screen to pack into this

The ways the weapon was changed still cause the damage per shot to be larger than the 2-tap burst of hellfire laser against a hos, but they were carefully adjusted to stay outside of the 4 shots to crit range. The weapon's damage should stay in such a spot that 5 hits are necessary to win a fight, as is **especially factoring slowdown**.

## Shotguns

The large shotgun and small shotgun were changed to account for their drastically increased damage, from 12 upclose against a HOS to 34-38, the goal for 1 less pellet and some variance was to reduce damage potential for the large shotgun and decrease the full success window of the small shotgun.

- Weakness to armour increases the armour two-fold when calculating damage. This meant that a predicted 30 damage upclose against a hos with say, 40 relevant armour wouldn't be multiplied by 0.6 and result in 18 damage, but rather 6 damage, which has shown up in some tests as well (some inconsistency was apparently there so as to not sugar-coat the results I took the higher value for old damage. In reality, the increase in DPS you will see might be twice as big as initially reported.) 

That variable completely negated the ability of the shotgun to function against antagonists which WILL have armour, as ERT's are called to deal with threats, and a threat wouldn't have grown this big if it weren't for some semblance of armour or overall damage output ability - which should be rivaled.

The damage is now comparable to that of the scattershot laser, albeit wounding less often. It fires slower compared to shotguns, but has more overall magazine size, performs worse at further ranges and can self-recharge. 
The guns are now technically worse at further ranges, but that should be kept the way it is as the ERT can swap to mid-range weaponry at any given time.

SHOTS/CRIT comparison, HOS dummy, human, from outfit selector under jobs, aiming head, pb'ing for 1 tile measurement.
Small Shotgun (carbine):
Range: within 1 tile, 4-5 shots depending on wounds.
Range: 2 tiles, 6
Range: 3 tiles, 8

Big Shotgun:
Range: within 1 tile, 4
Range: 2 tiles, 5
Range: 3 tiles, Inconsistent, 5-8 depending on spread.

The TTK for the guns is smaller than a combat shotgun at point blank, this is intentional. The guns have much more to offer and cannot trump a gun tailor-made for something that has way larger drawbacks, this extends to riot shotguns and double barelled ones as well.

The guns have a high burst, but only up close. This is not as damning as the aforementioned sniper and is not a contradiction, as having to get closer is a risk and enables much more counterplay than long-ranged play. This also extends to rifles of all sorts, and is the reason shotguns have the privilege of a stronger first strike - they are used more similarly to melee weapons than long ranged weapons when it comes to gameplay (with the exception of slugs). 





## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
balance: ERT sniper module: Damage: 50 -> 40, Proj. Velocity: 2.5 -> 2, AP: 0->15
balance: ERT blade module: Force: 18 -> 20, Wound bonus 0 -> 5, Bare wound bonus 10 -> 15
balance: ERT big shotgun module: Pellet amount 5 -> 4
balance: ERT small shotgun module: Variance 15 -> 20
balance: ERT shotgun pellets: Damage falloff: -0.5 -> -3, Damage: 10 -> 15, No longer weak against armour
/:cl:
