### PR TITLE
Clean up the damn map config

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -17,17 +17,19 @@ endmap
 
 # Production-level maps.
 
-map birdshot
+#map birdshot
 	#default
-	maxplayers 66
-	votable
-endmap
+#	maxplayers 66
+#	votable
+#endmap
 
 map deltastation
+	minplayers 50
 	votable
 endmap
 
 map icebox
+	minplayers 25
 	votable
 endmap
 
@@ -54,14 +56,36 @@ map nebulastation
 	votable
 endmap
 
-map nebulastation
-	minplayers 35
+#map wawastation
+#	votable
+#	minplayers 40
+#endmap
+
+# Bubberstation maps.
+
+map biodome
+	minplayers 40
 	votable
 endmap
 
-map wawastation
+map boxstation
+	minplayers 30
 	votable
+endmap
+
+map kilostation
+	maxplayers 40
+	votable
+endmap
+
+map moonstation
+	minplayers 50
+	votable
+endmap
+
+map voidraptor
 	minplayers 40
+	votable
 endmap
 
 # Debug-only maps.
@@ -73,33 +97,4 @@ map multiz_debug
 endmap
 
 map runtimestation
-endmap
-
-##SKYRAT MAPS##
-
-map voidraptor
-	votable
-endmap
-
-map biodome
-	votable
-endmap
-
-##BUBBERSTATION MAPS##
-
-map boxstation
-	votable
-endmap
-
-map moonstation
-	votable
-endmap
-
-map kilostation
-	votable
-endmap
-
-map kilostation
-	maxplayers 75
-	votable
 endmap


### PR DESCRIPTION
## About The Pull Request

This situation is a mess because the map config on this repo, the map config on the config repo, and the map config on the live server all differ from each other, most concerningly the live server one has almost no minimums set, and no maximums either, this changes the config file here to consolidate changes from TG (using their minimums for their maps) and here (the values set in the config repo for our maps)

## Why It's Good For The Game

Kilo is currently running with 80 people online

## Proof Of Testing

Yeah

## Changelog
:cl:
config: clean up the map config and ensure all maps have minimums/maximums set as necessary
/:cl:
