### PR TITLE
Adds the Hearing Protection Mod to our combat MODsuits

### DIFF
--- a/modular_skyrat/modules/blueshield/code/modsuit/mod_theme.dm
+++ b/modular_skyrat/modules/blueshield/code/modsuit/mod_theme.dm
@@ -17,6 +17,7 @@
 	siemens_coefficient = 0
 	complexity_max = DEFAULT_MAX_COMPLEXITY
 	slowdown_deployed = 0.25
+	inbuilt_modules = list(/obj/item/mod/module/hearing_protection)
 	allowed_suit_storage = list(
 		/obj/item/ammo_box,
 		/obj/item/ammo_casing,

--- a/modular_skyrat/modules/novaya_ert/code/mod_suit.dm
+++ b/modular_skyrat/modules/novaya_ert/code/mod_suit.dm
@@ -12,6 +12,7 @@
 	armor_type = /datum/armor/mod_theme_frontline
 	complexity_max = DEFAULT_MAX_COMPLEXITY
 	charge_drain = DEFAULT_CHARGE_DRAIN * 1.5
+	inbuilt_modules = list(/obj/item/mod/module/hearing_protection)
 	allowed_suit_storage = list(
 		/obj/item/flashlight,
 		/obj/item/tank/internals,
@@ -106,6 +107,7 @@
 		it would still be right at home in the service of gunrunners and private security forces. \
 		Though, it's internal systems have degraded, and some of the ablative plating has been removed."
 	armor_type = /datum/armor/mod_theme_frontline/surplus
+	inbuilt_modules = list(/obj/item/mod/module/hearing_protection)
 
 /datum/mod_theme/frontline/surplus/set_skin(obj/item/mod/control/mod, skin)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

/tg/ added modsuit based ear protection for all combat-rated suits, this adds that to ours. 

## Why It's Good For The Game

parity is good and cool

## Proof Of Testing

works on my machine

## Changelog
:cl:
add: adds the Hearing Protection Module to Skyrat-added MODsuits
/:cl:
