### PR TITLE
Add volume slider pref for emote sounds

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -112,7 +112,7 @@
 			frequency = rand(MIN_EMOTE_PITCH, MAX_EMOTE_PITCH) * (1 + sqrt(abs(user.pitch)) * SIGN(user.pitch) * EMOTE_TTS_PITCH_MULTIPLIER)
 		else if(vary)
 			frequency = rand(MIN_EMOTE_PITCH, MAX_EMOTE_PITCH)
-		playsound(source = user,soundin = tmp_sound,vol = 50, vary = FALSE, ignore_walls = sound_wall_ignore, frequency = frequency)
+		playsound(source = user,soundin = tmp_sound,vol = 50, vary = FALSE, ignore_walls = sound_wall_ignore, frequency = frequency, volume_preference = /datum/preference/numeric/volume/sound_emote) // BUBBER EDIT CHANGE - Add volume pref - ORIGINAL: playsound(source = user,soundin = tmp_sound,vol = 50, vary = FALSE, ignore_walls = sound_wall_ignore, frequency = frequency)
 
 
 	var/is_important = emote_type & EMOTE_IMPORTANT

--- a/modular_zubbers/code/modules/client/preferences/sounds.dm
+++ b/modular_zubbers/code/modules/client/preferences/sounds.dm
@@ -1,0 +1,5 @@
+/// Controls hearing emotes with audio
+/datum/preference/numeric/volume/sound_emote
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "sound_emote"
+	savefile_identifier = PREFERENCE_PLAYER

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9207,6 +9207,7 @@
 #include "modular_zubbers\code\modules\client\autopunctuation\preferences.dm"
 #include "modular_zubbers\code\modules\client\flavor_text\flavor_text.dm"
 #include "modular_zubbers\code\modules\client\preferences\permanent_limp.dm"
+#include "modular_zubbers\code\modules\client\preferences\sounds.dm"
 #include "modular_zubbers\code\modules\client\verbs\character_directory.dm"
 #include "modular_zubbers\code\modules\clothing\_job.dm"
 #include "modular_zubbers\code\modules\clothing\donator_clothing.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/bubber/sounds.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/bubber/sounds.tsx
@@ -1,0 +1,8 @@
+import { Feature, FeatureSliderInput } from '../../base';
+
+export const sound_emote: Feature<number> = {
+  name: 'Emote sound volume',
+  category: 'SOUND',
+  description: 'Volume of audible emotes.',
+  component: FeatureSliderInput,
+};


### PR DESCRIPTION

## About The Pull Request

Add a new volume pref in game options that controls how loud emotes that have sound effects are.
Note: This PR was made to fulfill a bounty by @NanoCats
## Why It's Good For The Game

Quality of life improvement, we have many emotes that play sounds here and not everyone wants to hear them. Also there's that one scream that's insanely fucking loud

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
Note: the emote cooldown was disabled in this video for demonstration purposes

https://github.com/user-attachments/assets/1e465ad1-6be9-4113-a564-72ace0c78118

</details>

## Changelog
:cl:
qol: added a volume slider for emote sounds to game options
/:cl:
