### PR TITLE
prevents proteans from rolling fake virus

### DIFF
--- a/modular_zubbers/code/modules/customization/species/proteans/_proteans_species.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/_proteans_species.dm
@@ -56,6 +56,7 @@
 		TRAIT_SYNTHETIC, // Not used in any code, but just in case
 		TRAIT_TOXIMMUNE,
 		TRAIT_NEVER_WOUNDED, // Does not wound.
+		TRAIT_VIRUSIMMUNE, // So they can't roll for fake virus, they can't get sick anyways
 
 		// Extra cool stuff
 		TRAIT_RADIMMUNE,


### PR DESCRIPTION

## About The Pull Request
It adds the virusimmune trait. They already cannot get sick. Fake virus checks for this trait. They did not have this trait.

## Why It's Good For The Game
fixes #4378

## Proof Of Testing
no

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
fix: Proteans can no longer roll the fake virus event.
/:cl:

