### PR TITLE
The LIGHT STEP trait makes you not squash micros

### DIFF
--- a/code/datums/components/squashable.dm
+++ b/code/datums/components/squashable.dm
@@ -62,8 +62,8 @@
 	if(isliving(crossing_movable))
 		var/mob/living/crossing_mob = crossing_movable
 		if(crossing_mob.mob_size > MOB_SIZE_SMALL && !(crossing_mob.movement_type & MOVETYPES_NOT_TOUCHING_GROUND))
-			if(HAS_TRAIT(crossing_mob, TRAIT_PACIFISM) || (crossing_mob.move_intent == MOVE_INTENT_WALK)) // BUBBER EDIT
-				crossing_mob.visible_message(span_notice("[crossing_mob] carefully steps over [parent_as_living]."), span_notice("You carefully step over [parent_as_living] to avoid hurting it."))
+			if(HAS_TRAIT(crossing_mob, TRAIT_PACIFISM) || (crossing_mob.move_intent == MOVE_INTENT_WALK) || HAS_TRAIT(crossing_mob, TRAIT_LIGHT_STEP)) // BUBBER EDIT
+				crossing_mob.visible_message(span_notice("[crossing_mob] carefully steps over [parent_as_living]."), span_notice("You carefully step over [parent_as_living] to avoid hurting [parent_as_living.p_them()].")) //BUBBER EDIT - Added pronouns
 				return
 			if(should_squash)
 				crossing_mob.visible_message(span_notice("[crossing_mob] squashed [parent_as_living]."), span_notice("You squashed [parent_as_living]."))


### PR DESCRIPTION

## About The Pull Request

The light step trait, the trait that makes your character step lightly, makes you not squash micros. Knockdown still applies.

(Also uses the correct pronouns for the interaction now)

## Why It's Good For The Game

![saw this](https://github.com/user-attachments/assets/5d2f2377-b868-4e8b-a55a-3ee1e9b38b52)
It makes sense that characters who have a really light step wouldn't break a micro's bones. This time it's tied to a positive quirk. Imo this offers both an intuitive way of opting out of the crush content and a fun interaction with our already existing quirk. Knockdown STILL applies so you can't really cheese combat with micro quirks.

## Proof Of Testing

![John McLightstep](https://github.com/user-attachments/assets/ed39b5b4-6090-4d3e-b2c5-9c21fbc1a8cc)


## Changelog


:cl:
balance: Light Step makes you carefully step over micros, without hurting them.
/:cl:
