### PR TITLE
High functioning zombie hair bugfix

### DIFF
--- a/modular_zubbers/code/modules/mob/living/carbon/human/species_types/zombie.dm
+++ b/modular_zubbers/code/modules/mob/living/carbon/human/species_types/zombie.dm
@@ -5,7 +5,7 @@
 	)
 	. = ..()
 
-/obj/item/bodypart/head/zombie //Override of /tg/ default (code\modules\surgery\bodyparts\species_parts\misc_bodyparts.dm), includes EYECOLOR
+/obj/item/bodypart/head/zombie //Override of /tg/ default (code\modules\surgery\bodyparts\species_parts\misc_bodyparts.dm), includes EYECOLOR, HAIR and FACIAL HAIR.
 	head_flags = HEAD_HAIR|HEAD_FACIAL_HAIR|HEAD_EYESPRITES|HEAD_DEBRAIN|HEAD_EYECOLOR
 
 /obj/item/bodypart/head/zombie/New(loc, ...)

--- a/modular_zubbers/code/modules/mob/living/carbon/human/species_types/zombie.dm
+++ b/modular_zubbers/code/modules/mob/living/carbon/human/species_types/zombie.dm
@@ -6,7 +6,7 @@
 	. = ..()
 
 /obj/item/bodypart/head/zombie //Override of /tg/ default (code\modules\surgery\bodyparts\species_parts\misc_bodyparts.dm), includes EYECOLOR
-	head_flags = HEAD_EYESPRITES|HEAD_DEBRAIN|HEAD_EYECOLOR
+	head_flags = HEAD_HAIR|HEAD_FACIAL_HAIR|HEAD_EYESPRITES|HEAD_DEBRAIN|HEAD_EYECOLOR
 
 /obj/item/bodypart/head/zombie/New(loc, ...)
 	head_flags |= (HEAD_HAIR|HEAD_FACIAL_HAIR)


### PR DESCRIPTION
## About The Pull Request

This fixes HFZs to allow them to select their hair in character creation

## Why It's Good For The Game

Bugs are bad, and this lets HFZs pick their hair properly.

## Proof Of Testing

Tested locally, works fine

## Changelog

:cl:
fix: high functioning zombies can now choose hair in character creation
/:cl: