### PR TITLE
Adds a verb for disabling taur clothing cropping

### DIFF
--- a/code/__DEFINES/~skyrat_defines/traits.dm
+++ b/code/__DEFINES/~skyrat_defines/traits.dm
@@ -7,3 +7,6 @@
 #define TRAIT_PERMIT_HUD "permit_hud"
 //for if we are army crawling or not
 #define TRAIT_PRONE "prone"
+
+/// If we are ignoring clothing cropping or not
+#define TRAIT_TAUR_IGNORING_CROPPING "taur_ignoring_cropping"

--- a/code/__DEFINES/~~bubber_defines/traits/sources.dm
+++ b/code/__DEFINES/~~bubber_defines/traits/sources.dm
@@ -8,3 +8,4 @@
 #define PROTEAN_SERVO_TRAIT "protean_servo"
 
 #define TRAIT_SOURCE_TAURLAY "taur-laydown"
+#define TRAIT_SOURCE_TAURCROP "taur-crop"

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -140,7 +140,7 @@ There are several things that need to be remembered:
 
 		// SKYRAT EDIT ADDITION START - Taur-friendly suits!
 		if(bodyshape & BODYSHAPE_TAUR)
-			if(istype(uniform) && uniform.gets_cropped_on_taurs)
+			if(istype(uniform) && (!HAS_TRAIT(src, TRAIT_TAUR_IGNORING_CROPPING) && uniform.gets_cropped_on_taurs))
 				mutant_styles |= get_taur_mode()
 		// SKYRAT EDIT END
 
@@ -597,7 +597,7 @@ There are several things that need to be remembered:
 
 		if(bodyshape & BODYSHAPE_TAUR)
 			var/obj/item/clothing/suit/worn_suit = wear_suit
-			if(istype(worn_suit) && worn_suit.gets_cropped_on_taurs)
+			if(istype(worn_suit) && (!HAS_TRAIT(src, TRAIT_TAUR_IGNORING_CROPPING) && worn_suit.gets_cropped_on_taurs))
 				mutant_styles |= get_taur_mode()
 		// SKYRAT EDIT END
 

--- a/modular_zubbers/modules/taur_mechanics/taur_body.dm
+++ b/modular_zubbers/modules/taur_mechanics/taur_body.dm
@@ -47,9 +47,6 @@
 	/// When considering how much to offset our rider, we multiply size scaling against this.
 	var/riding_offset_scaling_mult = 0.8
 
-	/// Are we ignoring taur cropping settings, and forcing all our clothes to render normally?
-	var/ignoring_cropping_setting = FALSE
-
 /obj/item/organ/taur_body/horselike
 	can_use_saddle = TRUE
 

--- a/modular_zubbers/modules/taur_mechanics/taur_body.dm
+++ b/modular_zubbers/modules/taur_mechanics/taur_body.dm
@@ -278,5 +278,4 @@
 		var/setting_string = (HAS_TRAIT(owner, TRAIT_TAUR_IGNORING_CROPPING) ? "now ignoring cropping setting" : "no longer ignoring cropping setting")
 		balloon_alert(owner, setting_string)
 
-		owner.update_clothing(ITEM_SLOT_OCLOTHING)
-		owner.update_clothing(ITEM_SLOT_ICLOTHING) // the only items with taur cropping
+		owner.update_clothing(ITEM_SLOT_OCLOTHING|ITEM_SLOT_ICLOTHING) // the only items with taur cropping

--- a/modular_zubbers/modules/taur_mechanics/taur_body.dm
+++ b/modular_zubbers/modules/taur_mechanics/taur_body.dm
@@ -275,7 +275,7 @@
 		else
 			ADD_TRAIT(owner, TRAIT_TAUR_IGNORING_CROPPING, TRAIT_SOURCE_TAURCROP)
 
-		var/setting_string = (HAS_TRAIT(owner, TRAIT_TAUR_IGNORING_CROPPING) ? "now ignoring cropping setting" : "no longer ignoring cropping setting")
+		var/setting_string = (HAS_TRAIT(owner, TRAIT_TAUR_IGNORING_CROPPING) ? "now ignoring cropping" : "no longer ignoring cropping")
 		balloon_alert(owner, setting_string)
 
 		owner.update_clothing(ITEM_SLOT_OCLOTHING|ITEM_SLOT_ICLOTHING) // the only items with taur cropping


### PR DESCRIPTION

## About The Pull Request

Title.

A verb is probably not the best way to do it, but also I can't be assed to find a better solution (an action button is overkill)
## Why It's Good For The Game

Theres so many clothing sprites that would work on taurs, but they dont have the flag set - and let's be honest, noone is gonna go through every clothing sprite they see to set the flag. This lets the taur players decide what works for their sprite.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="167" height="99" alt="image" src="https://github.com/user-attachments/assets/66acd2dd-4b27-468e-83e3-1541d05b499f" />

<img width="93" height="116" alt="image" src="https://github.com/user-attachments/assets/735dca39-a596-452b-bfc4-f46fc7773219" />


</details>

## Changelog
:cl:
add: New taur verb that lets you disable/enable taur clothing cropping
/:cl:
