### PR TITLE
Synths can now be sucked by bloodsuckers

### DIFF
--- a/modular_zubbers/code/modules/antagonists/bloodsucker/powers/feed.dm
+++ b/modular_zubbers/code/modules/antagonists/bloodsucker/powers/feed.dm
@@ -325,7 +325,7 @@
 		return FALSE
 
 	var/mob/living/carbon/human/target_user = target
-	if(!(target_user.dna?.species) || !(target_user.mob_biotypes & MOB_ORGANIC) || HAS_TRAIT(target_user, TRAIT_NOBLOOD))
+	if(HAS_TRAIT(target_user, TRAIT_NOBLOOD))
 		if(give_warnings)
 			owner.balloon_alert(owner, "no blood!")
 		return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removed a line of code stopping bloodsuckers from sucking dnaless and non-organic mobs
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game
1. Bloodsuckers come across synths a lot and it's annoying to not be able to suck the blood of someone you have killed or otherwise
2. Synths can be bloodsuckers, eye for an eye
3. sucking someone's blood is a partial aspect of bloodsuckers' offensive capabilities and as such having a major species be immune to it sucks (unfortunately some species like abductors and proteans will still be immune but they're weird in their own right and far less rare than synths, albeit proteans could probably have their no-blood trait removed to make them suckable but from what i recall they have a hard time regenerating their blood and are pretty weak anyway)
5. More esoterically it makes no sense why bloodsuckers cant suck the blood of synths, it is oil yet they can suck water from podpeople. Synths are usually created but even then some characters differ. Also bloodsuckers are immune to poison so it doesnt matter that it is oil, they only need the vitae anyway.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Proof Of Testing
I tested this extensively (once) and it runs and synths die at 20% blood so it should be fine. They also regenerate it fine.
most antag races have no-blood as a trait so they still cant be sucked and as such this should hopefully only majorly affect crew-sided synths.
<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Synths can be sucked by bloodsuckers now
/:cl:

(ps: I know theres a feature freeze but i have no clue whether this counts)
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
