### PR TITLE
Re-Buffs the Paddy a bit + Nerfs the Exosuit Disabler

### DIFF
--- a/modular_zubbers/code/modules/vehicles/mecha/equipment/weapons.dm
+++ b/modular_zubbers/code/modules/vehicles/mecha/equipment/weapons.dm
@@ -1,0 +1,2 @@
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/disabler
+	projectiles_per_shot = 4

--- a/modular_zubbers/code/modules/vehicles/mecha/ripley.dm
+++ b/modular_zubbers/code/modules/vehicles/mecha/ripley.dm
@@ -1,0 +1,3 @@
+/obj/vehicle/sealed/mecha/ripley/paddy
+	slow_pressure_step_in = 2.75
+	fast_pressure_step_in = 1.75

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9699,6 +9699,7 @@
 #include "modular_zubbers\code\modules\uplink\uplink_devices.dm"
 #include "modular_zubbers\code\modules\uplink\uplink_items\badass.dm"
 #include "modular_zubbers\code\modules\vehicles\mech_fabricator.dm"
+#include "modular_zubbers\code\modules\vehicles\mecha\ripley.dm"
 #include "modular_zubbers\code\modules\vending\armadyne.dm"
 #include "modular_zubbers\code\modules\vending\clothmate.dm"
 #include "modular_zubbers\code\modules\vending\cola.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9700,6 +9700,7 @@
 #include "modular_zubbers\code\modules\uplink\uplink_items\badass.dm"
 #include "modular_zubbers\code\modules\vehicles\mech_fabricator.dm"
 #include "modular_zubbers\code\modules\vehicles\mecha\ripley.dm"
+#include "modular_zubbers\code\modules\vehicles\mecha\equipment\weapons.dm"
 #include "modular_zubbers\code\modules\vending\armadyne.dm"
 #include "modular_zubbers\code\modules\vending\clothmate.dm"
 #include "modular_zubbers\code\modules\vending\cola.dm"


### PR DESCRIPTION

## About The Pull Request

TG decided to take the paddy out back and break it's knees after a CERTAIN INCIDENT. This puts the speed in between the 1 and 2 chassis for better balance, and ensures we don't have any low pressure lightspeed tomfoolery anymore. 

This also drops the exosuit disabler to 4 bolts with variance instead of 5. 
## Why It's Good For The Game

The paddy was unrightfully nerfed into the fucking ground, but at the same time the disabler was really strong with 5 bolts. 

## Proof Of Testing

worked on my machine 

</details>

## Changelog
:cl:
balance: Upped the paddy's speed to sit between the mk1 and mk2 
balance: Nerfed the exosuit disabler to 4 projectiles instead of 5 
/:cl:
