### PR TITLE
more positive quirks

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -592,7 +592,7 @@ NEGATIVE_STATION_TRAITS 3 1
 # If set to -1, then players will be able to select any quantity of positive quirks.
 # If set to 0, then players won't be able to select any positive quirks.
 # If commented-out or undefined, the maximum default is 6.
-MAX_POSITIVE_QUIRKS 6
+MAX_POSITIVE_QUIRKS 8
 
 # A config that skews with the random spawners weights
 # If the value is lower than 1, it'll tend to even out the odds


### PR DESCRIPTION
## About The Pull Request

An extremely simple pull request changing one value. Ups the max positive quirks from 6 to 8. Obviously this requires a config change.

## Why It's Good For The Game

People have been asking for this limit to be increased for a long long time now, its a very very popular suggestion on the discord. And letting people have more positive quirks allows for further customization of characters.

## Proof Of Testing



## Changelog

:cl:
balance: ups the limit of positive quirks to a max of 8
/:cl: