### PR TITLE
Fix decal colors from initializing as randomized garbage

### DIFF
--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -103,8 +103,6 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 		if(PATTERN_RAINBOW)
 			var/datum/holiday/pride_week/rainbow_datum = new()
 			return rainbow_datum.get_holiday_colors(thing_to_color, PATTERN_DEFAULT)
-	//if(!length(GLOB.holidays)) // BUBBER EDIT REMOVAL - Pride Flag Colors
-	//	return // BUBBER EDIT REMOVAL - Pride Flag Colors
 	if(!length(GLOB.holidays))
 		return
 	for(var/holiday_key in GLOB.holidays)
@@ -112,11 +110,6 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 		if(!holiday_real.holiday_colors)
 			continue
 		return holiday_real.get_holiday_colors(thing_to_color, pattern || holiday_real.holiday_pattern)
-	// BUBBER EDIT ADDITION BEGIN - Pride Flag Colors
-	if(prob(20))
-		var/datum/holiday/pride_week/rainbow_datum = new()
-		return rainbow_datum.get_holiday_colors(thing_to_color, pattern)
-	// BUBBER EDIT ADDITION END - Pride Flag Colors
 
 // The actual holidays
 

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -105,6 +105,8 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 			return rainbow_datum.get_holiday_colors(thing_to_color, PATTERN_DEFAULT)
 	//if(!length(GLOB.holidays)) // BUBBER EDIT REMOVAL - Pride Flag Colors
 	//	return // BUBBER EDIT REMOVAL - Pride Flag Colors
+	if(!length(GLOB.holidays))
+		return
 	for(var/holiday_key in GLOB.holidays)
 		var/datum/holiday/holiday_real = GLOB.holidays[holiday_key]
 		if(!holiday_real.holiday_colors)


### PR DESCRIPTION
## About The Pull Request

Fix floor tile decals from having a 20% chance of receiving a color. Disables the proc until I finish fixing it.

## Why It's Good For The Game

I done fucked up

## Changelog

:cl:
fix: Station tile decal color should be back to normal
/:cl: