### PR TITLE
renames the guilmon + renamon parts to toraxen + cyvian by headmin request

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/body_markings/body_marking_sets.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/body_markings/body_marking_sets.dm
@@ -144,8 +144,8 @@
 	body_marking_list = list("Scolipede", "Scolipede Spikes")
 
 /datum/body_marking_set/guilmon
-	name = "Guilmon"
-	body_marking_list = list("Guilmon", "Guilmon Mark")
+	name = "Toraxen"
+	body_marking_list = list("Toraxen", "Toraxen Mark")
 
 /datum/body_marking_set/xeno
 	name = "Xeno"

--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/body_markings/body_markings.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/body_markings/body_markings.dm
@@ -353,7 +353,7 @@
 	affected_bodyparts = HEAD | CHEST | ARM_LEFT | ARM_RIGHT | HAND_LEFT | HAND_RIGHT | LEG_RIGHT | LEG_LEFT
 
 /datum/body_marking/secondary/guilmon
-	name = "Guilmon"
+	name = "Toraxen"
 	icon_state = "guilmon"
 	affected_bodyparts = CHEST | ARM_LEFT | ARM_RIGHT | HAND_LEFT | HAND_RIGHT | LEG_RIGHT | LEG_LEFT
 
@@ -538,7 +538,7 @@
 	affected_bodyparts = CHEST
 
 /datum/body_marking/tertiary/guilmon
-	name = "Guilmon Mark"
+	name = "Toraxen Mark"
 	icon_state = "guilmon"
 	affected_bodyparts = HEAD | CHEST | ARM_LEFT | ARM_RIGHT | HAND_LEFT | HAND_RIGHT | LEG_RIGHT | LEG_LEFT
 

--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/horns.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/horns.dm
@@ -38,7 +38,7 @@
 	icon_state = "ram"
 
 /datum/sprite_accessory/horns/guilmon
-	name = "Guilmon"
+	name = "Toraxen"
 	icon_state = "guilmon"
 
 /datum/sprite_accessory/horns/drake

--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/snout.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/snout.dm
@@ -461,10 +461,11 @@
 	name = "Acrador 4 (Normal)"
 	icon_state = "acrador_4"
 
+//you know it just matters if the display name is different. I CBA risking breaking save slots.
 /datum/sprite_accessory/snouts/renamon
 	icon = 'modular_skyrat/master_files/icons/mob/sprite_accessory/snouts.dmi'
 	color_src = USE_MATRIXED_COLORS
-	name = "Renamon"
+	name = "Cyvian"
 	icon_state = "renamon"
 
 /datum/sprite_accessory/snouts/exsharp

--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/tails.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/tails.dm
@@ -191,7 +191,7 @@
 	icon_state = "fox3"
 
 /datum/sprite_accessory/tails/mammal/wagging/guilmon
-	name = "Guilmon"
+	name = "Toraxen"
 	icon_state = "guilmon"
 
 /datum/sprite_accessory/tails/mammal/wagging/hawk

--- a/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/wings.dm
+++ b/modular_skyrat/modules/customization/modules/mob/dead/new_player/sprite_accessories/wings.dm
@@ -296,7 +296,7 @@
 	icon_state = "low_jewel_top"
 
 /datum/sprite_accessory/wings/low_wings/renamon
-	name = "Renamon"
+	name = "Cyvian"
 	icon_state = "renamon"
 	color_src = USE_MATRIXED_COLORS
 // Ryva was here :3

--- a/modular_zubbers/code/modules/customization/sprite_accessories/ears.dm
+++ b/modular_zubbers/code/modules/customization/sprite_accessories/ears.dm
@@ -19,7 +19,7 @@
 	icon = 'modular_zubbers/icons/customization/ears.dmi'
 
 /datum/sprite_accessory/ears/renamon
-	name = "Renamon"
+	name = "Cyvian"
 	icon_state = "renamon"
 	icon = 'modular_zubbers/icons/customization/ears.dmi'
 


### PR DESCRIPTION

## About The Pull Request
One of our server rules is that you can't play species from other canons 1:1 so it's a bit misleading to have parts named after them. Headmin wanted them to be renamed. Will probably do the same for eevee+scolipede when they come up with names for it. Leaving the datum names the same and the like so it's still clear what it's meant to be if you decide to codedive.

## Why It's Good For The Game
code follows standards set by server rules this is a good thing

## Proof Of Testing
yeah it works

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
code: Renames the guilmon + renamon parts to toraxen + cyvian respectively.
/:cl:

