### PR TITLE
Restores traitor to 20tc instead of 25tc because i died to it once

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -338,7 +338,7 @@ GLOBAL_LIST_INIT(human_invader_antagonists, list(
 #define JOB_PROB 40
 
 /// How many telecrystals a normal traitor starts with
-#define TELECRYSTALS_DEFAULT 25 // BUBBER EDIT - GIMMICK TRAITOR
+#define TELECRYSTALS_DEFAULT 20
 /// How many telecrystals mapper/admin only "precharged" uplink implant
 #define TELECRYSTALS_PRELOADED_IMPLANT 10
 /// The normal cost of an uplink implant; used for calcuating how many

--- a/modular_zubbers/code/modules/opposing_force/code/equipment/antagonist_powers.dm
+++ b/modular_zubbers/code/modules/opposing_force/code/equipment/antagonist_powers.dm
@@ -6,7 +6,7 @@
 	item_type = /obj/item/uplink/standard
 	name = "Standard Syndicate Uplink"
 	description = "A mass-produced and cheap Syndicate uplink without a password and a balance of 25 telecrystals. It doesn't get more standard than this."
-	admin_note = "Traitor uplink with 25 telecrystals." // LIES. LIES. LIES!!! ITS NOT EMPTY, IT HAD 20 TC BEFORE! No more.
+	admin_note = "Traitor uplink with 20 telecrystals." // LIES. LIES. LIES!!! ITS NOT EMPTY, IT HAD 20 TC BEFORE! No more.
 
 /datum/opposing_force_equipment/antagonist_powers/tc1
 	item_type = /obj/item/stack/telecrystal

--- a/modular_zubbers/code/modules/uplink/uplink_devices.dm
+++ b/modular_zubbers/code/modules/uplink/uplink_devices.dm
@@ -1,4 +1,4 @@
 /obj/item/uplink/standard
 
-/obj/item/uplink/standard/Initialize(mapload, owner, tc_amount = 25, datum/uplink_handler/uplink_handler_override = null)
+/obj/item/uplink/standard/Initialize(mapload, owner, tc_amount = 20, datum/uplink_handler/uplink_handler_override = null)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
puts traitor back at 20tc

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game
Traitor, on bubber/skyrat, has had 25tc for quite some time. In part this was due to our lack of progtot, and in other parts due to traitor being quite weak compared to security at its prime. But truth be told, 5tc/20% is a LOT more than it seems.

However, this inflated amount of currency allows for quite a few combos which are less than fun to fight against. The many scarp + (something else) combos are some of the major examples. Whilst it's a major problem player in the economy, it is not worth being the sole balancing factor for cost. Discounts, additionally, do not impact the combos all that much. The raised cost cap does allow for more nonsense. For example, if you get an esword + ebow + noslips, that's 18tc. Under normal, no-discount scenarios, this would prevent you from also getting armor. However, with the raised amount of TC we have, this allows for you also get an infiltrator mod. A full 50% damage reduction. Discounts DO impact this, if you get lucky, you can snowball even further due to this, however, it's a mere symptom of the problem, as opposed to the root cause.

While yes, in theory, you could balance the costs of EVERY single item to work with the raised limit, this would be quite the effort to actively maintain, especially with how our upstream does regularly change/add stuff that is within the realm of traitor's gear. This change will prevent some of the more ridiculous goings-on, traitor has plenty good stuff even without that extra 5.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Proof Of Testing

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Sets traitor and loneinf's TC count to 20 as opposed to the 25 they had before.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
