### PR TITLE
prevent premium robo kits from storing normal sized & make all skyrat pouches bulky

### DIFF
--- a/modular_skyrat/modules/company_imports/code/armament_datums/deforest_medical.dm
+++ b/modular_skyrat/modules/company_imports/code/armament_datums/deforest_medical.dm
@@ -30,7 +30,7 @@
 
 /datum/armament_entry/company_import/deforest/first_aid_kit/robo_repair_super
 	item_type = /obj/item/storage/medkit/robotic_repair/preemo/stocked
-	cost = PAYCHECK_COMMAND * 2
+	cost = PAYCHECK_COMMAND * 4.5
 
 /datum/armament_entry/company_import/deforest/first_aid_kit/first_responder
 	item_type = /obj/item/storage/backpack/duffelbag/deforest_surgical/stocked

--- a/modular_skyrat/modules/company_imports/code/armament_datums/deforest_medical.dm
+++ b/modular_skyrat/modules/company_imports/code/armament_datums/deforest_medical.dm
@@ -30,7 +30,7 @@
 
 /datum/armament_entry/company_import/deforest/first_aid_kit/robo_repair_super
 	item_type = /obj/item/storage/medkit/robotic_repair/preemo/stocked
-	cost = PAYCHECK_COMMAND * 8
+	cost = PAYCHECK_COMMAND * 2
 
 /datum/armament_entry/company_import/deforest/first_aid_kit/first_responder
 	item_type = /obj/item/storage/backpack/duffelbag/deforest_surgical/stocked

--- a/modular_skyrat/modules/deforest_medical_items/code/storage_items_robotics.dm
+++ b/modular_skyrat/modules/deforest_medical_items/code/storage_items_robotics.dm
@@ -47,7 +47,8 @@
 /obj/item/storage/medkit/robotic_repair/preemo
 	name = "premium robotic repair equipment kit"
 	desc = "An industrial-strength plastic box filled with supplies for repairing synthetics from critical damage. \
-		This one has extra storage on the sides for even more equipment than the standard medkit model."
+		This one has extra storage on the sides for even more equipment than the standard medkit model, \
+		and can also fit smaller tools and welding gear inside."
 	icon_state = "synth_medkit_super"
 
 /obj/item/storage/medkit/robotic_repair/preemo/Initialize(mapload)

--- a/modular_skyrat/modules/deforest_medical_items/code/storage_items_robotics.dm
+++ b/modular_skyrat/modules/deforest_medical_items/code/storage_items_robotics.dm
@@ -53,7 +53,7 @@
 /obj/item/storage/medkit/robotic_repair/preemo/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 12
-	atom_storage.max_total_storage = 12 * WEIGHT_CLASS_NORMAL
+	atom_storage.max_total_storage = 12 * WEIGHT_CLASS_SMALL
 
 /obj/item/storage/medkit/robotic_repair/preemo/stocked
 

--- a/modular_skyrat/modules/deforest_medical_items/code/storage_items_robotics.dm
+++ b/modular_skyrat/modules/deforest_medical_items/code/storage_items_robotics.dm
@@ -52,7 +52,6 @@
 
 /obj/item/storage/medkit/robotic_repair/preemo/Initialize(mapload)
 	. = ..()
-	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
 	atom_storage.max_slots = 12
 	atom_storage.max_total_storage = 12 * WEIGHT_CLASS_NORMAL
 

--- a/modular_skyrat/modules/modular_items/code/bags.dm
+++ b/modular_skyrat/modules/modular_items/code/bags.dm
@@ -4,7 +4,7 @@
 	desc = "It's a nondescript pouch made with dark fabric. It has a clip, for fitting in pockets."
 	icon = 'modular_skyrat/modules/modular_items/icons/storage.dmi'
 	icon_state = "survival"
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY
 	resistance_flags = FLAMMABLE
 	slot_flags = ITEM_SLOT_POCKETS
 
@@ -18,7 +18,6 @@
 	desc = "A pouch for your ammo that goes in your pocket."
 	icon = 'modular_skyrat/modules/modular_items/icons/storage.dmi'
 	icon_state = "ammopouch"
-	w_class = WEIGHT_CLASS_BULKY
 	custom_price = PAYCHECK_CREW * 4
 	// this is just to have post_reskin called later
 	uses_advanced_reskins = TRUE
@@ -54,7 +53,6 @@
 	desc = "A pouch for sheets and RCD ammunition that manages to hang where you would normally put things in your pocket."
 	icon = 'modular_skyrat/modules/modular_items/icons/storage.dmi'
 	icon_state = "materialpouch"
-	w_class = WEIGHT_CLASS_BULKY
 	custom_price = PAYCHECK_CREW * 4
 
 /obj/item/storage/pouch/material/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request
prevent premium robo kits from storing normal sized, reduces total storage to 12 * 2 & make all skyrat pouches bulky

## Why It's Good For The Game
currently you can store pouches in backpacks meaning you can fit normal sized items in (some) pouches, same deal with the robo kit, and while it is comparable to the surgical medkit, it it can store 12*3=36 total storage in w_class of items, vs the surgery medkits 24, then, haha.

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
balance: Premium robo repair kits can only hold small items now and hold 24 w_class worth of items and costs 900 to account for this removal, as it still contains cargo-order items
balance: All skyrat pouches are now bulky.
/:cl:

