### PR TITLE
Uncomments the experimental syndicate teleporter back into the traitor shop

### DIFF
--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -85,7 +85,7 @@
 	item = /obj/item/storage/briefcase/launchpad
 	cost = 6
 	progression_minimum = 50 MINUTES //Normally this is not there but it exist to delay you just buying it and getting into everywhere before sec is prepared
-/* //Bubber edit - Moves the comment to keep the syndicate teleport commented out. Skyrat commented this out.
+
 /datum/uplink_item/device_tools/syndicate_teleporter
 	name = "Experimental Syndicate Teleporter"
 	desc = "A handheld device that teleports the user 4-8 meters forward. \
@@ -94,7 +94,6 @@
 			Comes with 4 charges, recharges randomly. Warranty null and void if exposed to an electromagnetic pulse."
 	item = /obj/item/storage/box/syndie_kit/syndicate_teleporter
 	cost = 8
-*/ //END SKYRAT EDIT
 
 /datum/uplink_item/device_tools/camera_app
 	name = "SyndEye Program"

--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -92,7 +92,7 @@
 			Beware, teleporting into a wall will trigger a parallel emergency teleport; \
 			however if that fails, you may need to be stitched back together. \
 			Comes with 4 charges, recharges randomly. Warranty null and void if exposed to an electromagnetic pulse."
-	item =
+	item = /obj/item/storage/box/syndie_kit/syndicate_teleporter
 	cost = 8
 
 /datum/uplink_item/device_tools/camera_app

--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -92,7 +92,7 @@
 			Beware, teleporting into a wall will trigger a parallel emergency teleport; \
 			however if that fails, you may need to be stitched back together. \
 			Comes with 4 charges, recharges randomly. Warranty null and void if exposed to an electromagnetic pulse."
-	item = /obj/item/storage/box/syndie_kit/syndicate_teleporter
+	item =
 	cost = 8
 
 /datum/uplink_item/device_tools/camera_app


### PR DESCRIPTION
## About The Pull Request
This PR brings back the skyrat-removed experimental syndicate teleporter

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

1. Diversification of loadouts. 
The reason the traitor is seen with only 6 items ever is due to the fact that the variety of interesting options has decreased as players tried more and more and have stuck to the best options. By adding a new item, or rather, readding it, the meta will breathe a bit and the pool of common loadouts will split up into more varied encounters. 

2. Uniqueness. 
This item is not something slapped on traitor without a second thought, as it is rather something that traitor missed in it's long road to modern SS13's state - a mobility option like the rest of antagonists, this time with serious risk and reward. The unorthodox use of the item helps for easier accesibility to some more magic-related gimmicks. Budget wizards, ninja-wannabes, Disappearing looming figures with kitchen knives - list goes on. It's fresh. It's something we haven't played a thousand times.

3. Accessibility and the teleportation argument.
I hear a concern is that antagonists have a lot of teleports lately which make them annoying to fight. Yes. Antagonists lasting longer than a fight and being hard to catch has been a thing since changeling adrenaline and sting, since ethereal jaunt, heretic being released in what, 2020? The hard pill to swallow, though, is that you can take every single teleport away from every antag and they'll just steal the hand teleporter or abuse spin inverters.

However, if a traitor is to be given the option to sacrifice 8 TC, now that is an esword in price iirc, a bit more than a makarov or a whole syndicate modsuit to gain a usable, interesting and fun tool for teleportation - they will spend less TC on pure murderbone, less time stacking 50 spin inverters, less time getting game-ier tools since the price matches what they get. 

4. Difficulty of fighting.
It's not that tough. It's arguably one of the weaker teleportation tools. 

Predictable direction, chance to instantly RR yourself, unpredictability, reliance on mesons all make it less of a problem than a traitor with a hand teleporter.
Setting traps, infinite teleports, zero risk in use, lets you strand people in the middle of nowhere.
Hierophant rod lets you yoink anyone you killed to your safehouse to fullstrip and loot safely
Spin inverters work cross z level
Mining cubes are a joke balance-wise
Don't start on heretics and vamps.

So no, this won't be the downfall of balance and an overpowered teleport. It's More risk, More restrictions, actually needs an Investment and even is countered by ion rifles. It has more counterplay than EVERY single teleport ingame. There is no argument to be made against it being too strong. It also comes from another RP server originally (beestation) and is doing just fine.

## Proof Of Testing

Trust me

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: readds the experimental syndicate teleporter to the uplink!
/:cl: