### PR TITLE
Colorful Reagent + Crayons can no longer color internal organs because I died to it once.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2219,17 +2219,15 @@
 	if(!can_color_organs)
 		return
 
+	/* BUBBERSTATION CHANGE START: ORGANS CANNOT BE COLORED.
 	var/mob/living/carbon/carbon_mob = affected_mob
 	var/color_priority = WASHABLE_COLOUR_PRIORITY
-	// BUBBER EDIT REMOVAL BEGIN - COLORFUL REAGENT IS ALWAYS TEMPORARY
-	/*
 	if (current_cycle >= 30) // Seeps deep into your tissues
 		color_priority = FIXED_COLOUR_PRIORITY
-	*/
-	// BUBBER EDIT REMOVAL END - COLORFUL REAGENT IS ALWAYS TEMPORARY
 
 	for (var/obj/item/organ/organ as anything in carbon_mob.organs)
 		organ.add_atom_colour(color_transition_filter(pick(random_color_list), SATURATION_OVERRIDE), color_priority)
+	BUBBERSTATION CHANGE END*/
 
 /// Colors anything it touches a random color.
 /datum/reagent/colorful_reagent/expose_atom(atom/exposed_atom, reac_volume)


### PR DESCRIPTION
## About The Pull Request

Colorful Reagent + Crayons can no longer color internal organs.

## Why It's Good For The Game

/tg/ thought it was a good idea to make it so that colorful reagents, including crayons, can color your internal organs. This includes eye color as well, which usually ends up looking terrible because because of how colors mix and whatnot.

This cannot be fixed by SAD or space cleaner or shower or soap. You literally have to get medical to take out your organs and wash them. This sounds hilarious and s o u l f u l but as mentioned above, the colors aren't applied in a way that looks good and this requires medical to actually be competent/active/whatever and not fucking in the medical break room.

I am considering this a fix because this was the intent of another PR previously made but either the author (me) forgot to take out this line or /tg/ added this recently.

## Proof Of Testing

If it compiles, it werks.

</details>

## Changelog

:cl: BurgerBB
fix: Colorful Reagent + Crayons can no longer color internal organs because I died to it once.
/:cl:
