### PR TITLE
Fix flaky runtime related to stowaway landmark

### DIFF
--- a/modular_zubbers/code/modules/jobs/stowaway.dm
+++ b/modular_zubbers/code/modules/jobs/stowaway.dm
@@ -53,4 +53,4 @@
 	blacklisted_stations = list("Runtime Station", "MultiZ Debug", "Gateway Test")
 	amount_to_spawn = 5
 	desired_atom = /obj/effect/landmark/start/stowaway
-	target_areas = list(/area/station/hallway/secondary/entry)
+	target_areas = list(/area/station/hallway/secondary/entry, /area/station/terminal/interlink)

--- a/modular_zubbers/code/modules/jobs/stowaway.dm
+++ b/modular_zubbers/code/modules/jobs/stowaway.dm
@@ -53,7 +53,4 @@
 	blacklisted_stations = list("Runtime Station", "MultiZ Debug", "Gateway Test")
 	amount_to_spawn = 5
 	desired_atom = /obj/effect/landmark/start/stowaway
-
-/datum/area_spawn/stowaway_landmark/New()
-	. = ..()
-	target_areas = shuffle(typesof(/area/station/maintenance/fore) | typesof(/area/station/maintenance/aft) | typesof(/area/station/maintenance/port) | typesof(/area/station/maintenance/starboard))
+	target_areas = list(/area/station/hallway/secondary/entry)


### PR DESCRIPTION

## About The Pull Request

Change the target areas for this to just be the arrivals shuttle hallway instead of random maintenance areas

## Why It's Good For The Game

Hopefully fix the bug

## Proof Of Testing

It works locally but the only way to test if it un-flakys CI is to try this

## Changelog

No player-facing changes
