### PR TITLE
weather announcers now warn for Sol

### DIFF
--- a/modular_zubbers/code/datums/components/weatherannouncer.dm
+++ b/modular_zubbers/code/datums/components/weatherannouncer.dm
@@ -1,0 +1,20 @@
+/datum/component/weather_announcer
+	var/warning_range_low = 60
+	var/warning_range_high = TIME_BLOODSUCKER_DAY_WARN
+
+/datum/component/weather_announcer/Initialize(state_normal, state_warning, state_danger)
+	. = ..()
+	RegisterSignal(SSsunlight, COMSIG_SOL_NEAR_START, PROC_REF(on_daylight_warning))
+
+/datum/component/weather_announcer/proc/on_daylight_warning(datum/controller/subsystem/processing/sunlight)
+	var/variability = rand(warning_range_low, warning_range_high)
+	addtimer(CALLBACK(src, PROC_REF(warn_user)), variability)
+
+/datum/component/weather_announcer/proc/warn_user()
+	var/list/messages = list(
+		"Detecting solar activity. Seek cover if vulnerable.",
+		"Warning: Solar flares detected incoming within [TIME_BLOODSUCKER_DAY_WARN] seconds.",
+		"Solar activity imminent within [TIME_BLOODSUCKER_DAY_WARN] seconds. Please find shelter.",
+	)
+	var/atom/movable/speaker = parent
+	speaker?.say(pick(messages))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8878,6 +8878,7 @@
 #include "modular_zubbers\code\datums\components\squeak.dm"
 #include "modular_zubbers\code\datums\components\surgery_initiator.dm"
 #include "modular_zubbers\code\datums\components\udder.dm"
+#include "modular_zubbers\code\datums\components\weatherannouncer.dm"
 #include "modular_zubbers\code\datums\components\crafting\furniture.dm"
 #include "modular_zubbers\code\datums\components\crafting\tailoring.dm"
 #include "modular_zubbers\code\datums\components\crafting\utility.dm"


### PR DESCRIPTION

## About The Pull Request
Weather announcers now warn for Sol, within 90-60 with seconds before it starts

## Why It's Good For The Game
Sol is hard for non-hemophages to predict, so letting weather announcers warn them with some randomness should make it more possible to play around bloodsucker sol on the opposing side

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
balance: Weather announcers will now detect Sol cycles within 60-90 seconds before it starts
/:cl:

