### PR TITLE
Gives proteans the expanded storage module roundstart.

### DIFF
--- a/modular_zubbers/code/modules/customization/species/proteans/_proteans_species.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/_proteans_species.dm
@@ -141,7 +141,7 @@
 
 	var/obj/item/mod/module/storage/storage = locate() in species_modsuit.modules // Give a storage if we don't have one.
 	if(!storage)
-		storage = new()
+		storage = new /obj/item/mod/module/storage/large_capacity()
 		species_modsuit.install(storage, owner, TRUE)
 
 	if(outfit.backpack_contents)


### PR DESCRIPTION

## About The Pull Request
Gives proteans the expanded storage module roundstart.
## Why It's Good For The Game
The default mod storage is extremely limiting for something that is Not Leaving Your Back, Ever. The other way of having a modsuit you can't remove is entombed, they **DO** get this expanded storage.

Either you have to go to cargo to order one roundstart for 100 of your roundstart credits (added tedium for something that shouldn't have to be the case). Or you wait for robotics to research it. (takes forever.) The wait would be a lot more reasonable if it were a choice for you to wear it with being able to swap back to your regular bag, however, this is not the case for proteans.
## Proof Of Testing
yeah i loaded it on local and it was expanded
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
add: Proteans now start with the expanded storage module instead of the regular one.
/:cl:
