### PR TITLE
Gravity sickness no longer causes stuttering

### DIFF
--- a/code/modules/surgery/organs/internal/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/internal/stomach/_stomach.dm
@@ -344,7 +344,8 @@
 		var/pukeprob = 2.5 + (0.025 * disgust)
 		if(disgust >= DISGUST_LEVEL_GROSS)
 			if(SPT_PROB(5, seconds_per_tick))
-				disgusted.adjust_stutter(2 SECONDS)
+				if (!disgusted.has_status_effect(/datum/status_effect/spacer/gravity_sickness)) // BUBBER EDIT CHANGE - no more constant spacer stutter anshallah
+					disgusted.adjust_stutter(2 SECONDS)
 				disgusted.adjust_confusion(2 SECONDS)
 			if(SPT_PROB(5, seconds_per_tick) && !disgusted.stat)
 				to_chat(disgusted, span_warning("You feel kind of iffy..."))

--- a/code/modules/surgery/organs/internal/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/internal/stomach/_stomach.dm
@@ -344,7 +344,7 @@
 		var/pukeprob = 2.5 + (0.025 * disgust)
 		if(disgust >= DISGUST_LEVEL_GROSS)
 			if(SPT_PROB(5, seconds_per_tick))
-				if (!disgusted.has_status_effect(/datum/status_effect/spacer/gravity_sickness)) // BUBBER EDIT CHANGE - no more constant spacer stutter anshallah
+				if(!disgusted.has_status_effect(/datum/status_effect/spacer/gravity_sickness)) // BUBBER EDIT CHANGE - no more constant spacer stutter anshallah
 					disgusted.adjust_stutter(2 SECONDS)
 				disgusted.adjust_confusion(2 SECONDS)
 			if(SPT_PROB(5, seconds_per_tick) && !disgusted.stat)


### PR DESCRIPTION

## About The Pull Request

This is a salt PR.

Makes gravity sickness, the status effect given by spacer (and to my knowledge nothing else), cause the holder to be immune to level 1 nausea's stuttering effect.
## Why It's Good For The Game

Spacer is a good quirk. I like it. Adds nice flavor to my character. But oh my god, the stuttering. The only thing stuttering does it be annoying and make it hard to talk, which is generally not a very good thing for "roleplay". Theres a reason very few people take social anxiety and instead opt to just stutter and stammer with their own fleshy fingers.

This is especially bad on bubber where we have three whole planet maps, and it seems they're voted very often.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="529" height="106" alt="image" src="https://github.com/user-attachments/assets/645a6382-f750-4642-8857-ab4e272d8e16" />


</details>

## Changelog
:cl:
balance: Spacer no longer causes disgust stuttering
/:cl:
