### PR TITLE
Changes the Medtech kit's bonesaw's force from 20 > 15

### DIFF
--- a/modular_skyrat/modules/exp_corps/code/gear.dm
+++ b/modular_skyrat/modules/exp_corps/code/gear.dm
@@ -19,7 +19,7 @@
 /obj/item/circular_saw/field_medic
 	name = "bone saw"
 	desc = "Did that sting? SAW-ry!"
-	force = 14
+	force = 15
 	icon_state = "bonesaw"
 	icon = 'modular_skyrat/modules/exp_corps/icons/bonesaw.dmi'
 	lefthand_file = 'modular_skyrat/modules/exp_corps/icons/bonesaw_l.dmi'

--- a/modular_skyrat/modules/exp_corps/code/gear.dm
+++ b/modular_skyrat/modules/exp_corps/code/gear.dm
@@ -19,7 +19,7 @@
 /obj/item/circular_saw/field_medic
 	name = "bone saw"
 	desc = "Did that sting? SAW-ry!"
-	force = 20
+	force = 14
 	icon_state = "bonesaw"
 	icon = 'modular_skyrat/modules/exp_corps/icons/bonesaw.dmi'
 	lefthand_file = 'modular_skyrat/modules/exp_corps/icons/bonesaw_l.dmi'


### PR DESCRIPTION
## About The Pull Request

Title explains it. Goes from 6.7 hits/crit to 9
## Why It's Good For The Game
A circular saw having the damage of more dedicated melee weapons (on par with the bowie knife/cap's sabre minus the block and AP) whilst also being pocket sized - AND being included in a medkit just don't make sense. A little less damage than a regular circular saw is reasonable given it's more compact. In its current state it does more damage than the upgraded medical tools. There is very little reason for this to do as much damage as it does.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
balance: Moved the Bone Saw's force from 20 > 15
/:cl:
