### PR TITLE
Reduces damage taken from disposals by 60%

### DIFF
--- a/modular_skyrat/modules/hurtsposals/code/pipe.dm
+++ b/modular_skyrat/modules/hurtsposals/code/pipe.dm
@@ -22,4 +22,4 @@
 			continue
 		if(HAS_TRAIT(living_within, TRAIT_TRASHMAN))
 			continue
-		living_within.adjustBruteLoss(5)
+		living_within.adjustBruteLoss(2)


### PR DESCRIPTION
## About The Pull Request
title.

## Why It's Good For The Game
Disposals as it stands is quite horrible to be shoved within, what is a potential emergency exit for dire situations, is currently a one-way-ticket to crit, and on some stations with particularly long pipes (nebula...), death. This change causes it to still be dangerous- it definitely isn't a get-out-of-jail-free card with these changes, but it leaves it as a somewhat viable option. It's fun to use it as a "oh shit" option, or a way to get rid of an assailaint without damn-near killing them. There still being damage means it cannot be spammed either. Would you rather get fucked up by pipes in an effort to escape john antag, or get REALLY fucked up by john antag?

There was a conversation a few days ago in one of the discord channels (either contributorbus or balance-channel) about this, and the vast majority of people there agreed that if not a full removal, a reduction would be nice.

There additionally are a few ruins (and a bitrunning domain) that use disposals, in its current state the clown one will leave you on red health, from full health.

## Proof Of Testing
1 number change

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
balance: Reduces damage taken from disposals by 60%
/:cl:

