### PR TITLE
Reduces the frequency and duration of Moon Station sandstorms because I died to it once.

### DIFF
--- a/modular_zubbers/code/datums/weather/weather_types/sand_storm.dm
+++ b/modular_zubbers/code/datums/weather/weather_types/sand_storm.dm
@@ -9,12 +9,12 @@
 	telegraph_overlay = "sandstorm_light"
 
 	weather_message = "<span class='userdanger'><i>Smoldering particles of sand billow down around you! Get inside!</i></span>"
-	weather_duration_lower = 2 MINUTES
-	weather_duration_upper = 4 MINUTES
+	weather_duration_lower = 1 MINUTES
+	weather_duration_upper = 3 MINUTES
 	weather_overlay = "sandstorm"
 
 	end_message = "<span class='boldannounce'>The shrieking wind whips away the last of the sand and falls to its usual murmur. It should be safe to go outside now.</span>"
-	end_duration = 60 SECONDS
+	end_duration = 30 SECONDS
 	end_overlay = "sandstorm_light"
 
 	area_type = /area
@@ -22,7 +22,7 @@
 
 	immunity_type = TRAIT_ASHSTORM_IMMUNE
 
-	probability = 40
+	probability = 20
 
 	weather_flags = (WEATHER_MOBS | WEATHER_BAROMETER)
 	var/list/weak_sounds = list()


### PR DESCRIPTION
## About The Pull Request

Reduces the chance of Moon Station sandstorms from 40% to 20%.
Reduces the duration of Moon Station sandstorms from 2-4 minutes to 1-3 minutes.

## Why It's Good For The Game

People don't like how common these are.

## Proof Of Testing

If it compiles, it werks.

## Changelog

:cl: BurgerBB
balance: Reduces the chance of Moon Station sandstorms from 40% to 20%. Reduces the duration of Moon Station sandstorms from 2-4 minutes to 1-3 minutes.
/:cl:
