### PR TITLE
The Drunken Nanite

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -481,6 +481,7 @@
 	name = "Goldschlager"
 	description = "100 proof cinnamon schnapps, made for alcoholic teen girls on spring break."
 	color = "#FFFF91" // rgb: 255, 255, 145
+	process_flags = REAGENT_ORGANIC | REAGENT_PROTEAN
 	boozepwr = 25
 	quality = DRINK_NICE
 	taste_description = "burning cinnamon"

--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -311,6 +311,7 @@
 	name = "Three Mile Island Iced Tea"
 	description = "Made for a woman, strong enough for a man."
 	color = "#666340" // rgb: 102, 99, 64
+	process_flags = REAGENT_ORGANIC | REAGENT_PROTEAN
 	boozepwr = 10
 	quality = DRINK_FANTASTIC
 	taste_description = "dryness"
@@ -516,6 +517,7 @@
 	name = "Patron"
 	description = "Tequila with silver in it, a favorite of alcoholic women in the club scene."
 	color = "#585840" // rgb: 88, 88, 64
+	process_flags = REAGENT_ORGANIC | REAGENT_PROTEAN
 	boozepwr = 60
 	quality = DRINK_VERYGOOD
 	taste_description = "metallic and expensive"
@@ -734,6 +736,7 @@
 	name = "Toxins Special"
 	description = "This thing is ON FIRE! CALL THE DAMN SHUTTLE!"
 	color = "#8880a8" // rgb: 136,128,168
+	process_flags = REAGENT_ORGANIC | REAGENT_PROTEAN
 	boozepwr = 25
 	quality = DRINK_VERYGOOD
 	taste_description = "spicy toxins"
@@ -747,6 +750,7 @@
 	name = "Beepsky Smash"
 	description = "Drink this and prepare for the LAW."
 	color = COLOR_OLIVE // rgb: 128,128,0
+	process_flags = REAGENT_ORGANIC | REAGENT_PROTEAN
 	boozepwr = 60 //THE FIST OF THE LAW IS STRONG AND HARD
 	quality = DRINK_GOOD
 	metabolization_rate = 1.25 * REAGENTS_METABOLISM
@@ -902,6 +906,7 @@
 	name = "Manhattan Project"
 	description = "A scientist's drink of choice, for pondering ways to blow up the station."
 	color = COLOR_MOSTLY_PURE_RED
+	process_flags = REAGENT_ORGANIC | REAGENT_PROTEAN
 	boozepwr = 45
 	quality = DRINK_VERYGOOD
 	taste_description = "death, the destroyer of worlds"
@@ -1330,6 +1335,7 @@
 	name = "Fetching Fizz"
 	description = "Whiskey sour/iron/uranium mixture resulting in a highly magnetic slurry. Mild alcohol content." //Requires no alcohol to make but has alcohol anyway because ~magic~
 	color = rgb(255, 91, 15)
+	process_flags = REAGENT_ORGANIC | REAGENT_PROTEAN
 	boozepwr = 10
 	quality = DRINK_VERYGOOD
 	metabolization_rate = 0.1 * REAGENTS_METABOLISM
@@ -1375,6 +1381,7 @@
 	name = "Atomic Bomb"
 	description = "Nuclear proliferation never tasted so good."
 	color = "#666300" // rgb: 102, 99, 0
+	process_flags = REAGENT_ORGANIC | REAGENT_PROTEAN
 	boozepwr = 0 //custom drunk effect
 	quality = DRINK_FANTASTIC
 	taste_description = "da bomb"
@@ -1939,6 +1946,7 @@
 	description = "A bubbling glass of blank paper. Just looking at it makes you feel fresh."
 	nutriment_factor = 1
 	color = "#DCDCDC" // rgb: 220, 220, 220
+	process_flags = REAGENT_ORGANIC | REAGENT_PROTEAN
 	boozepwr = 20
 	quality = DRINK_GOOD
 	taste_description = "bubbling possibility"
@@ -2207,6 +2215,7 @@
 /datum/reagent/consumable/ethanol/blazaam
 	name = "Blazaam"
 	description = "A strange drink that few people seem to remember existing. Doubles as a Berenstain remover."
+	process_flags = REAGENT_ORGANIC | REAGENT_PROTEAN
 	boozepwr = 70
 	quality = DRINK_FANTASTIC
 	taste_description = "alternate realities"
@@ -2227,6 +2236,7 @@
 /datum/reagent/consumable/ethanol/planet_cracker
 	name = "Planet Cracker"
 	description = "This jubilant drink celebrates humanity's triumph over the alien menace. May be offensive to non-human crewmembers."
+	process_flags = REAGENT_ORGANIC | REAGENT_PROTEAN
 	boozepwr = 50
 	quality = DRINK_FANTASTIC
 	taste_description = "triumph with a hint of bitterness"
@@ -2431,6 +2441,7 @@
 	name = "The Juice"
 	description = "Woah man, this like, feels familiar to you dude."
 	color = "#4c14be"
+	process_flags = REAGENT_ORGANIC | REAGENT_PROTEAN
 	boozepwr = 50
 	quality = DRINK_GOOD
 	taste_description = "like, the future, man"

--- a/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/drink_reagents.dm
@@ -452,6 +452,7 @@
 	name = "Nuka Cola"
 	description = "Cola, cola never changes."
 	color = "#100800" // rgb: 16, 8, 0
+	process_flags = REAGENT_ORGANIC | REAGENT_PROTEAN
 	quality = DRINK_VERYGOOD
 	taste_description = "the future"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
@@ -998,12 +999,12 @@
 	. = ..()
 	if(IS_REVOLUTIONARY(drinker))
 		to_chat(drinker, span_warning("Antioxidants are weakening your radical spirit!"))
-		
+
 /datum/reagent/consumable/grenadine/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, times_fired)
 	. = ..()
 	if(IS_REVOLUTIONARY(drinker))
 		drinker.set_dizzy_if_lower(10 SECONDS * REM * seconds_per_tick)
-		if(drinker.getStaminaLoss() < 80) 
+		if(drinker.getStaminaLoss() < 80)
 			drinker.adjustStaminaLoss(12, required_biotype = affected_biotype) //The pomegranate stops free radicals! Har har.
 
 /datum/reagent/consumable/parsnipjuice

--- a/modular_skyrat/modules/customization/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/modular_skyrat/modules/customization/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -37,7 +37,7 @@
 	name = "Synthanol"
 	description = "A runny liquid with conductive capacities. Its effects on synthetics are similar to those of alcohol on organics."
 	color = "#1BB1FF"
-	process_flags = REAGENT_ORGANIC | REAGENT_SYNTHETIC
+	process_flags = REAGENT_ORGANIC | REAGENT_SYNTHETIC | REAGENT_PROTEAN
 	boozepwr = 50
 	quality = DRINK_NICE
 	taste_description = "motor oil"


### PR DESCRIPTION
## About The Pull Request

I went through every drink and checked whether or not it had a metal in it, and if it did, I made it so a protean can drink it. A nice bit of flavour that goes with the fact that they use metals as a resource. You add metals to a drink, a protean gets effected by them, and if a metals infused with alcohol, well it seems fitting that it gets them a little tipsy~ I also gave them the synth drinks but im not too tied to that idea, but they are still synthetic so I threw em in.

## Why It's Good For The Game

At the moment, they have no drinks that effects them. This gives some roleplay and flavour to them.

## Proof Of Testing

I also checked to ensure it doesn't allow Synths to drink them, it did not.

https://i.imgur.com/CXJlS4L.png

</details>

## Changelog

:cl:
add: Proteans can now process Synthetic Drinks and Drinks with Metals in.

/:cl:
