### PR TITLE
Makes bilingual function the same as Linguist

### DIFF
--- a/code/__DEFINES/~~bubber_defines/traits/declarations.dm
+++ b/code/__DEFINES/~~bubber_defines/traits/declarations.dm
@@ -4,6 +4,7 @@
 #define TRAIT_CAN_BE_PICKED_UP "can_be_picked_up"
 #define TRAIT_CHANGELING_ZOMBIE "changelingzombie"
 #define TRAIT_RESEARCH_CYBORG "research_cyborg"
+#define TRAIT_BILINGUAL "Bilingual"
 
 /// Cyborgs with unique sprites
 /// 32x32 quadruped skins with resting, sitting, and belly up sprites

--- a/code/datums/quirks/positive_quirks/bilingual.dm
+++ b/code/datums/quirks/positive_quirks/bilingual.dm
@@ -3,11 +3,13 @@
 	desc = "Over the years you've picked up an extra language!"
 	icon = FA_ICON_GLOBE
 	value = 4
+	mob_trait = TRAIT_BILINGUAL //BUBBER EDIT ADDITION: Marks down that you're bilingual
 	gain_text = span_notice("Some of the words of the people around you certainly aren't common. Good thing you studied for this.")
 	lose_text = span_notice("You seem to have forgotten your second language.")
 	medical_record_text = "Patient speaks multiple languages."
 	mail_goodies = list(/obj/item/taperecorder, /obj/item/clothing/head/beret/frenchberet, /obj/item/clothing/mask/fakemoustache/italian)
 
+/* //BUBBER EDIT REMOVAL: MAKING THIS DO THE SAME THING AS LINGUIST
 /datum/quirk_constant_data/bilingual
 	associated_typepath = /datum/quirk/bilingual
 	customization_options = list(
@@ -44,3 +46,4 @@
 		return
 	quirk_holder.remove_all_languages(source = LANGUAGE_QUIRK)
 	quirk_holder.remove_all_partial_languages(source = LANGUAGE_QUIRK)
+*/ //BUBBER EDIT REMOVAL: MAKING THIS DO THE SAME THING AS LINGUIST

--- a/modular_skyrat/master_files/code/modules/client/preferences/middleware/languages.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/middleware/languages.dm
@@ -1,6 +1,3 @@
-#define MAX_LANGUAGES_NORMAL 3
-#define MAX_LANGUAGES_LINGUIST 4
-
 /datum/asset/spritesheet/languages
 	name = "languages"
 	early = TRUE
@@ -65,7 +62,11 @@
 
 	var/list/data = list()
 
-	var/max_languages = preferences.all_quirks.Find(TRAIT_LINGUIST) ? MAX_LANGUAGES_LINGUIST : MAX_LANGUAGES_NORMAL
+	var/max_languages = 3
+	if(/datum/quirk/linguist::name in preferences.all_quirks)
+		max_languages++
+	if(/datum/quirk/bilingual::name in preferences.all_quirks)
+		max_languages++
 	var/species_type = preferences.read_preference(/datum/preference/choiced/species)
 	var/datum/species/species = new species_type()
 	var/datum/language_holder/lang_holder = preferences.get_adjusted_language_holder()
@@ -129,7 +130,11 @@
  */
 /datum/preference_middleware/languages/proc/give_language(list/params, mob/user)
 	var/language_name = params["language_name"]
-	var/max_languages = preferences.all_quirks.Find(TRAIT_LINGUIST) ? MAX_LANGUAGES_LINGUIST : MAX_LANGUAGES_NORMAL
+	var/max_languages = 3
+	if(/datum/quirk/linguist::name in preferences.all_quirks)
+		max_languages++
+	if(/datum/quirk/bilingual::name in preferences.all_quirks)
+		max_languages++
 
 	if(preferences.languages && preferences.languages.len == max_languages) // too many languages
 		return TRUE
@@ -162,6 +167,3 @@
 	var/language_name = params["language_name"]
 	preferences.languages -= name_to_language[language_name]
 	return TRUE
-
-#undef MAX_LANGUAGES_NORMAL
-#undef MAX_LANGUAGES_LINGUIST

--- a/modular_skyrat/modules/customization/modules/jobs/_job.dm
+++ b/modular_skyrat/modules/customization/modules/jobs/_job.dm
@@ -246,14 +246,10 @@
 /datum/job/proc/has_required_languages(datum/preferences/pref)
 	if(!required_languages)
 		return TRUE
-	// if we have a bilingual quirk, check that as well
-	var/bilingual_pref
-	if(/datum/quirk/bilingual::name in pref.all_quirks)
-		bilingual_pref = pref.read_preference(/datum/preference/choiced/language)
 
 	for(var/datum/language/lang as anything in required_languages)
 		//Doesnt have language, or the required "level" is too low (understood, while needing spoken)
-		if((!pref.languages[lang] || pref.languages[lang] < required_languages[lang]) && bilingual_pref != lang.name)
+		if((!pref.languages[lang] || pref.languages[lang] < required_languages[lang]))
 			return FALSE
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request
This PR removes a bunch of extra, unneeded code related to bilingual by making it function the same as Linguist, giving an extra language point in the language menu. Atomized from #4513 

## Why It's Good For The Game
Simplifies accessing new languages by making both language quirks work the same

## Proof Of Testing
<img width="1023" height="683" alt="image" src="https://github.com/user-attachments/assets/f6fa2389-6f21-409e-871e-5489ae769f3d" />
<img width="1036" height="669" alt="image" src="https://github.com/user-attachments/assets/1e784fef-e47e-4973-b6ba-f22f5e14a018" />

## Changelog

:cl: ReturnToZender
add: The Bilingual trait now grants an extra language point.
/:cl:

