### PR TITLE
Fix midround malf runtime

### DIFF
--- a/modular_zubbers/code/modules/storyteller/event_defines/crewset/malf.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/crewset/malf.dm
@@ -20,17 +20,11 @@
 	return ..() && !HAS_TRAIT(SSstation, STATION_TRAIT_HUMAN_AI)
 
 /datum/round_event_control/antagonist/solo/malf/get_candidates()
-	var/list/candidates = list()
-	for(var/mob/living/silicon/ai/candidate as anything in GLOB.ai_list)
-		if(!(candidate.client.prefs) || !(antag_flag in candidate.client.prefs.be_special))
-			continue
-		if(candidate.client.get_days_to_play_antag(antag_flag) > 0)
-			continue
-		if(is_banned_from(candidate.ckey, list(antag_flag, ROLE_SYNDICATE, BAN_ANTAGONIST)))
-			continue
-		if(!candidate.client?.prefs?.read_preference(/datum/preference/toggle/be_antag))
-			continue
-		candidates += candidate
+	var/list/candidates = ..()
+	for(var/mob/candidate in candidates)
+		if(!istype(candidate.mind.assigned_role, /datum/job/ai))
+			candidates -= candidate
+
 	return candidates
 
 /datum/round_event_control/antagonist/solo/malf/roundstart


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Candidate selection for midround malf rolls was sometimes runtiming because the code was written bad, changed it to use the more durable parent proc and just filter non-AIs out after

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

It's broken and erroring

## Proof Of Testing

No

## Changelog

N/A
