### PR TITLE
Fix being unable to change NIF examine text

### DIFF
--- a/modular_skyrat/modules/modular_implants/code/nifs_tgui.dm
+++ b/modular_skyrat/modules/modular_implants/code/nifs_tgui.dm
@@ -77,6 +77,9 @@
 	data["blood_drain"] = blood_drain
 	data["minimum_blood_level"] = minimum_blood_level
 
+	var/datum/component/nif_examine/nif_examine = linked_mob.GetComponent(/datum/component/nif_examine)
+	data["nif_examine_text"] = nif_examine?.nif_examine_text
+
 	//Durability Variables.
 	data["durability"] = durability
 

--- a/tgui/packages/tgui/interfaces/NifPanel.jsx
+++ b/tgui/packages/tgui/interfaces/NifPanel.jsx
@@ -200,6 +200,7 @@ const NifSettings = (props) => {
     minimum_blood_level,
     blood_level,
     stored_points,
+    nif_examine_text,
   } = data;
   return (
     <LabeledList>
@@ -213,9 +214,8 @@ const NifSettings = (props) => {
       </LabeledList.Item>
       <LabeledList.Item label="NIF Flavor Text">
         <Input
-          onChange={(e, value) =>
-            act('change_examine_text', { new_text: value })
-          }
+          onBlur={(value) => act('change_examine_text', { new_text: value })}
+          value={nif_examine_text}
           width="100%"
         />
       </LabeledList.Item>


### PR DESCRIPTION

## About The Pull Request

Data was being sent to `e` instead of `value`, also changed it so it will autofill with your current examine text because it apparently didn't have that already

## Why It's Good For The Game

Fixes #3966 

## Proof Of Testing

Tested on a local

## Changelog
:cl:
fix: fixed being unable to edit NIF examine text
/:cl:
