### PR TITLE
Removes a black market uplink from the prison infinite dorms

### DIFF
--- a/modular_skyrat/modules/hotel_rooms/prisoninfdorm.dmm
+++ b/modular_skyrat/modules/hotel_rooms/prisoninfdorm.dmm
@@ -440,7 +440,6 @@
 /area/misc/hilbertshotel)
 "TT" = (
 /obj/structure/closet,
-/obj/item/market_uplink,
 /obj/effect/spawner/random/entertainment/coin,
 /obj/effect/spawner/random/entertainment/coin,
 /obj/item/gun/ballistic/automatic/l6_saw/toy,


### PR DESCRIPTION

## About The Pull Request

Removes a black market uplink from the prison infinite dorms
## Why It's Good For The Game

Methods for ghost cafe to impact the station bad and also oversight
## Proof Of Testing

yep its gone
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: Removes a black market uplink from the prison infinite dorms. This was an oversight.
/:cl:
