### PR TITLE
Polymorph/Shapeshift now takes colors from your prefs + Polymorph gets color changing now

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -392,7 +392,9 @@
 
 			var/list/new_acc_list = list()
 			new_acc_list[MUTANT_INDEX_NAME] = selected_sprite_accessory.name
-			new_acc_list[MUTANT_INDEX_COLOR_LIST] = selected_sprite_accessory.get_default_color(alterer.dna.features, alterer.dna.species)
+			// using a var here to save some horizontal space
+			var/color = alterer.dna.mutant_bodyparts[chosen_key]?["color"] || selected_sprite_accessory.get_default_color(alterer.dna.features, alterer.dna.species)
+			new_acc_list[MUTANT_INDEX_COLOR_LIST] = color
 			alterer.dna.mutant_bodyparts[chosen_key] = new_acc_list.Copy()
 
 			if(robot_organs)

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/roundstartslime.dm
@@ -393,7 +393,7 @@
 			var/list/new_acc_list = list()
 			new_acc_list[MUTANT_INDEX_NAME] = selected_sprite_accessory.name
 			// using a var here to save some horizontal space
-			var/color = alterer.dna.mutant_bodyparts[chosen_key]?["color"] || selected_sprite_accessory.get_default_color(alterer.dna.features, alterer.dna.species)
+			var/color = alterer.dna.mutant_bodyparts[chosen_key]?[MUTANT_INDEX_COLOR_LIST] || selected_sprite_accessory.get_default_color(alterer.dna.features, alterer.dna.species)
 			new_acc_list[MUTANT_INDEX_COLOR_LIST] = color
 			alterer.dna.mutant_bodyparts[chosen_key] = new_acc_list.Copy()
 

--- a/modular_skyrat/modules/modular_implants/code/nifsofts/shapeshifter.dm
+++ b/modular_skyrat/modules/modular_implants/code/nifsofts/shapeshifter.dm
@@ -27,6 +27,7 @@
 		alterer,
 		alterer,
 		list(
+			"Body Colours" = image(icon = 'modular_skyrat/master_files/icons/mob/actions/actions_slime.dmi', icon_state = "slime_rainbow"),
 			"DNA" = image(icon = 'modular_skyrat/master_files/icons/mob/actions/actions_slime.dmi', icon_state = "dna"),
 			"Hair" = image(icon = 'modular_skyrat/master_files/icons/mob/actions/actions_slime.dmi', icon_state = "scissors"),
 			"Markings" = image(icon = 'modular_skyrat/master_files/icons/mob/actions/actions_slime.dmi', icon_state = "rainbow_spraycan"),
@@ -36,6 +37,8 @@
 	if(!selected_alteration)
 		return
 	switch(selected_alteration)
+		if("Body Colours")
+			alter_colours(alterer)
 		if("DNA")
 			alter_dna(alterer)
 		if("Hair")


### PR DESCRIPTION

## About The Pull Request

Title.
## Why It's Good For The Game

Consistancy, for one. As it stands, polymorph completely breaks your colors in a way the SAD can't even fix (wow). This prevents that, while making it far more predictable.

Also, I can't think of a good reason polymorph doesn't let you change your color.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="949" height="621" alt="image" src="https://github.com/user-attachments/assets/ead25cc8-fbbd-4306-8b0a-828e5b61f63d" />


</details>

## Changelog
:cl:
qol: Polymorph/Shapeshift now takes from your pref's colors when making a new part
add: Polymorph can now let you change your general colors
/:cl:
