### PR TITLE
Lets cyborgs filter medical combitool

### DIFF
--- a/modular_skyrat/modules/filtersandsetters/code/filtersandsetters.dm
+++ b/modular_skyrat/modules/filtersandsetters/code/filtersandsetters.dm
@@ -127,6 +127,9 @@
 /obj/item/blood_filter/advanced/attack_self_secondary(mob/user)
 	ui_interact(user)
 
+/obj/item/blood_filter/advanced/BorgCtrlClick(mob/user)
+	ui_interact(user)
+
 /obj/item/blood_filter/advanced/get_all_tool_behaviours()
 	return list(TOOL_BLOODFILTER, TOOL_BONESET)
 


### PR DESCRIPTION

## About The Pull Request

Quick fix to let cyborgs add filters to the combitool with CTRL click.
Ideally, the cyborg click code would be fixed for this. But I am not skilled enough at coding or modularization to do that
## Why It's Good For The Game

Cyborgs should have access to the same functions of the tools they are given that carbons do

## Proof Of Testing

Compiled, CTRL clicking as cyborg opened whitelisting menu

## Changelog
:cl:
fix: Cyborgs can now add filters to medical Combitools with CTRL click
/:cl:
