### PR TITLE
[Part of SR ungunnening] Shotgun ammo changes AND Huge combat shotguns

### DIFF
--- a/modular_skyrat/modules/aesthetics/guns/code/guns.dm
+++ b/modular_skyrat/modules/aesthetics/guns/code/guns.dm
@@ -34,12 +34,10 @@
 	inhand_icon_state = "shotgun_combat"
 	inhand_x_dimension = 32
 	inhand_y_dimension = 32
-	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/gun/ballistic/shotgun/automatic/combat/compact
 	name = "\improper Peacekeeper compact combat shotgun"
 	desc = "A tactical variant of the peacekeeper combat shotgun used by NT Raiding Parties and Space Marines. It has a gyroscopic stabilizer on it, letting you fire one handed."
-	weapon_weight = WEAPON_MEDIUM
 
 /obj/item/gun/grenadelauncher
 	icon = 'modular_skyrat/modules/aesthetics/guns/icons/guns.dmi'

--- a/modular_skyrat/modules/shotgunrebalance/code/shotgun.dm
+++ b/modular_skyrat/modules/shotgunrebalance/code/shotgun.dm
@@ -70,6 +70,52 @@
 	<i>HORNET'S NEST: Fire an overwhelming amount of projectiles in a single shot.</i>"
 	can_be_printed = FALSE
 
+/obj/item/ammo_casing/shotgun/buckshot
+	name = "buckshot shell"
+	desc = "A 12 gauge buckshot shell."
+	icon_state = "gshell"
+	projectile_type = /obj/projectile/bullet/pellet/shotgun_buckshot
+
+/obj/projectile/bullet/pellet/shotgun_buckshot
+	name = "buckshot pellet"
+	damage = 6
+
+/obj/item/ammo_casing/shotgun/rubbershot
+	name = "rubber shot"
+	desc = "A shotgun casing filled with densely-packed rubber balls, used to incapacitate crowds from a distance."
+	icon_state = "rshell"
+	projectile_type = /obj/projectile/bullet/pellet/shotgun_rubbershot
+	harmful = FALSE
+
+/obj/projectile/bullet/pellet/shotgun_rubbershot
+	damage = 2
+	stamina = 10
+
+/obj/item/ammo_casing/shotgun/flechette
+	name = "flechette shell"
+	desc = "A 12 gauge flechette shell that specializes in ripping armored targets apart. These are exceptionally strong against armored targets."
+	icon_state = "fshell"
+	projectile_type = /obj/projectile/bullet/pellet/shotgun_buckshot/flechette
+	custom_materials = AMMO_MATS_SHOTGUN_FLECH
+	advanced_print_req = TRUE
+
+/obj/projectile/bullet/pellet/shotgun_buckshot/flechette
+	name = "flechette"
+	icon_state = "flechette"
+	damage = 2
+	wound_bonus = 5
+	exposed_wound_bonus = 5
+	armour_penetration = 30
+	damage_falloff_tile = -0.2
+	wound_falloff_tile = -0.5
+	speed = 1.2
+	sharpness = SHARP_POINTY
+	embed_type = /datum/embedding/bullet/flechette
+
+/obj/projectile/bullet/pellet/shotgun_buckshot/flechette/Initialize(mapload)
+	. = ..()
+	SpinAnimation()
+
 /obj/item/ammo_casing/shotgun/beehive
 	name = "hornet shell"
 	desc = "A less-lethal 12 gauge shell that fires four pellets capable of bouncing off nearly any surface \


### PR DESCRIPTION

## About The Pull Request

https://github.com/Bubberstation/Bubberstation/pull/4511

Something went wrong with updating the branch so I re-did the brief changes on a freshly made branch off of upstream.  Look at linked original PR for discussion, argumentation, etc.

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

The huge combat shotguns part is there because our overrides prevent the changes TG made during their rebalance of it. Due to the weight override, it eats the cookie (1.5x multiplier on damage) and gets to keep it too (holsterable).

## Changelog

:cl:
balance: Buckshot and Rubbershot now aren't weak to armour, making them viable in firefights.
balance: Buckshot pellets have 1 extra damage, for 36 total. 
balance: Flechettes reverted to TG state.
fix: Combat shotguns are now huge, as was intended
/:cl:
