### PR TITLE
Adds Whitelisting to medical Combitool

### DIFF
--- a/modular_skyrat/modules/filtersandsetters/code/filtersandsetters.dm
+++ b/modular_skyrat/modules/filtersandsetters/code/filtersandsetters.dm
@@ -124,6 +124,9 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	toolspeed = 0.7
 
+/obj/item/blood_filter/advanced/attack_self_secondary(mob/user)
+	ui_interact(user)
+
 /obj/item/blood_filter/advanced/get_all_tool_behaviours()
 	return list(TOOL_BLOODFILTER, TOOL_BONESET)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the whitelisting of the combitool being overriden by the transform, adding it to right click

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

Fixing bug/unintended behauvior. Upgraded tools should not lack functions from the basic tools

## Proof Of Testing

Compiled and loaded into test map, opened up the whitelisting menu with right click. Filtered blood from dead carbon to make doubly sure it worked

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Medical Combitools can now setup whitelists for blood filtering with right click
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
