### PR TITLE
Forbids some categories of uplink items from receiving discounts + doubles the amount of discounts available.

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -4,10 +4,25 @@
 	var/list/sales = list()
 	var/list/per_category = list()
 
+	/* BUBBERSTATION CHANGE START: DISCOUNT OVERHAUL
 	for (var/datum/uplink_item/possible_sale as anything in sale_items)
 		if (!(possible_sale.category in per_category))
 			per_category[possible_sale.category] = list()
 		per_category[possible_sale.category] += possible_sale
+	BUBBERSTATION CHANGE END*/
+
+
+	//BUBBERSTATION CHANGE START: DISCOUNT OVERHAUL.
+	//SEE MODULAR FILE DISCOUNT_TWEAKS.DM FOR SETTINGS.
+	for (var/datum/uplink_item/possible_sale as anything in sale_items)
+		var/datum/uplink_category/our_category = possible_sale.category
+		if(!initial(our_category.allowed_discount))
+			continue
+		if (!(possible_sale.category in per_category))
+			per_category[our_category] = list()
+		per_category[our_category] += possible_sale
+	//BUBBERSTATION CHANGE END.
+
 
 	for (var/i in 1 to num)
 		var/datum/uplink_category/item_category = pick(per_category)

--- a/modular_zubbers/code/modules/uplink/discount_tweaks.dm
+++ b/modular_zubbers/code/modules/uplink/discount_tweaks.dm
@@ -1,0 +1,29 @@
+/datum/uplink_category
+	var/allowed_discount = TRUE
+
+/datum/uplink_category/spy_unique
+	allowed_discount = FALSE
+
+/datum/uplink_category/special
+	allowed_discount = FALSE
+
+/datum/uplink_category/explosives
+	allowed_discount = FALSE
+
+/datum/uplink_category/dangerous
+	allowed_discount = FALSE
+
+/datum/uplink_category/bundle
+	allowed_discount = FALSE
+
+/datum/uplink_category/badassery
+	allowed_discount = FALSE
+
+/datum/uplink_category/mech
+	allowed_discount = FALSE
+
+/datum/uplink_category/reinforcements
+	allowed_discount = FALSE
+
+/datum/uplink_category/base_keys
+	allowed_discount = FALSE

--- a/modular_zubbers/code/modules/uplink/discount_tweaks.dm
+++ b/modular_zubbers/code/modules/uplink/discount_tweaks.dm
@@ -1,3 +1,8 @@
+/datum/antagonist/traitor
+	//Double what is normally there.
+	uplink_sales_min = 8
+	uplink_sales_max = 12
+
 /datum/uplink_category
 	var/allowed_discount = TRUE
 

--- a/modular_zubbers/code/modules/uplink/uplink_devices.dm
+++ b/modular_zubbers/code/modules/uplink/uplink_devices.dm
@@ -1,4 +1,4 @@
 /obj/item/uplink/standard
 
-/obj/item/uplink/standard/Initialize(mapload, owner, tc_amount = 25, datum/uplink_handler/uplink_handler_override = null)
+/obj/item/uplink/standard/Initialize(mapload, owner, tc_amount = TELECRYSTALS_DEFAULT, datum/uplink_handler/uplink_handler_override = null)
 	. = ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9712,6 +9712,7 @@
 #include "modular_zubbers\code\modules\tgui_input\color.dm"
 #include "modular_zubbers\code\modules\title_screen\code\title_screen_subsystem.dm"
 #include "modular_zubbers\code\modules\tojo_outfits\tojos_outfits.dm"
+#include "modular_zubbers\code\modules\uplink\discount_tweaks.dm"
 #include "modular_zubbers\code\modules\uplink\uplink_devices.dm"
 #include "modular_zubbers\code\modules\uplink\uplink_items\badass.dm"
 #include "modular_zubbers\code\modules\uplink\uplink_items\job.dm"


### PR DESCRIPTION
## About The Pull Request

Changes the amount of discounts available to traitors from 4-6 to 8-12.

Forbids some categories of uplink items from receiving discounts.
Categories include:
- Spy Unique items (Mostly redundant, as all items of this category have discounts disabled)
- Special items. (So far, only a gimmicky autosurgeon implanter that appears only during a certain station trait that I think is disabled).
- Explosive items.
- Dangerous items.
- Bundles (Mostly redundant, as all items of this category have discounts disabled).
- Badassery  (Mostly redundant, as all items of this category have discounts disabled).
- Mech stuff (job-exclusive stuff not counted here) (Nukes Ops Only).
- Extra Reinforcements. (Nukes Ops Only)
- Base Keys (Nukes Ops Only)

## Why It's Good For The Game

From what I understand, discounts were meant to shake up the meta and allow more interesting stuff to happen by offering discounts to random items. Problem is, the discounts can be granted to... very insane items if RNG has its way, leading to questionably powerful antagonists.

Another problem the discounts had is that people feel obligated to buy discounted items, even if the situation isn't appropriate. For example, I recall a round where a traitor bought a syndicate bomb solely because it had a serious discount attached to it, not because they needed it or a gimmick relied on it (See: Like all the psychological studies on sales on how it affects impulse buying).

Since we have 25 TC for traitors, I think it's fair to disable discounts on certain categories.

## Proof Of Testing

Draft because untested and needs feedback.

## Changelog

:cl: BurgerBB
balance: Changes the amount of discounts available to traitors from 4-6 to 8-12.
balance: Forbids some categories of uplink items from receiving discounts.
/:cl:

