### PR TITLE
Fixes some clarity issues in Teshari lore

### DIFF
--- a/modular_skyrat/modules/teshari/code/_teshari.dm
+++ b/modular_skyrat/modules/teshari/code/_teshari.dm
@@ -114,7 +114,7 @@
 		"Sirisai is a tropical world with temperatures ranging from 20 to 30 celsius on average. \
 		It has three notable mountain ranges, the only places on the planet where snow can be seen year-round. Temperatures can go as low as -15 Celsius. \
 		The planet itself is generally very biologically diverse, mostly undisturbed ecologically by the Teshari or their predecessors.",
-		"Teshari had a generally uneventful early history, until they were discovered by a species that resided on the planet Penelope 3, which Sirisai once orbited. \
+		"Modern Teshari history began when they were discovered and uplifted by a species that resided on the planet Penelope 3, which Sirisai once orbited. \
 		After years of oppression and being sold as a labor force, the Teshari made their demand: Comply, or explode. This species seemed to not have taken the threat seriously, \
 		and were made extinct by the destruction of their entire planet. Fossils have been uncovered on Sirisai, and while they have yet to be named, \
 		A meeting of Teshari flocks have democratically named the species after the Teshari word for \"bastard\". \


### PR DESCRIPTION
## About The Pull Request
This removes excess mentions of Penelope 3a, since it creates confusion with Penelope 3 (and Penelope 3i, though it isn't mentioned in the primer)

## Why It's Good For The Game
Helps not spin the brains of people trying to wrap their head around the structure of this set of planets

## Proof Of Testing
It compiles

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
spellcheck: Penelope Penelope Penelope Penelope Penelope
/:cl:

