### PR TITLE
Ghosts cant finalize paintings anymore

### DIFF
--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -235,7 +235,7 @@
 			. = TRUE
 			if(isobserver(user)) // Ghosts cant finalize
 				return
-			if(istype(user, /mob/living/silicon) && !Adjacent(user, src)) // Cyborgs cant finalize unless adjacent
+			if(istype(user, /mob/living/silicon) && !Adjacent(user, src)) // Silicons cant finalize unless adjacent
 				return
 			finalize(user)
 		if("patronage")


### PR DESCRIPTION

## About The Pull Request
Added check to paintings finalize action to make sure that user is not ghost.
Added check which requires silicon to be adjacent. That way cyborgs still can finalize paintings, but not from distance and AI can finalize paintings only near it's core.
If there any better options to check for silicon than `istype(user, /mob/living/silicon` - make me know.
## Why It's Good For The Game
Reducing potential for bad people ruining paintings.
## Proof Of Testing
tested
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
