### PR TITLE
Makes !little guys! get thrown exactly one tile by shotguns

### DIFF
--- a/modular_skyrat/modules/modular_weapons/code/gun_launches_little_guys_element.dm
+++ b/modular_skyrat/modules/modular_weapons/code/gun_launches_little_guys_element.dm
@@ -7,14 +7,20 @@
 	var/throwing_force
 	/// The throwing range applied to the gun's user
 	var/throwing_range
+	/// The knockdown time applied to the gun's user
+	var/knockdown_time
+	/// Is the throw gentle?
+	var/gentle
 
-/datum/element/gun_launches_little_guys/Attach(datum/target, throwing_force = 2, throwing_range = 3)
+/datum/element/gun_launches_little_guys/Attach(datum/target, throwing_force = 2, throwing_range = 3, knockdown_time = 1 SECONDS, gentle = FALSE)
 	. = ..()
 	if(!isgun(target))
 		return ELEMENT_INCOMPATIBLE
 
 	src.throwing_force = throwing_force
 	src.throwing_range = throwing_range
+	src.knockdown_time = knockdown_time
+	src.gentle = gentle
 
 	RegisterSignal(target, COMSIG_ATOM_EXAMINE, PROC_REF(examine))
 	RegisterSignal(target, COMSIG_GUN_FIRED, PROC_REF(throw_it_back))
@@ -39,8 +45,9 @@
 
 	var/fling_direction = REVERSE_DIR(user.dir)
 	var/atom/throw_target = get_edge_target_turf(user, fling_direction)
-	user.Knockdown(1 SECONDS)
-	user.throw_at(throw_target, throwing_range, throwing_force)
+	if (knockdown_time > 0)
+		user.Knockdown(knockdown_time)
+	user.throw_at(throw_target, throwing_range, throwing_force, gentle = gentle)
 
 	user.visible_message(span_warning("[weapon] sends [user] flying back as it fires!"), \
 		span_warning("[weapon] sends you flying back as it fires!"))

--- a/modular_skyrat/modules/shotgunrebalance/code/shotgun.dm
+++ b/modular_skyrat/modules/shotgunrebalance/code/shotgun.dm
@@ -333,3 +333,8 @@
 
 /obj/item/ammo_casing/shotgun/beanbag
 	harmful = FALSE
+
+/obj/item/gun/ballistic/shotgun/Initialize(mapload)
+	AddElement(/datum/element/gun_launches_little_guys, throwing_force = 1, throwing_range = 1, knockdown_time = 0, gentle = TRUE)
+
+	return ..()


### PR DESCRIPTION

## About The Pull Request

Title.

Teshari anmd other small guys are thrown exactly one tile when firing a shotgun. This does no damage, cannot stun, and does not knockdown. Its almost entirely flavor.

Drafted due to freeze (Im assuming its okay to keep PRs open and drafted due to that one verb PR being open?)
## Why It's Good For The Game

Funny!
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
I forgor... to record...
</details>

## Changelog
:cl:
add: Little guys now get flung by shotguns
/:cl:
