### PR TITLE
Fix russian and babylon derelict ruins interfering with one another

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/skyrat/drones_derelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/drones_derelict.dmm
@@ -2377,7 +2377,9 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/bb13/service)
 "Ms" = (
-/obj/machinery/door/airlock/vault/derelict,
+/obj/machinery/door/airlock/vault/derelict{
+	id_tag = "babylonvault"
+	},
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
 /area/ruin/space/bb13/engineering/vault)
@@ -3032,7 +3034,9 @@
 /turf/template_noop,
 /area/ruin/space/bb13/engineering/n_solars_control)
 "WF" = (
-/obj/machinery/computer/vaultcontroller,
+/obj/machinery/computer/vaultcontroller{
+	door_id = "babylonvault"
+	},
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
 /area/ruin/space/bb13/engineering/sec_eng)


### PR DESCRIPTION

## About The Pull Request

The base TG russian derelict and the babylon station derelict both use these vault door controller setups where you have to power them to unlock the vault, but they both use the same ID so if both ruins spawn it will sometimes open the doors in the other ruin and you get nothing
## Why It's Good For The Game

I was swindled

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
map: fixed the russian and babylon derelicts vault doors interfering with each other
/:cl:
