### PR TITLE
Add COMPONENT_CANCEL_ATTACK_CHAIN to repackable element

### DIFF
--- a/modular_skyrat/modules/colony_fabricator/code/repacking_element.dm
+++ b/modular_skyrat/modules/colony_fabricator/code/repacking_element.dm
@@ -42,6 +42,7 @@
 		return
 
 	INVOKE_ASYNC(src, PROC_REF(repack), source, user)
+	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 /// Removes the element target and spawns a new one of whatever item_to_pack_into is
 /datum/element/repackable/proc/repack(atom/source, mob/user)


### PR DESCRIPTION

## About The Pull Request

Make the repackable element return COMPONENT_CANCEL_ATTACK_CHAIN in its signal handler so the interaction is properly cancelled and it doesn't do stuff like open GUIs

## Why It's Good For The Game

Bug fix

## Proof Of Testing

Yeah

## Changelog
:cl:
fix: fixed repackable things like colony synthesizers opening their GUI when you right click to repack
/:cl:
