### PR TITLE
Fixes Proteans Being Able To Process ALL Chems (Pls Speedmerge)

### DIFF
--- a/code/__DEFINES/~skyrat_defines/DNA.dm
+++ b/code/__DEFINES/~skyrat_defines/DNA.dm
@@ -10,11 +10,11 @@
 //Defines for processing reagents, for synths, IPC's, Protean's and Vox
 #define PROCESS_ORGANIC 1		//Only processes reagents with "ORGANIC" or "ORGANIC | SYNTHETIC" or "ORGANIC | PROTEAN" or "ORGANIC | SYNTHETIC | PROTEAN"
 #define PROCESS_SYNTHETIC 2		//Only processes reagents with "SYNTHETIC" or "ORGANIC | SYNTHETIC" or "SYNTHETIC | PROTEAN" or "ORGANIC | SYNTHETIC | PROTEAN"
-#define PROCESS_PROTEAN 3		//Only processes reagents with "PROTEAN" or "ORGANIC | PROTEAN" or "ORGANIC | SYNTHETIC | PROTEAN"
+#define PROCESS_PROTEAN 4		//Only processes reagents with "PROTEAN" or "ORGANIC | PROTEAN" or "ORGANIC | SYNTHETIC | PROTEAN"
 
 #define REAGENT_ORGANIC 1
 #define REAGENT_SYNTHETIC 2
-#define REAGENT_PROTEAN 3
+#define REAGENT_PROTEAN 4
 
 //Some defines for sprite accessories
 // Which color source we're using when the accessory is added


### PR DESCRIPTION
## About The Pull Request

Turns out 3 was being used, now its 4.

## Why It's Good For The Game

I mean if you don't think its good, then ill enjoy the huge protean buff xoxox

## Proof Of Testing

https://i.imgur.com/8FeolNW.png - Yup only good chems working (The lewd ones)

</details>

## Changelog

:cl:

fix: Proteans can only use Protean marked chems.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
