### PR TITLE
fixes text and ghouling mindshielded people

### DIFF
--- a/modular_zubbers/code/modules/antagonists/bloodsucker/powers/tremere/dominate.dm
+++ b/modular_zubbers/code/modules/antagonists/bloodsucker/powers/tremere/dominate.dm
@@ -135,7 +135,7 @@
 		pay_cost(TEMP_GHOULIZE_COST - bloodcost)
 		log_combat(owner, target, "tremere revived", addition="Revived their ghoul using dominate")
 		return FALSE
-	if(!bloodsuckerdatum_power.make_ghoul(target) )
+	if(!bloodsuckerdatum_power.make_ghoul(target))
 		owner.balloon_alert(owner, "not a valid target for ghouling!.")
 		return
 

--- a/modular_zubbers/code/modules/antagonists/bloodsucker/structures/crypt.dm
+++ b/modular_zubbers/code/modules/antagonists/bloodsucker/structures/crypt.dm
@@ -401,11 +401,11 @@
 			disloyalty_confirm = TRUE
 			target.visible_message(
 				span_notice("[target] gives in to [user]'s offer of servitude!"),
-				span_usernotice("You give in to [user]'s offer of servitude!"))
+				span_userdanger("You give in to [user]'s offer of servitude!"))
 		else
 			target.visible_message(
 				span_danger("[target] stares defiantly at [user], refusing to give in!"),
-				span_userdanger("You stare defiantly at [user], refusing to give in!"))
+				span_danger("You stare defiantly at [user], refusing to give in!"))
 	disloyalty_offered = FALSE
 	return TRUE
 

--- a/modular_zubbers/code/modules/antagonists/bloodsucker/structures/crypt.dm
+++ b/modular_zubbers/code/modules/antagonists/bloodsucker/structures/crypt.dm
@@ -331,8 +331,8 @@
 		return
 	// Convert to Ghoul!
 	bloodsuckerdatum.AdjustBloodVolume(-TORTURE_CONVERSION_COST)
+	remove_loyalties(target)
 	if(bloodsuckerdatum.make_ghoul(target))
-		remove_loyalties(target)
 		SEND_SIGNAL(bloodsuckerdatum, COMSIG_BLOODSUCKER_MADE_GHOUL, user, target)
 
 /obj/structure/bloodsucker/ghoulrack/proc/do_torture(mob/living/user, mob/living/carbon/target, mult = 1)
@@ -378,7 +378,7 @@
 	target.apply_damages(brute = torture_dmg_brute, burn = torture_dmg_burn, def_zone = selected_bodypart.body_zone)
 	return TRUE
 
-/// Offer them the oppertunity to join now.
+/// Offer them the opportunity to join now.
 /obj/structure/bloodsucker/ghoulrack/proc/do_disloyalty(mob/living/user, mob/living/target)
 	if(disloyalty_offered)
 		return FALSE
@@ -399,8 +399,13 @@
 	switch(alert_response)
 		if("Accept")
 			disloyalty_confirm = TRUE
+			target.visible_message(
+				span_notice("[target] gives in to [user]'s offer of servitude!"),
+				span_usernotice("You give in to [user]'s offer of servitude!"))
 		else
-			target.balloon_alert_to_viewers("stares defiantly", "refused ghouling!")
+			target.visible_message(
+				span_danger("[target] stares defiantly at [user], refusing to give in!"),
+				span_userdanger("You stare defiantly at [user], refusing to give in!"))
 	disloyalty_offered = FALSE
 	return TRUE
 

--- a/modular_zubbers/code/modules/antagonists/bloodsucker/vassal/vassal_datum.dm
+++ b/modular_zubbers/code/modules/antagonists/bloodsucker/vassal/vassal_datum.dm
@@ -155,7 +155,7 @@
 		return
 
 	owner.current.visible_message(
-		span_deconversion_message("[owner.current]'s eyes dart feverishly from side to side, and then stop. [owner.current.p_they(TRUE)] seem[owner.current.p_s()] calm, \
+		span_deconversion_message("[owner.current]'s eyes dart feverishly from side to side, and then stop. [owner.current.p_They(TRUE)] seem[owner.current.p_s()] to calm, \
 			like [owner.current.p_they()] [owner.current.p_have()] regained some lost part of [owner.current.p_them()]self."), \
 		span_deconversion_message("With a snap, you are no longer enslaved to [master.owner]! You breathe in heavily, having regained your free will."))
 	owner.current.playsound_local(null, 'sound/effects/magic/mutate.ogg', 100, FALSE, pressure_affected = FALSE)


### PR DESCRIPTION

## About The Pull Request
fixes some bloodsucker-related text and ghouling mindshielded people.
Seems like it broke at some point.

## Why It's Good For The Game
Stuff working is good, if we want to remove this feature should be done in a separate PR, but is better to have working features than broken ones.

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
fix: Fixes/changes some conversion messages to make it make more sense
fix: mindshielded conversion
/:cl:

