### PR TITLE
Reverts the space carp HP to upstream values

### DIFF
--- a/modular_zubbers/code/modules/mob/living/basic/space_fauna/carp.dm
+++ b/modular_zubbers/code/modules/mob/living/basic/space_fauna/carp.dm
@@ -1,12 +1,3 @@
-/mob/living/basic/carp
-	health = 50
-	maxHealth = 50
-
-
-/mob/living/basic/carp/advanced
-	health = 100
-	maxHealth = 100
-
 /mob/living/basic/carp/mega/Initialize(mapload)
 	. = ..()
 	maxHealth += rand(15, 40)


### PR DESCRIPTION
## About The Pull Request
carp hp goes from 50 > 25 and from 100 > 50 for advanced carp
was asked to atomize this
## Why It's Good For The Game
when we go to 100hp from the other PR the carp will have half the health of crew and honestly that'd just be fucking cruel man. We don't want carp brutalizing everyone. 

I like the Mega Carp still getting extra bonus health so that one is staying.
## Proof Of Testing
it worked on my other PR which had it until I got asked to atomize it and it works the same.
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
balance: changed space carp HP from 50 > 25
balance: changed advanced carp HP from 100 > 50
/:cl:
