### PR TITLE
Proteans are no longer immune to hypnotic flash

### DIFF
--- a/modular_zubbers/code/modules/customization/species/proteans/organs/protean_brain.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/organs/protean_brain.dm
@@ -186,4 +186,18 @@
 	icon_state = "from_puddle"
 	duration = 12
 
+/obj/item/organ/brain/protean/emp_act(severity) // technically, a protean brain isn't a cybernetic brain, so it's not inherting the normal cybernetic proc.
+	. = ..()
+	if(. & EMP_PROTECT_SELF)
+		return
+	if(owner.stat == DEAD)
+		return
+	switch(severity)
+		if (EMP_HEAVY)
+			to_chat(owner, span_boldwarning("Your core nanites [pick("buzz erratically", "surge chaotically")]!"))
+			owner.set_drugginess_if_lower(40 SECONDS)
+		if (EMP_LIGHT)
+			to_chat(owner, span_warning("Your core nanites feel [pick("fuzzy", "unruly", "sluggish")]."))
+			owner.set_drugginess_if_lower(20 SECONDS)
+
 #undef TRANSFORM_TRAITS

--- a/modular_zubbers/code/modules/customization/species/proteans/organs/protean_eyes.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/organs/protean_eyes.dm
@@ -2,7 +2,6 @@
 	name = "imaging nanites"
 	desc = "Nanites designed to collect visual data from the surrounding world"
 	organ_flags = ORGAN_ROBOTIC
-	flash_protect = FLASH_PROTECTION_WELDER
 
 /obj/item/organ/eyes/robotic/protean/Initialize(mapload)
 	if(QDELETED(src))


### PR DESCRIPTION
## About The Pull Request

This is a two parter: This causes Proteans to get a drugginess effect when EMP'd (minor) and also removes their inherent flash protection. This means they can be affected by hypnoflash.

## Why It's Good For The Game

Fixes #3968 - and I'll also say from a balance perspective, having a species that is default flash immune is.. not great.

## Proof Of Testing

Tested on local by EMPing a protean with an EMP flashlight and using the hypnoflash to hypnotize the target with an objective like normal carbons.

</details>

## Changelog

:cl:
balance: Protean eyes are no longer flash immune
balance: Proteans now have a slight drugginess effect when EMP'd
fix: Proteans can now be subjected to the hypnoflash
/:cl: