### PR TITLE
Fixes Synth "Reset Posibrain Logic" Surgery

### DIFF
--- a/modular_zubbers/code/modules/synths/code/surgery/robot_brain_surgery.dm
+++ b/modular_zubbers/code/modules/synths/code/surgery/robot_brain_surgery.dm
@@ -30,7 +30,6 @@
 	implements = list(
 		TOOL_MULTITOOL = 100,
 		TOOL_HEMOSTAT = 90,
-		TOOL_SCREWDRIVER = 35,
 		/obj/item/pen = 15)
 	repeatable = TRUE
 	preop_sound = 'sound/items/handling/tools/multitool_pickup.ogg'


### PR DESCRIPTION

## About The Pull Request

Fixes #4294 
The synth surgery "Reset Posibrain Logic", aka the synth brain surgery, is currently bugged. Right now, it cannot be completed due to the only tool that can complete the final step, instead always doing the optional step. To finish the surgery properly, you must use a screwdriver to close the synth, but the optional step takes priority, and since the screwdriver is a ghetto option for that specific surgery step, it will always do the optional step.
This PR removes the screwdriver as a ghetto option for ```/datum/surgery_step/fix_robot_brain```, which allows the final step to process normally. While this does remove an option for completing surgeries on a synth, and does affect other surgeries than this one in the same way, it was destined to cause a conflict from the very beginning.
TL;DR, you can't use the screwdriver as a ghetto option for synth brain surgery anymore, and the final step for a surgery is actually completeable.
## Why It's Good For The Game
Bugfix. Takes care of an oversight made during original development of these surgeries.
## Proof Of Testing
<img width="659" height="115" alt="image" src="https://github.com/user-attachments/assets/60db2308-f256-4e59-8fd9-3fc1576e159b" />


## Changelog
:cl:
fix: Synth brain surgery is now completeable
/:cl:
