### PR TITLE
Makes it so having WALKMODE on doesn't crush people with the micro quirks

### DIFF
--- a/code/datums/components/squashable.dm
+++ b/code/datums/components/squashable.dm
@@ -62,7 +62,7 @@
 	if(isliving(crossing_movable))
 		var/mob/living/crossing_mob = crossing_movable
 		if(crossing_mob.mob_size > MOB_SIZE_SMALL && !(crossing_mob.movement_type & MOVETYPES_NOT_TOUCHING_GROUND))
-			if(HAS_TRAIT(crossing_mob, TRAIT_PACIFISM))
+			if(HAS_TRAIT(crossing_mob, TRAIT_PACIFISM) || (crossing_mob.move_intent == MOVE_INTENT_WALK)) // BUBBER EDIT
 				crossing_mob.visible_message(span_notice("[crossing_mob] carefully steps over [parent_as_living]."), span_notice("You carefully step over [parent_as_living] to avoid hurting it."))
 				return
 			if(should_squash)


### PR DESCRIPTION

## About The Pull Request

Having WALK MODE on makes it so you don't give micros any wounds/damage. Knockdown still applies.
## Why It's Good For The Game
Giving people a way to not accidentally squish micros is good, having it tied to walkmode which everyone can turn on willingly and not just a quirk like before (Pacifism) is also good. The knockdown is still there. 
## Proof Of Testing

Tested it on a localhost
![it works](https://github.com/user-attachments/assets/a81bd5a4-1244-45e3-b488-8e25cbe0fde5)
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
balance: Having WALK mode on makes you not squish micros.
/:cl:
