### PR TITLE
Reduces status indicators from POINT_PLAIN to ABOVE_GAME_PLANE so they don't show through effects like smoke.

### DIFF
--- a/modular_zubbers/code/modules/status_indicators/status_indicator.dm
+++ b/modular_zubbers/code/modules/status_indicators/status_indicator.dm
@@ -1,7 +1,7 @@
 /obj/effect/overlay/status_indicator/
 	icon = 'modular_zubbers/icons/mob/status_indicators.dmi'
 	pixel_z = 16
-	plane = POINT_PLANE
+	plane = ABOVE_GAME_PLANE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	alpha = 0
 


### PR DESCRIPTION
## About The Pull Request

Reduces the status indicators from POINT_PLAIN to ABOVE_GAME_PLANE

## Why It's Good For The Game

Makes them more visible if your mob is only visible, while also maintaining a clickthru.

## Proof Of Testing

It works

## Changelog

:cl:
fix: Status indicators will no longer show through certain effects like smoke.
/:cl: