### PR TITLE
Add 1% chance for pitbull to spawn with a name

### DIFF
--- a/modular_skyrat/master_files/code/modules/mob/living/simple_animal/friendly/dogs.dm
+++ b/modular_skyrat/master_files/code/modules/mob/living/simple_animal/friendly/dogs.dm
@@ -373,6 +373,8 @@
 
 /mob/living/basic/pet/dog/pitbull/Initialize(mapload)
 	. = ..()
+	if(prob(1))
+		name = pick("Crayon", "Pimpy", "Staypuft", "Bape", "BLOODSKULL", "Baby G")
 	AddElement(/datum/element/tiny_mob_hunter, MOB_SIZE_SMALL) //He eats anything that he sees as a toddler.
 	AddElement(/datum/element/footstep, footstep_type = FOOTSTEP_MOB_CLAW)
 


### PR DESCRIPTION
## About The Pull Request

Add 1% chance for the pitbull mob to spawn with a name

## Why It's Good For The Game

Crayon

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/3099a28e-4a32-4d7d-907f-8bb1fb9ba7ef)

</details>

## Changelog

:cl:
add: Sometimes your pitbull will have a name
/:cl:
