### PR TITLE
Disable harmful RPG loot affixes

### DIFF
--- a/modular_skyrat/modules/blueshield/code/blueshield.dm
+++ b/modular_skyrat/modules/blueshield/code/blueshield.dm
@@ -1,5 +1,6 @@
 /datum/job/blueshield
 	title = JOB_BLUESHIELD
+	rpg_title = "Guild Protectorate"
 	description = "Protect the Heads of Staff and get your hands dirty so they can keep theirs clean."
 	auto_deadmin_role_flags = DEADMIN_POSITION_SECURITY
 	department_head = list(JOB_NT_REP)

--- a/modular_skyrat/modules/goofsec/code/department_guards.dm
+++ b/modular_skyrat/modules/goofsec/code/department_guards.dm
@@ -159,6 +159,7 @@
 */
 /datum/job/science_guard
 	title = JOB_SCIENCE_GUARD
+	rpg_title = "Secrets Keeper"
 	description = "Figure out why the emails aren't working, keep an eye on the eggheads, protect them from their latest mistakes."
 	department_head = list(JOB_RESEARCH_DIRECTOR)
 	faction = FACTION_STATION
@@ -264,6 +265,7 @@
 */
 /datum/job/orderly
 	title = JOB_ORDERLY
+	rpg_title = "Praetorian"
 	description = "Defend the medical department, hold down idiots who refuse the vaccine, assist medical with prep and/or cleanup."
 	department_head = list(JOB_CHIEF_MEDICAL_OFFICER)
 	faction = FACTION_STATION
@@ -369,6 +371,7 @@
 */
 /datum/job/engineering_guard
 	title = JOB_ENGINEERING_GUARD
+	rpg_title = "Crystal Guardian"
 	description = "Monitor the supermatter, keep an eye on atmospherics, make sure everyone is wearing Proper Protective Equipment."
 	department_head = list(JOB_CHIEF_ENGINEER)
 	faction = FACTION_STATION
@@ -475,6 +478,7 @@
 */
 /datum/job/customs_agent
 	title = JOB_CUSTOMS_AGENT
+	rpg_title = "Vault Keeper"
 	description = "Inspect the packages coming to and from the station, protect the cargo department, beat the shit out of people trying to ship Cocaine to the Spinward Stellar Coalition."
 	department_head = list(JOB_QUARTERMASTER)
 	faction = FACTION_STATION
@@ -575,6 +579,7 @@
 */
 /datum/job/bouncer
 	title = JOB_BOUNCER
+	rpg_title = "Tavern Watch"
 	description = "Make sure people don't jump the kitchen counter, stop Chapel vandalism, check bargoer's IDs, prevent the dreaded \"food fight\"."
 	department_head = list(JOB_HEAD_OF_PERSONNEL)
 	faction = FACTION_STATION

--- a/modular_skyrat/modules/nanotrasen_rep/code/nanotrasen_consultant.dm
+++ b/modular_skyrat/modules/nanotrasen_rep/code/nanotrasen_consultant.dm
@@ -1,5 +1,6 @@
 /datum/job/nanotrasen_consultant
 	title = JOB_NT_REP
+	rpg_title = "Guild Adviser"
 	description = "Represent Nanotrasen on the station, argue with the HoS about why he can't just field execute people for petty theft, get drunk in your office."
 	department_head = list(JOB_CENTCOM)
 	faction = FACTION_STATION

--- a/modular_skyrat/modules/sec_haul/code/corrections_officer/corrections_officer.dm
+++ b/modular_skyrat/modules/sec_haul/code/corrections_officer/corrections_officer.dm
@@ -1,5 +1,6 @@
 /datum/job/corrections_officer
 	title = JOB_CORRECTIONS_OFFICER
+	rpg_title = "Beefeater"
 	description = "Guard the permabrig, stand around looking imposing, get fired for abusing the prisoners"
 	auto_deadmin_role_flags = DEADMIN_POSITION_SECURITY
 	department_head = list("The Warden and Head of Security")

--- a/modular_skyrat/modules/telecomms_specialist/telecomms_specialist.dm
+++ b/modular_skyrat/modules/telecomms_specialist/telecomms_specialist.dm
@@ -41,7 +41,7 @@
 		/obj/item/banhammer = 8,
 		/obj/item/computer_disk/maintenance = 1,
 	)
-	rpg_title = "Diviner"
+	rpg_title = "Code Whisperer"
 	job_flags = STATION_JOB_FLAGS
 
 /obj/effect/landmark/start/telecomms_specialist

--- a/modular_zubbers/code/datums/components/fantasy/weight_overrides.dm
+++ b/modular_zubbers/code/datums/components/fantasy/weight_overrides.dm
@@ -1,48 +1,8 @@
-// We only want cosmetic/mostly harmless affixes added to items when the RPG loot event runs
-
-// Affix
-/datum/fantasy_affix
-	weight = 0
-
-// Prefix
-/datum/fantasy_affix/cosmetic_prefixes
-	weight = 15
-
-/datum/fantasy_affix/tactical
-	weight = 5
-
-/datum/fantasy_affix/vampiric
-	weight = 5
-
-/datum/fantasy_affix/beautiful
-	weight = 5
-
-/datum/fantasy_affix/ugly
-	weight = 0
-
-/datum/fantasy_affix/venomous
-	weight = 5
-
+// Disables some RPG loot affixes
 /datum/fantasy_affix/soul_stealer
 	weight = 0
 
-// Suffix
-/datum/fantasy_affix/cosmetic_suffixes
-	weight = 15
-
-/datum/fantasy_affix/bane
-	weight = 5
-
 /datum/fantasy_affix/summoning
