### PR TITLE
[FIX] "Structural Damage" Now Added to Synthetic Humanoids Species Panel

### DIFF
--- a/modular_skyrat/modules/synths/code/species/synthetic.dm
+++ b/modular_skyrat/modules/synths/code/species/synthetic.dm
@@ -261,8 +261,8 @@
 	perk_descriptions += list(list(
 		SPECIES_PERK_TYPE = SPECIES_NEGATIVE_PERK,
 		SPECIES_PERK_ICON = "band-aid",
-		SPECIES_PERK_NAME = "Brute Weakness",
-		SPECIES_PERK_DESC = "[plural_form] are weak to brute damage.",
+		SPECIES_PERK_NAME = "Structural Damage",
+		SPECIES_PERK_DESC = "[plural_form] are weak to blunt objects.",
 	))
 
 	return perk_descriptions


### PR DESCRIPTION
## About The Pull Request

This PR adds the synthetic structural damage weakness to the species menu, as NOT seen in pictures, because those pictures are old.
## Why It's Good For The Game

It's important for players to know if their species has a weakness, especially a 25% damage bonus for blunt objects.

This had to be manually added since Synthetic Humanoids technically don't have a brute mod, and are shitcode. So, I've had to shitcode their weakness into the menu by hand.

# >>> This PR does not make synthetics take any more damage than they already do <<<

## Changelog
:cl:
qol: Synthetic Humanoids now know they have a blunt weakness.
/:cl:
