### PR TITLE
Nerfs the Colony Fabricator Medkit and Removes Printable Storage Extensions from the Colony Fab (Alternative to #4251)

### DIFF
--- a/modular_skyrat/modules/food_replicator/code/clothing.dm
+++ b/modular_skyrat/modules/food_replicator/code/clothing.dm
@@ -62,31 +62,3 @@
 		return FALSE
 
 	return ..()
-
-/obj/item/clothing/accessory/colonial_webbing
-	name = "slim colonial webbing vest"
-	desc = "A versatile individual carrying equipment, cherished by colonists and hoarders alike. Compact enough to be worn underneath bulky clothing."
-	icon = 'modular_skyrat/modules/food_replicator/icons/clothing.dmi'
-	worn_icon = 'modular_skyrat/modules/food_replicator/icons/clothing_worn.dmi'
-	icon_state = "accessory_webbing"
-	w_class = WEIGHT_CLASS_NORMAL
-
-/obj/item/clothing/accessory/colonial_webbing/Initialize(mapload)
-	. = ..()
-	create_storage(storage_type = /datum/storage/pockets/colonial_webbing)
-
-/obj/item/clothing/accessory/colonial_webbing/can_attach_accessory(obj/item/clothing/under/attach_to, mob/living/user)
-	. = ..()
-	if(!.)
-		return
-
-	if(!isnull(attach_to.atom_storage))
-		if(user)
-			attach_to.balloon_alert(user, "not compatible!")
-		return FALSE
-	return TRUE
-
-/datum/storage/pockets/colonial_webbing
-	do_rustle = TRUE
-	max_slots = 3
-	max_specific_storage = WEIGHT_CLASS_SMALL

--- a/modular_skyrat/modules/food_replicator/code/replicator_designs/replicator_clothing.dm
+++ b/modular_skyrat/modules/food_replicator/code/replicator_designs/replicator_clothing.dm
@@ -31,27 +31,6 @@
 		RND_CATEGORY_NRI_CLOTHING,
 	)
 
-/datum/design/colonial_webbing
-	name = "Slim Colonial Webbing"
-	id = "slavic_webbing"
-	build_type = BIOGENERATOR
-	materials = list(/datum/material/biomass = 200)
-	build_path = /obj/item/clothing/accessory/colonial_webbing
-	category = list(
-		RND_CATEGORY_INITIAL,
-		RND_CATEGORY_NRI_CLOTHING,
-	)
-
-/datum/design/genpouch
-	name = "Empty General Purpose Pouch"
-	id = "slavic_genpouch"
-	build_type = BIOGENERATOR
-	materials = list(/datum/material/biomass = 250)
-	build_path = /obj/item/storage/pouch/cin_general
-	category = list(
-		RND_CATEGORY_INITIAL,
-		RND_CATEGORY_NRI_CLOTHING,
-	)
 
 /datum/design/cool_hat
 	name = "Colonial Cap"

--- a/modular_skyrat/modules/food_replicator/code/storage.dm
+++ b/modular_skyrat/modules/food_replicator/code/storage.dm
@@ -32,17 +32,5 @@
 	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
 	atom_storage.max_total_storage = 4
 	atom_storage.max_slots = 4
-	atom_storage.cant_hold = typecacheof(list(/obj/item/gun, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/stack/sheet))
+	atom_storage.cant_hold = typecacheof(list(/obj/item/gun, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/stack/sheet, /obj/item/storage/pill_bottle))
 
-/obj/item/storage/pouch/cin_general
-	name = "colonial general pouch"
-	desc = "A synthleather general purpose pouch that goes in your pocket."
-	icon = 'modular_skyrat/modules/food_replicator/icons/pouch.dmi'
-	icon_state = "gen_pouch"
-	w_class = WEIGHT_CLASS_NORMAL
-
-/obj/item/storage/pouch/cin_general/Initialize(mapload)
-	. = ..()
-	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
-	atom_storage.max_total_storage = WEIGHT_CLASS_SMALL*3
-	atom_storage.max_slots = 3


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Apparently printable pocket/bag storage is somewhat bad for the game according to balancers

Also apparently you could fit pill bottles into the medkit, that one's a fair complaint tbh

## Why It's Good For The Game

we don't need to remove cool shit when we can just tweak it bubberbros 

## Proof Of Testing

<img width="407" height="503" alt="7f57a9f1ebd4cc2d9deb88647ee33381" src="https://github.com/user-attachments/assets/8743c0a4-1d27-44d6-8d21-4aaf91af569e" />



## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removes the Slim Colonial Webbing and the Empty Colonial Supply Pouch from the colonial printer
balance: Prevents the Colonial Medkit from storing pill bottles 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
