### PR TITLE
Fixes stripping of proteans

### DIFF
--- a/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
@@ -66,15 +66,15 @@
 /obj/item/mod/control/pre_equipped/protean/equipped(mob/user, slot, initial)
 	. = ..()
 
-	if(isprotean(wearer))
+	if(isprotean(user))
 		return
-	if(slot == ITEM_SLOT_BACK && wearer)
-		RegisterSignal(wearer, COMSIG_OOC_ESCAPE, PROC_REF(ooc_escape))
+	if(slot == ITEM_SLOT_BACK && user)
+		RegisterSignal(user, COMSIG_OOC_ESCAPE, PROC_REF(ooc_escape))
 		if(modlocked)
 			ADD_TRAIT(src, TRAIT_NODROP, "protean")
-			to_chat(wearer, span_warning("The suit does not seem to be able to come off..."))
+			to_chat(user, span_warning("The suit does not seem to be able to come off..."))
 	else
-		UnregisterSignal(wearer, COMSIG_OOC_ESCAPE)
+		UnregisterSignal(user, COMSIG_OOC_ESCAPE)
 
 /obj/item/mod/control/pre_equipped/protean/choose_deploy(mob/user)
 	if(!isprotean(user) && modlocked && active)

--- a/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
@@ -86,7 +86,7 @@
 	if(!force_deactivate && modlocked && !isprotean(user) && active)
 		balloon_alert(user, "it doesn't turn off")
 		return FALSE
-	if(!active && wearer.has_status_effect(/datum/status_effect/protean_low_power_mode))
+	if(!active && user.has_status_effect(/datum/status_effect/protean_low_power_mode))
 		balloon_alert(user, "low power")
 		playsound(src, 'sound/machines/scanner/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
 		return FALSE

--- a/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
@@ -280,7 +280,7 @@
 	if (!isnull(should_strip_proc_path) && !call(species.owner, should_strip_proc_path)(user))
 		return
 	suit.balloon_alert_to_viewers("stripping")
-	suit.wearer.visible_message(span_warning("[source] begins to dump the contents of [suit.wearer]'s control unit!"))
+	user.visible_message(span_warning("[user] begins to dump the contents of [source]!"))
 	ASYNC
 		var/datum/strip_menu/protean/strip_menu = LAZYACCESS(strip_menus, species.owner)
 		if (isnull(strip_menu))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
`/datum/element/strippable/protean/proc/click_control_shit(datum/source, mob/user)`
Fixes https://github.com/Bubberstation/Bubberstation/issues/4121. We had NULL in suit.wearer when displayed message except when suit was on the back. It resulted in exception and players being unable to strip it unless they wearing it.

`/obj/item/mod/control/pre_equipped/protean/equipped(mob/user, slot, initial)`
Fixed some exceptions. Caused by wearer being NULL as well when interacting with it when not wearing on your back. (Picking up, equipping to backpack slot) Not sure if it fixes any actual issues, but not handled exceptions shouldn't be a thing.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game
Bugfixes good
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Proof Of Testing

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->
<details>
<summary>Screenshots/Videos</summary>
![Screenshot 2025-06-28 002255](https://github.com/user-attachments/assets/cff73b5a-92ea-4ed7-ab54-b2467851011c)
![Screenshot 2025-06-27 235011](https://github.com/user-attachments/assets/4116657c-f415-4990-b7df-81280d885749)
![image](https://github.com/user-attachments/assets/75c8d05d-aff7-49db-88a5-36c25b74c572)
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed stripping of proteans
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
