### PR TITLE
Quick Persistence hotfix to make the elevator work on icebox

### DIFF
--- a/_maps/bubber/automapper/templates/IceBoxStation/iceboxstation_persistence_roof.dmm
+++ b/_maps/bubber/automapper/templates/IceBoxStation/iceboxstation_persistence_roof.dmm
@@ -302,7 +302,7 @@
 /obj/effect/turf_decal/trimline/dark/line,
 /obj/structure/transport/linear/public,
 /obj/machinery/lift_indicator/directional/north,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/openspace,
 /area/ruin/space/has_grav/bubbers/persistance/controltower)
 "hj" = (
 /obj/machinery/modular_shield/module/node{
@@ -504,7 +504,7 @@
 /obj/structure/railing/corner/end/flip{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/openspace,
 /area/ruin/space/has_grav/bubbers/persistance/controltower)
 "nx" = (
 /obj/structure/railing/corner{
@@ -743,7 +743,7 @@
 /obj/effect/turf_decal/bot_red,
 /obj/effect/turf_decal/box/red,
 /obj/structure/transport/linear/public,
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/openspace,
 /area/ruin/space/has_grav/bubbers/persistance/controltower)
 "rN" = (
 /obj/effect/turf_decal/stripes/red/full,
@@ -1400,7 +1400,7 @@
 	preset_destination_names = list("2" = "Bridge Bottom", "3" = "Bridge Upper");
 	req_access = list("syndicate")
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/openspace,
 /area/ruin/space/has_grav/bubbers/persistance/controltower)
 "FM" = (
 /turf/open/floor/mineral/plastitanium/red{
@@ -2061,7 +2061,7 @@
 /obj/structure/railing/corner/end{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/openspace,
 /area/ruin/space/has_grav/bubbers/persistance/controltower)
 "UX" = (
 /obj/machinery/door/airlock/external,
@@ -2164,13 +2164,13 @@
 /obj/effect/landmark/transport/transport_id{
 	specific_transport_id = "PersistenceElevator"
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/openspace,
 /area/ruin/space/has_grav/bubbers/persistance/controltower)
 "Xq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/openspace/icemoon,
+/turf/open/openspace,
 /area/ruin/space/has_grav/bubbers/persistance/controltower)
 "Xz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,


### PR DESCRIPTION

## About The Pull Request

For whatever reason, a total of seven open air tiles got lost at some point between my testing on the final version and the merged version. This readds them which makes the elevator work again.
## Why It's Good For The Game

Its preferred to have stuff working usually. 
## Proof Of Testing

![image](https://github.com/user-attachments/assets/b6e86060-8e0b-4b2b-9ac5-5eadbcdd2669)

![image](https://github.com/user-attachments/assets/771ca0b8-67d1-4b3c-9390-4ff6f4eccac6)

![image](https://github.com/user-attachments/assets/7cff4c05-e76a-40e7-852c-256370466416)

![image](https://github.com/user-attachments/assets/1b582c7a-bbf9-488f-b2d6-d6ac7c2d1cb3)
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: The elevator on persistence works again. Pretty sure we had Jimmy Hoffa stuck there or say the SOSHA folks say.
/:cl:
