### PR TITLE
Increases the minimum players for blob to spawn from 20 to 50 because I saw a suggestion in #suggestions about it once.

### DIFF
--- a/modular_zubbers/code/modules/storyteller/event_defines/major/major_overrides.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/major/major_overrides.dm
@@ -11,6 +11,7 @@
 	track = EVENT_TRACK_MAJOR
 	tags = list(TAG_DESTRUCTIVE, TAG_COMBAT, TAG_CHAOTIC)
 	weight = 10
+	min_players = 50 //previously 20.
 
 /datum/round_event_control/meteor_wave
 	track = EVENT_TRACK_MAJOR


### PR DESCRIPTION
## About The Pull Request

Increases the minimum players for blob to spawn from 20 to 50.

## Why It's Good For The Game

20 players minimum for blob to spawn is absurd. Note that this does not mean 20 crew, but 20 living human non-afk players on the server.

## Proof Of Testing

Untested.

## Changelog

:cl: BurgerBB
balance: Increases the minimum players for blob to spawn from 20 to 50.
/:cl:
