### PR TITLE
Fish Tail Fixes

### DIFF
--- a/code/datums/sprite_accessories.dm
+++ b/code/datums/sprite_accessories.dm
@@ -1910,7 +1910,7 @@ GLOBAL_LIST_EMPTY(blended_hair_icons_cache)
 ///Used for fish-infused tails, which come in different flavors.
 /datum/sprite_accessory/tails/fish
 	icon = 'icons/mob/human/fish_features.dmi'
-	color_src = TRUE
+	USE_ONE_COLOR = TRUE
 
 /datum/sprite_accessory/tails/fish/simple
 	name = "Simple"

--- a/code/datums/sprite_accessories.dm
+++ b/code/datums/sprite_accessories.dm
@@ -1910,7 +1910,7 @@ GLOBAL_LIST_EMPTY(blended_hair_icons_cache)
 ///Used for fish-infused tails, which come in different flavors.
 /datum/sprite_accessory/tails/fish
 	icon = 'icons/mob/human/fish_features.dmi'
-	USE_ONE_COLOR = TRUE
+	color_src = USE_ONE_COLOR
 
 /datum/sprite_accessory/tails/fish/simple
 	name = "Simple"


### PR DESCRIPTION
## About The Pull Request

This PR fixes 4 already greyscaled fish tail sprites and allows them to be colored, because they couldnt be colored previously for some reason

Tails which are now colorable are:

> Simple
> Crescent
> Long
> Chonky

## Why It's Good For The Game

Better customization is poggers :3

## Proof Of Testing

It works!!

<details>
<summary>Screenshots/Videos</summary>
<img width="259" height="386" alt="image" src="https://github.com/user-attachments/assets/9e30a0f6-aa44-4203-bbd2-e17139d888c5" />
<img width="244" height="398" alt="image" src="https://github.com/user-attachments/assets/b216471e-27bb-47c5-8510-1a1631514946" />
<img width="243" height="348" alt="image" src="https://github.com/user-attachments/assets/46552ca3-332c-47d4-9ca3-3b83d55b566c" />
<img width="255" height="419" alt="image" src="https://github.com/user-attachments/assets/dc1408c4-4b52-4499-aace-b6cd0c9505dc" />

</details>

## Changelog

:cl:
fix: Simple, Crescent, Long and Chonky Fish/Shark tails are now colorable!
/:cl:

