### PR TITLE
OOC Escape should now remove milker handcuffs

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/clothing_pref_check.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/clothing_pref_check.dm
@@ -19,7 +19,6 @@ GLOBAL_LIST_INIT(pref_checked_clothes, list(
 	/obj/item/clothing/gloves/shibari_hands,
 	/obj/item/clothing/shoes/shibari_legs,
 	/obj/item/clothing/under/shibari,
-	/obj/item/restraints/handcuffs/milker,
 ))
 
 /obj/item/clothing/mob_can_equip(mob/living/user, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE, ignore_equipped = FALSE, indirect_action)

--- a/modular_skyrat/modules/modular_items/lewd_items/code/clothing_pref_check.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/clothing_pref_check.dm
@@ -19,6 +19,7 @@ GLOBAL_LIST_INIT(pref_checked_clothes, list(
 	/obj/item/clothing/gloves/shibari_hands,
 	/obj/item/clothing/shoes/shibari_legs,
 	/obj/item/clothing/under/shibari,
+	/obj/item/restraints/handcuffs/milker,
 ))
 
 /obj/item/clothing/mob_can_equip(mob/living/user, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE, ignore_equipped = FALSE, indirect_action)

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_machinery/milking_machine.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_machinery/milking_machine.dm
@@ -186,6 +186,7 @@
 		current_mob.set_handcuffed(cuffs)
 		cuffs.parent_chair = WEAKREF(src)
 		current_mob.update_abstract_handcuffed()
+		RegisterSignal(current_mob, COMSIG_OOC_ESCAPE, PROC_REF(ooc_escape))
 
 	update_overlays()
 	affected_mob.layer = BELOW_MOB_LAYER
@@ -217,6 +218,7 @@
 		current_mob.set_handcuffed(null)
 		current_mob.update_abstract_handcuffed()
 
+	UnregisterSignal(current_mob, COMSIG_OOC_ESCAPE)
 	current_mob = null
 	current_selected_organ = null
 	current_breasts = null
@@ -224,6 +226,12 @@
 	current_vagina = null
 
 	return
+
+/obj/structure/chair/milking_machine/ooc_escape(mob/living/carbon/user)
+	SIGNAL_HANDLER
+
+	unbuckle_mob(user)
+
 
 /obj/structure/chair/milking_machine/is_buckle_possible(mob/living/target, force, check_loc)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

When using the OOC Escape verb, it'll now eject you from the milking machine.
## Why It's Good For The Game

Fixes #3930 

## Proof Of Testing

Untested right now.

## Changelog
:cl:
fix: The milking machine now respects the OOC Safeword.
/:cl:
