### PR TITLE
Fix delam suppression time restriction

### DIFF
--- a/code/__DEFINES/~~bubber_defines/machines.dm
+++ b/code/__DEFINES/~~bubber_defines/machines.dm
@@ -5,3 +5,5 @@
 #define SCRAM_AUTO_FIRE "auto_fire"
 /// admin fuckery
 #define SCRAM_DIVINE_INTERVENTION "divine_intervention"
+/// how long from roundstart the scram is functional
+#define SCRAM_TIME_RESTRICTION (1 * 30 MINUTES)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -348,7 +348,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		set_delam(SM_DELAM_PRIO_NONE, SM_DELAM_STRATEGY_PURGE) // This one cant clear any forced delams.
 	delamination_strategy.delam_progress(src)
 	// BUBBER EDIT ADDITION BEGIN - DELAM_SCRAM
-	if(damage > SUPERMATTER_SUPPRESSION_THRESHOLD && is_main_engine && !suppression_fired && world.time - SSticker.round_start_time < 30 MINUTES)
+	if(damage > SUPERMATTER_SUPPRESSION_THRESHOLD && is_main_engine && !suppression_fired && world.time - SSticker.round_start_time < SCRAM_TIME_RESTRICTION)
 		investigate_log("Integrity at time of suppression signal was [100 - damage]", INVESTIGATE_ENGINE)
 		SEND_GLOBAL_SIGNAL(COMSIG_MAIN_SM_DELAMINATING, SCRAM_AUTO_FIRE)
 		suppression_fired = TRUE

--- a/modular_skyrat/modules/delam_emergency_stop/code/admin_scram.dm
+++ b/modular_skyrat/modules/delam_emergency_stop/code/admin_scram.dm
@@ -8,7 +8,7 @@ ADMIN_VERB(try_stop_delam, R_ADMIN, "Delam Emergency Stop", "Activate the delam 
 		return
 
 	// Warn them if they're intervening in the work of God
-	if(world.time - SSticker.round_start_time < 30 MINUTES)
+	if(world.time - SSticker.round_start_time < SCRAM_TIME_RESTRICTION)
 		var/go_early = tgui_alert(user, "The [suppression_system.name] is set to automatically start at the programmed time. \
 			Are you sure you want to override this and fire it early? It's less scary that way.", "Suffering premature delamination?", list("No", "Yes"))
 		if(go_early != "Yes")

--- a/modular_skyrat/modules/delam_emergency_stop/code/scram.dm
+++ b/modular_skyrat/modules/delam_emergency_stop/code/scram.dm
@@ -123,7 +123,7 @@
 	if(trigger_reason == SCRAM_DIVINE_INTERVENTION)
 		return TRUE
 
-	if(world.time - SSticker.round_start_time > 30 MINUTES)
+	if(world.time - SSticker.round_start_time > SCRAM_TIME_RESTRICTION)
 		audible_message(span_danger("[src] makes a series of sad beeps. The internal gas buffer is past its 30 minute expiry... what a feat of engineering!"))
 		investigate_log("Delam SCRAM signal was received but failed precondition check. (Round time or trigger reason)", INVESTIGATE_ENGINE)
 		radio.talk_into(src, "Supermatter delam suppression system fault! Unable to trigger, internal gas mix integrity check failed.", emergency_channel, list(SPAN_COMMAND))
@@ -346,7 +346,7 @@
 	visible_message(span_danger("[user] smashes [src] with their hand!"))
 	message_admins("[ADMIN_LOOKUPFLW(user)] pushed [src]!")
 	investigate_log("[key_name(user)] pushed [src]!", INVESTIGATE_ENGINE)
-	if(world.time - SSticker.round_start_time > 30 MINUTES)
+	if(world.time - SSticker.round_start_time > SCRAM_TIME_RESTRICTION)
 		playsound(
 			source = src.loc,
 			soundin = 'sound/machines/compiler/compiler-failure.ogg',


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Bubberstation/Bubberstation/issues/4387 by actually passing args to the prerequisite check. Moves logging to consistently be in Engine

## Changelog

:cl: LT3
fix: Fixed SM emergency stop button working beyond 30 minutes
/:cl: