### PR TITLE
fix hemos to be able to drink from each other and lizards again

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage/corrupted_tongue.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage/corrupted_tongue.dm
@@ -66,7 +66,7 @@
 		hemophage.balloon_alert(hemophage, "needs a living victim!")
 		return FALSE
 
-	if(!victim.blood_volume || (victim.dna && ((HAS_TRAIT(victim, TRAIT_NOBLOOD)) || victim.dna.species.exotic_bloodtype)))
+	if(!victim.blood_volume || HAS_TRAIT(victim, TRAIT_NOBLOOD) || victim.get_bloodtype()?.reagent_type != /datum/reagent/blood)
 		hemophage.balloon_alert(hemophage, "[victim] doesn't have blood!")
 		return FALSE
 

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage/corrupted_tongue.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/hemophage/corrupted_tongue.dm
@@ -66,7 +66,7 @@
 		hemophage.balloon_alert(hemophage, "needs a living victim!")
 		return FALSE
 
-	if(!victim.blood_volume || HAS_TRAIT(victim, TRAIT_NOBLOOD) || victim.get_bloodtype()?.reagent_type != /datum/reagent/blood)
+	if(!victim.blood_volume || HAS_TRAIT(victim, TRAIT_NOBLOOD) || victim.get_blood_reagent() != /datum/reagent/blood)
 		hemophage.balloon_alert(hemophage, "[victim] doesn't have blood!")
 		return FALSE
 


### PR DESCRIPTION

## About The Pull Request
Hemophages couldn't drink blood from anyone with a non-standard bloodtype, even if they had blood, like lizards with L bloodtype.
## Why It's Good For The Game
Bug fix. (I don't want to die from blood loss because the only willing donor at the time was a lizard but oops I can't bite them.)
## Proof Of Testing
i tested this so fucking much to figure out a way to actually make it work 
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: hemophages can drink from lizards and other hemophages once more
/:cl:
