### PR TITLE
more designs

### DIFF
--- a/modular_zubbers/code/modules/designs/medical_designs.dm
+++ b/modular_zubbers/code/modules/designs/medical_designs.dm
@@ -1,0 +1,4 @@
+//Adds health analyzers to the science lathe for genetics and roboticists use.
+
+/datum/design/healthanalyzer_advanced
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SCIENCE

--- a/modular_zubbers/code/modules/designs/tool_designs.dm
+++ b/modular_zubbers/code/modules/designs/tool_designs.dm
@@ -1,0 +1,37 @@
+//Adds alien tools for roboticists use.
+
+/datum/design/alienwrench
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
+
+/datum/design/alienwirecutters
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
+
+/datum/design/alienscrewdriver
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
+
+/datum/design/aliencrowbar
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
+
+/datum/design/alienwelder
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
+
+/datum/design/alienmultitool
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
+
+/datum/design/alienscalpel
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SCIENCE
+
+/datum/design/alienhemostat
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SCIENCE
+
+/datum/design/alienretractor
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SCIENCE
+
+/datum/design/aliensaw
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SCIENCE
+
+/datum/design/aliendrill
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SCIENCE
+
+/datum/design/aliencautery
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SCIENCE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9292,6 +9292,8 @@
 #include "modular_zubbers\code\modules\debug_tools\toolgun_module\phys_size.dm"
 #include "modular_zubbers\code\modules\debug_tools\toolgun_module\phys_spawn.dm"
 #include "modular_zubbers\code\modules\designs\limbgrower_designs.dm"
+#include "modular_zubbers\code\modules\designs\medical_designs.dm"
+#include "modular_zubbers\code\modules\designs\tool_designs.dm"
 #include "modular_zubbers\code\modules\disease\disease_transmission.dm"
 #include "modular_zubbers\code\modules\disease\hidden.dm"
 #include "modular_zubbers\code\modules\dna_vault\vault_mutation.dm"


### PR DESCRIPTION
## About The Pull Request

Adds the advanced health analyzer to the science fabricator, and also grants them access to both forms of alien tools once researched.

## Why It's Good For The Game

The advanced health analyzer is the only analyzer that shows genetic stability, so it is exceptionally useful for geneticists working with mutations. It also gives roboticists another option where they can print out their analyzer from. I also included alien tools of both variants for roboticists as they are an incredible boon for synthetic surgeries, and for other surgeries in general.

## Proof Of Testing

## Changelog

:cl:
add: Science fabricator now prints advanced health analyzers and alien tools
/:cl:

