### PR TITLE
Reworks protean regeneration

### DIFF
--- a/modular_zubbers/code/modules/customization/species/proteans/organs/protean_stomach.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/organs/protean_stomach.dm
@@ -1,4 +1,4 @@
-#define REGEN_TIME (60 SECONDS) // () are important for order of operations. Fuck you too, byond
+#define REGEN_TIME (30 SECONDS) // () are important for order of operations. Fuck you too, byond
 /obj/item/organ/stomach/protean
 	name = "refactory"
 	desc = "An extremely fragile factory used to recycle materials and create more nanite mass. Needed to facilitate the repair process on a collapsed Protean; it can be installed as a module in the rig, or as an organ."


### PR DESCRIPTION
## About The Pull Request

Makes it so when a protean takes damage, their regeneration has a delay factor to it. It will slowly ramp back up over the course of 30 seconds with a multiplier.

The timer is adjustable to feedback and gameplay. Needs a test merge
## Why It's Good For The Game

Protean regeneration is a bit substantial, I'll admit after playing a few combat roles with them especially if you have armor.

## Proof Of Testing

This is the multiplicative number. 2 * 0.1 will be 0.2 damage healed.

<img width="730" height="223" alt="image" src="https://github.com/user-attachments/assets/903bb97b-ef14-4dd3-b4ea-e7e061e5c2c2" />

## Changelog

:cl:
balance: Protean regeneration now has a delay factor where it slowly ramps up back to normal over 30 seconds
/:cl:
