### PR TITLE
Equal Pay For All

### DIFF
--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -116,7 +116,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	///multiplier for stun durations
 	var/stunmod = 1
 	///multiplier for money paid at payday
-	var/payday_modifier = 0.75
+	var/payday_modifier = 1
 	///Base electrocution coefficient.  Basically a multiplier for damage from electrocutions.
 	var/siemens_coeff = 1
 	///To use MUTCOLOR with a fixed color that's independent of the mcolor feature in DNA.

--- a/modular_zubbers/code/modules/customization/species/proteans/_proteans_species.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/_proteans_species.dm
@@ -6,7 +6,7 @@
 	sexes = TRUE
 
 	siemens_coeff = 1.5 // Electricty messes you up.
-	payday_modifier = 0.7 // 30 percent poorer
+	payday_modifier = 1
 
 	exotic_bloodtype = BLOOD_TYPE_NANITE_SLURRY
 	digitigrade_customization = DIGITIGRADE_OPTIONAL


### PR DESCRIPTION
## About The Pull Request

We are not a human server, where everyone gets different amounts of pay, lets keep it that way and not bring speciesism into the game. Its changed to the base species type because human only gets 0.75 at the moment due to the fact their modifier is commented out for some reason.

## Why It's Good For The Game

Equality good

## Proof Of Testing

Just a numbers change

## Changelog

:cl:
balance: Humans and Proteans now get the same pay as everyone else.
/:cl:
