### PR TITLE
Makes the walls in kilo lesser port maint slightly less infuriating

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -12830,12 +12830,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
-"enU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/burnt_floor,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "eob" = (
 /obj/structure/sign/warning,
 /turf/closed/wall,
@@ -31556,10 +31550,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"kdq" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/station/maintenance/port/lesser)
 "kdr" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 1
@@ -46592,6 +46582,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
+"pcS" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/light/small/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lesser)
 "pdg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53646,9 +53642,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "rrt" = (
+/obj/machinery/space_heater,
 /obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/rust,
+/turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "rrG" = (
 /obj/effect/turf_decal/stripes/line{
@@ -89006,7 +89002,7 @@ vjh
 vjh
 pqD
 lbJ
-kdq
+rrt
 qKv
 fKs
 iza
@@ -89263,7 +89259,7 @@ qSJ
 hIT
 iza
 iVR
-rrt
+iza
 gBf
 pqD
 pqD
@@ -89520,7 +89516,7 @@ hyQ
 iIP
 dfS
 wyY
-enU
+pcS
 wgK
 nCL
 nCL

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -12830,6 +12830,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
+"enU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lesser)
 "eob" = (
 /obj/structure/sign/warning,
 /turf/closed/wall,
@@ -31550,6 +31556,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"kdq" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lesser)
 "kdr" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 1
@@ -34558,7 +34568,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "lbK" = (
@@ -53638,10 +53647,8 @@
 /area/station/maintenance/port/fore)
 "rrt" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/space_heater,
-/obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/closed/wall/rust,
 /area/station/maintenance/port/lesser)
 "rrG" = (
 /obj/effect/turf_decal/stripes/line{
@@ -88999,7 +89006,7 @@ vjh
 vjh
 pqD
 lbJ
-iza
+kdq
 qKv
 fKs
 iza
@@ -89255,7 +89262,7 @@ uOo
 qSJ
 hIT
 iza
-wyY
+iVR
 rrt
 gBf
 pqD
@@ -89513,7 +89520,7 @@ hyQ
 iIP
 dfS
 wyY
-jqI
+enU
 wgK
 nCL
 nCL


### PR DESCRIPTION

## About The Pull Request

![image](https://github.com/user-attachments/assets/63db4b10-a9a0-48a7-8bc5-8d83cdaf68cf)

WHAT WERE THEY THINKING 

![image](https://github.com/user-attachments/assets/2db3d802-db63-4595-abca-6fb67069638c)

At least now the airlock isn't connected to fucking nothing
## Why It's Good For The Game

Look man this shit pisses me off and I'm doing this just to quell my own insatiable hatred of this one corner
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
Fix: Makes the walls in kilo lesser port maint slightly less infuriating
/:cl:
