### PR TITLE
Replaces the Full Toolbox in loadout with Emergency Toolbox

### DIFF
--- a/modular_skyrat/master_files/code/modules/loadout/categories/inhands.dm
+++ b/modular_skyrat/master_files/code/modules/loadout/categories/inhands.dm
@@ -23,9 +23,9 @@
 	name = "Skateboard"
 	item_path = /obj/item/melee/skateboard
 
-/datum/loadout_item/inhand/toolbox
-	name = "Full Toolbox"
-	item_path = /obj/item/storage/toolbox/mechanical
+/datum/loadout_item/inhand/emergency_toolbox
+	name = "Emergency Toolbox"
+	item_path = /obj/item/storage/toolbox/emergency
 	blacklisted_roles = list(JOB_PRISONER)
 
 /datum/loadout_item/inhand/bouquet_mixed


### PR DESCRIPTION

## About The Pull Request

Replaces the Full Toolbox in loadout with Emergency Toolbox
## Why It's Good For The Game

Starting with a full suite of tools is arguably a tad much, why grab tools from tool storage/autolathe/the vendor when you start with everything but a multitool anyways?
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
balance: Replaced toolboxes in loadout with emergency toolboxes.
/:cl:
