### PR TITLE
Removes pay-to-win military gloves from the loadout (they were free insulated + temp resist + could shoot guns available to server donators only lol)

### DIFF
--- a/modular_skyrat/master_files/code/modules/loadout/categories/gloves.dm
+++ b/modular_skyrat/master_files/code/modules/loadout/categories/gloves.dm
@@ -104,12 +104,3 @@
 /datum/loadout_item/gloves/diamondring
 	name = "Diamond Ring"
 	item_path = /obj/item/clothing/gloves/ring/diamond
-
-/*
-*	DONATOR
-*/
-
-/datum/loadout_item/gloves/military
-	name = "Military Gloves"
-	item_path = /obj/item/clothing/gloves/military
-	donator_only = TRUE


### PR DESCRIPTION
## About The Pull Request

Removes pay-to-win military gloves from the loadout (they were free insulated + temp resist + could shoot guns available to server donators only lol)

## Why It's Good For The Game

For some reason Skyrat added the best gloves in the game to the loadout and then made them donator only. That's wack as hell considering these are

1. high strip delay(6 seconds to take them off of someone)
2. fully insulated
3. fully temperature proofed for space
4. able to fire guns while using even though it's insulated

this is pay 2 win as hell lol

## Proof Of Testing

deletes a loadout item

## Changelog

:cl:
del: Removes pay-to-win military gloves from the loadout
/:cl:
