### PR TITLE
Adds the engineering equipment access lock to IRCD goodie packs

### DIFF
--- a/modular_skyrat/modules/cargo/code/goodies.dm
+++ b/modular_skyrat/modules/cargo/code/goodies.dm
@@ -37,6 +37,7 @@
 	name = "Improved RCD"
 	desc = "An upgraded RCD featuring superior material storage. Comes with complimentary frames and circuitry upgrades to boot!"
 	cost = PAYCHECK_CREW * 38
+	access_view = ACCESS_ENGINE_EQUIP
 	contains = list(/obj/item/construction/rcd/improved)
 
 /*


### PR DESCRIPTION

## About The Pull Request
Adds engineering equipment access to the required access to purchase IRCD goodie packs, bringing it in-line with the IRCD crates.
## Why It's Good For The Game
Ideally, we should not have random assistants or *literally anybody* being able to purchase IRCDs.
## Proof Of Testing
See the screenshot below.
<details>
<summary>Screenshots/Videos</summary>
<img width="667" height="148" alt="image" src="https://github.com/user-attachments/assets/b121bf5d-e58d-4bc0-ac3a-31842a9fd1ea" />

</details>

## Changelog
:cl:
balance: IRCD goodie packs now require engineering equipment access
/:cl:
