### PR TITLE
Removes a pipe under airlock to nowhere on biodome + normalizes SM layout

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -14221,6 +14221,12 @@
 /obj/structure/chair/plastic,
 /turf/open/floor/carpet/green,
 /area/station/command/heads_quarters/nt_rep)
+"eQT" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Gas To Cold Loop"
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "eRd" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -24230,13 +24236,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "isp" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Cooling Loop Bypass"
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "isx" = (
@@ -67978,6 +67981,13 @@
 	},
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/captain)
+"xlK" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Cooling Loop Bypass"
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "xlT" = (
 /turf/open/floor/fakespace,
 /area/station/maintenance/port/greater)
@@ -109455,7 +109465,7 @@ kPl
 meW
 gjj
 isp
-gXp
+eQT
 eHk
 afA
 fnZ
@@ -109711,7 +109721,7 @@ vlo
 gXp
 vlo
 gXp
-wqN
+xlK
 tgU
 eHk
 jLf


### PR DESCRIPTION
## About The Pull Request
![image](https://github.com/user-attachments/assets/7c55c964-f97f-4bcf-af1b-474e217af8ac)


This pipe is gone


Also makes the SM not delaminate instantly when using default setup
<details>
<summary> before </summary>

BEFORE
![image](https://github.com/user-attachments/assets/63ce292a-5945-400f-acfc-cac58df3a949)
</details>

<details>
<summary> after </summary>

AFTER
![image](https://github.com/user-attachments/assets/30133dfa-96be-41f3-9ea1-5677d1d048b0)
</details>

## Why It's Good For The Game

oh right uhhh you see pipe to nowhere bad

also SM normalization good, don't make new engineers suffer

## Proof Of Testing
no
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: Removed pipe to nowhere on biodome
fix: normalizes SM setup on biodome so it no longer delaminates on the default setup
/:cl:
