### PR TITLE
Cyborg sprite update on buckle/unbuckle

### DIFF
--- a/code/__HELPERS/~bubber_helpers/mobs.dm
+++ b/code/__HELPERS/~bubber_helpers/mobs.dm
@@ -2,6 +2,6 @@
 /proc/select_priority_ai()
 	var/mob/living/silicon/ai/selected
 	var/list/active = active_ais(FALSE, priority = TRUE)
-	selected = pick(active)
+	selected = active.len ? pick(active) : null
 
 	return selected

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -21,6 +21,9 @@
 	RegisterSignal(src, COMSIG_PROCESS_BORGCHARGER_OCCUPANT, PROC_REF(charge))
 	RegisterSignal(src, COMSIG_LIGHT_EATER_ACT, PROC_REF(on_light_eater))
 	RegisterSignal(src, SIGNAL_ADDTRAIT(TRAIT_GOT_DAMPENED), PROC_REF(on_dampen))
+	// BUBBER EDIT: Register buckle/unbuckle signal to update sprite on tallborgs
+	RegisterSignal(src, COMSIG_MOB_BUCKLED, PROC_REF(on_buckled))
+	RegisterSignal(src, COMSIG_MOB_UNBUCKLED, PROC_REF(on_unbuckled))
 
 	inv1 = new /atom/movable/screen/robot/module1()
 	inv2 = new /atom/movable/screen/robot/module2()
@@ -1096,3 +1099,10 @@
 		buckled_mob.Paralyze(1 SECONDS)
 		unbuckle_mob(buckled_mob)
 	do_sparks(5, 0, src)
+
+// BUBBER EDIT: Update sprites on buckle/unbuckle(for tallborgs)
+/mob/living/silicon/robot/proc/on_buckled(mob/living/silicon/buckling)
+	update_icons()
+
+/mob/living/silicon/robot/proc/on_unbuckled(mob/living/silicon/buckling)
+	update_icons()


### PR DESCRIPTION
## About The Pull Request
As cyborg by flashing light while bucked to chair(flashlight call has `update_icons()` in it), I figured out that tallborgs have their sprite changed, but game does not update that sprite. I think I fixed that.

Checking if we have any AI to not cause runtimes each time cyborgs get spawned when there no active AI.
## Why It's Good For The Game
I think it supposed to be that way
## Proof Of Testing
<details>
<img width="103" height="175" alt="image" src="https://github.com/user-attachments/assets/137d59b9-b4a8-425c-9fbe-d1e7836efdfa" />
<img width="114" height="198" alt="image" src="https://github.com/user-attachments/assets/58564ebf-ffe6-4adf-8a23-5a81d9151355" />
<img width="196" height="88" alt="image" src="https://github.com/user-attachments/assets/90fc4c12-6072-40a4-a0ae-16515aaed986" />


</details>

## Changelog
:cl:
fix: Tallborgs now have have their sit sprite when they buckled to chairs
/:cl:
