### PR TITLE
Fixes a runtime in neck wearing code

### DIFF
--- a/modular_zubbers/code/modules/clothing/neck_wearing.dm
+++ b/modular_zubbers/code/modules/clothing/neck_wearing.dm
@@ -53,7 +53,7 @@ Use CTRL + SHIFT + LEFT CLICK to turn them on and off.
 		slowdown = 0
 		set_armor(/datum/armor/none)
 		user.visible_message(span_notice("[user] adjusts [user.p_their()] [src] for non-functional use."), span_notice("You adjust your [src] for non-functional use."))
-	else
+	else if(!isnull(functional_suit_values))
 		slot_flags = functional_suit_values[PREV_SLOT_FLAGS]
 		cold_protection = functional_suit_values[PREV_COLD_PROTECTION]
 		heat_protection = functional_suit_values[PREV_HEAT_PROTECTION]


### PR DESCRIPTION

## About The Pull Request

Title. Neck wearing is the stuff that lets you wear suits on your neck.

If a suit is damaged, say the nobility dresscoat, its functional_suit_values is null. This should fix that.
## Why It's Good For The Game

bugs bad
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

i cant actually test rn but this should work

</details>

## Changelog
:cl:
fix: Neck wearing shouldnt runtime if the item is damaged
/:cl:
