### PR TITLE
Changes Mech Thermal Cannon Crate Access

### DIFF
--- a/code/modules/cargo/packs/science.dm
+++ b/code/modules/cargo/packs/science.dm
@@ -197,7 +197,7 @@
 		When used simultaneously, their excess power used to heat and cool the opposing weapon, \
 		increasing the reload speed."
 	cost = CARGO_CRATE_VALUE * 25
-	access = ACCESS_RD
+	access = ACCESS_ROBOTICS
 	access_view = ACCESS_ROBOTICS
 	contains = list(
 		/obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/cryo,

--- a/code/modules/cargo/packs/science.dm
+++ b/code/modules/cargo/packs/science.dm
@@ -190,3 +190,19 @@
 	contains = list(/obj/item/mod/core/standard = 3)
 	crate_name = "\improper MOD core crate"
 	crate_type = /obj/structure/closet/crate/nakamura
+
+/datum/supply_pack/science/mechthermal
+	name = "Heavy Thermal Guns Crate"
+	desc = "Contains two experimental thermal cannons for use by mechs. \
+		When used simultaneously, their excess power used to heat and cool the opposing weapon, \
+		increasing the reload speed."
+	cost = CARGO_CRATE_VALUE * 25
+	access = ACCESS_RD
+	access_view = ACCESS_ROBOTICS
+	contains = list(
+		/obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/cryo,
+		/obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/inferno,
+	)
+	crate_name = "thermal cannons crate"
+	crate_type = /obj/structure/closet/crate/secure/plasma
+

--- a/code/modules/cargo/packs/science.dm
+++ b/code/modules/cargo/packs/science.dm
@@ -191,7 +191,7 @@
 	crate_name = "\improper MOD core crate"
 	crate_type = /obj/structure/closet/crate/nakamura
 
-/datum/supply_pack/science/mechthermal
+/datum/supply_pack/science/mechthermal //Bubber edit
 	name = "Heavy Thermal Guns Crate"
 	desc = "Contains two experimental thermal cannons for use by mechs. \
 		When used simultaneously, their excess power used to heat and cool the opposing weapon, \

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -380,14 +380,3 @@
 	contains = list(/obj/item/clothing/glasses/sunglasses = 1)
 	crate_name = "sunglasses crate"
 
-/datum/supply_pack/security/armory/mechthermal
-	name = "Heavy Thermal Guns Crate"
-	desc = "Contains two experimental thermal cannons for use by mechs. \
-		When used simultaneously, their excess power used to heat and cool the opposing weapon, \
-		increasing the reload speed."
-	cost = CARGO_CRATE_VALUE * 25
-	contains = list(
-		/obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/cryo,
-		/obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/inferno,
-	)
-	crate_name = "thermal cannons crate"

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -379,4 +379,5 @@
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/clothing/glasses/sunglasses = 1)
 	crate_name = "sunglasses crate"
+//Bubber edit, moved mech thermals to science
 

--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -189,35 +189,6 @@
 	icon_state = "mecha_pyrogun"
 	projectile = /obj/projectile/energy/inferno
 
-/obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/cryo/try_attach_part(mob/user, obj/vehicle/sealed/mecha/themech, attach_right)
-	var/has_molten = FALSE
-	for (var/obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/thegun in themech.flat_equipment)
-		if (istype(thegun, /obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/cryo))
-			to_chat(user, span_warning("[themech] already has [thegun] installed!"))
-			return ITEM_INTERACT_BLOCKING
-		if (istype(thegun, /obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/inferno))
-			has_molten = TRUE
-	if (has_molten)
-		for (var/obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/thegun in themech.flat_equipment)
-			if (istype(thegun, /obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/inferno))
-				thegun.equip_cooldown = 8
-		equip_cooldown = 8
-
-/obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/inferno/try_attach_part(mob/user, obj/vehicle/sealed/mecha/themech, attach_right)
-	var/has_cryo = FALSE
-	for (var/obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/thegun in themech.flat_equipment)
-		if (istype(thegun, /obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/inferno))
-			to_chat(user, span_warning("[themech] already has [thegun] installed!"))
-			return ITEM_INTERACT_BLOCKING
-		if (istype(thegun, /obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/cryo))
-			has_cryo = TRUE
-	if (has_cryo)
-		for (var/obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/thegun in themech.flat_equipment)
-			if (istype(thegun, /obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/cryo))
-				thegun.equip_cooldown = 8
-		equip_cooldown = 8
-	return ..()
-
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/detach(atom/moveto)
 	for (var/obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/thermal_gun in chassis.flat_equipment)
 		thermal_gun.equip_cooldown = 20

--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -189,6 +189,35 @@
 	icon_state = "mecha_pyrogun"
 	projectile = /obj/projectile/energy/inferno
 
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/cryo/try_attach_part(mob/user, obj/vehicle/sealed/mecha/themech, attach_right)
+	var/has_molten = FALSE
+	for (var/obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/thegun in themech.flat_equipment)
+		if (istype(thegun, /obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/cryo))
+			to_chat(user, span_warning("[themech] already has [thegun] installed!"))
+			return ITEM_INTERACT_BLOCKING
+		if (istype(thegun, /obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/inferno))
+			has_molten = TRUE
+	if (has_molten)
+		for (var/obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/thegun in themech.flat_equipment)
+			if (istype(thegun, /obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/inferno))
+				thegun.equip_cooldown = 8
+		equip_cooldown = 8
+
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/inferno/try_attach_part(mob/user, obj/vehicle/sealed/mecha/themech, attach_right)
+	var/has_cryo = FALSE
+	for (var/obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/thegun in themech.flat_equipment)
+		if (istype(thegun, /obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/inferno))
+			to_chat(user, span_warning("[themech] already has [thegun] installed!"))
+			return ITEM_INTERACT_BLOCKING
+		if (istype(thegun, /obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/cryo))
+			has_cryo = TRUE
+	if (has_cryo)
+		for (var/obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/thegun in themech.flat_equipment)
+			if (istype(thegun, /obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/cryo))
+				thegun.equip_cooldown = 8
+		equip_cooldown = 8
+	return ..()
+
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/detach(atom/moveto)
 	for (var/obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/thermal_gun in chassis.flat_equipment)
 		thermal_gun.equip_cooldown = 20


### PR DESCRIPTION
## About The Pull Request

Did you know that /tg/ added New Mech Content? New guns, in fact. Unfortunately, they were locked to not JUST Security/Armory access, but could ONLY be bought, not even departmentally ordered. 

This PR the access/order requirements to science/Robotics instead. Also, moves the crate data to the science pack instead of sec to reflect the new accesses properly. 
## Why It's Good For The Game

I doubt you even knew these existed due to the really really weird access requirements. Maybe they'll be used now! 

## Proof Of Testing
Worked on my machine:tm:

## Changelog
:cl:
add: Reworked access requirements for the Prototype Mech Thermal Cannons 
/:cl:
