### PR TITLE
nosferatu ventcrawling now prevents held items/backpack

### DIFF
--- a/code/__DEFINES/~~bubber_defines/signals.dm
+++ b/code/__DEFINES/~~bubber_defines/signals.dm
@@ -16,3 +16,11 @@
 #define COMSIG_OOC_ESCAPE "ooc_escape"
 /// From [/datum/outfit]: (datum/outfit)
 #define COMSIG_OUTFIT_EQUIP "outfit_equip"
+/// at the end of /mob/living/proc/can_enter_vent(obj/machinery/atmospherics/components/ventcrawl_target, provide_feedback = TRUE)
+/// Return true in this signal to allow ventcrawling, but you need atleast TRAIT_VENTCRAWLER_NUDE on the mob. Sorry. It does allow for custom config via the signal, however
+#define COMSIG_CAN_VENTCRAWL "can_ventcrawl"
+#define COMISG_VENTCRAWL_PRE_ENTER "ventcrawling_pre_enter"
+#define COMSIG_VENTCRAWL_PRE_EXIT "ventcrawling_pre_exit"
+#define COMSIG_VENTCRAWL_ENTER "ventcrawling_enter"
+#define COMSIG_VENTCRAWL_EXIT "ventcrawling_exit"
+#define COMSIG_VENTCRAWL_PRE_CANCEL "ventcrawling_pre_cancel"

--- a/modular_zubbers/code/modules/antagonists/bloodsucker/clans/clan.dm
+++ b/modular_zubbers/code/modules/antagonists/bloodsucker/clans/clan.dm
@@ -33,6 +33,7 @@
 	// what percentage of blood you need to spend to level up, divided by 100
 	var/level_cost = BLOODSUCKER_LEVELUP_PERCENTAGE
 
+// TODO add handling for body transfers
 /datum/bloodsucker_clan/New(datum/antagonist/bloodsucker/owner_datum)
 	. = ..()
 	src.bloodsuckerdatum = owner_datum

--- a/modular_zubbers/code/modules/antagonists/bloodsucker/clans/clan_nosferatu.dm
+++ b/modular_zubbers/code/modules/antagonists/bloodsucker/clans/clan_nosferatu.dm
@@ -2,7 +2,7 @@
 	name = CLAN_NOSFERATU
 	description = "The Nosferatu Clan is unable to blend in with the crew, with no abilities such as Masquerade and Veil. \n\
 		Additionally, has a permanent bad back and looks like a Bloodsucker upon a simple examine, and their face is disfigured \n\
-		they can fit in the vents regardless of their form and equipment. \n\
+		they can fit in the vents. \n\
 		The Favorite Ghoul is also permanently disfigured, and can also ventcrawl, but only while entirely nude. \n\
 		They also have night vision, know what each wire does, and have silent footsteps."
 	clan_objective = /datum/objective/bloodsucker/kindred
@@ -10,16 +10,69 @@
 	join_description = "You are permanetly disfigured, look like a Bloodsucker to all who examine you, \
 		lose your Masquerade ability, but gain the ability to Ventcrawl even while clothed."
 	blood_drink_type = BLOODSUCKER_DRINK_INHUMANELY
+	var/ventcrawl_time = 10 SECONDS
 
 /datum/bloodsucker_clan/nosferatu/New(datum/antagonist/bloodsucker/owner_datum)
 	. = ..()
 	for(var/datum/action/cooldown/bloodsucker/power as anything in bloodsuckerdatum.powers)
 		if(istype(power, /datum/action/cooldown/bloodsucker/masquerade) || istype(power, /datum/action/cooldown/bloodsucker/veil))
 			bloodsuckerdatum.RemovePower(power)
-	if(!bloodsuckerdatum.owner.current.has_quirk(/datum/quirk/badback))
-		bloodsuckerdatum.owner.current.add_quirk(/datum/quirk/badback)
-	bloodsuckerdatum.owner.current.add_traits(list(TRAIT_VENTCRAWLER_ALWAYS, TRAIT_DISFIGURED), BLOODSUCKER_TRAIT)
+	var/mob/living/mob = bloodsuckerdatum.owner.current
+	if(!mob.has_quirk(/datum/quirk/badback))
+		mob.add_quirk(/datum/quirk/badback)
+
+	mob.add_traits(list(TRAIT_DISFIGURED, TRAIT_VENTCRAWLER_NUDE), BLOODSUCKER_TRAIT)
+
 	RegisterSignal(bloodsuckerdatum, COMSIG_BLOODSUCKER_EXAMINE, PROC_REF(on_mob_examine))
+	RegisterSignal(mob, COMSIG_CAN_VENTCRAWL, PROC_REF(can_ventcrawl))
+	RegisterSignal(mob, COMISG_VENTCRAWL_PRE_ENTER, PROC_REF(on_ventcrawl_enter))
+	RegisterSignal(mob, COMSIG_VENTCRAWL_PRE_EXIT, PROC_REF(on_ventcrawl_pre_exit))
+	RegisterSignal(mob, COMSIG_VENTCRAWL_EXIT, PROC_REF(on_ventcrawl_exit))
+	RegisterSignal(mob, COMSIG_VENTCRAWL_PRE_CANCEL, PROC_REF(on_ventcrawl_cancel))
+
+/datum/bloodsucker_clan/nosferatu/proc/get_ventcrawl_time()
+	return max(ventcrawl_time - bloodsuckerdatum.GetRank() SECONDS, 2 SECONDS)
+
+/datum/bloodsucker_clan/nosferatu/proc/can_ventcrawl(mob/living/carbon/human/owner_mob, atom/vent, provide_feedback)
+	SIGNAL_HANDLER
+	var/obj/back_slot = owner_mob.get_item_by_slot(ITEM_SLOT_BACK)
+	if(back_slot && !istype(back_slot, /obj/item/storage/backpack/satchel/flat))
+		if(provide_feedback)
+			to_chat(owner_mob, span_warning("You cannot ventcrawl with [back_slot] on your back!"))
+		return FALSE
+	for(var/item in owner_mob.held_items)
+		if(isnull(item))
+			continue
+		if(provide_feedback)
+			to_chat(owner_mob, span_warning("You cannot ventcrawl while holding items!"))
+		return FALSE
+	return TRUE
+
+/datum/bloodsucker_clan/nosferatu/proc/on_ventcrawl_cancel(mob/living/carbon/human/owner_mob, obj/machinery/atmospherics/components/ventcrawl_target)
+	SIGNAL_HANDLER
+	animate(ventcrawl_target)
+
+/datum/bloodsucker_clan/nosferatu/proc/on_ventcrawl_enter(mob/living/carbon/human/owner_mob, obj/machinery/atmospherics/components/ventcrawl_target)
+	SIGNAL_HANDLER
+	var/crawl_time = get_ventcrawl_time()
+	ventcrawl_target.Shake(pixelshiftx = 1, pixelshifty = 1, duration = crawl_time, shake_interval = 0.3 SECONDS)
+	return crawl_time
+
+/datum/bloodsucker_clan/nosferatu/proc/on_ventcrawl_pre_exit(mob/living/carbon/human/owner_mob, obj/machinery/atmospherics/components/ventcrawl_target)
+	SIGNAL_HANDLER
+	var/crawl_time = get_ventcrawl_time()
+	playsound(ventcrawl_target, 'sound/effects/bang.ogg', 25)
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(playsound), crawl_time, 'sound/effects/bang.ogg', 25), ventcrawl_time * 0.6)
+	ventcrawl_target.Shake(pixelshiftx = 1, pixelshifty = 1, duration = crawl_time, shake_interval = 0.3 SECONDS)
+	return crawl_time
+
+/datum/bloodsucker_clan/nosferatu/proc/on_ventcrawl_exit(mob/living/carbon/human/owner_mob, obj/machinery/atmospherics/components/ventcrawl_target)
+	SIGNAL_HANDLER
+	// cooldown all non-inherent abilities on exit to prevent instant ambushes
+	for(var/datum/action/cooldown/bloodsucker/power as anything in bloodsuckerdatum.powers)
+		if(power.purchase_flags & BLOODSUCKER_DEFAULT_POWER)
+			continue
+		power.StartCooldown()
 
 /datum/bloodsucker_clan/nosferatu/proc/on_mob_examine(datum/antagonist/bloodsucker/owner_datum, datum/source, mob/examiner, examine_text)
 	SIGNAL_HANDLER
@@ -38,8 +91,8 @@
 		bloodsuckerdatum.RemovePower(suck)
 	bloodsuckerdatum.give_starting_powers()
 	bloodsuckerdatum.owner.current.remove_quirk(/datum/quirk/badback)
-	bloodsuckerdatum.owner.current.remove_traits(list(TRAIT_VENTCRAWLER_ALWAYS, TRAIT_DISFIGURED), BLOODSUCKER_TRAIT)
-	UnregisterSignal(bloodsuckerdatum, COMSIG_BLOODSUCKER_EXAMINE)
+	bloodsuckerdatum.owner.current.remove_traits(list(TRAIT_VENTCRAWLER_NUDE, TRAIT_DISFIGURED), BLOODSUCKER_TRAIT)
+	UnregisterSignal(bloodsuckerdatum, list(COMSIG_BLOODSUCKER_EXAMINE, COMSIG_CAN_VENTCRAWL, COMISG_VENTCRAWL_PRE_ENTER, COMSIG_VENTCRAWL_PRE_EXIT, COMSIG_VENTCRAWL_EXIT))
 	return ..()
 
 /datum/bloodsucker_clan/nosferatu/favorite_ghoul_gain(datum/antagonist/bloodsucker/source, datum/antagonist/ghoul/ghouldatum)


### PR DESCRIPTION

## About The Pull Request
nosferatu ventcrawling now prevents ventcrawling while you are holding items or have a back item (unless it's the floor satchel), and now has 10 seconds of base time to enter/exit a vent minus a second for each level, plus exiting vents sets all abilites on cooldown to prevent instant casts of them on exiting. Plus it's visible/audible when you are exiting and entering

## Why It's Good For The Game
Ventcrawling is super strong and this should hopefully go a long way towards balancing nosferatu

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
balance: Nosferatu ventcrawling now takes 10 seconds - 1 second per rank, and prevents ventcrawling with satchels/hand items, and has visual/audio effects
/:cl:

