### PR TITLE
Fix certain species being unable to spawn with digigrade legs

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences/species_features/digitigrade_legs.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/species_features/digitigrade_legs.dm
@@ -9,7 +9,6 @@
 /datum/preference/choiced/digitigrade_legs/create_default_value()
 	return NORMAL_LEGS
 
-
 /datum/preference/choiced/digitigrade_legs/init_possible_values()
 	return list(NORMAL_LEGS, DIGITIGRADE_LEGS)
 
@@ -25,11 +24,8 @@
  * * preferences - The relevant character preferences.
  */
 /datum/preference/choiced/digitigrade_legs/proc/is_usable(datum/preferences/preferences)
-	var/species_type = preferences.read_preference(/datum/preference/choiced/species)
-	var/datum/species/species = new species_type
-
-	return (savefile_key in species.get_features()) \
-		&& species.digitigrade_customization == DIGITIGRADE_OPTIONAL
+	var/datum/species/species_type = preferences.read_preference(/datum/preference/choiced/species)
+	return initial(species_type.digitigrade_customization) == DIGITIGRADE_OPTIONAL
 
 /datum/preference/choiced/digitigrade_legs/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	if(!preferences || !is_usable(preferences))


### PR DESCRIPTION

## About The Pull Request

We have an override to make the default digigrade option for species `DIGITIGRADE_OPTIONAL` but for some reason this override code was still enforcing the pref being locked behind the species having mutant digigrade legs

## Why It's Good For The Game

Greater customization as was intended

## Proof Of Testing

Checked a good handful of species in the character creator and it looked fine

## Changelog
:cl:
fix: fixed certain species being unable to access the digigrade legs pref
/:cl:
