### PR TITLE
Fix changeling meteor not properly spawning mob

### DIFF
--- a/modular_zubbers/code/modules/storyteller/event_defines/ghostset/changeling.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/ghostset/changeling.dm
@@ -25,6 +25,7 @@
 	var/mob/chosen_one = SSpolling.poll_ghost_candidates(check_jobban = ROLE_CHANGELING, role = ROLE_CHANGELING_MIDROUND, alert_pic = /obj/item/melee/arm_blade, role_name_text = role_name, amount_to_pick = 1)
 	if(isnull(chosen_one))
 		return NOT_ENOUGH_PLAYERS
-	spawned_mobs += generate_changeling_meteor(chosen_one)
+	var/datum/mind/player_mind = new(chosen_one.key)
+	spawned_mobs += generate_changeling_meteor(player_mind)
 	if(spawned_mobs)
 		return SUCCESSFUL_SPAWN


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

`generate_changeling_meteor` got refactored to take a `/datum/mind` instead of a mob so give it that instead

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

Fixes #4171 

## Proof Of Testing

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->
<details>
<summary>Screenshots/Videos</summary>
<img width="1262" height="997" alt="image" src="https://github.com/user-attachments/assets/d83d183d-85ea-4fb6-80b0-f3deb3d87a42" />

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed changeling meteor event not putting the chosen candidate in control of the mob
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