-	weight = 0
-
-/datum/fantasy_affix/shrapnel
-	weight = 5
-
-/datum/fantasy_affix/strength
-	weight = 5
-
-/datum/fantasy_affix/fool
 	weight = 0
 
 /datum/fantasy_affix/curse_of_hunger
@@ -50,12 +10,3 @@
 
 /datum/fantasy_affix/curse_of_polymorph
 	weight = 0
-
-/datum/fantasy_affix/speed
-	weight = 5
-
-/datum/fantasy_affix/doot
-	weight = 0
-
-/datum/fantasy_affix/windseeker
-	weight = 5

--- a/modular_zubbers/code/datums/components/fantasy/weight_overrides.dm
+++ b/modular_zubbers/code/datums/components/fantasy/weight_overrides.dm
@@ -9,19 +9,19 @@
 	weight = 15
 
 /datum/fantasy_affix/tactical
-	weight = 0
+	weight = 5
 
 /datum/fantasy_affix/vampiric
-	weight = 0
+	weight = 5
 
 /datum/fantasy_affix/beautiful
-	weight = 3
+	weight = 5
 
 /datum/fantasy_affix/ugly
 	weight = 0
 
 /datum/fantasy_affix/venomous
-	weight = 0
+	weight = 5
 
 /datum/fantasy_affix/soul_stealer
 	weight = 0
@@ -31,16 +31,16 @@
 	weight = 15
 
 /datum/fantasy_affix/bane
-	weight = 3
+	weight = 5
 
 /datum/fantasy_affix/summoning
 	weight = 0
 
 /datum/fantasy_affix/shrapnel
-	weight = 0
+	weight = 5
 
 /datum/fantasy_affix/strength
-	weight = 3
+	weight = 5
 
 /datum/fantasy_affix/fool
 	weight = 0
@@ -52,10 +52,10 @@
 	weight = 0
 
 /datum/fantasy_affix/speed
-	weight = 3
+	weight = 5
 
 /datum/fantasy_affix/doot
 	weight = 0
 
 /datum/fantasy_affix/windseeker
-	weight = 3
+	weight = 5

--- a/modular_zubbers/code/datums/components/fantasy/weight_overrides.dm
+++ b/modular_zubbers/code/datums/components/fantasy/weight_overrides.dm
@@ -1,0 +1,61 @@
+// We only want cosmetic/mostly harmless affixes added to items when the RPG loot event runs
+
+// Affix
+/datum/fantasy_affix
+	weight = 0
+
+// Prefix
+/datum/fantasy_affix/cosmetic_prefixes
+	weight = 15
+
+/datum/fantasy_affix/tactical
+	weight = 0
+
+/datum/fantasy_affix/vampiric
+	weight = 0
+
+/datum/fantasy_affix/beautiful
+	weight = 3
+
+/datum/fantasy_affix/ugly
+	weight = 0
+
+/datum/fantasy_affix/venomous
+	weight = 0
+
+/datum/fantasy_affix/soul_stealer
+	weight = 0
+
+// Suffix
+/datum/fantasy_affix/cosmetic_suffixes
+	weight = 15
+
+/datum/fantasy_affix/bane
+	weight = 3
+
+/datum/fantasy_affix/summoning
+	weight = 0
+
+/datum/fantasy_affix/shrapnel
+	weight = 0
+
+/datum/fantasy_affix/strength
+	weight = 3
+
+/datum/fantasy_affix/fool
+	weight = 0
+
+/datum/fantasy_affix/curse_of_hunger
+	weight = 0
+
+/datum/fantasy_affix/curse_of_polymorph
+	weight = 0
+
+/datum/fantasy_affix/speed
+	weight = 3
+
+/datum/fantasy_affix/doot
+	weight = 0
+
+/datum/fantasy_affix/windseeker
+	weight = 3

--- a/modular_zubbers/code/modules/jobs/job_types/blacksmith.dm
+++ b/modular_zubbers/code/modules/jobs/job_types/blacksmith.dm
@@ -34,7 +34,7 @@
 	job_spawn_title = JOB_ASSISTANT
 
 	voice_of_god_silence_power = 3
-	rpg_title = "Ye olde Smithy"
+	rpg_title = "Smithy"
 
 /datum/outfit/job/blacksmith
 	name = "Blacksmith"

--- a/modular_zubbers/code/modules/jobs/job_types/warden.dm
+++ b/modular_zubbers/code/modules/jobs/job_types/warden.dm
@@ -4,3 +4,4 @@
 	// Feel free to remove this if you ever decide so
 	// ~Waterpig
 	exp_required_type_department = EXP_TYPE_SECURITY
+	rpg_title = "Beefeater"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8877,6 +8877,7 @@
 #include "modular_zubbers\code\datums\components\crafting\utility.dm"
 #include "modular_zubbers\code\datums\components\crafting\crafting\furniture.dm"
 #include "modular_zubbers\code\datums\components\crafting\crafting\melee_weapon.dm"
+#include "modular_zubbers\code\datums\components\fantasy\weight_overrides.dm"
 #include "modular_zubbers\code\datums\components\vore\_defines.dm"
 #include "modular_zubbers\code\datums\components\vore\absorb_control.dm"
 #include "modular_zubbers\code\datums\components\vore\belly.dm"


### PR DESCRIPTION
## About The Pull Request

Disables some of the harmful RPG loot affixes, so that the event can be run without dealing with players ending up cursed, polymorphed, etc.

Also adds some missing RPG titles.

## Why It's Good For The Game

Allows admemes to run this event without worry it's gonna fuck things up.

## Changelog

:cl: LT3
balance: RPG Loot event will no longer add certain negative traits to items
/:cl:
