### PR TITLE
Webbing holding guns consistency

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_clothing.dm
+++ b/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_clothing.dm
@@ -237,8 +237,6 @@
 	. = ..()
 	atom_storage.max_slots = 7
 	atom_storage.set_holdable(list(
-		/obj/item/gun/ballistic/automatic/pistol,
-		/obj/item/gun/ballistic/revolver,
 		/obj/item/melee/baton,
 		/obj/item/melee/baton,
 		/obj/item/grenade,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Webbings act as they were meant to back in https://github.com/Bubberstation/Bubberstation/pull/3675
So the same as security belts.
This only goes for security webbings, the syndicate one is not affected.

## Proof Of Testing

Tested on private server, syndicate webbings hold small guns, security do not 

## Changelog

:cl:
fix: security webbing gun-holding is consistent with secbelt gun holding
/:cl:
