### PR TITLE
[DO NOT MAKE THE CHANGES ON BOX CONFIG] Disables random events in config (not storyteller)

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -144,7 +144,7 @@ DYNAMIC_CONFIG_ENABLED
 
 ## RANDOM EVENTS ###
 ## Comment this out to disable random events during the round.
-ALLOW_RANDOM_EVENTS
+#ALLOW_RANDOM_EVENTS
 
 ## Uncomment this to disable station traits.
 #FORBID_STATION_TRAITS


### PR DESCRIPTION

## About The Pull Request

Disables random events in the config. It should already be this way on the box config. Either way this change is just for people running their own fork. 
## Why It's Good For The Game

look man I've been testing stuff on local and halting storyteller and going "hm what the fuck man why are anomalies still spawning" only to realize it's because this shit is on in the config if you run a local and you have to manually turn it off. Saves people from a pitfall. 

![image](https://github.com/user-attachments/assets/11e5f63f-0dad-43e3-ac05-49018708032b)
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
no 
