### PR TITLE
Removes the smokey remains from biodome

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -56538,10 +56538,10 @@
 /area/station/medical/medbay/central)
 "tmX" = (
 /obj/item/lighter,
-/obj/effect/decal/remains/human/smokey,
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/effect/decal/cleanable/glitter/white,
 /obj/effect/decal/cleanable/fuel_pool,
+/obj/effect/decal/remains/human,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "tna" = (


### PR DESCRIPTION
## About The Pull Request

Per title. It can spew any number of random gases, it was the wrong type (should of been the maint one) and it should be kept to this rare loot spawner. Not mapped directly into the map.

```
/obj/effect/spawner/random/structure/crate
	name = "crate spawner"
	icon_state = "crate_secure"
	loot = list(
		/obj/effect/spawner/random/structure/crate_loot = 744,
		/obj/structure/closet/crate/trashcart/filled = 75,
		/obj/effect/spawner/random/trash/moisture_trap = 50,
		/obj/effect/spawner/random/trash/hobo_squat = 30,
		/obj/structure/closet/mini_fridge = 35,
		/obj/effect/spawner/random/trash/mess = 30,
		/obj/item/kirbyplants/fern = 20,
		/obj/structure/closet/crate/decorations = 15,
		/obj/effect/decal/remains/human/smokey/maintenance = 7,
		/obj/structure/destructible/cult/pants_altar = 1,
	)
```

## Why It's Good For The Game

It's all fun and games until it starts spewing Magilitis (turns people into Gorillas). Yeah, this happened, so here we are since it RRs you.

Yeah the random smoke reagent is fun, but let's be sane. 

## Changelog

:cl:
map: Smokey remains have been removed from biodome maintenance
/:cl:
