### PR TITLE
[TM ONLY] finally eat the stupid honey sweet roll

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_lizard.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_lizard.dm
@@ -196,6 +196,7 @@
 	result = /obj/item/food/rootdough
 	added_foodtypes = NUTS
 	category = CAT_LIZARD
+	crafting_flags = CRAFT_CLEARS_REAGENTS
 
 /datum/crafting_recipe/food/rootdough/with_eggs
 	name = "Rootdough (With Eggs)"
@@ -207,6 +208,7 @@
 	)
 	result = /obj/item/food/rootdough/egg
 	removed_foodtypes = RAW
+	crafting_flags = CRAFT_CLEARS_REAGENTS
 
 /datum/crafting_recipe/food/snail_nizaya
 	name = "Desert snail nizaya"


### PR DESCRIPTION

## About The Pull Request

adds my fix to eat the honey sweetroll, hasn't been upstreamed here yet, just posting it now. SPECIFICALLY it adds the CRAFT_CLEARS_REAGENTS flag to the rootdough recipes, so any future recipes using bananas wont cause this issue.
## Why It's Good For The Game

eat the goddamn roll

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

https://github.com/user-attachments/assets/6495f9c4-839f-4668-95f5-03909047175c

<img width="387" height="238" alt="Screenshot 2025-09-01 094311" src="https://github.com/user-attachments/assets/8ab85b26-5397-4ebc-b5eb-800823c6f1bf" />

</details>

## Changelog
:cl:
fix: rejoice you can finally eat the honey sweetrolls
/:cl:
