### PR TITLE
BR-38 Removal

### DIFF
--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -255,7 +255,7 @@
 	contains = list(/obj/item/gun/energy/disabler/smg = 3)
 	crate_name = "disabler smg crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
-/*
+/* //BUBBER REMOVAL
 /datum/supply_pack/security/armory/battle_rifle
 	name = "NT BR-38 Crate"
 	desc = "An experimental energy-based ballistic battle rifle. Only available to \
@@ -279,7 +279,7 @@
 		/obj/item/ammo_box/magazine/m38/iceblox =2,
 	)
 	crate_name = ".38 magazine crate"
-*/
+*/ //END BUBBER REMOVAL
 /datum/supply_pack/security/armory/exileimp
 	name = "Exile Implants Crate"
 	desc = "Contains five Exile implants."


### PR DESCRIPTION
## About The Pull Request

Removes the NT BR-38 from purchase from cargo, along with its associated magazines
(on draft because Freeze)

## Why It's Good For The Game
The gun is hideously powerful (it buffs the damage of its .38 rounds by 1.2) and the main limiting factor for obtaining them is "high cargo cost", something that isn't a good balancing factor in our average 3 hour rounds where 6 digit budgets are normal.

The main downsides of actually using the weapon are that you occasionally have to use a multitool or a recharger it to keep it accurate, and that EMPs fuck it up a bit like most energy weapons (although our antags on Bubber rarely take advantage of this weakness)

You can also emag it to give it an eye-watering 1.6x damage multiplier, for the downside that the gun will explode and fucking kill you if you don't maintain it. I guess this is cool and balanced for antags and will not at all be abused by security at every possible oppurtunity

.38 is also a relatively poor choice in ammo type, given its main use (the Detective Revolver) was meant more for a variety of utility ammo like TRACs and ANCR rounds, which aren't really balanced for a magazine-fed gun.

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
del: NT BR-38 obtainability
/:cl:
