### PR TITLE
Significantly reworks how explosions deal damage to humanoids because I looked at the code once.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -327,13 +327,14 @@
 
 	//BUBBERSTATION CHANGE START. REWORKS HOW DISMEMBERMENT IS APPLIED.
 	var/list/obj/item/bodypart/possible_parts = get_damageable_bodyparts()
-	if(length(possible_parts))
+	var/possible_parts_length = length(possible_parts)
+	if(possible_parts_length)
 		var/attack_direction = get_dir(src,origin)
 		possible_parts = shuffle(possible_parts)
-		var/flat_brute_loss = CEILING( brute_loss*(1/length(possible_parts))*0.5, DAMAGE_PRECISION)
-		var/flat_burn_loss = CEILING( burn_loss*(1/length(possible_parts))*0.5, DAMAGE_PRECISION)
-		brute_loss -= flat_brute_loss
-		burn_loss -= flat_burn_loss
+		var/flat_brute_loss = CEILING( brute_loss*(1/possible_parts_length)*0.5, DAMAGE_PRECISION)
+		var/flat_burn_loss = CEILING( burn_loss*(1/possible_parts_length)*0.5, DAMAGE_PRECISION)
+		brute_loss -= flat_brute_loss*possible_parts_length
+		burn_loss -= flat_burn_loss*possible_parts_length
 		var/did_damage = FALSE
 		for(var/obj/item/bodypart/limb as anything in possible_parts)
 			var/brute_damage_to_deal = 5 + CEILING( brute_loss*Rand(), DAMAGE_PRECISION)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -321,8 +321,43 @@
 				ears.adjustEarDamage(15,60)
 			Knockdown(160 - (bomb_armor * 1.6)) //100 bomb armor will prevent knockdown altogether
 
-	take_overall_damage(brute_loss,burn_loss)
 
+	// take_overall_damage(brute_loss,burn_loss) BUBBERSTATION CHANGE: REWORKS HOW EXPLOSION DAMAGE IS APPLIED.
+
+
+	//BUBBERSTATION CHANGE START. REWORKS HOW DISMEMBERMENT IS APPLIED.
+	var/list/obj/item/bodypart/possible_parts = get_damageable_bodyparts()
+	if(length(possible_parts))
+		var/attack_direction = get_dir(src,origin)
+		possible_parts = shuffle(possible_parts)
+		var/flat_brute_loss = CEILING( brute_loss*(1/length(possible_parts))*0.5, DAMAGE_PRECISION)
+		var/flat_burn_loss = CEILING( burn_loss*(1/length(possible_parts))*0.5, DAMAGE_PRECISION)
+		brute_loss -= flat_brute_loss
+		burn_loss -= flat_burn_loss
+		var/did_damage = FALSE
+		for(var/obj/item/bodypart/limb as anything in possible_parts)
+			var/brute_damage_to_deal = 5 + CEILING( brute_loss*Rand(), DAMAGE_PRECISION)
+			brute_loss -= brute_damage_to_deal
+			var/burn_damage_to_deal = 5 + CEILING( burn_loss*Rand(), DAMAGE_PRECISION)
+			burn_loss -= burn_damage_to_deal
+			did_damage += limb.receive_damage(
+				flat_brute_loss + brute_damage_to_deal,
+				flat_burn_loss + burn_damage_to_deal,
+				getarmor(limb, BOMB),
+				updating_health = FALSE,
+				wound_bonus = DISMEMBER_MINIMUM_DAMAGE,
+				exposed_wound_bonus = DISMEMBER_MINIMUM_DAMAGE,
+				attack_direction = attack_direction,
+				damage_source = origin
+			)
+		if(did_damage)
+			updatehealth()
+
+	//BUBBERSTATION CHANGE END
+
+
+
+	/* BUBBERSTAION CHANGE: REMOVES FORCED DISMEMBERMENT
 	//attempt to dismember bodyparts
 	if(severity >= EXPLODE_HEAVY || !bomb_armor)
 		var/max_limb_loss = 0
@@ -348,6 +383,7 @@
 				max_limb_loss--
 				if(!max_limb_loss)
 					break
+	BUBBERSTATION CHANGE END.*/
 
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

Significantly reworks how explosions deal damage to humanoids by reworking how explosion damage is applied and how dismemberment is applied. Previously, explosions used custom dismemberment code, but in this PR it defers that to the dismemberment code that already exists.

## Why It's Good For The Game

The code involving how explosions work was a little wonky and had a custom way to handle dismemberments, which was really... questionable, especially for explosions that weren't considered heavy.

To simplify it, the code would check for bomb armor, and if you had zero bomb armor or experienced a heavy explosion, **each limb** would roll the dice on whether or not your limb would be removed. This means that if you had at least 1 overall bomb armor, you'd be protected up until heavy explosions, if you had 0 overall then you'd probably lose a limb, regardless of how damaged the limb actually was. This means that if you were wearing a bandana that had exactly 1 bomb resist, then you'd be fine from dismemberments up to heavy explosions.

I discovered this during testing with Security Rocket launchers. Naked humans I spawn would have 1-2 limbs just straight up removed, even though they barely took any damage or were near the epicenter of the explosion. A few code diving sessions later, I discovered this code and was extremely confused at the implementation.

Here is the code in question if you want a look.
```

	if(severity >= EXPLODE_HEAVY || !bomb_armor)
		var/max_limb_loss = 0
		var/probability = 0
		switch(severity)
			if(EXPLODE_NONE)
				max_limb_loss = 1
				probability = 20
			if(EXPLODE_LIGHT)
				max_limb_loss = 2
				probability = 30
			if(EXPLODE_HEAVY)
				max_limb_loss = 3
				probability = 40
			if(EXPLODE_DEVASTATE)
				max_limb_loss = 4
				probability = 50
		for(var/X in bodyparts)
			var/obj/item/bodypart/BP = X
			if(prob(probability) && !prob(getarmor(BP, BOMB)) && BP.body_zone != BODY_ZONE_HEAD && BP.body_zone != BODY_ZONE_CHEST)
				BP.receive_damage(INFINITY, wound_bonus = CANT_WOUND) //Capped by proc
				BP.dismember()
				max_limb_loss--
				if(!max_limb_loss)
					break

```

This means it is theoretically possible to create a funny mini bomb factory with chemistry or other nonsense that triggers multiple times, resulting in nuggeting people without bomb armor. I remember a few times I experienced this myself accidentally, where I suffered multiple light explosions in quick succession, turning me into a chicken mcnugget.

## Proof Of Testing

Untested. PR is a draft because feedback is needed.

## Changelog

:cl: BurgerBB
balance: Significantly reworks how explosions deal damage to humanoids by reworking how explosion damage is applied and how dismemberment is applied. Previously, explosions used custom dismemberment code, but in this PR it defers that to the dismemberment code that already exists.
/:cl:

