### PR TITLE
Marked One re-add

### DIFF
--- a/html/changelogs/AutoChangeLog-bubber-pr-4296.yml
+++ b/html/changelogs/AutoChangeLog-bubber-pr-4296.yml
@@ -1,0 +1,4 @@
+author: "BurgerBB"
+delete-after: True
+changes:
+  - balance: "Reduces the chance of Moon Station sandstorms from 40% to 20%. Reduces the duration of Moon Station sandstorms from 2-4 minutes to 1-3 minutes."

--- a/modular_skyrat/modules/gladiator/code/datums/ruins/lavaland.dm
+++ b/modular_skyrat/modules/gladiator/code/datums/ruins/lavaland.dm
@@ -1,4 +1,3 @@
-/* Disabled until someone wants to bother maintaining it.
 /datum/map_template/ruin/lavaland/arena
 	name = "Lava-Ruin Grand Arena"
 	id = "arena"
@@ -8,4 +7,4 @@
 	cost = 0
 	always_place = TRUE //WOULD BE UNFAIR IF SOMETHING THAT IS ALWAYS PLACED HAD A COST...
 	allow_duplicates = FALSE
-*/
+

--- a/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
+++ b/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
@@ -161,9 +161,9 @@
 	var/roll_stamcost = 10
 	/// how far do we roll?
 	var/roll_range = 3
-	var/charged = TRUE 
-    	var/charge_time = 2 SECONDS
-    	// prevents you from becoming a bayblade
+	var/roll_delay = 2 SECONDS
+	// prevents you from becoming a bayblade
+	COOLDOWN_DECLARE(gatsu_cooldown)
 
 /obj/item/claymore/dragonslayer/examine()
 	. = ..()
@@ -183,16 +183,15 @@
 /obj/item/claymore/dragonslayer/ranged_interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
 	if(user.IsImmobilized()) // no free dodgerolls
 		return NONE
-	if(!charged)
-        	return
 	var/turf/where_to = get_turf(interacting_with)
+	COOLDOWN_START(src, gatsu_cooldown, roll_delay)
 	user.apply_damage(damage = roll_stamcost, damagetype = STAMINA)
 	user.Immobilize(0.1 SECONDS) // you dont get to adjust your roll
 	user.throw_at(where_to, range = roll_range, speed = 1, force = MOVE_FORCE_NORMAL)
 	user.apply_status_effect(/datum/status_effect/dodgeroll_iframes)
 	playsound(user, SFX_BODYFALL, 50, TRUE)
 	playsound(user, SFX_RUSTLE, 50, TRUE)
-	charged = FALSE
+	
 	return ITEM_INTERACT_SUCCESS
 
 /datum/status_effect/dodgeroll_iframes

--- a/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
+++ b/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
@@ -161,9 +161,9 @@
 	var/roll_stamcost = 10
 	/// how far do we roll?
 	var/roll_range = 3
-	var/roll_delay = 2 SECONDS
-	// prevents you from becoming a bayblade
-	COOLDOWN_DECLARE(gatsu_cooldown)
+	var/charged = TRUE 
+    	var/charge_time = 2 SECONDS
+    	// prevents you from becoming a bayblade
 
 /obj/item/claymore/dragonslayer/examine()
 	. = ..()
@@ -183,16 +183,16 @@
 /obj/item/claymore/dragonslayer/ranged_interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
 	if(user.IsImmobilized()) // no free dodgerolls
 		return NONE
+	if(!charged)
+        	return
 	var/turf/where_to = get_turf(interacting_with)
-	COOLDOWN_START(src, gatsu_cooldown, roll_delay)
 	user.apply_damage(damage = roll_stamcost, damagetype = STAMINA)
 	user.Immobilize(0.1 SECONDS) // you dont get to adjust your roll
 	user.throw_at(where_to, range = roll_range, speed = 1, force = MOVE_FORCE_NORMAL)
 	user.apply_status_effect(/datum/status_effect/dodgeroll_iframes)
 	playsound(user, SFX_BODYFALL, 50, TRUE)
 	playsound(user, SFX_RUSTLE, 50, TRUE)
-	if (!COOLDOWN_FINISHED(src, gatsu_cooldown))
-        	return TRUE
+	charged = FALSE
 	return ITEM_INTERACT_SUCCESS
 
 /datum/status_effect/dodgeroll_iframes

--- a/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
+++ b/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
@@ -162,7 +162,6 @@
 	/// how far do we roll?
 	var/roll_range = 3
 	var/roll_delay = 2 SECONDS
-	var/dodgeroll_cooldown = 2 SECONDS
 	// prevents you from becoming a bayblade
 	COOLDOWN_DECLARE(dodgeroll_cooldown)
 

--- a/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
+++ b/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
@@ -163,7 +163,7 @@
 	var/roll_range = 3
 	var/roll_delay = 2 SECONDS
 	// prevents you from becoming a bayblade
-	COOLDOWN_DECLARE(gatsu_cooldown)
+	COOLDOWN_DECLARE(dodgeroll_cooldown)
 
 /obj/item/claymore/dragonslayer/examine()
 	. = ..()
@@ -181,10 +181,10 @@
 		force -= faction_bonus_force
 
 /obj/item/claymore/dragonslayer/ranged_interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
-	if(user.IsImmobilized()) // no free dodgerolls
+	if(user.IsImmobilized() || COOLDOWN_FINISHED(src, dodgeroll_cooldown)) // no free dodgerolls
 		return NONE
 	var/turf/where_to = get_turf(interacting_with)
-	COOLDOWN_START(src, gatsu_cooldown, roll_delay)
+	COOLDOWN_START(src, dodgeroll_cooldown, roll_delay)
 	user.apply_damage(damage = roll_stamcost, damagetype = STAMINA)
 	user.Immobilize(0.1 SECONDS) // you dont get to adjust your roll
 	user.throw_at(where_to, range = roll_range, speed = 1, force = MOVE_FORCE_NORMAL)

--- a/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
+++ b/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
@@ -245,22 +245,6 @@
 	new /obj/item/clothing/neck/warrior_cape(src)
 	new /obj/item/crusher_trophy/gladiator(src)
 
-// Bubber Edit and alt varient for berserker suit
-
-/obj/item/clothing/suit/hooded/berserker/gladiator
-	desc = "A suit of ancient body armor imbued with potent spiritual magnetism, capable of massively boosting a wearer's close combat skills at the cost of ravaging their mind and overexerting their body."
-	icon_state = "berk_suit"
-	icon = 'modular_skyrat/modules/gladiator/icons/berserk_icons.dmi'
-	worn_icon = 'modular_skyrat/modules/gladiator/icons/berserk_suit.dmi'
-	worn_icon_digi = 'modular_skyrat/modules/gladiator/icons/berserk_suit_digi.dmi'
-	hoodtype = /obj/item/clothing/head/hooded/berserker/gladiator
-
-/obj/item/clothing/head/hooded/berserker/gladiator
-	desc = "A uniquely styled helmet with ghastly red eyes that seals it's user inside."
-	icon_state = "berk_helm"
-	icon = 'modular_skyrat/modules/gladiator/icons/berserk_icons.dmi'
-	worn_icon = 'modular_skyrat/modules/gladiator/icons/berserk_suit.dmi'
-
 #undef BERSERK_MAX_CHARGE
 #undef PROJECTILE_HIT_MULTIPLIER
 #undef DAMAGE_TO_CHARGE_SCALE

--- a/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
+++ b/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
@@ -60,13 +60,14 @@
 
 /datum/armor/berserker_gatsu
 	melee = 40
-	bullet = 30
-	laser = 15
-	energy = 25
+	bullet = 10
+	laser = -15
+	energy = -25
 	bomb = 70
 	bio = 70
 	fire = 100
 	acid = 100
+	wound = -15
 
 /datum/armor/drake_empowerment //Modular Override: nerfs beserker armour so I can keep this armour balanced
 	laser = 10

--- a/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
+++ b/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
@@ -181,7 +181,7 @@
 		force -= faction_bonus_force
 
 /obj/item/claymore/dragonslayer/ranged_interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
-	if(user.IsImmobilized() || COOLDOWN_FINISHED(src, dodgeroll_cooldown)) // no free dodgerolls
+	if(user.IsImmobilized() || !COOLDOWN_FINISHED(src, dodgeroll_cooldown)) // can't dodge
 		return NONE
 	var/turf/where_to = get_turf(interacting_with)
 	COOLDOWN_START(src, dodgeroll_cooldown, roll_delay)

--- a/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
+++ b/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
@@ -162,6 +162,7 @@
 	/// how far do we roll?
 	var/roll_range = 3
 	var/roll_delay = 2 SECONDS
+	var/dodgeroll_cooldown = 2 seconds
 	// prevents you from becoming a bayblade
 	COOLDOWN_DECLARE(dodgeroll_cooldown)
 

--- a/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
+++ b/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
@@ -191,7 +191,6 @@
 	user.apply_status_effect(/datum/status_effect/dodgeroll_iframes)
 	playsound(user, SFX_BODYFALL, 50, TRUE)
 	playsound(user, SFX_RUSTLE, 50, TRUE)
-	
 	return ITEM_INTERACT_SUCCESS
 
 /datum/status_effect/dodgeroll_iframes

--- a/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
+++ b/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
@@ -61,20 +61,20 @@
 /datum/armor/berserker_gatsu
 	melee = 40
 	bullet = 10
-	laser = -15
-	energy = -25
+	laser = 10
+	energy = 10
 	bomb = 70
 	bio = 70
 	fire = 100
 	acid = 100
-	wound = -15
+	wound = -5
 
 /datum/armor/drake_empowerment //Modular Override: nerfs beserker armour so I can keep this armour balanced
 	laser = 10
 	energy = 0
 
 /datum/armor/drake_empowerment_gatsu
-	melee = 35
+	melee = 30
 	laser = 10
 	bomb = 20
 

--- a/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
+++ b/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
@@ -161,6 +161,9 @@
 	var/roll_stamcost = 10
 	/// how far do we roll?
 	var/roll_range = 3
+	var/roll_delay = 2 SECONDS
+	// prevents you from becoming a bayblade
+	COOLDOWN_DECLARE(gatsu_cooldown)
 
 /obj/item/claymore/dragonslayer/examine()
 	. = ..()
@@ -181,6 +184,7 @@
 	if(user.IsImmobilized()) // no free dodgerolls
 		return NONE
 	var/turf/where_to = get_turf(interacting_with)
+	COOLDOWN_START(src, gatsu_cooldown, roll_delay)
 	user.apply_damage(damage = roll_stamcost, damagetype = STAMINA)
 	user.Immobilize(0.1 SECONDS) // you dont get to adjust your roll
 	user.throw_at(where_to, range = roll_range, speed = 1, force = MOVE_FORCE_NORMAL)

--- a/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
+++ b/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
@@ -162,7 +162,7 @@
 	/// how far do we roll?
 	var/roll_range = 3
 	var/roll_delay = 2 SECONDS
-	var/dodgeroll_cooldown = 2 seconds
+	var/dodgeroll_cooldown = 2 SECONDS
 	// prevents you from becoming a bayblade
 	COOLDOWN_DECLARE(dodgeroll_cooldown)
 

--- a/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
+++ b/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
@@ -191,6 +191,8 @@
 	user.apply_status_effect(/datum/status_effect/dodgeroll_iframes)
 	playsound(user, SFX_BODYFALL, 50, TRUE)
 	playsound(user, SFX_RUSTLE, 50, TRUE)
+	if (!COOLDOWN_FINISHED(src, gatsu_cooldown))
+        	return TRUE
 	return ITEM_INTERACT_SUCCESS
 
 /datum/status_effect/dodgeroll_iframes

--- a/modular_skyrat/modules/gladiator/code/modules/mob/living/simple_animal/hostile/megafauna/markedone.dm
+++ b/modular_skyrat/modules/gladiator/code/modules/mob/living/simple_animal/hostile/megafauna/markedone.dm
@@ -29,6 +29,7 @@
 	gender = MALE
 	rapid_melee = 1
 	melee_queue_distance = 2
+	armour_penetration = 40
 	melee_damage_lower = 40
 	melee_damage_upper = 40
 	speed = 1
@@ -278,6 +279,7 @@
 				icon_state = "marked2"
 				rapid_melee = 2
 				move_to_delay = 2
+				armour_penetration = 30
 				melee_damage_upper = 30
 				melee_damage_lower = 30
 		if(SHOWDOWN_PERCENT to FIFTY_PERCENT)
@@ -286,6 +288,7 @@
 				INVOKE_ASYNC(src, PROC_REF(charge), target, 21)
 				ranged_cooldown += 5 SECONDS
 				rapid_melee = 4
+				armour_penetration = 25
 				melee_damage_upper = 25
 				melee_damage_lower = 25
 				move_to_delay = 1.5
@@ -298,6 +301,7 @@
 				ranged_cooldown += 8 SECONDS
 				icon_state = "marked3"
 				rapid_melee = 1
+				armour_penetration = 50
 				melee_damage_upper = 50
 				melee_damage_lower = 50
 				move_to_delay = 1.2

--- a/modular_zubbers/code/datums/components/crafting/tailoring.dm
+++ b/modular_zubbers/code/datums/components/crafting/tailoring.dm
@@ -60,15 +60,6 @@
 	..()
 	blacklist += subtypesof(/obj/item/clothing/mask/gas)
 
-/datum/crafting_recipe/berserker_reskin
-	name = "Marked One Grafting"
-	result = /obj/item/clothing/suit/hooded/berserker/gladiator
-	reqs = list(/obj/item/clothing/suit/hooded/berserker = 1,
-				/obj/item/stack/ore/glass/basalt = 5,
-				/obj/item/stack/ore/titanium =5)
-	time = 5 SECONDS
-	category = CAT_CLOTHING
-
 /datum/crafting_recipe/hudsunciv
 	name = "Civilian HUDsunglasses"
 	result = /obj/item/clothing/glasses/hud/civilian/sunglasses


### PR DESCRIPTION
## About The Pull Request

Basically: we're re-adding the marked one, nerfing the stats on it's armor into the ground- (and technically below ground too!) so it's more in line with the design goals of the maintainers. The concept is simple; by directly making it so you'll take *more* damage by wearing the armor, it would be monumentally idiotic to go out and try to "frag out for valids" in armor which renders you more vulnerable to conventional weapons. You'd be better off using a basic survival suit than this set of armor.

## Why It's Good For The Game

re-adds a long, long lost fight from a while ago- essentially putting more content back in the game and a optional "final boss" for the experienced, or not-so-experienced shaft miner to try their hand at. 

It also addresses a long standing gripe- that shaft miners take their fancy new toys and steam roll other players / antagonists, or go proto-murderboning in their suits of indestructible fuck-you armor. This armor *literally* is worse than wearing nothing; thus severely limiting it's practicality to lavaland only and it's related ecosystem.

## Proof Of Testing

Going to comment my proof of concept because github isn't working right for me, standbye.

## Changelog

:cl:

balance: heavily nerfs the berserker armor's stats to make it more in line with a SEVA suit
balance: drastically increases the difficulty of the marked one fight, giving his attacks armor penetration
balance: re-adds the marked one ruin and bossfight now that he's no longer lobotomized.

/:cl: