### PR TITLE
Makes house roll only 10% of the time, and disables the weight evening (DOES NOT ENABLE HOUSE)

### DIFF
--- a/modular_zubbers/code/modules/storyteller/gamemode.dm
+++ b/modular_zubbers/code/modules/storyteller/gamemode.dm
@@ -694,6 +694,8 @@ SUBSYSTEM_DEF(gamemode)
 			continue
 		if((storyboy.population_min && storyboy.population_min > client_amount) || (storyboy.population_max && storyboy.population_max < client_amount))
 			continue
+		if(!prob(storyboy.chance))
+			continue
 		choices += storyboy.name
 		///Because the vote subsystem is dumb and does not support any descriptions, we dump them into world.
 		vote_message += "<b>[storyboy.name]</b>"

--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/_storyteller.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/_storyteller.dm
@@ -42,6 +42,8 @@
 	var/population_max
 	/// The antag divisor, the higher it is the lower the antag cap gets. Basically means "for every antag_divisor crew, spawn 1 antag".
 	var/antag_divisor = 8
+	/// The chance, 0-100, of this storyteller to be picked. Checked after all other checks.
+	var/chance = 100
 
 	/// Two tellers of the same intensity group can't run in 2 consecutive rounds
 	var/storyteller_type = STORYTELLER_TYPE_ALWAYS_AVAILABLE

--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_6_house.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_6_house.dm
@@ -9,8 +9,4 @@
 	population_min = 50
 	storyteller_type = STORYTELLER_TYPE_INTENSE
 
-// All the weights are the same to the house
-/datum/storyteller/house/calculate_weights(track)
-	for(var/datum/round_event_control/event as anything in SSgamemode.event_pools[track])
-		if(event.weight)
-			event.calculated_weight = 1
+	chance = 10 // rare


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

_**THIS IS PRIMARILY A SHOWCASE PR TO SEE WHAT PEOPLE THINK OF THIS. THIS DOES NOT ENABLE HOUSE!!!!!!!!!!**_

If this is merged, however, and house enabled, I highly recommend restricting most high-tier bussing into house.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

A big issue with house was that it was just constantly fucking voted. So, for half the rounds, you just had no idea what you were in for. Or, maybe, the admins would just spawn nukies. Cult. 5 ninjas. Again. And again.

But now, this will only be approximately 5% of rounds! Admins can rest assured knowing that there will be a storyteller where people will not complain about their bussing, and hopefully admins will feel a little less bus-happy. 

Also, I dont get why it... evened out all the weights. It's supposed to be fragile except for the bussing... so why does it do this? I don't get it. I don't like it. So I removed it.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Proof Of Testing

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->
<details>
<summary>Screenshots/Videos</summary>

<img width="528" height="93" alt="image" src="https://github.com/user-attachments/assets/8482f0ce-dc83-48b0-a2ef-f4f06e1c840f" />

Idk where to show it compiled besides this lol

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: House can only run 10% of the time, now
add: House no longer weights all events evenly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
