### PR TITLE
Remove forced size changes on Settler and Spacer

### DIFF
--- a/code/datums/quirks/positive_quirks/settler.dm
+++ b/code/datums/quirks/positive_quirks/settler.dm
@@ -1,7 +1,7 @@
 /datum/quirk/item_quirk/settler
 	name = "Settler"
-	desc = "You are from a lineage of the earliest space settlers! While your family's generational exposure to varying gravity \
-		has resulted in a ... smaller height than is typical for your species, you make up for it by being much better at outdoorsmanship and \
+	//BUBBER EDIT (Changes text a bit)
+	desc = "You are from a lineage of the earliest space settlers!  You are much better at outdoorsmanship and \
 		carrying heavy equipment. You also get along great with animals. However, you are a bit on the slow side due to your small legs."
 	gain_text = span_bold("You feel like the world is your oyster!")
 	lose_text = span_danger("You think you might stay home today.")
@@ -26,8 +26,10 @@
 /datum/quirk/item_quirk/settler/add(client/client_source)
 	var/mob/living/carbon/human/human_quirkholder = quirk_holder
 	//SKYRAT EDIT BEGIN - This is so Teshari don't get the height decrease.
-	if(!isteshari(human_quirkholder))
-		human_quirkholder.set_mob_height(HUMAN_HEIGHT_SHORTEST)
+	//BUBBER EDIT REMOVAL START - Lol, not any more.
+	//if(!isteshari(human_quirkholder))
+	//	human_quirkholder.set_mob_height(HUMAN_HEIGHT_SHORTEST)
+	//BUBBER EDIT REMOVAL END
 	//SKYRAT EDIT END
 	human_quirkholder.add_movespeed_modifier(/datum/movespeed_modifier/settler)
 	human_quirkholder.physiology.hunger_mod *= 0.75 //good for you, shortass, you don't get hungry nearly as often
@@ -41,7 +43,9 @@
 	if(QDELING(quirk_holder))
 		return
 	var/mob/living/carbon/human/human_quirkholder = quirk_holder
-	human_quirkholder.set_mob_height(HUMAN_HEIGHT_MEDIUM)
+	//BUBBER EDIT REMOVAL START
+	//human_quirkholder.set_mob_height(HUMAN_HEIGHT_MEDIUM)
+	//BUBBER EDIT REMOVAL END
 	human_quirkholder.remove_movespeed_modifier(/datum/movespeed_modifier/settler)
 	human_quirkholder.physiology.hunger_mod /= 0.75
 	human_quirkholder.remove_traits(settler_traits, QUIRK_TRAIT)

--- a/code/datums/quirks/positive_quirks/spacer.dm
+++ b/code/datums/quirks/positive_quirks/spacer.dm
@@ -46,7 +46,9 @@
 	quirk_holder.inertia_move_multiplier *= 0.8
 
 	var/mob/living/carbon/human/human_quirker = quirk_holder
-	human_quirker.set_mob_height(modded_height)
+	//BUBBER EDIT REMOVAL START
+	//human_quirker.set_mob_height(modded_height)
+	//BUBBER EDIT REMOVAL END
 	human_quirker.physiology.pressure_mod *= 0.8
 	human_quirker.physiology.cold_mod *= 0.8
 
@@ -79,7 +81,9 @@
 	quirk_holder.remove_status_effect(/datum/status_effect/spacer)
 
 	var/mob/living/carbon/human/human_quirker = quirk_holder
-	human_quirker.set_mob_height(HUMAN_HEIGHT_MEDIUM)
+	//BUBBER EDIT REMOVAL START
+	//human_quirker.set_mob_height(HUMAN_HEIGHT_MEDIUM)
+	//BUBBER EDIT REMOVAL END
 	human_quirker.physiology.pressure_mod /= 0.8
 	human_quirker.physiology.cold_mod /= 0.8
 

--- a/modular_zubbers/code/modules/customization/height_scaling/preferences.dm
+++ b/modular_zubbers/code/modules/customization/height_scaling/preferences.dm
@@ -13,8 +13,10 @@
 	)
 
 	var/static/list/incompatable_quirk_ids = list(
-		"Spacer",
-		"Settler"
+		//BUBBER EDIT REMOVAL START
+		//"Spacer",
+		//"Settler"
+		//BUBBER EDIT REMOVAL END
 	)
 
 /datum/preference/choiced/height_scaling/init_possible_values()


### PR DESCRIPTION
## About The Pull Request

These changes modularly remove the forced height changes for the quirks Settler and Spacer by commenting out the part that applies them on creation and removal

## Why It's Good For The Game

Blubberstation is about roleplaying and character creation.  In my mind, a "Settler" character would be a giant equine man with a cowboy hat who can carry flatpacks over one shoulder but he also drives around his ranch in a pickup so he's not very fast.  Or maybe he's just not in much of a hurry from the idyllic farm life.  Also, Settler is a great perk and people should use it more.

And a Spacer is like, someone's special spacefaring race that's small for getting inside of engine compartments.  (Though the tallness fits equally as well)  Spacer honestly needs some buffs to be as good as Settler is.

## Proof Of Testing

<img width="550" height="50" alt="Screenshot 2025-07-12 083213" src="https://github.com/user-attachments/assets/d3fe1ef6-3a43-4fb9-a3d9-d1de108d2d8f" />


## Changelog

:cl: Stonetear
balance: Spacer and Settler no longer change your height.

/:cl:
