### PR TITLE
Removes The Colonial Supply Core From Company Imports + goodie first aid pouches

### DIFF
--- a/modular_skyrat/modules/cargo/code/goodies.dm
+++ b/modular_skyrat/modules/cargo/code/goodies.dm
@@ -183,21 +183,3 @@
 	contains = list(
 		/obj/item/disk/nifsoft_uploader/summoner,
 	)
-
-/datum/supply_pack/goody/firstaid_pouch
-	name = "Mini-Medkit First Aid Pouch"
-	desc = "Contains a single surplus first-aid pouch, complete with pocket clip. Repackaged with station-standard medical supplies, \
-	but nothing's stopping you from repacking it yourself, though."
-	cost = PAYCHECK_CREW * 6
-	contains = list(
-		/obj/item/storage/pouch/medical/firstaid/loaded,
-	)
-
-/datum/supply_pack/goody/stabilizer_pouch
-	name = "Stabilizer First Aid Pouch"
-	desc = "Contains a single surplus first-aid pouch, complete with pocket clip. Repackaged with a wound stabilizing-focused loadout, \
-	but nothing's stopping you from repacking it yourself, though."
-	cost = PAYCHECK_CREW * 6
-	contains = list(
-		/obj/item/storage/pouch/medical/firstaid/stabilizer,
-	)

--- a/modular_skyrat/modules/company_imports/code/armament_datums/nri_military_surplus.dm
+++ b/modular_skyrat/modules/company_imports/code/armament_datums/nri_military_surplus.dm
@@ -82,13 +82,6 @@
 	item_type = /obj/item/trench_tool
 	cost = PAYCHECK_CREW
 
-/datum/armament_entry/company_import/nri_surplus/misc/food_replicator
-	description = "Once widespread technology used by numerous fringe colonies of NRI origin and even in some TerraGov territories, that ultimately went out of fashion due to \
-	TerraGov propaganda deeming it unprofitable and imposing severe trading fees on anyone trying to sell them. A small portion of government-backed manufacturers still produce \
-	'food replicators' for private and government use; a few of them is selling this via us."
-	item_type = /obj/item/circuitboard/machine/biogenerator/food_replicator
-	cost = CARGO_CRATE_VALUE * 9
-
 /datum/armament_entry/company_import/nri_surplus/misc/nri_flag
 	item_type = /obj/item/sign/flag/nri
 	cost = PAYCHECK_LOWER


### PR DESCRIPTION
## About The Pull Request
Title states it. Removes the colonial supply core (the machine that uses biomass to create food/first aid kits/meds/etc) from the cargo console. It stays available through other methods, especially since some ghost roles get it for free.

The same applies for the goodie first aid pouches, gone from cargo, stays in the bitrunning sim.
## Why It's Good For The Game

Well, it's an easily accessible machine that can be loaded up to hell and back by any (semi-)competent botanist, or more likely, an assistant in the public garden for 15 minutes. 

What makes the items inside egregious to the point that it warrants a removal from cargo?
The majority of the first tab is fine, and nothing too bad. The pretty good meals are nice, but it's not that major given we have food vendors around every corner. The same can be said for the third tab with the exception of the slim colonial webbing which gives you 3 extra storage slots for small or tiny items as an accessory to your jumpsuit, as well as the general purpose pouch, which serves the same purpose but in your pocket.

The vast majorities of reasons for not having this be crew orderable however, is within the medicine tab. Just about infinite-printable sidegrades to mesh and sutures, gauze, decent enough brute/burn patches. Epinephrine, multiver, and convermol pills. As well as two types of medical storage. The medipen pouch is, mostly fine. It stores 8 medipens- so basically a pill bottle but for pens. Pill bottles carry 7 patches/pills which can carry 50 reagents. So it's not that overkill. 

However. Pocket first aid kit allows you to store pill bottles. This means you can carry 28 pills/patches in one pocket slot. What the fuck. That is a lot of medication.

The PR also removes the firstaid_pouches you can order from goodies at 250 credits a pop. Similarly an issue due to having an extra slot even over the pocket kits for medications.

## Proof Of Testing
Yes
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
del: Removed the Colonial Supply Core from cargo's company imports.
del: Removed the Firstaid Pouches from cargo's goodies section.
/:cl:
