### PR TITLE
Minor Visual Fixes To Biodome's SM Room

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -15245,6 +15245,7 @@
 /obj/structure/cable,
 /obj/structure/cable/layer1,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "fjm" = (
@@ -18770,6 +18771,7 @@
 "gtH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/structure/cable/layer1,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "gtN" = (
@@ -29947,6 +29949,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
+"krt" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "kru" = (
 /obj/machinery/light_switch/directional/east,
 /obj/machinery/light/small/directional/east,
@@ -35732,7 +35741,9 @@
 "mjV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/meter,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "mkb" = (
@@ -65206,8 +65217,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
 "wpi" = (
+/obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
@@ -107889,7 +107901,7 @@ hNy
 siV
 oyH
 mDF
-bGq
+wpi
 ppF
 cix
 cix
@@ -109688,8 +109700,8 @@ vtU
 siV
 wIa
 ric
-bGq
-wpi
+krt
+gXp
 vlo
 gXp
 vlo
@@ -111242,8 +111254,8 @@ oRg
 oRg
 aFz
 nyG
-unN
 dxV
+unN
 siV
 xHf
 gNx


### PR DESCRIPTION
## About The Pull Request
Before it looked like this 

<details>
<summary>BEFORE</summary>

![image](https://github.com/user-attachments/assets/844ab7de-702f-48db-b264-a443ac384686)

![image](https://github.com/user-attachments/assets/ba98deff-f3a3-49a9-a08a-09b1d4642b6f)

![image](https://github.com/user-attachments/assets/2b01061e-6507-4c1d-9565-47f53569a099)

![image](https://github.com/user-attachments/assets/e806f42b-1f57-472a-ab49-1a59315a17ca)


</details>

and now it no longer has these horrible no good visual issues

<details>
<summary>After</summary>

![image](https://github.com/user-attachments/assets/c1272578-8725-4e3b-9419-6aa6d098f201)

</details>

## Why It's Good For The Game

oh right bug is bad


## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: Makes biodome's supermatter room not have a floating camera and misaligned decals
/:cl:
