### PR TITLE
Fix antag banned people being able to roll obsessed

### DIFF
--- a/code/datums/brain_damage/creepy_trauma.dm
+++ b/code/datums/brain_damage/creepy_trauma.dm
@@ -23,6 +23,10 @@
 		if(!obsession)//we didn't find one
 			lose_text = ""
 			return FALSE
+	// BUBBER EDIT ADDITION BEGIN - Antag banned can't roll obsessed
+	if(is_banned_from(owner.ckey, list(ROLE_SYNDICATE, BAN_ANTAGONIST)))
+		return FALSE
+	// BUBBER EDIT ADDITION END - Antag banned can't roll obsessed
 	gain_text = span_warning("You hear a sickening, raspy voice in your head. It wants one small task of you...")
 	owner.mind.add_antag_datum(/datum/antagonist/obsessed)
 	antagonist = owner.mind.has_antag_datum(/datum/antagonist/obsessed)

--- a/code/modules/events/creep_awakening.dm
+++ b/code/modules/events/creep_awakening.dm
@@ -13,6 +13,10 @@
 	for(var/mob/living/carbon/human/H in shuffle(GLOB.player_list))
 		if(!H.client || !(ROLE_OBSESSED in H.client.prefs.be_special) || !H.client.prefs?.read_preference(/datum/preference/toggle/be_antag))
 			continue
+		// BUBBER EDIT ADDITION BEGIN - Antag banned can't roll obsessed
+		if(is_banned_from(H.client.ckey, list(ROLE_SYNDICATE, BAN_ANTAGONIST)))
+			continue
+		// BUBBER EDIT ADDITION END - Antag banned can't roll obsessed
 		if(H.stat == DEAD)
 			continue
 		if(!(H.mind.assigned_role.job_flags & JOB_CREW_MEMBER)) //only station jobs sans nonhuman roles, prevents ashwalkers trying to stalk with crewmembers they never met


### PR DESCRIPTION

## About The Pull Request

Because obsessed is treated as a weird antagonist not antagonist in the code there's no checks for antag ban status before someone rolls it meaning if someone with an antag ban rolls it it polls ghosts to take over their body and then just forces them out. which sucks. Changes the code so during the Obsessed Awakening event they will be passed over for the role and if they end up with it from admin shenanigans it simply won't apply 

## Why It's Good For The Game

Randomly being wrenched out of your body for something you can't control (storyteller picking Obsessed Awakening) sucks

## Proof Of Testing

Tested it on a local with two clients

## Changelog
:cl:
fix: antag banned people will no longer roll obsessed and be forcefully ghosted
/:cl:
