### PR TITLE
Re-enables Piratespeak

### DIFF
--- a/modular_skyrat/master_files/code/modules/language/_language.dm
+++ b/modular_skyrat/master_files/code/modules/language/_language.dm
@@ -15,8 +15,5 @@
 /datum/language/narsie
 	secret = TRUE
 
-/datum/language/piratespeak
-	secret = TRUE
-
 /datum/language/xenocommon
 	secret = FALSE


### PR DESCRIPTION

## About The Pull Request
This PR makes Piratespeak no longer secret. I plan to update it with lore here as well to spruce it up and make it a little less of a meme language.

I made this PR because my other PR, #4524, disabled a bypass some players used to get ahold of languages like Piratespeak.

## Why It's Good For The Game
yarr

## Proof Of Testing
It compiles

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl: ReturnToZender
add: Piratespeak is now available in the languages menu
/:cl:

