### PR TITLE
Adds cables under the SMESes on Void Raptor

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -3731,6 +3731,7 @@
 /area/station/command/heads_quarters/rd)
 "bbz" = (
 /obj/machinery/power/smes,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/solars/port/fore)
 "bbN" = (
@@ -41801,6 +41802,7 @@
 /area/station/service/bar)
 "lOz" = (
 /obj/machinery/power/smes,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/solars/starboard/aft)
 "lOC" = (
@@ -64594,6 +64596,7 @@
 /area/station/commons/lounge)
 "sbU" = (
 /obj/machinery/power/smes,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/solars/port/aft)
 "scd" = (
@@ -77237,6 +77240,7 @@
 /area/station/service/kitchen/abandoned)
 "vwi" = (
 /obj/machinery/power/smes,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/solars/starboard/fore)
 "vwl" = (


### PR DESCRIPTION

## About The Pull Request
Fixes https://github.com/Bubberstation/Bubberstation/issues/4360
## Why It's Good For The Game
It makes it in-line with every other map
## Proof Of Testing
It was a simple map edit, it SHOULD work.
## Changelog
:cl:
fix: fixed the SMESes on Void Raptor not having cables under them
/:cl:
