### PR TITLE
Fixes abnormal body temp being skrunkled by the SAD

### DIFF
--- a/modular_zubbers/code/modules/quirks/neutral_quirks/body_temp.dm
+++ b/modular_zubbers/code/modules/quirks/neutral_quirks/body_temp.dm
@@ -34,15 +34,24 @@
 /datum/preference/numeric/bodytemp_customization/bodytemp
 	savefile_key = "bodytemp"
 
-/datum/quirk/bodytemp/add()
+
+/datum/quirk/bodytemp/add(client/client_source)
+	. = ..()
+
+	var/mob/living/carbon/human/user = quirk_holder
+	species_normal = user.dna.species.bodytemp_normal
+	species_heat = user.dna.species.bodytemp_heat_damage_limit //Storing the species's default body temps incase the quirk is removed.
+	species_cold = user.dna.species.bodytemp_cold_damage_limit
+	user.dna.species.bodytemp_normal += bodytemp
+	user.dna.species.bodytemp_heat_damage_limit += bodytemp
+	user.dna.species.bodytemp_cold_damage_limit += bodytemp
+
+/datum/quirk/bodytemp/post_add()
 	. = ..()
 
 	var/mob/living/carbon/human/user = quirk_holder
 	var/datum/preferences/prefs = user.client.prefs
 	bodytemp = prefs.read_preference(/datum/preference/numeric/bodytemp_customization/bodytemp)
-	species_normal = user.dna.species.bodytemp_normal
-	species_heat = user.dna.species.bodytemp_heat_damage_limit //Storing the species's default body temps incase the quirk is removed.
-	species_cold = user.dna.species.bodytemp_cold_damage_limit
 	user.dna.species.bodytemp_normal += bodytemp
 	user.dna.species.bodytemp_heat_damage_limit += bodytemp
 	user.dna.species.bodytemp_cold_damage_limit += bodytemp
@@ -53,7 +62,8 @@
 	if(QDELETED(quirk_holder))
 		return
 	var/mob/living/carbon/human/user = quirk_holder
-	bodytemp = 0
 	user.dna.species.bodytemp_normal = species_normal
 	user.dna.species.bodytemp_heat_damage_limit = species_heat
 	user.dna.species.bodytemp_cold_damage_limit = species_cold
+
+

--- a/modular_zubbers/code/modules/quirks/neutral_quirks/body_temp.dm
+++ b/modular_zubbers/code/modules/quirks/neutral_quirks/body_temp.dm
@@ -34,7 +34,7 @@
 /datum/preference/numeric/bodytemp_customization/bodytemp
 	savefile_key = "bodytemp"
 
-/datum/quirk/bodytemp/post_add()
+/datum/quirk/bodytemp/add()
 	. = ..()
 
 	var/mob/living/carbon/human/user = quirk_holder


### PR DESCRIPTION

## About The Pull Request
Fixes https://github.com/Bubberstation/Bubberstation/issues/4260
who knew just changing post_add() to add() would fix it? not me for sure.
## Why It's Good For The Game
People probably shouldn't have their body temperature try to equalize to 0k
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: abnormal body temperature is no longer skrunkled by the SAD
/:cl:
