### PR TITLE
Emagging Meteor Satellites sends candy instead of a dark singulo because I died to it once.

### DIFF
--- a/code/modules/station_goals/meteor_shield.dm
+++ b/code/modules/station_goals/meteor_shield.dm
@@ -179,8 +179,8 @@
 			say("Warning. Further tampering has been reported.")
 			priority_announce("Warning. Tampering of meteor satellites puts the station at risk of exotic, deadly meteor collisions. Please intervene by checking your GPS devices for strange signals, and dismantling the tampered meteor shields.", "Strange Meteor Signal Warning")
 		if(EMAGGED_METEOR_SHIELD_THRESHOLD_FOUR)
-			say("Warning. Warning. Dark Matt-eor on course for station.")
-			force_event_async(/datum/round_event_control/dark_matteor, "an array of tampered meteor satellites")
+			say("Warning. Warning. Hyper-lethal exotic meteors on course for station.") //BUBBERSTATION CHANGE: DARK SINGULO TO CANDY
+			force_event_async(/datum/round_event_control/meteor_wave/candy, "an array of tampered meteor satellites") //BUBBERSTATION CHANGE: DARK SINGULO TO CANDY
 
 /obj/machinery/satellite/meteor_shield/proc/change_meteor_chance(mod)
 	// Update the weight of all meteor events


### PR DESCRIPTION
## About The Pull Request

Emagging Meteor Satellites sends candy instead of a dark singulo because I died to it once.

## Why It's Good For The Game

https://www.youtube.com/watch?v=UsfGvwqZkAw

## Proof Of Testing

Untested.

## Changelog

:cl: BurgerBB
balance: Emagging Meteor Satellites sends candy instead of a dark singulo because I died to it once.
/:cl:

