### PR TITLE
Adds missing age-text for an age range

### DIFF
--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -688,8 +688,8 @@
 			age_text = "too young to be here"
 		if(18 to 25)
 			age_text = "a young adult"
-		if(26 to 35) // BUBBER EDIT END
-			age_text = "an adult"
+		if(26 to 35)
+			age_text = "an adult" // BUBBER EDIT END
 		if(36 to 55)
 			age_text = "middle-aged"
 		if(56 to 75)

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -689,7 +689,7 @@
 		if(18 to 25)
 			age_text = "a young adult"
 		if(26 to 35)
-			age_text = "an adult" // BUBBER EDIT END
+			age_text = "a adult" // BUBBER EDIT END
 		if(36 to 55)
 			age_text = "middle-aged"
 		if(56 to 75)

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -684,10 +684,12 @@
 
 	var/age_text
 	switch(age)
-		if(-INFINITY to 17) // SKYRAT EDIT ADD START -- AGE EXAMINE
+		if(-INFINITY to 17) // BUBBER EDIT ADD START -- AGE EXAMINE
 			age_text = "too young to be here"
 		if(18 to 25)
-			age_text = "a young adult" // SKYRAT EDIT END
+			age_text = "a young adult"
+		if(26 to 35) // BUBBER EDIT END
+			age_text = "an adult"
 		if(36 to 55)
 			age_text = "middle-aged"
 		if(56 to 75)

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -689,7 +689,7 @@
 		if(18 to 25)
 			age_text = "a young adult"
 		if(26 to 35)
-			age_text = "a adult" // BUBBER EDIT END
+			age_text = "an adult" // BUBBER EDIT END
 		if(36 to 55)
 			age_text = "middle-aged"
 		if(56 to 75)


### PR DESCRIPTION

## About The Pull Request

Title.

From 26-35, you are listed as being an adult. I can't think of a better term for this - "average" adult?
## Why It's Good For The Game

Bugs bad.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
so i didnt actually test this
</details>

## Changelog
:cl:
fix: Carbons 26-35 are now described as "an adult"
/:cl:
