### PR TITLE
Ports oversized sprite toggle - click behind your own sprite.

### DIFF
--- a/modular_zubbers/code/datums/quirks/neutral_quirks/oversized_quirk.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/oversized_quirk.dm
@@ -30,6 +30,8 @@
 	human_holder.blood_volume_normal = BLOOD_VOLUME_OVERSIZED
 	human_holder.physiology.hunger_mod *= OVERSIZED_HUNGER_MOD //50% hungrier
 	human_holder.add_movespeed_modifier(/datum/movespeed_modifier/oversized)
+	var/datum/action/sizecode_smallsprite/action = new /datum/action/sizecode_smallsprite(human_holder)
+	action.Grant(human_holder)
 	var/obj/item/organ/stomach/old_stomach = human_holder.get_organ_slot(ORGAN_SLOT_STOMACH)
 	if(!istype(old_stomach) || old_stomach.organ_flags & ORGAN_ROBOTIC || old_stomach.organ_traits & TRAIT_NOHUNGER)
 		return
@@ -50,6 +52,8 @@
 	human_holder.maptext_height = 32 * human_holder.dna.features["body_size"]
 	human_holder.dna.update_body_size()
 	human_holder.mob_size = MOB_SIZE_HUMAN
+	var/datum/action/sizecode_smallsprite/action = locate(/datum/action/sizecode_smallsprite) in quirk_holder.actions
+	action.Remove()
 
 	var/obj/item/bodypart/arm/left/left_arm = human_holder.get_bodypart(BODY_ZONE_L_ARM)
 	if(left_arm)
@@ -98,7 +102,6 @@
 
 /datum/movespeed_modifier/oversized
 	multiplicative_slowdown = OVERSIZED_SPEED_SLOWDOWN
-
 
 #undef OVERSIZED_HUNGER_MOD
 #undef OVERSIZED_SPEED_SLOWDOWN

--- a/modular_zubbers/code/datums/quirks/oversize_action.dm
+++ b/modular_zubbers/code/datums/quirks/oversize_action.dm
@@ -1,0 +1,28 @@
+//Porting it into here because it's directly relevant to oversized, if anyone will be looking for it, they will look for oversized and Oh There It Is
+//Technically the same as /datum/action/small_sprite but for our macro players (I'm one of them)
+
+/datum/action/sizecode_smallsprite
+	name = "Toggle Giant Sprite"
+	desc = "Others will always see you as giant"
+	button_icon = 'icons/hud/screen_gen.dmi'
+	button_icon_state = "healthdoll_OVERLAY"
+	background_icon_state = "bg_alien"
+	var/small = FALSE
+	//var/image/small_icon
+
+/datum/action/sizecode_smallsprite/Trigger(trigger_flags)
+	. = ..()
+	if(!owner)
+		return
+
+	if(!small)
+		var/image/I = image(icon = owner.icon, icon_state = owner.icon_state, loc = owner, layer = owner.layer, pixel_x = owner.pixel_x, pixel_y = owner.pixel_y)
+		I.override = TRUE
+		I.overlays += owner.overlays
+		owner.add_alt_appearance(/datum/atom_hud/alternate_appearance/basic, "smallsprite_sizecode", I)
+		//small_icon = I
+	else
+		owner.remove_alt_appearance("smallsprite_sizecode")
+
+	small = !small
+	return TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8906,6 +8906,7 @@
 #include "modular_zubbers\code\datums\mood_events\nanite_events.dm"
 #include "modular_zubbers\code\datums\mutations\visuals_override.dm"
 #include "modular_zubbers\code\datums\quirks\_quirk.dm"
+#include "modular_zubbers\code\datums\quirks\oversize_action.dm"
 #include "modular_zubbers\code\datums\quirks\negative_quirks\all_nighter.dm"
 #include "modular_zubbers\code\datums\quirks\negative_quirks\blooddeficiency.dm"
 #include "modular_zubbers\code\datums\quirks\negative_quirks\bloodloss_dusting.dm"


### PR DESCRIPTION
## About The Pull Request

Characters with the oversized trait get an ability that changes their sprite to a normal size **on their own screen**. This allows them to fight as normal and avoid hitting themselves, whilst maintaining their character's looks for everyone else.
## Why It's Good For The Game

An oversized sprite can reach 2 tiles of height, meaning that anyone directly above your character is unable to be interacted with without using the alt click menu on the tile itself. This goes for structures, machines, tables, even wall-mounted equipment. This is unnecessary for a neutral quirk (which arguably has more downsides anyhow). 

Ranging from situation to situation, this can either be a mild annoyance in filling out paperwork or cost you fights if you commit the sin of wanting a big character as a security memeber, antag, or existing nearby a monkey, as fighting anything above you becomes impossible once they attempt to exploit your stature to hide behind your sprite. 

## Proof Of Testing


https://github.com/user-attachments/assets/38a86642-bfff-400b-b32d-3d06e4fedcc3

<img width="1920" height="1080" alt="obraz" src="https://github.com/user-attachments/assets/ebe58e38-e10e-4b8f-91f7-6c13604fe559" />

I see no runtimes past the saddles and workbench which have been there for ??? time already

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Oversized characters can shrink their sprite on their own screen (to 100% size)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
