### PR TITLE
Adds the hand labeler to the loadout

### DIFF
--- a/modular_skyrat/master_files/code/modules/loadout/categories/pocket.dm
+++ b/modular_skyrat/master_files/code/modules/loadout/categories/pocket.dm
@@ -190,6 +190,10 @@
 	name = "Liberty Cap Seeds"
 	item_path = /obj/item/seeds/liberty
 
+/datum/loadout_item/pocket_items/hand_labeler
+	name = "Hand Labeler"
+	item_path = /obj/item/hand_labeler
+
 /*
 *	DONATOR
 */


### PR DESCRIPTION

## About The Pull Request

Title.

It's in the other section.
## Why It's Good For The Game

Hand laborers have many uses and are so so nice for organization, but are rarely used because you need an autolathe and it's generally a bit of a hassle for something so minor?

Also, I just think it'd be neat and I'd probably use it a lot.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
add: Loadout other section now has a hand labeler
/:cl:
