### PR TITLE
[FIXES OVERSIGHT] Removes Shamebrero From Moonstation EVA

### DIFF
--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -58453,9 +58453,10 @@
 /area/station/maintenance/port/aft)
 "pMu" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/costume/poncho/ponchoshame,
-/obj/item/clothing/head/costume/sombrero/shamebrero,
 /obj/effect/turf_decal/stripes/line,
+/obj/item/clothing/suit/costume/poncho/green,
+/obj/item/clothing/head/costume/sombrero/green,
+/obj/item/clothing/glasses/sunglasses,
 /turf/open/floor/engine,
 /area/station/ai_monitored/command/storage/eva)
 "pMz" = (


### PR DESCRIPTION

## About The Pull Request
Turns out those particular items would superglue to your hand if you picked them up. 
Replaced them with non-superglue sombrero.
## Why It's Good For The Game
oversight = bad
## Proof Of Testing
trust me bro
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: Replaces the superglue sombrero in Moon EVA with ones that dont stick to your hands forever.
/:cl:
