### PR TITLE
Killing simplemob clowns creates gibs instead of corpses because I lagged to them once.

### DIFF
--- a/code/modules/mob/living/basic/clown/clown.dm
+++ b/code/modules/mob/living/basic/clown/clown.dm
@@ -29,7 +29,7 @@
 	faction = list(FACTION_CLOWN)
 	ai_controller = /datum/ai_controller/basic_controller/clown
 	///list of stuff we drop on death
-	var/list/loot = list(/obj/effect/gibspawner/human) //BUBBERSTATION CHANGE: /obj/effect/mob_spawn/corpse/human/clown TO /obj/effect/gibspawner/human
+	var/list/loot = list(/obj/effect/gibspawner/human) // BUBBER EDIT CHANGE - Original: /obj/effect/mob_spawn/corpse/human/clown
 	///blackboard emote list
 	var/list/emotes = list(
 		BB_EMOTE_SAY = list("HONK", "Honk!", "Welcome to clown planet!"),

--- a/code/modules/mob/living/basic/clown/clown.dm
+++ b/code/modules/mob/living/basic/clown/clown.dm
@@ -29,7 +29,7 @@
 	faction = list(FACTION_CLOWN)
 	ai_controller = /datum/ai_controller/basic_controller/clown
 	///list of stuff we drop on death
-	var/list/loot = list(/obj/effect/mob_spawn/corpse/human/clown)
+	var/list/loot = list(/obj/effect/gibspawner/human) //BUBBERSTATION CHANGE: /obj/effect/mob_spawn/corpse/human/clown TO /obj/effect/gibspawner/human
 	///blackboard emote list
 	var/list/emotes = list(
 		BB_EMOTE_SAY = list("HONK", "Honk!", "Welcome to clown planet!"),


### PR DESCRIPTION
## About The Pull Request

Killing simplemob normal clowns creates gibs instead of corpses

## Why It's Good For The Game

Clown bombs are a thing and once you kill all of them, the amount of overlays on screen increases substantially, creating a ton of GPU lag clientside.

## Proof Of Testing

If it compiles, it werks.

## Changelog


:cl: BurgerBB
qol: Killing simplemob clowns creates gibs instead of corpses because I lagged to them once.
/:cl:

