### PR TITLE
lets nanite defib revive client-less mobs

### DIFF
--- a/modular_zubbers/code/modules/nanites/nanite_programs/healing.dm
+++ b/modular_zubbers/code/modules/nanites/nanite_programs/healing.dm
@@ -166,7 +166,7 @@
 	if(!iscarbon(host_mob)) //nonstandard biology
 		return FALSE
 	var/mob/living/carbon/C = host_mob
-	return C.can_defib() == DEFIB_POSSIBLE
+	return C.can_defib() & DEFIB_POSSIBLE | DEFIB_NOGRAB_AGHOST
 
 /datum/nanite_program/defib/proc/zap()
 	var/mob/living/carbon/C = host_mob

--- a/modular_zubbers/code/modules/nanites/nanite_programs/healing.dm
+++ b/modular_zubbers/code/modules/nanites/nanite_programs/healing.dm
@@ -166,14 +166,13 @@
 	if(!iscarbon(host_mob)) //nonstandard biology
 		return FALSE
 	var/mob/living/carbon/C = host_mob
-	if(C.get_ghost())
-		return FALSE
 	return C.can_defib() == DEFIB_POSSIBLE
 
 /datum/nanite_program/defib/proc/zap()
 	var/mob/living/carbon/C = host_mob
 	playsound(C, 'sound/machines/defib/defib_zap.ogg', 50, FALSE)
 	C.balloon_alert_to_viewers("twitches violently")
+	C.get_ghost()
 	if(check_revivable())
 		if(C.stat == DEAD)
 			var/original_oxyloss = C.getOxyLoss()


### PR DESCRIPTION

## About The Pull Request
lets nanite defib revive client-less mobs

## Why It's Good For The Game
Nanite defib is outwardly very unclear why it fails, so you'd think the program itself doesn't work if it doesn't defib even if all other conditions are correct, so why not let this defib ghost-less mobs

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
balance: Nanite defibs can defib client-less mobs
/:cl:

