### PR TITLE
Protean Balance: Removes the brute and burn modifiers from Proteans

### DIFF
--- a/modular_zubbers/code/modules/customization/species/proteans/__DEFINES.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/__DEFINES.dm
@@ -36,8 +36,6 @@
 	bodypart_species = SPECIES_PROTEAN; \
 	bodytype = BODYTYPE_NANO; \
 	dmg_overlay_type = "robotic"; \
-	brute_modifier = 0.8; \
-	burn_modifier = 1.2; \
 	light_brute_msg = LIGHT_NANO_BRUTE; \
 	medium_brute_msg = MEDIUM_NANO_BRUTE; \
 	heavy_brute_msg = HEAVY_NANO_BRUTE; \
@@ -99,8 +97,6 @@ PROTEAN_BODYPART_DEFINE(/obj/item/bodypart/arm/right/mutant/protean, 40)
 	bodypart_species = SPECIES_PROTEAN
 	bodytype = BODYTYPE_NANO
 	dmg_overlay_type = "robotic"
-	brute_modifier = 0.8
-	burn_modifier = 1.2
 	light_brute_msg = LIGHT_NANO_BRUTE
 	medium_brute_msg = MEDIUM_NANO_BRUTE
 	heavy_brute_msg = HEAVY_NANO_BRUTE
@@ -116,8 +112,6 @@ PROTEAN_BODYPART_DEFINE(/obj/item/bodypart/arm/right/mutant/protean, 40)
 	bodypart_species = SPECIES_PROTEAN
 	bodytype = BODYTYPE_NANO
 	dmg_overlay_type = "robotic"
-	brute_modifier = 0.8
-	burn_modifier = 1.2
 	light_brute_msg = LIGHT_NANO_BRUTE
 	medium_brute_msg = MEDIUM_NANO_BRUTE
 	heavy_brute_msg = HEAVY_NANO_BRUTE


### PR DESCRIPTION
## About The Pull Request

Per title. Removes burn weakness and brute resistance from proteans

## Why It's Good For The Game

The idea behind this was you shoot proteans with laters, but it comes to be an issue when these are multiplicative. So a Protean wearing riot armor would have an armor rating much higher to brute damage. Also, these sources of damage are not entirely uniform. Antags don't have too many lasers to be shooting proteans with, on top of the regeneration they already have.

- Players aren't going to be inately aware of this. They're just a damage spounge.
- Players won't really realize you can just shoot off their limbs, which you still can. (Which is why I'm not touching the regen yet)
- Players won't really know that bleeding will make metal consumption shoot up signifigantly. (Another reason I'm not touching the regen yet)

## Proof Of Testing

4 lines

## Changelog

:cl:
balance: Brute resistence and burn weakness has been removed from proteans
/:cl:
