### PR TITLE
Proteans use nutrition now + Even more dynamic regen

### DIFF
--- a/html/changelogs/AutoChangeLog-bubber-pr-4355.yml
+++ b/html/changelogs/AutoChangeLog-bubber-pr-4355.yml
@@ -1,0 +1,4 @@
+author: "StrangeWeirdKitten"
+delete-after: True
+changes:
+  - balance: "Protean regeneration now has a delay factor where it slowly ramps up back to normal over 30 seconds"

--- a/modular_zubbers/code/modules/customization/species/proteans/_proteans_species.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/_proteans_species.dm
@@ -46,7 +46,6 @@
 		TRAIT_NOBREATH,
 		TRAIT_ROCK_EATER,
 		TRAIT_STABLEHEART, // TODO: handle orchestrator code
-		TRAIT_NOHUNGER, // They will have metal stored in the stomach. Fuck nutrition code.
 		TRAIT_LIMBATTACHMENT,
 
 		// Synthetic lifeforms

--- a/modular_zubbers/code/modules/customization/species/proteans/organs/protean_brain.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/organs/protean_brain.dm
@@ -129,7 +129,9 @@
 	var/obj/item/organ/ears/cybernetic/protean/ears = owner.get_organ_slot(ORGAN_SLOT_EARS)
 	var/obj/item/organ/liver/protean/liver = owner.get_organ_slot(ORGAN_SLOT_LIVER)
 
-	if(stomach.metal <= PROTEAN_STOMACH_FULL * 0.6 && istype(stomach))
+	if(!istype(stomach))
+		return to_chat(owner, span_warning("Missing refactory!"))
+	if(stomach.owner.nutrition <= NUTRITION_LEVEL_WELL_FED)
 		to_chat(owner, span_warning("Not enough metal to heal body!"))
 		return
 	if(!istype(owner.loc, /obj/item/mod/control))
@@ -139,7 +141,7 @@
 	if(!do_after(owner, 30 SECONDS, species.species_modsuit, IGNORE_INCAPACITATED))
 		return
 
-	stomach.metal = clamp(stomach.metal - (PROTEAN_STOMACH_FULL * 0.6), 0, 10)
+	stomach.owner.nutrition = clamp(stomach.owner.nutrition - 200, NUTRITION_LEVEL_STARVING, NUTRITION_LEVEL_FULL)
 	owner.fully_heal(HEAL_LIMBS)
 	if(isnull(eyes))
 		eyes = new /obj/item/organ/eyes/robotic/protean

--- a/modular_zubbers/code/modules/customization/species/proteans/organs/protean_stomach.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/organs/protean_stomach.dm
@@ -9,14 +9,6 @@
 	var/metabolism_modifier = 1
 	COOLDOWN_DECLARE(starving_message)
 
-/obj/item/organ/stomach/protean/on_mob_insert(mob/living/carbon/receiver, special, movement_flags)
-	. = ..()
-	RegisterSignal(receiver, COMSIG_MOB_AFTER_APPLY_DAMAGE, PROC_REF(damage_listener))
-
-/obj/item/organ/stomach/protean/on_mob_remove(mob/living/carbon/stomach_owner, special, movement_flags)
-	. = ..()
-	UnregisterSignal(stomach_owner, COMSIG_MOB_AFTER_APPLY_DAMAGE)
-
 /obj/item/organ/stomach/protean/on_life(seconds_per_tick, times_fired)
 	if(isnull(owner.client)) // So we dont die from afk/crashing out
 		return
@@ -51,13 +43,6 @@
 		to_chat(owner, span_warning("You are starving! You must find metal now!"))
 		owner.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/protean_slowdown, multiplicative_slowdown = 2)
 		COOLDOWN_START(src, starving_message, 20 SECONDS)
-
-/obj/item/organ/stomach/protean/proc/damage_listener()
-	SIGNAL_HANDLER
-
-	if(COOLDOWN_STARTED(src, damage_delay))
-		COOLDOWN_RESET(src, damage_delay)
-	COOLDOWN_START(src, damage_delay, REGEN_TIME)
 
 /// If we ate a sheet of metal, add it to storage.
 /obj/item/organ/stomach/protean/after_eat(atom/edible)

--- a/modular_zubbers/code/modules/customization/species/proteans/organs/protean_stomach.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/organs/protean_stomach.dm
@@ -11,19 +11,11 @@
 
 /obj/item/organ/stomach/protean/on_mob_insert(mob/living/carbon/receiver, special, movement_flags)
 	. = ..()
-<<<<<<< Updated upstream
-	RegisterSignal(receiver, COMSIG_CARBON_ATTEMPT_EAT, PROC_REF(try_stomach_eat))
-
-/obj/item/organ/stomach/protean/on_mob_remove(mob/living/carbon/stomach_owner, special, movement_flags)
-	. = ..()
-	UnregisterSignal(stomach_owner, COMSIG_CARBON_ATTEMPT_EAT)
-=======
 	RegisterSignal(receiver, COMSIG_MOB_AFTER_APPLY_DAMAGE, PROC_REF(damage_listener))
 
 /obj/item/organ/stomach/protean/on_mob_remove(mob/living/carbon/stomach_owner, special, movement_flags)
 	. = ..()
 	UnregisterSignal(stomach_owner, COMSIG_MOB_AFTER_APPLY_DAMAGE)
->>>>>>> Stashed changes
 
 /obj/item/organ/stomach/protean/on_life(seconds_per_tick, times_fired)
 	if(isnull(owner.client)) // So we dont die from afk/crashing out
@@ -60,24 +52,12 @@
 		owner.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/protean_slowdown, multiplicative_slowdown = 2)
 		COOLDOWN_START(src, starving_message, 20 SECONDS)
 
-<<<<<<< Updated upstream
-/// Check to see if our metal storage is full.
-/obj/item/organ/stomach/protean/proc/try_stomach_eat(mob/eater, atom/eating)
-	SIGNAL_HANDLER
-
-	if(istype(eating, /obj/item/food/golem_food))
-		var/obj/item/food/golem_food/food = eating
-		if(metal > (PROTEAN_STOMACH_FULL - 0.3) && food.owner.loc == owner)
-			balloon_alert(owner, "storage full!")
-			return COMSIG_CARBON_BLOCK_EAT
-=======
 /obj/item/organ/stomach/protean/proc/damage_listener()
 	SIGNAL_HANDLER
 
 	if(COOLDOWN_STARTED(src, damage_delay))
 		COOLDOWN_RESET(src, damage_delay)
 	COOLDOWN_START(src, damage_delay, REGEN_TIME)
->>>>>>> Stashed changes
 
 /// If we ate a sheet of metal, add it to storage.
 /obj/item/organ/stomach/protean/after_eat(atom/edible)

--- a/modular_zubbers/code/modules/customization/species/proteans/organs/protean_stomach.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/organs/protean_stomach.dm
@@ -4,49 +4,47 @@
 	icon = PROTEAN_ORGAN_SPRITE
 	icon_state = "refactory"
 	organ_flags = ORGAN_ROBOTIC | ORGAN_NANOMACHINE
-	organ_traits = list(TRAIT_NOHUNGER)
-
-	/// How much max metal can we hold at any given time (In sheets). This isn't using nutrition code because nutrition code gets weird without livers.
-	var/metal_max = PROTEAN_STOMACH_FULL
-	/// How much metal are we holding currently (In sheets)
-	var/metal = PROTEAN_STOMACH_FULL
+	organ_traits = list(TRAIT_ROCK_EATER)
 	/// Multiplicative modifier to how fast we lose metal
 	var/metabolism_modifier = 1
 	COOLDOWN_DECLARE(starving_message)
 
-/obj/item/organ/stomach/protean/Initialize(mapload)
-	. = ..() // Call the rest of the proc
-	metal = round(rand(PROTEAN_STOMACH_FULL/2, PROTEAN_STOMACH_FULL))
-
 /obj/item/organ/stomach/protean/on_mob_insert(mob/living/carbon/receiver, special, movement_flags)
 	. = ..()
+<<<<<<< Updated upstream
 	RegisterSignal(receiver, COMSIG_CARBON_ATTEMPT_EAT, PROC_REF(try_stomach_eat))
 
 /obj/item/organ/stomach/protean/on_mob_remove(mob/living/carbon/stomach_owner, special, movement_flags)
 	. = ..()
 	UnregisterSignal(stomach_owner, COMSIG_CARBON_ATTEMPT_EAT)
+=======
+	RegisterSignal(receiver, COMSIG_MOB_AFTER_APPLY_DAMAGE, PROC_REF(damage_listener))
+
+/obj/item/organ/stomach/protean/on_mob_remove(mob/living/carbon/stomach_owner, special, movement_flags)
+	. = ..()
+	UnregisterSignal(stomach_owner, COMSIG_MOB_AFTER_APPLY_DAMAGE)
+>>>>>>> Stashed changes
 
 /obj/item/organ/stomach/protean/on_life(seconds_per_tick, times_fired)
-	var/datum/species/protean/species = owner?.dna.species
-	var/obj/item/mod/control/pre_equipped/protean/suit = species.species_modsuit
-	if(owner.loc == suit)
+	if(isnull(owner.client)) // So we dont die from afk/crashing out
 		return
-	/// Zero out any nutrition. We do not use hunger in this species.
 	for(var/datum/reagent/consumable/food in reagents.reagent_list)
+		if(istype(food, /datum/reagent/consumable/nutriment/mineral))
+			continue
 		food.nutriment_factor = 0
 	. = ..()
 	handle_protean_hunger(owner, seconds_per_tick)
 
 /obj/item/organ/stomach/protean/proc/handle_protean_hunger(mob/living/carbon/human/human, seconds_per_tick)
 	if(!istype(owner.dna.species, /datum/species/protean))
-		return
-	if(isnull(owner.client)) // So we dont die from afk/crashing out
-		return
-	if(metal > PROTEAN_STOMACH_FALTERING)
+		return ..()
+
+	var/nutrition = owner.nutrition
+	if(nutrition > NUTRITION_LEVEL_VERY_HUNGRY)
 		owner.remove_movespeed_modifier(/datum/movespeed_modifier/protean_slowdown)
 		var/hunger_modifier = metabolism_modifier
 		// If we're high enough on metal we might try to heal or recover blood
-		if(metal > PROTEAN_STOMACH_FULL * 0.3)
+		if(nutrition > NUTRITION_LEVEL_HUNGRY)
 			if(owner.health < owner.maxHealth)
 				hunger_modifier += 20
 				owner.adjustBruteLoss(-2, forced = TRUE)
@@ -54,7 +52,7 @@
 			if(owner.blood_volume < BLOOD_VOLUME_NORMAL)
 				hunger_modifier += 100
 				owner.blood_volume = min(owner.blood_volume + (((BLOOD_REGEN_FACTOR * PROTEAN_METABOLISM_RATE) * 0.05) * seconds_per_tick), BLOOD_VOLUME_NORMAL)
-		metal -= clamp(((PROTEAN_STOMACH_FULL / PROTEAN_METABOLISM_RATE) * hunger_modifier * seconds_per_tick), 0, metal_max)
+		nutrition -= clamp((HUNGER_FACTOR * hunger_modifier * seconds_per_tick), 0, NUTRITION_LEVEL_FULL)
 		return
 	owner.adjustBruteLoss(2, forced = TRUE)
 	if(COOLDOWN_FINISHED(src, starving_message))
@@ -62,6 +60,7 @@
 		owner.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/protean_slowdown, multiplicative_slowdown = 2)
 		COOLDOWN_START(src, starving_message, 20 SECONDS)
 
+<<<<<<< Updated upstream
 /// Check to see if our metal storage is full.
 /obj/item/organ/stomach/protean/proc/try_stomach_eat(mob/eater, atom/eating)
 	SIGNAL_HANDLER
@@ -71,15 +70,23 @@
 		if(metal > (PROTEAN_STOMACH_FULL - 0.3) && food.owner.loc == owner)
 			balloon_alert(owner, "storage full!")
 			return COMSIG_CARBON_BLOCK_EAT
+=======
+/obj/item/organ/stomach/protean/proc/damage_listener()
+	SIGNAL_HANDLER
+
+	if(COOLDOWN_STARTED(src, damage_delay))
+		COOLDOWN_RESET(src, damage_delay)
+	COOLDOWN_START(src, damage_delay, REGEN_TIME)
+>>>>>>> Stashed changes
 
 /// If we ate a sheet of metal, add it to storage.
 /obj/item/organ/stomach/protean/after_eat(atom/edible)
 	if(istype(edible, /obj/item/food/golem_food))
 		var/obj/item/food/golem_food/food = edible
-		metal = clamp(metal + 1, 0, PROTEAN_STOMACH_FULL)
 		if(food.owner.loc != owner) // Other people feeding them will heal them.
 			owner.adjustBruteLoss(-20, forced = TRUE)
-			var/health_check = owner.health >= owner.maxHealth ? "fully healed!" : "healed!"
+			owner.adjustFireLoss(-20, forced = TRUE)
+			var/health_check = owner.health >= owner.maxHealth ? "fully healed!" : "healing"
 			owner.balloon_alert_to_viewers("[health_check]")
 
 #undef PROTEAN_STOMACH_FULL

--- a/modular_zubbers/code/modules/customization/species/proteans/organs/protean_stomach.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/organs/protean_stomach.dm
@@ -31,7 +31,7 @@
 
 /obj/item/organ/stomach/protean/proc/health_calculations() // Heals one at 4 ticks or both damages at 2 ticks
 	var/health_amount = 4
-	if(owner.getBruteLoss() > 0 && owner.getFireLoss() > 0)
+	if((owner.getBruteLoss() > 0) && (owner.getFireLoss() > 0))
 		health_amount -= 2
 	return health_amount
 
@@ -47,7 +47,7 @@
 		// If we're high enough on metal we might try to heal or recover blood
 		if(nutrition > NUTRITION_LEVEL_HUNGRY)
 			if(owner.health < owner.maxHealth)
-				var/healing_amount = health_calculations()
+				var/healing_amount = health_calculations() * -1
 				hunger_modifier += 20
 				if(!COOLDOWN_FINISHED(src, damage_delay))
 					var/cooldown_left = (REGEN_TIME - COOLDOWN_TIMELEFT(src, damage_delay)) / REGEN_TIME

--- a/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit_core.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit_core.dm
@@ -21,10 +21,10 @@
 		return null
 	if(brain.dead)
 		return null
-	return stomach.metal
+	return stomach.owner.nutrition
 
 /obj/item/mod/core/protean/max_charge_amount()
-	return PROTEAN_STOMACH_FULL
+	return NUTRITION_LEVEL_FULL
 
 /// We don't charge in a standard way
 /obj/item/mod/core/protean/add_charge(amount)
@@ -36,7 +36,7 @@
 /obj/item/mod/core/protean/check_charge(amount)
 	var/obj/item/organ/stomach/protean/stomach = charge_source()
 	var/obj/item/organ/brain/protean/brain = linked_species.owner.get_organ_slot(ORGAN_SLOT_BRAIN)
-	if(stomach.metal <= PROTEAN_STOMACH_FALTERING)
+	if(stomach.owner.nutrition <= NUTRITION_LEVEL_STARVING)
 		return FALSE
 	if(!istype(brain) || brain.dead)
 		return FALSE
@@ -49,9 +49,9 @@
 	if(isnull(charge_amount()))
 		return "transparent"
 	switch(charge_amount())
-		if (-INFINITY to (PROTEAN_STOMACH_FULL * 0.3))
+		if (-INFINITY to NUTRITION_LEVEL_VERY_HUNGRY)
 			return "bad"
-		if((PROTEAN_STOMACH_FULL * 0.3) to (PROTEAN_STOMACH_FULL * 0.7))
+		if(NUTRITION_LEVEL_VERY_HUNGRY to NUTRITION_LEVEL_FED)
 			return "average"
-		if((PROTEAN_STOMACH_FULL * 0.7) to INFINITY)
+		if(NUTRITION_LEVEL_FED to INFINITY)
 			return "good"


### PR DESCRIPTION
## About The Pull Request

- Switches the snowflakey metal variable to instead use mob nutrition.

- More dynamic regen. 

For example, if you have 100 brute and 0 burn, it will heal the brute at 4 brute a tick. If you have 50 brute and 50 burn, it will heal at 2 brute and burn per tick. Multiplied by the cooldown factor.
## Why It's Good For The Game

Proteans will get better hunger indications and mood buffs if their nutrition is tied to metal consumption.

This will also help offset the regeneration delay by healing single damages faster.

## Proof Of Testing

Tested it all and it works.

## Changelog

:cl:
balance: Protean regeneration now dynamically allocates unused healing into single damage types
refactor: Proteans now use nutrition for metal consumption and storage
/:cl:
