### PR TITLE
Modsuit assimilation will no longer make suit storages vanish (again)

### DIFF
--- a/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
@@ -212,11 +212,12 @@
 	desc = to_assimilate.desc
 	extended_desc = to_assimilate.extended_desc
 	for(var/obj/item/mod/module/module in to_assimilate.modules) // Insert every module
-		var/obj/item/mod/module/storage/protean_storage = locate() in modules
-		if(protean_storage) //snowflake storage module code
-			cached_modules += protean_storage
-			to_chat(user, span_notice("[protean_storage] has been pushed aside!"))
-			uninstall(protean_storage)
+		if(istype(module, /obj/item/mod/module/storage))
+			var/obj/item/mod/module/storage/existing_storage = locate() in modules
+			if(existing_storage)
+				cached_modules += existing_storage
+				to_chat(user, span_notice("[existing_storage] has been pushed aside!"))
+				uninstall(existing_storage)
 		if(install(module, user, TRUE))
 			continue
 		if(!module.removable) // Just leave it inside the original suit if it doesn't transfer.


### PR DESCRIPTION
## About The Pull Request

Actually fixes storages vanishing when you assimilate modsuits. Pushes aside the old storage until the modsuit is removed.

## Why It's Good For The Game

I guess I didn't fix this when I thought I did.

## Proof Of Testing

![NVIDIA_Overlay_bmBS1lEaSl](https://github.com/user-attachments/assets/8f891de6-3aa7-4acb-9bbe-afa52b5b7425)

## Changelog

:cl:
fix: Suit assimilation for proteans will no longer make expensive suit storages vanish. Old suit storage is pushed aside in favor of the incoming one. 
/:cl:
