### PR TITLE
Rebalances the cargo sabre and cargo bowie knife

### DIFF
--- a/modular_skyrat/modules/company_imports/code/armament_datums/jarnsmiour.dm
+++ b/modular_skyrat/modules/company_imports/code/armament_datums/jarnsmiour.dm
@@ -17,7 +17,7 @@
 
 /datum/armament_entry/company_import/blacksteel/blade/bowie_knife
 	item_type = /obj/item/storage/belt/bowie_sheath
-	cost = PAYCHECK_COMMAND * 2
+	cost = PAYCHECK_COMMAND * 3
 
 /datum/armament_entry/company_import/blacksteel/blade/shamshir_sabre
 	item_type = /obj/item/storage/belt/sabre/cargo

--- a/modular_skyrat/modules/company_imports/code/armament_datums/jarnsmiour.dm
+++ b/modular_skyrat/modules/company_imports/code/armament_datums/jarnsmiour.dm
@@ -17,7 +17,7 @@
 
 /datum/armament_entry/company_import/blacksteel/blade/bowie_knife
 	item_type = /obj/item/storage/belt/bowie_sheath
-	cost = PAYCHECK_COMMAND * 6
+	cost = PAYCHECK_COMMAND * 2
 
 /datum/armament_entry/company_import/blacksteel/blade/shamshir_sabre
 	item_type = /obj/item/storage/belt/sabre/cargo

--- a/modular_skyrat/modules/knives/knives.dm
+++ b/modular_skyrat/modules/knives/knives.dm
@@ -10,7 +10,7 @@
 	lefthand_file = 'modular_skyrat/modules/knives/icons/bowie_lefthand.dmi'
 	righthand_file = 'modular_skyrat/modules/knives/icons/bowie_righthand.dmi'
 	worn_icon_state = "knife"
-	force = 20 // Zoowee Momma!
+	force = 15 // why was this 20 what the fuck man
 	w_class = WEIGHT_CLASS_NORMAL
 	throwforce = 15
 	wound_bonus = 10 //scalpel tier

--- a/modular_skyrat/modules/knives/knives.dm
+++ b/modular_skyrat/modules/knives/knives.dm
@@ -10,7 +10,7 @@
 	lefthand_file = 'modular_skyrat/modules/knives/icons/bowie_lefthand.dmi'
 	righthand_file = 'modular_skyrat/modules/knives/icons/bowie_righthand.dmi'
 	worn_icon_state = "knife"
-	force = 15 // why was this 20 what the fuck man
+	force = 17 // why was this 20 what the fuck man
 	w_class = WEIGHT_CLASS_NORMAL
 	throwforce = 25
 	wound_bonus = 10 //scalpel tier

--- a/modular_skyrat/modules/knives/knives.dm
+++ b/modular_skyrat/modules/knives/knives.dm
@@ -12,7 +12,7 @@
 	worn_icon_state = "knife"
 	force = 15 // why was this 20 what the fuck man
 	w_class = WEIGHT_CLASS_NORMAL
-	throwforce = 15
+	throwforce = 20
 	wound_bonus = 10 //scalpel tier
 	exposed_wound_bonus = 20 // Very-bigly
 

--- a/modular_skyrat/modules/knives/knives.dm
+++ b/modular_skyrat/modules/knives/knives.dm
@@ -12,7 +12,7 @@
 	worn_icon_state = "knife"
 	force = 17 // why was this 20 what the fuck man
 	w_class = WEIGHT_CLASS_NORMAL
-	throwforce = 25
+	throwforce = 20
 	wound_bonus = 10 //scalpel tier
 	exposed_wound_bonus = 20 // Very-bigly
 

--- a/modular_skyrat/modules/knives/knives.dm
+++ b/modular_skyrat/modules/knives/knives.dm
@@ -12,7 +12,7 @@
 	worn_icon_state = "knife"
 	force = 15 // why was this 20 what the fuck man
 	w_class = WEIGHT_CLASS_NORMAL
-	throwforce = 20
+	throwforce = 25
 	wound_bonus = 10 //scalpel tier
 	exposed_wound_bonus = 20 // Very-bigly
 

--- a/modular_skyrat/modules/modular_weapons/code/melee.dm
+++ b/modular_skyrat/modules/modular_weapons/code/melee.dm
@@ -23,6 +23,7 @@
 	righthand_file = 'modular_skyrat/modules/modular_weapons/icons/mob/inhands/weapons/swords_righthand.dmi'
 	block_chance = 20
 	armour_penetration = 25
+	force = 15
 
 
 // This is here so that people can't buy the Sabres and craft them into powercrepes


### PR DESCRIPTION
## About The Pull Request

Adjusts the damage of the cargo-orderable bowie knife to 17 and sabre to 15 force, as opposed to the 20 they both were.

Gives the cargo bowie knife 20 throwforce. Throwing knifes is cool. Also also makes it cheaper because it's weaker now.
## Why It's Good For The Game

20 force is a LOT. There are VERY few crew-accessible weapons that have this much force. The captain's sabre is one of them (by merit of skyrat override but whatever the cap can have that). The vast majority of crew-accessible melee weapons have 15 force, these include circsaw, butchers cleaver, etc. 

For reference, heretic blades start with 20 force.
The soulscythe (bubblegum reward) has 20 force.
The captain's sabre has 20 force.

These 2 weapons having the extra damage is far out of tune with the rest of crew-side melee weapons.

These weapons are still going to be very strong even with the lessened damage. A knife that fits in the pocket slot with 17 force is good. A belt-slot sabre with block AND armor pen for 600 credits is also still VERY good. They will just not be "best in slot in every scenario" anymore.
## Proof Of Testing

I changed the number :)
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
balance: Changed the cargo sabre's force from 20 to 15
balance: Changed the cargo bowie knife's force from 20 to 17
balance: Changed the cargo bowie knife's throwforce from 15 to 20. Throwing stuff is cool.
balance: Lowered to cost of the cargo bowie knife to 300 credits
/:cl:
