### PR TITLE
Adds taur parts to the bioscrambler blacklist

### DIFF
--- a/code/__DEFINES/research/anomalies.dm
+++ b/code/__DEFINES/research/anomalies.dm
@@ -46,6 +46,7 @@ GLOBAL_LIST_INIT(bioscrambler_organs_blacklist, typecacheof(list (
 	/obj/item/organ/empowered_borer_egg, // SKYRAT EDIT ADDITION
 	/obj/item/organ/eyes/robotic, // SKYRAT EDIT ADDITION
 	/obj/item/organ/eyes/night_vision/cyber, // SKYRAT EDIT ADDITION
+	/obj/item/organ/taur_body // BUBBER EDIT ADDITION
 )))
 
 /// List of body parts we can apply to people


### PR DESCRIPTION

## About The Pull Request
Currently, taur parts cause a nightmare for both staff/maintainers and the players that receive them from the bioscrambler due to them being near unremovable.
## Why It's Good For The Game
Fixes https://github.com/Bubberstation/Bubberstation/issues/2797
## Proof Of Testing
It was a one line addition, it should work but I'm not sitting and waiting to see if I get the parts or not.
## Changelog
:cl:
fix: fixed unremovable taur limbs being granted from bioscramblers
/:cl:
