### PR TITLE
Add early return to get_user_vetted_status_hot

### DIFF
--- a/modular_zubbers/code/modules/vetted/vetted.dm
+++ b/modular_zubbers/code/modules/vetted/vetted.dm
@@ -27,6 +27,8 @@ GLOBAL_PROTECT(vetted_list)
 /datum/controller/subsystem/player_ranks/proc/get_user_vetted_status_hot(ckey)
 	if(IsAdminAdvancedProcCall())
 		return
+	if(!SSdbcore.Connect())
+		return
 	var/datum/db_query/query_load_player_rank = SSdbcore.NewQuery("SELECT ckey FROM vetted_list WHERE ckey = :ckey", list("ckey" = ckey))
 	if(!query_load_player_rank.warn_execute())
 		qdel(query_load_player_rank)


### PR DESCRIPTION

## About The Pull Request

Add an early return to `/datum/controller/subsystem/player_ranks/get_user_vetted_status_hot()` if the DB isn't enabled

## Why It's Good For The Game

Without this, opening a player's player panel causes an SQL error in chat because of the `warn_execute()` 

## Proof Of Testing

Tested it and no SQL error

## Changelog

N/A
