### PR TITLE
heretics are getting a rework so let's make them more likely

### DIFF
--- a/modular_zubbers/code/modules/storyteller/event_defines/crewset/heretic.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/crewset/heretic.dm
@@ -4,10 +4,10 @@
 
 	antag_flag = ROLE_HERETIC
 	antag_datum = /datum/antagonist/heretic
-	weight = 3
+	weight = 9
 	min_players = 35
 
-	maximum_antags_global = 2
+	maximum_antags_global = 4
 
 	tags = list(TAG_COMBAT, TAG_SPOOKY, TAG_CREW_ANTAG)
 


### PR DESCRIPTION

## About The Pull Request
gives heretic a weight of 9, above lings by 1, and ups them to max 4,
make sure this is TM'd with the rework cause it's a bit pointless withotu it.
TM only, unless...?

## Why It's Good For The Game
i wanna play heretic and not RNG the fuck out of it, since the rework may get TM'd

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
add: heretic weight is now 9 and has a maximum of 4 heretics
/:cl:

