### PR TITLE
Include next map on new round announcement

### DIFF
--- a/modular_zubbers/code/modules/quote_of_the_round/ticker.dm
+++ b/modular_zubbers/code/modules/quote_of_the_round/ticker.dm
@@ -34,6 +34,6 @@
 	. = ..()
 
 /datum/controller/subsystem/ticker/proc/generate_quote_of_the_round()
-	return "A shift on [SSmapping.current_map.map_name] has ended. <@&[CONFIG_GET(string/game_alert_role_id)]> get ready! A new round starts soon!\n\
+	return "A shift on [SSmapping.current_map.map_name] has ended. <@&[CONFIG_GET(string/game_alert_role_id)]> get ready! A new round on **[SSmap_vote.next_map_config.map_name]** starts soon!\n\
 	[pick(strings("quote_of_the_round.json", "workers"))] [pick(strings("quote_of_the_round.json", "action"))] [pick(strings("quote_of_the_round.json", "message"))] that occured during said shift:\n\
 	> *[quote_of_the_round_text]*\n \\- *[quote_of_the_round_attribution]*"


### PR DESCRIPTION
## About The Pull Request

Adds the upcoming map to the new game announcement

## Changelog

:cl: LT3
qol: New round discord notification now includes the upcoming map name
/:cl:
