### PR TITLE
The bureaucratic event no longer locks all joins to one job slot because I died to it once.

### DIFF
--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -14,7 +14,7 @@
 
 /datum/round_event/bureaucratic_error/start()
 	var/list/jobs = SSjob.get_valid_overflow_jobs()
-	// BUBBER EDIT BEGIN /* SKYRAT EDIT REMOVAL START
+	/* SKYRAT EDIT REMOVAL START
 	if(prob(33)) // Only allows latejoining as a single role.
 		var/datum/job/overflow = pick_n_take(jobs)
 		overflow.spawn_positions = -1
@@ -23,7 +23,7 @@
 			var/datum/job/current = job
 			current.total_positions = 0
 		return
-	// BUBBER EDIT END */ // SKYRAT EDIT REMOVAL - no more locking off jobs
+	*/ // SKYRAT EDIT REMOVAL - no more locking off jobs
 	// Adds/removes a random amount of job slots from all jobs.
 	for(var/datum/job/current as anything in jobs)
 		current.total_positions = max(current.total_positions + rand(-2,4), 1) // SKYRAT EDIT CHANGE - No more locking off jobs - ORIGINAL: current.total_positions = max(current.total_positions + rand(-2,4), 0)


### PR DESCRIPTION
## About The Pull Request

The bureaucratic event no longer has a chance to locks all joins to one job slot. This does not change the "infinite job slots of one role" aspect on the event.

## Why It's Good For The Game

We shouldn't be restricting player freedom based on whether or not there is a competent non-erping captain/HoP on the station willing to re-open all the job slots.

## Proof Of Testing

If it compiles, it werks.

## Changelog

:cl: BurgerBB
del: The bureaucratic event no longer has a chance to locks all joins to one job slot. This does not change the "infinite job slots of one role" aspect on the event.
/:cl:
