### PR TITLE
Disables stowaways until policy is written

### DIFF
--- a/config/jobconfig.toml
+++ b/config/jobconfig.toml
@@ -345,8 +345,8 @@
 "Playtime Requirements" = 2400
 "Required Account Age" = 7
 "# Required Character Age" = 0
-"Spawn Positions" = 20
-"Total Positions" = 20
+"Spawn Positions" = 0
+"Total Positions" = 0
 
 [VANGUARD_OPERATIVE]
 "Playtime Requirements" = 400

--- a/modular_zubbers/code/modules/jobs/stowaway.dm
+++ b/modular_zubbers/code/modules/jobs/stowaway.dm
@@ -4,8 +4,8 @@
 	faction = FACTION_NONE
 	supervisors = "yourself"
 	minimal_player_age = 7
-	total_positions = 20
-	spawn_positions = 20
+	total_positions = 0
+	spawn_positions = 0
 	exp_requirements = 2400
 	exp_required_type = EXP_TYPE_CREW
 	exp_granted_type = EXP_TYPE_SPECIAL
@@ -14,7 +14,7 @@
 	liver_traits = list(TRAIT_MAINTENANCE_METABOLISM)
 
 
-	job_flags = JOB_NEW_PLAYER_JOINABLE|JOB_REOPEN_ON_ROUNDSTART_LOSS|JOB_ASSIGN_QUIRKS|JOB_CANNOT_OPEN_SLOTS
+	job_flags = JOB_HIDE_WHEN_EMPTY
 
 /datum/job/assistant/stowaway/after_spawn(mob/living/spawned, client/player_client)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Code's still there

## Why It's Good For The Game

No policy = bad

I'll start writing the policy until other staff tie me down and stop me

## Proof Of Testing

![wow](https://github.com/user-attachments/assets/0e582c04-4e67-49e3-ba8d-a80dc5865079)


## Changelog

:cl:
config: Disabled stowaways
/:cl:

