### PR TITLE
The security-based antag cap is now modified by the current alert level.

### DIFF
--- a/modular_zubbers/code/modules/storyteller/gamemode.dm
+++ b/modular_zubbers/code/modules/storyteller/gamemode.dm
@@ -236,7 +236,23 @@ SUBSYSTEM_DEF(gamemode)
 		return 0
 	if(!storyteller.antag_divisor)
 		return 0
-	return round(max(min(get_correct_popcount() / storyteller.antag_divisor + sec_crew ,sec_crew * 1.5),ANTAG_CAP_FLAT))
+
+	var/current_population = get_correct_popcount()
+
+	var/crew_cap = FLOOR(current_population / storyteller.antag_divisor,1)
+
+	var/alert_cap_multiplier = 0 //Anything above red means 0, like Delta and world ending events.
+	switch(SSsecurity_level.get_current_level_as_number())
+		if(SEC_LEVEL_GREEN to SEC_LEVEL_ORANGE)
+			alert_cap_multiplier = 1.5
+		if(SEC_LEVEL_AMBER)
+			alert_cap_multiplier = 1.25
+		if(SEC_LEVEL_RED)
+			alert_cap_multiplier = 1
+
+	var/sec_cap = FLOOR(sec_crew * alert_cap_multiplier,1)
+
+	return max( min(crew_cap,sec_cap), ANTAG_CAP_FLAT )
 
 /// Whether events can inject more antagonists into the round
 /datum/controller/subsystem/gamemode/proc/can_inject_antags()

--- a/modular_zubbers/code/modules/storyteller/gamemode.dm
+++ b/modular_zubbers/code/modules/storyteller/gamemode.dm
@@ -236,23 +236,20 @@ SUBSYSTEM_DEF(gamemode)
 		return 0
 	if(!storyteller.antag_divisor)
 		return 0
-
-	var/current_population = get_correct_popcount()
-
-	var/crew_cap = FLOOR(current_population / storyteller.antag_divisor,1)
-
 	var/alert_cap_multiplier = 0 //Anything above red means 0, like Delta and world ending events.
-	switch(SSsecurity_level.get_current_level_as_number())
-		if(SEC_LEVEL_GREEN to SEC_LEVEL_ORANGE)
-			alert_cap_multiplier = 1.5
-		if(SEC_LEVEL_AMBER)
-			alert_cap_multiplier = 1.25
-		if(SEC_LEVEL_RED)
-			alert_cap_multiplier = 1
-
-	var/sec_cap = FLOOR(sec_crew * alert_cap_multiplier,1)
-
-	return max( min(crew_cap,sec_cap), ANTAG_CAP_FLAT )
+	if(!SSsecurity_level)
+		alert_cap_multiplier = 1.25 //Something is wrong
+	else
+		switch(SSsecurity_level.get_current_level_as_number())
+			if(SEC_LEVEL_GREEN to SEC_LEVEL_ORANGE)
+				alert_cap_multiplier = 1.5
+			if(SEC_LEVEL_AMBER)
+				alert_cap_multiplier = 1.25
+			if(SEC_LEVEL_RED)
+				alert_cap_multiplier = 1
+	var/crew_cap = get_correct_popcount() / storyteller.antag_divisor
+	var/sec_cap = sec_crew * alert_cap_multiplier
+	return FLOOR( max( min(crew_cap,sec_cap), ANTAG_CAP_FLAT ), 1)
 
 /// Whether events can inject more antagonists into the round
 /datum/controller/subsystem/gamemode/proc/can_inject_antags()


### PR DESCRIPTION
## About The Pull Request

Antag cap calculations now round down the number of antagonists, instead of rounding to the nearest whole number.

The **security-based** antag cap is now modified by the current alert level.

On code green, blue, orange, and violet, the antag to security ratio is 1.5. This is how it currently is.
On code amber, the antag to security ratio is 1.25.
On code red, the antag to security ratio is 1.
All other alert levels have a ratio of 0. This should be reserved for world-ending events.

Antagonist roles will not be removed if the alert level changes. This just  generally means that alert level increases won't spawn any new antagonists unless the antag count is lacking.

(Antag to Security ratio refers to how many antags to spawn per member in the security department. A value of 1.5 means spawn 1.5 antags for every security officer.)

(There are two antag caps here, the security based one, which is based on sec population, and the crew based one, which is based on crew population. This only affects the security based one.)



## Why It's Good For The Game

I've been trying to figure out how to intelligently control the amount of chaos in a round so that shifts aren't either a nothingburger or a insane clusterfuck of a shift. I think that this implementation is a good way to control that given that:
- If a round is out of control, code blue is used.
- If a round is very manageable, code blue or green is used.
- If a round is experiencing some minor difficulties, code amber is used.
- If shit is hitting the fan, code red is used.

This assumes that people who are setting the alert level are acting in good faith, which is generally the case. If it isn't, then it's usually very obvious if the captain is trying to reduce the amount of antags, and thus can probably be smacked by other command staff or even central command.

## Proof Of Testing

If it compiles, it werks.

## Changelog

:cl: BurgerBB
balance: The security-based antag cap is now modified by the current alert level. Antag cap calculations now round down the number of antagonists, instead of rounding to the nearest whole number.
/:cl:
