### PR TITLE
Increase compile all templates workflow timeout to 7 minutes

### DIFF
--- a/.github/workflows/compile_all_maps.yml
+++ b/.github/workflows/compile_all_maps.yml
@@ -32,7 +32,7 @@ jobs:
   compile_all_templates:
     name: Compile All Templates
     runs-on: ubuntu-22.04
-    timeout-minutes: 5
+    timeout-minutes: 7
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Bump the timeout for the compile all templates workflow to 7 minutes instead of 5

## Why It's Good For The Game

We have a bunch more templates than upstream and while the memory issues are sorted now, if you happen to get a slow runner this will timeout and cancel before it can finish
