### PR TITLE
Improves disposals code so it actually deals damage to you on direction changes and nerfs disposals damage.

### DIFF
--- a/modular_skyrat/modules/hurtsposals/code/pipe.dm
+++ b/modular_skyrat/modules/hurtsposals/code/pipe.dm
@@ -1,8 +1,12 @@
 // Make disposal pipes hurt you if you ride them.
 
+/obj/structure/disposalpipe
+	// Set this to true if you want a disposal pipe to deal no damage.
+	var/padded_corners = FALSE
+
 /obj/structure/disposalpipe/transfer_to_dir(obj/structure/disposalholder/holder, nextdir)
 
-	if(!holder || !holder.hasmob || holder.dir == next_dir || !prob(80)) //Disposals optimization.
+	if(padded_corners || !holder || !holder.hasmob || holder.dir == nextdir || !prob(80)) //Disposals optimization.
 		return ..()
 
 	. = ..() //We don't put this at the start of the the proc in case the direction of the holder changes.
@@ -12,4 +16,4 @@
 			continue
 		if(HAS_TRAIT(found_victim, TRAIT_TRASHMAN))
 			continue
-		living_within.adjustBruteLoss(4)
+		found_victim.adjustBruteLoss(4)

--- a/modular_skyrat/modules/hurtsposals/code/pipe.dm
+++ b/modular_skyrat/modules/hurtsposals/code/pipe.dm
@@ -6,14 +6,21 @@
 
 /obj/structure/disposalpipe/transfer_to_dir(obj/structure/disposalholder/holder, nextdir)
 
-	if(padded_corners || !holder || !holder.hasmob || holder.dir == nextdir || !prob(80)) //Disposals optimization.
+	if(padded_corners || !holder || !holder.hasmob || holder.dir == nextdir || prob(80)) //Disposals optimization.
 		return ..()
 
 	. = ..() //We don't put this at the start of the the proc in case the direction of the holder changes.
 
+	var/did_damage = FALSE
 	for(var/mob/living/found_victim in holder.contents)
 		if(found_victim.stat >= HARD_CRIT) //Hard crit or worse.
 			continue
 		if(HAS_TRAIT(found_victim, TRAIT_TRASHMAN))
 			continue
+		//Moon has ~100 disposal corners if you fall in the main loop, worst case scenario.
+		//20% * 100 * 4 = 80 damage.
 		found_victim.adjustBruteLoss(4)
+		did_damage = TRUE
+
+	if(did_damage)
+		playsound(src, 'modular_zubbers/code/modules/emotes/sound/effects/bonk.ogg', 25, TRUE, -1)

--- a/modular_skyrat/modules/hurtsposals/code/pipe.dm
+++ b/modular_skyrat/modules/hurtsposals/code/pipe.dm
@@ -1,25 +1,15 @@
 // Make disposal pipes hurt you if you ride them.
 
-/obj/structure/disposalpipe
-	/// Whether a disposal pipe will hurt if a person changes direction. `FALSE` for hurting, `TRUE` to prevent making them hurt.
-	var/padded_corners = FALSE
-
 /obj/structure/disposalpipe/transfer_to_dir(obj/structure/disposalholder/holder, nextdir)
-	. = ..(holder, nextdir)
-	var/obj/structure/disposalpipe/next_pipe = .
 
-	if(!next_pipe || dir == next_pipe.dir || padded_corners)
-		return
+	if(!holder || !holder.hasmob || holder.dir == next_dir || !prob(80)) //Disposals optimization.
+		return ..()
 
-	if(!prob(20))
-		return
+	. = ..() //We don't put this at the start of the the proc in case the direction of the holder changes.
 
-	for(var/objects_within in holder.contents)
-		if(!isliving(objects_within))
+	for(var/mob/living/found_victim in holder.contents)
+		if(found_victim.stat >= HARD_CRIT) //Hard crit or worse.
 			continue
-		var/mob/living/living_within = objects_within
-		if(living_within.stat == DEAD)
+		if(HAS_TRAIT(found_victim, TRAIT_TRASHMAN))
 			continue
-		if(HAS_TRAIT(living_within, TRAIT_TRASHMAN))
-			continue
-		living_within.adjustBruteLoss(5)
+		living_within.adjustBruteLoss(4)


### PR DESCRIPTION
## About The Pull Request

Improves disposals code so it actually deals damage to you on direction changes.
Nerfs disposals damage so that it has a 20% chance to apply instead of an 80% chance to apply.
You no longer take disposals damage if you're in hard crit or dead.
Disposals damage when it procs deals 4 damage instead of 5.

## Why It's Good For The Game

Making disposals damage work as intended is always good.

With the new 100hp change, people are feeling the (disposals) burn, so the damage was reduced.

## Proof Of Testing

Draft because I literally coded this from scratch in the github online code editor.

## Changelog

:cl: BurgerBB
balance: Nerfs disposals damage so that it has a 20% chance to apply instead of an 80% chance to apply. You no longer take disposals damage if you're in hard crit or dead. You take 1 less disposals damage when it applies, now, a total of 4 per turn
fix: Improves disposals code so it actually deals damage to you on direction changes.
/:cl:
