### PR TITLE
Fixes Yet Another Belt Gun Oversight

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_clothing.dm
+++ b/modular_skyrat/modules/sec_haul/code/peacekeeper/peacekeeper_clothing.dm
@@ -194,9 +194,6 @@
 	. = ..()
 	atom_storage.max_slots = 5
 	atom_storage.set_holdable(list(
-		/obj/item/gun/ballistic/automatic/pistol,
-		/obj/item/gun/ballistic/revolver,
-		/obj/item/gun/energy/disabler,
 		/obj/item/melee/baton,
 		/obj/item/melee/baton,
 		/obj/item/grenade,


### PR DESCRIPTION
an view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Same as the webbing, the peacekeper belt also did it's own override. I went through all overrides of this type, now. 

## Why It's Good For The Game
Check previous PRs for reasoning I'm just making sure there's consistency.

## Proof Of Testing

Trust

## Changelog

:cl:
fix: Armadyne belt is no longer exempt from the no guns in secbelts rule
/:cl: