### PR TITLE
Adds red warden hat to garment bag.

### DIFF
--- a/code/game/objects/items/storage/garment.dm
+++ b/code/game/objects/items/storage/garment.dm
@@ -138,6 +138,7 @@
 	new /obj/item/clothing/gloves/krav_maga/sec(src)
 	new /obj/item/clothing/glasses/hud/security/sunglasses(src)
 	new /obj/item/clothing/mask/gas/sechailer(src)
+	new /obj/item/clothing/head/hats/warden/red(src) //BUBBER ADDITION
 
 /obj/item/storage/bag/garment/research_director/PopulateContents()
 	new /obj/item/clothing/under/rank/rnd/research_director(src)


### PR DESCRIPTION

## About The Pull Request

Adds the red warden hat, to the garment bag per a request. ~~REDSEC BEST SEC~~

## Why It's Good For The Game

So you can get drip, without drowning in cargo's slow motions.

## Proof Of Testing

<details>
I haven't because it's a single line of code added, but can if you require me to.

</details>

## Changelog
:cl:
add: Added red hat to angryman's (warden) bag 
/:cl:
