### PR TITLE
Adds age vet messages to lustwish portals. Bonus: at maintainer request also removes the non-vetted message entirely

### DIFF
--- a/modular_zubbers/code/game/objects/structures/lewd_portals.dm
+++ b/modular_zubbers/code/game/objects/structures/lewd_portals.dm
@@ -377,8 +377,6 @@
 		return
 	if(SSplayer_ranks.is_vetted(owner?.client, admin_bypass = FALSE))
 		. += span_greenannounce("This player has been vetted as 18+ by staff.")
-	else
-		. += span_velvet("THIS PLAYER IS NOT VETTED! CONTINUE AT YOUR OWN RISK!")
 
 /obj/lewd_portal_relay/Topic(href, href_list)
 	. = ..()

--- a/modular_zubbers/code/modules/vetted/examine.dm
+++ b/modular_zubbers/code/modules/vetted/examine.dm
@@ -6,8 +6,6 @@
 		return
 	if(SSplayer_ranks.is_vetted(client, admin_bypass = FALSE))
 		. += span_greenannounce("This player has been vetted as 18+ by staff.")
-	else
-		. += span_velvet("THIS PLAYER IS NOT VETTED! CONTINUE AT YOUR OWN RISK!")
 
 /mob/living/carbon/human/examine(mob/user)
 	. = ..()
@@ -17,5 +15,3 @@
 		return
 	if(SSplayer_ranks.is_vetted(client, admin_bypass = FALSE))
 		. += span_greenannounce("This player has been vetted as 18+ by staff.")
-	else
-		. += span_velvet("THIS PLAYER IS NOT VETTED! CONTINUE AT YOUR OWN RISK!")


### PR DESCRIPTION
## About The Pull Request

I removed this from the original PR since it was removed elsewhere but since the merge its been re-added, just adding it back here for consistency. 

At StrangeWeirdKitten's request this PR also removes the non vetted message entirely. This should not be player facing.

## Why It's Good For The Game

Consistency pretty much
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

![Portal4](https://github.com/user-attachments/assets/3d81838a-1712-4425-8765-f7686e808391)

</details>

## Changelog
:cl:
fix: Age vetting message added to lust wish portals.
/:cl:
