### PR TITLE
Prisoners can no longer clock out of their sentence

### DIFF
--- a/modular_zubbers/modules/plexagon_selfserve/code/plexagon_selfserve.dm
+++ b/modular_zubbers/modules/plexagon_selfserve/code/plexagon_selfserve.dm
@@ -76,7 +76,7 @@
 
 	if(istype(authenticated_card.trim, /datum/id_trim/job/prisoner))
 		tgui_alert(usr, "You cannot clock out of prison. Nice try, inmate.")
-			return TRUE
+		return TRUE
 
 	log_econ("[authenticated_card.registered_name] clocked out from role [authenticated_card.get_trim_assignment()]")
 	var/datum/component/off_duty_timer/timer_component = authenticated_card.AddComponent(/datum/component/off_duty_timer, TIMECLOCK_COOLDOWN)


### PR DESCRIPTION
## About The Pull Request
Prisoners can no longer use the punch clock app on PDAs.
## Why It's Good For The Game
As silly as "John Ghoul, Prisoner has gone off-duty." is, we probably shouldn't have prisoners clocking out.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="490" height="308" alt="image" src="https://github.com/user-attachments/assets/a45bd480-0dbc-4e15-bfe4-b70a68ed4003" />

<img width="505" height="320" alt="image" src="https://github.com/user-attachments/assets/5f97d9f4-2fa2-4182-b74e-e34ee85f11b6" />

</details>

## Changelog
:cl:
fix: fixed prisoners being able to clock out using the Plexagon Punch Clock app
/:cl:
