### PR TITLE
Fix washing off colorful reagent

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1152,6 +1152,11 @@
 			// /obj/item/wash() already updates our clothing slot
 			. = worn.wash(clean_types) || .
 
+	// BUBBER EDIT ADDITION BEGIN - COLORFUL REAGENT COLORS MOB INSTEAD OF ORGANS
+	if(clean_types & CLEAN_TYPE_LIGHT_DECAL)
+		remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
+	// BUBBER EDIT ADDITION END - COLORFUL REAGENT COLORS MOB INSTEAD OF ORGANS
+
 /// if any of our bodyparts are bleeding
 /mob/living/carbon/proc/is_bleeding()
 	for(var/obj/item/bodypart/part as anything in bodyparts)

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -1261,14 +1261,22 @@ Basically, we fill the time between now and 2s from now with hands based off the
 		for (var/obj/item/to_color in exposed_mob.get_equipped_items(include_flags))
 			to_color.add_atom_colour(color_filter, WASHABLE_COLOUR_PRIORITY)
 
+	// BUBBER EDIT REMOVAL BEGIN - COLORFUL REAGENT COLORS MOB INSTEAD OF ORGANS
+	/*
 	if (ishuman(exposed_mob))
 		var/mob/living/carbon/human/exposed_human = exposed_mob
 		exposed_human.set_facial_haircolor(picked_color, update = FALSE)
 		exposed_human.set_haircolor(picked_color)
+	*/
+	// BUBBER EDIT REMOVAL END - COLORFUL REAGENT COLORS MOB INSTEAD OF ORGANS
 
 	if (!can_color_mobs)
 		return
 
+	exposed_mob.add_atom_colour(color_filter, WASHABLE_COLOUR_PRIORITY) // BUBBER EDIT ADDITION: COLORFUL REAGENT COLORS MOB INSTEAD OF ORGANS
+
+	// BUBBER EDIT REMOVAL BEGIN - COLORFUL REAGENT COLORS MOB INSTEAD OF ORGANS
+	/*
 	if (!iscarbon(exposed_mob))
 		exposed_mob.add_atom_colour(color_filter, WASHABLE_COLOUR_PRIORITY)
 		return
@@ -1280,6 +1288,8 @@ Basically, we fill the time between now and 2s from now with hands based off the
 
 	for (var/obj/item/bodypart/part as anything in exposed_carbon.bodyparts)
 		part.add_atom_colour(color_filter, WASHABLE_COLOUR_PRIORITY)
+	*/
+	// BUBBER EDIT REMOVAL END - COLORFUL REAGENT COLORS MOB INSTEAD OF ORGANS
 
 /datum/reagent/inverse/colorful_reagent/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -1294,8 +1304,12 @@ Basically, we fill the time between now and 2s from now with hands based off the
 
 	var/mob/living/carbon/carbon_mob = affected_mob
 	var/color_priority = WASHABLE_COLOUR_PRIORITY
+	// BUBBER EDIT REMOVAL BEGIN - COLORFUL REAGENT IS ALWAYS TEMPORARY
+	/*
 	if (current_cycle >= 30)
 		color_priority = FIXED_COLOUR_PRIORITY
+	*/
+	// BUBBER EDIT REMOVAL END - COLORFUL REAGENT IS ALWAYS TEMPORARY
 
 	for (var/obj/item/organ/organ as anything in carbon_mob.organs)
 		organ.add_atom_colour(color_transition_filter(pick(random_color_list), SATURATION_OVERRIDE), color_priority)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2179,17 +2179,22 @@
 		for (var/obj/item/to_color in exposed_mob.get_equipped_items(include_flags))
 			to_color.add_atom_colour(color_filter, WASHABLE_COLOUR_PRIORITY)
 
+	// BUBBER EDIT REMOVAL BEGIN - COLORFUL REAGENT COLORS MOB INSTEAD OF ORGANS
+	/*
 	if (ishuman(exposed_mob))
 		var/mob/living/carbon/human/exposed_human = exposed_mob
 		exposed_human.set_facial_haircolor(picked_color, update = FALSE)
 		exposed_human.set_haircolor(picked_color)
+	*/
+	// BUBBER EDIT REMOVAL END - COLORFUL REAGENT COLORS MOB INSTEAD OF ORGANS
 
 	if (!can_color_mobs)
 		return
 
-	exposed_mob.add_atom_colour(color_filter, WASHABLE_COLOUR_PRIORITY) // BUBBERSTATION CHANGE: REVERTS COLORFUL REAGENT BACK TO THE WAY IT USED TO BE
+	exposed_mob.add_atom_colour(color_filter, WASHABLE_COLOUR_PRIORITY) // BUBBER EDIT ADDITION: COLORFUL REAGENT COLORS MOB INSTEAD OF ORGANS
 
-	/* BUBBERSTATION CHANGE: REVERTS COLORFUL REAGENT BACK TO THE WAY IT USED TO BE
+	// BUBBER EDIT REMOVAL BEGIN - COLORFUL REAGENT COLORS MOB INSTEAD OF ORGANS
+	/*
 	if (!iscarbon(exposed_mob))
 		exposed_mob.add_atom_colour(color_filter, WASHABLE_COLOUR_PRIORITY)
 		return
@@ -2201,6 +2206,7 @@
 	for (var/obj/item/bodypart/part as anything in exposed_carbon.bodyparts)
 		part.add_atom_colour(color_filter, WASHABLE_COLOUR_PRIORITY)
 	*/
+	// BUBBER EDIT REMOVAL END - COLORFUL REAGENT COLORS MOB INSTEAD OF ORGANS
 
 /datum/reagent/colorful_reagent/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -2215,8 +2221,12 @@
 
 	var/mob/living/carbon/carbon_mob = affected_mob
 	var/color_priority = WASHABLE_COLOUR_PRIORITY
+	// BUBBER EDIT REMOVAL BEGIN - COLORFUL REAGENT IS ALWAYS TEMPORARY
+	/*
 	if (current_cycle >= 30) // Seeps deep into your tissues
 		color_priority = FIXED_COLOUR_PRIORITY
+	*/
+	// BUBBER EDIT REMOVAL END - COLORFUL REAGENT IS ALWAYS TEMPORARY
 
 	for (var/obj/item/organ/organ as anything in carbon_mob.organs)
 		organ.add_atom_colour(color_transition_filter(pick(random_color_list), SATURATION_OVERRIDE), color_priority)

--- a/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
+++ b/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
@@ -215,6 +215,7 @@
 
 	patient.client?.prefs?.safe_transfer_prefs_to_with_damage(patient, visuals_only = TRUE)
 	patient.dna.update_dna_identity()
+	patient.wash(CLEAN_SCRUB)
 	if(patient.dna.real_name != original_name)
 		log_game("[key_name(patient)] has used the Self-Actualization Device at [loc_name(src)], changed the name of their character. \
 		Original Name: [original_name], New Name: [patient.dna.real_name].")


### PR DESCRIPTION
## About The Pull Request

#3947 moved colorful reagent's application to the mob instead of bodyparts/organs, however this left it unable to be washed off (in effect, permanent.)

Fixes washing, removes the hair color component, adds the changes to the inverse reagent reaction, adds color removal to the SAD.

## Why It's Good For The Game

I don't like a dozen ahelps when the clown throws a colorful reagent grenade

## Changelog

:cl: LT3
fix: Fixed washing colorful reagent off mobs
qol: The SAD removes colorful reagent when regenerating
/:cl: