### PR TITLE
Renames Lizardperson to Tiziran Lizardperson

### DIFF
--- a/modular_zubbers/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/modular_zubbers/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -1,5 +1,5 @@
 /datum/species/lizard
-	name = "\improper Tiziran Lizardperson"
+	name = "Tiziran Lizardperson"
 	//renames Lizardpeople to Tizirans for clarity.
 
 /datum/species/lizard/on_bloodsucker_gain(mob/living/carbon/human/target, datum/species/current_species)


### PR DESCRIPTION

## About The Pull Request
I figured there might be some confusion between Lizardperson and Lizardperson (Generic), so I'm making this PR to suggest renaming them to Tiziran Lizardperson.

## Why It's Good For The Game
Species are differentiated a little better

## Proof Of Testing
Compiles

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl: ReturnToZender
qol: Renames Lizardpeople to Tiziran Lizardpeople by default
/:cl:

