### PR TITLE
Mech Launchpads Are Now In the Techweb

### DIFF
--- a/code/__DEFINES/~~bubber_defines/research/techweb_nodes.dm
+++ b/code/__DEFINES/~~bubber_defines/research/techweb_nodes.dm
@@ -3,3 +3,5 @@
 
 #define TECHWEB_NODE_NERD "nerd"
 #define TECHWEB_NODE_NERD_ADV "nerd_adv"
+
+#define TECHWEB_NODE_MECHLAUNCHPAD "mechpad"

--- a/modular_zubbers/code/modules/research/designs/comp_board_designs.dm
+++ b/modular_zubbers/code/modules/research/designs/comp_board_designs.dm
@@ -7,3 +7,13 @@
 		RND_CATEGORY_COMPUTER + RND_SUBCATEGORY_COMPUTER_ENTERTAINMENT
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SERVICE
+
+/datum/design/board/mechpad_console
+	name = "Mecha Orbital Pad Console Board"
+	desc = "The circuit board for the console of the mecha orbital pad."
+	id = "mechlauncher_console"
+	build_path = /obj/item/circuitboard/computer/mechpad
+	category = list(
+		RND_CATEGORY_COMPUTER + RND_SUBCATEGORY_COMPUTER_RESEARCH
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE

--- a/modular_zubbers/code/modules/research/designs/machine_board_designs.dm
+++ b/modular_zubbers/code/modules/research/designs/machine_board_designs.dm
@@ -7,3 +7,14 @@
 		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_SERVICE
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SERVICE
+
+/datum/design/board/mechpad
+	name = "Mecha Orbital Pad Board"
+	desc = "The circuit board for a mecha orbital pad."
+	id = "mechlauncher_pad"
+	build_type = IMPRINTER
+	build_path = /obj/item/circuitboard/machine/mechpad
+	category = list(
+		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_TELEPORT
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE

--- a/modular_zubbers/code/modules/research/techweb/all_nodes.dm
+++ b/modular_zubbers/code/modules/research/techweb/all_nodes.dm
@@ -108,6 +108,17 @@
 		"pinpointer_vent_cyborg",
 		"adv_xenoarchbag_cyborg"
 	)
+/datum/techweb_node/mechlaunchpad
+	id = TECHWEB_NODE_MECHLAUNCHPAD
+	display_name = "Mech Logistics Solutions"
+	description = "Advancements in utilizing bluespace technology allow us to rapidly deliver mechs from workshop to destination."
+	prereq_ids = list(TECHWEB_NODE_BLUESPACE_TRAVEL, TECHWEB_NODE_MECH_EQUIPMENT)
+	design_ids = list(
+		"mechlauncher_pad",
+		"mechlauncher_console",
+	)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_2_POINTS)
+	announce_channels = list(RADIO_CHANNEL_SCIENCE)
 
 // Computer Tech
 /datum/techweb_node/gaming/New()


### PR DESCRIPTION

## About The Pull Request

Fixes #2820 
Adds Mech Launchpads into the techweb after mech research and bluespace research is completed.
## Why It's Good For The Game
Bugfix, allows for people to actually use the mech launchpad again.
(I'm pretty sure this is a bug, let me know if this was an intentional removal, either on our end or TG's end)
## Proof Of Testing
<img width="249" height="140" alt="image" src="https://github.com/user-attachments/assets/0521e435-d737-4b84-9cd8-c80292f9547f" />
<img width="548" height="105" alt="image" src="https://github.com/user-attachments/assets/27e28c1a-8f65-4a1d-b4a6-27f7c3013a8b" />


## Changelog
:cl:
fix: Mech Launchpad Boards Are Researchable Again
/:cl:
