### PR TITLE
Makes species in the menu sort themselves better

### DIFF
--- a/code/modules/client/preferences/species.dm
+++ b/code/modules/client/preferences/species.dm
@@ -61,5 +61,6 @@
 		data[species_id]["enabled_features"] = species.get_features()
 		data[species_id]["perks"] = species.get_species_perks()
 		data[species_id]["diet"] =  species.get_species_diet()
+		data[species_id]["sort_bottom"] = species.sort_bottom //BUBBER EDIT ADDITION: is it a template species?
 
 	return data

--- a/modular_skyrat/modules/ashwalkers/code/species/Ashwalkers.dm
+++ b/modular_skyrat/modules/ashwalkers/code/species/Ashwalkers.dm
@@ -8,6 +8,7 @@
 		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/lizard/ashwalker,
 		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/lizard/ashwalker,
 	)
+	sort_bottom = TRUE
 
 /datum/species/lizard/ashwalker/on_species_gain(mob/living/carbon/carbon_target, datum/species/old_species, regenerate_icons)
 	. = ..()

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/aquatic.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/aquatic.dm
@@ -1,5 +1,5 @@
 /datum/species/aquatic
-	name = "Akula (Generic)"
+	name = "Aquatic"
 	id = SPECIES_AQUATIC
 	inherent_traits = list(
 		TRAIT_ADVANCEDTOOLUSER,
@@ -24,6 +24,7 @@
 	)
 
 	meat = /obj/item/food/fishmeat/moonfish/akula
+	sort_bottom = TRUE
 
 /datum/species/aquatic/get_default_mutant_bodyparts()
 	return list(

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/humanoid.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/humanoid.dm
@@ -12,6 +12,7 @@
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	payday_modifier = 1.0
 	examine_limb_id = SPECIES_HUMAN
+	sort_bottom = TRUE
 
 /datum/species/humanoid/get_default_mutant_bodyparts()
 	return list(

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/insect.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/insect.dm
@@ -22,6 +22,7 @@
 		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/mutant/insect,
 	)
 	eyes_icon = 'modular_skyrat/modules/organs/icons/insect_eyes.dmi'
+	sort_bottom = TRUE
 
 /datum/species/insect/get_default_mutant_bodyparts()
 	return list(

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/mammal.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/mammal.dm
@@ -20,6 +20,7 @@
 		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/mutant,
 		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/mutant,
 	)
+	sort_bottom = TRUE
 
 /datum/species/mammal/get_default_mutant_bodyparts()
 	return list(

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/podweak.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/podweak.dm
@@ -25,6 +25,7 @@
 		TRAIT_LITERATE,
 		TRAIT_MUTANT_COLORS,
 	)
+	sort_bottom = FALSE
 
 	always_customizable = FALSE
 

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/unathi.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/unathi.dm
@@ -1,5 +1,5 @@
 /datum/species/unathi
-	name = "Unathi"
+	name = "Lizardperson (Generic)"
 	id = SPECIES_UNATHI
 	inherent_traits = list(
 		TRAIT_ADVANCEDTOOLUSER,
@@ -13,6 +13,7 @@
 	payday_modifier = 1.0
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	examine_limb_id = SPECIES_LIZARD
+	sort_bottom = TRUE
 
 	bodypart_overrides = list(
 		BODY_ZONE_HEAD = /obj/item/bodypart/head/lizard,

--- a/modular_skyrat/modules/primitive_catgirls/code/species.dm
+++ b/modular_skyrat/modules/primitive_catgirls/code/species.dm
@@ -32,6 +32,7 @@
 		TRAIT_RESISTCOLD,
 		TRAIT_USES_SKINTONES,
 	)
+	sort_bottom = TRUE
 
 	always_customizable = TRUE
 

--- a/modular_skyrat/modules/synths/code/species/synthetic.dm
+++ b/modular_skyrat/modules/synths/code/species/synthetic.dm
@@ -45,6 +45,7 @@
 	coldmod = 1.2
 	heatmod = 2 // TWO TIMES DAMAGE FROM BEING TOO HOT?! WHAT?! No wonder lava is literal instant death for us.
 	siemens_coeff = 1.4 // Not more because some shocks will outright crit you, which is very unfun
+	sort_bottom = TRUE
 	/// The innate action that synths get, if they've got a screen selected on species being set.
 	var/datum/action/innate/monitor_change/screen
 	/// This is the screen that is given to the user after they get revived. On death, their screen is temporarily set to BSOD before it turns off, hence the need for this var.

--- a/modular_zubbers/code/modules/mob/living/carbon/human/_species.dm
+++ b/modular_zubbers/code/modules/mob/living/carbon/human/_species.dm
@@ -1,3 +1,7 @@
+/datum/species
+	var/sort_bottom = FALSE
+//Whether or not a given species is sorted to the bottom of the list
+
 /// Called once the target is made into a bloodsucker. Used for removing conflicting species organs mostly
 /datum/species/proc/on_bloodsucker_gain(mob/living/carbon/human/target)
 	return null
@@ -32,7 +36,6 @@
 	mutantstomach = initial(mutantstomach)
 	mutanttongue = initial(mutanttongue)
 	regenerate_organs(target, replace_current = TRUE)
-
 
 /datum/species/get_species_description()
 	SHOULD_CALL_PARENT(FALSE)

--- a/modular_zubbers/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/modular_zubbers/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -1,5 +1,6 @@
 /datum/species/pod
 	inert_mutation = /datum/mutation/harmonizing_pulses
+	sort_bottom = TRUE
 
 /datum/species/pod/get_species_description()
 	return list(

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/SpeciesPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/SpeciesPage.tsx
@@ -266,12 +266,21 @@ function SpeciesPageInner(props: SpeciesPageInnerProps) {
       return [species, data];
     },
   );
-
   // Humans are always the top of the list
   const humanIndex = species.findIndex(([species]) => species === 'human');
   const swapWith = species[0];
   species[0] = species[humanIndex];
   species[humanIndex] = swapWith;
+
+  //Bubber edit begin: species menu sorting
+  species.sort(([, speciesA], [, speciesB]) => {
+    if (speciesA.sort_bottom !== speciesB.sort_bottom) {
+      return speciesA.sort_bottom ? 1 : -1;
+    }
+
+    return speciesB.lore.length - speciesA.lore.length;
+  });
+  //Bubber edit end: Species menu sorting
 
   const currentSpecies = species.filter(([speciesKey]) => {
     return speciesKey === data.character_preferences.misc.species;

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/types.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/types.ts
@@ -49,6 +49,7 @@ export type Species = {
   desc: string[];
   lore: string[];
   icon: string;
+  sort_bottom: BooleanLike; //Bubber edit: adds bottom sorting
 
   use_skintones: BooleanLike;
   sexes: BooleanLike;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR makes species in the species menu sort themselves by how much lore is present for them, and also sorts template species to the bottom of the species list.

This should help ensure that players see finished species to get their brains whirling first. As more species have lore written for them, this list is likely to change, and we will probably rewrite species with excessive lore in order to simplify them.

Unathi are renamed to Lizardperson (generic) and moved to a template species.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game
The species we've finished so far come first in the species menu, without removing any species from the game
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Proof Of Testing

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: ReturnToZender
add: The species menu now sorts itself based on the length of provided lore. Species with lore come first.
del: Unathi have been renamed to Lizardperson (Generic). They don't have lore, and lack a lot of the engaging mechanics that Lizardpeople have, so we've moved them to a template species.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
