### PR TITLE
Fixes bandolier not holding epipens

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/storage/belts.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/storage/belts.dm
@@ -155,6 +155,7 @@
 		/obj/item/storage/pill_bottle,
 		/obj/item/implanter,
 		/obj/item/hypospray,
+		/obj/item/reagent_containers/hypospray,
 		/obj/item/reagent_containers/cup/vial,
 		/obj/item/weaponcell/medical,
 		/obj/item/reagent_containers/cup/tube


### PR DESCRIPTION

## About The Pull Request
Adds reagent container hyposprays (medipens) to bandolier holding type.
## Why It's Good For The Game
This was meant to be done in #3872 But I don't think they quite realized the item path was different for medipens. For that matter, I didn't realize it either.
## Proof Of Testing
</details>

## Changelog
:cl:
fix: Medipens fit  in the medical bandolier
/:cl:
