### PR TITLE
Fixes pAI and Protean MOD Pathfinder and MOD Chameleon module usage (TM only)

### DIFF
--- a/code/__DEFINES/mod.dm
+++ b/code/__DEFINES/mod.dm
@@ -22,6 +22,9 @@
 #define MODULE_ALLOW_INCAPACITATED (1<<1)
 /// This module can be used while the suit is off
 #define MODULE_ALLOW_INACTIVE (1<<2)
+/// This module can be activated while unworn
+#define MODULE_ALLOW_UNWORN (1<<3) // BLUBBER ADDITION ADD
+
 
 #define UNSEALED_LAYER "unsealed_layer"
 #define SEALED_LAYER "sealed_layer"

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -394,7 +394,8 @@
 
 /obj/item/mod/control/GetAccess()
 	if(ai_controller)
-		return req_access.Copy()
+		if(req_access)
+			return req_access.Copy()
 	else
 		return ..()
 

--- a/code/modules/mod/modules/_module.dm
+++ b/code/modules/mod/modules/_module.dm
@@ -109,6 +109,12 @@
 	if(!mod.wearer)
 		if(ismob(mod.loc))
 			balloon_alert(mod.loc, "not equipped!")
+		// BLUBBER ADDITION BEGIN - pAI and protean nonsense
+		if(allow_flags & MODULE_ALLOW_INACTIVE && module_type == MODULE_USABLE)
+			balloon_alert_to_viewers("attempting no-wear activation")
+			used()
+			SEND_SIGNAL(mod, COMSIG_MOD_MODULE_SELECTED, src)
+		// BLUBBER ADDITION END
 		return
 	if(((!mod.active || mod.activating) && !(allow_flags & MODULE_ALLOW_INACTIVE)) || module_type == MODULE_PASSIVE)
 		if(mod.wearer)
@@ -213,10 +219,21 @@
 	else if (length(required_slots))
 		for (var/slot in required_slots)
 			updated_slots |= slot
-	mod.wearer.update_clothing(updated_slots)
+	// BLUBBER EDIT ADDITION BEGIN - No wearer checks
+	if(mod.wearer)
+		mod.wearer.update_clothing(updated_slots)
+	// BLUBBER EDIT ADDITION BEGIN - No suit checks
 
 /// Called when the module is used
 /obj/item/mod/module/proc/used()
+	// BLUBBER EDIT ADDITION BEGIN - No suit checks
+	if(allow_flags & MODULE_ALLOW_UNWORN && !mod.wearer)
+		start_cooldown()
+		update_clothing_slots()
+		SEND_SIGNAL(src, COMSIG_MODULE_USED)
+		on_use()
+		return TRUE
+	// BLUBBER EDIT ADDITION END
 	if(!COOLDOWN_FINISHED(src, cooldown_timer))
 		balloon_alert(mod.wearer, "on cooldown!")
 		return FALSE

--- a/code/modules/mod/modules/_module.dm
+++ b/code/modules/mod/modules/_module.dm
@@ -111,7 +111,6 @@
 			balloon_alert(mod.loc, "not equipped!")
 		// BLUBBER ADDITION BEGIN - pAI and protean nonsense
 		if(allow_flags & MODULE_ALLOW_INACTIVE && module_type == MODULE_USABLE)
-			balloon_alert_to_viewers("attempting no-wear activation")
 			used()
 			SEND_SIGNAL(mod, COMSIG_MOD_MODULE_SELECTED, src)
 		// BLUBBER ADDITION END

--- a/code/modules/mod/modules/module_pathfinder.dm
+++ b/code/modules/mod/modules/module_pathfinder.dm
@@ -13,10 +13,16 @@
 	complexity = 1
 	module_type = MODULE_USABLE
 	use_energy_cost = DEFAULT_CHARGE_DRAIN * 10
-	incompatible_modules = list(/obj/item/mod/module/pathfinder)
-	required_slots = list(ITEM_SLOT_BACK|ITEM_SLOT_BELT)
+	incompatible_modules = list() // BLUBBER EDIT REMOVAL - Jarvis, do the funniest thing ever
+	required_slots = list(ITEM_SLOT_BACK|ITEM_SLOT_BELT) // BLUBBER EDIT REMOVAL
 	/// The pathfinding implant.
 	var/obj/item/implant/mod/implant
+	// BLUBBER EDIT BEGIN
+	/// The implant as implanted in someone
+	var/obj/item/implant/mod/implant_implanted
+	allow_flags = list(MODULE_ALLOW_INACTIVE|MODULE_ALLOW_UNWORN) // lets pAIs actually hit the button
+	cooldown_time = 20
+	// BLUBBER EDIT END
 
 /obj/item/mod/module/pathfinder/Initialize(mapload)
 	. = ..()
@@ -28,6 +34,7 @@
 
 /obj/item/mod/module/pathfinder/Exited(atom/movable/gone, direction)
 	if(gone == implant)
+		implant_implanted = gone
 		implant = null
 		update_icon_state()
 	return ..()
@@ -57,7 +64,18 @@
 	else
 		target.visible_message(span_notice("[user] implants [target]."), span_notice("[user] implants you with [implant]."))
 	playsound(src, 'sound/effects/spray.ogg', 30, TRUE, -6)
-	module_type = MODULE_PASSIVE
+	//module_type = MODULE_PASSIVE // BLUBBER EDIT REMOVAL - More compatable with pAIs
+
+// BLUBBER EDIT ADDITION BEGIN
+/obj/item/mod/module/pathfinder/used()
+	if(implant_implanted)
+		balloon_alert_to_viewers("attempting to recall")
+		implant_implanted.recall() // Lets pAIs fly to you.
+		return FALSE
+
+	return ..()
+// BLUBBER EDIT ADDITION END
+
 
 /obj/item/mod/module/pathfinder/on_use()
 	. = ..()
@@ -68,7 +86,7 @@
 		return
 	balloon_alert(mod.wearer, "implanted")
 	playsound(src, 'sound/effects/spray.ogg', 30, TRUE, -6)
-	module_type = MODULE_PASSIVE
+	//module_type = MODULE_PASSIVE // BLUBBER EDIT REMOVAL - More compatable with pAIs
 	var/datum/action/item_action/mod/pinnable/module/existing_action = pinned_to[REF(mod.wearer)]
 	if(existing_action)
 		mod.remove_item_action(existing_action)
@@ -95,6 +113,9 @@
 	var/obj/item/mod/module/pathfinder/module
 	/// The jet icon we apply to the MOD.
 	var/image/jet_icon
+	// BLUBBER EDIT ADDITION BEGIN
+	allow_multiple = TRUE //If you lose your suit/module, you can just replace it (No more surgery to remove the old one)
+	// BLUBBER EDIT ADDITION END
 
 /obj/item/implant/mod/Initialize(mapload)
 	. = ..()

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -324,7 +324,6 @@
 		return
 	// BLUBBER EDIT BEGIN - This is awful, I'm sorry.  Needs upsteam PR for parameters.
 	if(istype(mod, /obj/item/mod/control/pre_equipped/protean) && !mod.wearer)
-		balloon_alert_to_viewers("Protean detected")
 		for(var/stuff in mod.contents)
 			if(ishuman(stuff))
 				var/picked_name = tgui_input_list(mod.wearer, "Select look to change into", "Chameleon Settings", possible_disguises)

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -290,7 +290,7 @@
 	complexity = 2
 	incompatible_modules = list(/obj/item/mod/module/chameleon)
 	cooldown_time = 0.5 SECONDS
-	allow_flags = MODULE_ALLOW_INACTIVE
+	allow_flags = MODULE_ALLOW_INACTIVE|MODULE_ALLOW_UNWORN // BLUBBER EDIT ADDITION
 	/// A list of all the items the suit can disguise as.
 	var/list/possible_disguises = list()
 	/// The path of the item we're disguised as.
@@ -322,6 +322,35 @@
 	if(current_disguise)
 		return_look()
 		return
+	// BLUBBER EDIT BEGIN - This is awful, I'm sorry.  Needs upsteam PR for parameters.
+	if(istype(mod, /obj/item/mod/control/pre_equipped/protean) && !mod.wearer)
+		balloon_alert_to_viewers("Protean detected")
+		for(var/stuff in mod.contents)
+			if(ishuman(stuff))
+				var/picked_name = tgui_input_list(mod.wearer, "Select look to change into", "Chameleon Settings", possible_disguises)
+				if(!possible_disguises[picked_name] || mod.active || mod.activating)
+					return
+				current_disguise = possible_disguises[picked_name]
+				update_look()
+				return
+		return
+
+
+	if(mod.ai_assistant)
+		balloon_alert(mod.wearer, "Getting Suit AI opinion first...")
+		var/picked_name = "None"
+		switch(tgui_alert(mod.ai_assistant, "Would you like to to choose the disguise?", "<3?", list("Yes!", "Nope"), timeout = 5 SECONDS))
+			if("Yes!")
+				picked_name = tgui_input_list(mod.ai_assistant, "Select look to change into", "Chameleon Settings", possible_disguises)
+			else
+				picked_name = tgui_input_list(mod.wearer, "Select look to change into", "Chameleon Settings", possible_disguises)
+
+		if(!possible_disguises[picked_name] || mod.active || mod.activating)
+			return
+		current_disguise = possible_disguises[picked_name]
+		update_look()
+		return
+	// BLUBBER EDIT END
 	var/picked_name = tgui_input_list(mod.wearer, "Select look to change into", "Chameleon Settings", possible_disguises)
 	if(!possible_disguises[picked_name] || mod.active || mod.activating)
 		return


### PR DESCRIPTION
## About The Pull Request

This makes it so that the MOD Pathfinder module and MOD Chameleon modules work when the suit isn't worn, such as by Proeans in suit form and pAIs.  This is pretty logical since those modules *should* be able to work without it.

Very slightly shitcode since `/obj/item/mod/module/used()` doesn't pass a user, and instead assumes the user is always `mod.wearer`.  It might be a good idea to just make this a testmerge while I add a bunch of `if(!mod.wearer)` checks to everything in modsuit code upstream.

I did my best to test all of the edge cases, but there's still potentially a few bugs in here.

## Why It's Good For The Game

pAIs controlling modsuits is actually kind of fun.  With the Chameleon modules, your pAI can now control your suit's appearance, and Proteans can change how they look while in suit form.  (Although the chameleon module is currently slightly broken.  Also an upstream thing.)

With the pathfinder module, pAIs can now hit the recall button.  Mechanically, this is meaningless since it's identical to the user hitting it.

## Proof Of Testing

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->
<details>
<summary>Screenshots/Videos
<img width="585" height="427" alt="proof" src="https://github.com/user-attachments/assets/70c18dfe-3629-44ff-b2bf-ffd697aae7f1" />
</summary>

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Stonetear
fix: pAIs and Proteans can now use the Chameleon module and Pathfinder modules without the suit being worn.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
