### PR TITLE
Fix a few action button related bugs

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/bdsm_mask.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/bdsm_mask.dm
@@ -33,6 +33,7 @@
 		/datum/action/item_action/mask_inhale,
 		/datum/action/item_action/toggle_gag,
 	)
+	action_slots = ITEM_SLOT_HANDS | ITEM_SLOT_MASK
 	var/list/moans = list("Mmmph...", "Hmmphh", "Mmmfhg", "Gmmmh...") // Phrases to be said when the player attempts to talk when speech modification / voicebox is enabled.
 	var/list/moans_alt = list("Mhgm...", "Hmmmp!...", "Gmmmhp!") // Power probability phrases to be said when talking.
 	var/moans_alt_probability = 5 // Probability for alternative sounds to play.

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/deprivation_helmet.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_clothing/deprivation_helmet.dm
@@ -26,6 +26,7 @@
 		/datum/action/item_action/toggle_hearing,
 		/datum/action/item_action/toggle_speech,
 	)
+	action_slots = ITEM_SLOT_HANDS | ITEM_SLOT_HEAD
 
 //Declare action types
 /datum/action/item_action/toggle_vision

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/_sex_toy.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/_sex_toy.dm
@@ -30,7 +30,7 @@
 
 	// Give out actions our item has to people who equip it.
 	for(var/datum/action/action as anything in actions)
-		give_item_action(action, user)
+		give_item_action(action, user, slot)
 
 /obj/item/clothing/sextoy/dropped(mob/user)
 	..()

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/dildo.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/dildo.dm
@@ -305,6 +305,9 @@ GLOBAL_LIST_INIT(dildo_colors, list(//mostly neon colors
 	. = ..()
 	AddElement(/datum/element/update_icon_updates_onmob)
 
+/obj/item/clothing/sextoy/dildo/double_dildo/item_action_slot_check(slot, mob/user, datum/action/action)
+	return is_inside_lewd_slot(user)
+
 /obj/item/clothing/sextoy/dildo/double_dildo/populate_dildo_designs()
 	return
 


### PR DESCRIPTION

## About The Pull Request

A few months ago action buttons were refactored so that you set a var, `action_slots`, that controls what slots an item needs to be equipped into to grant the associated action buttons, it defaults to whatever slots the clothing occupies. We have a few items that work a little differently or explicitly block using the action button when equipped, so adding `ITEM_SLOT_HANDS` to their `action_slots` was necessary.

## Why It's Good For The Game

Fixes items that were broken

## Proof Of Testing

Yes

## Changelog
:cl:
fix: fixed the latex gasmask, deprivation helmet, and double-ended dildo not properly granting associated action buttons when held
/:cl:
