### PR TITLE
Cryostylane now halts death degradation

### DIFF
--- a/modular_skyrat/modules/death_consequences_perk/death_consequences_trauma.dm
+++ b/modular_skyrat/modules/death_consequences_perk/death_consequences_trauma.dm
@@ -210,7 +210,7 @@
 		if (base_degradation_reduction_per_second_while_alive < 0) // if you wanna die slowly while alive, go ahead bud
 			increase -= base_degradation_reduction_per_second_while_alive
 
-	if (HAS_TRAIT(owner, TRAIT_STASIS))
+	if (HAS_TRAIT(owner, TRAIT_STASIS) || owner.has_reagent(/datum/reagent/cryostylane, needs_metabolizing = FALSE)) // Cryostylane gives a stasis-like effect, so I'm throwing this here.
 		increase *= stasis_passive_degradation_multiplier
 
 	return increase


### PR DESCRIPTION

## About The Pull Request
Does as the title says, makes it so having cryostylane counts as being in stasis for the multiplier. Also resolves https://github.com/Bubberstation/Bubberstation/issues/4227.
## Why It's Good For The Game
It seems like this was an oversight and not a deliberate balance choice, so I went ahead and added it in.
## Proof Of Testing
The funny number didn't go up while the reagent was in my spaceman.
## Changelog
:cl:
fix: cryostylane now halts death degradation, just like being on stasis beds does
/:cl:
