### PR TITLE
Revert "[Ready] Beepsky can no longer see you if you haven't moved or interacted with something for 4 seconds or more."

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -494,14 +494,6 @@
 		if((nearby_carbons.name == oldtarget_name) && (world.time < last_found + 100))
 			continue
 
-		//BUBBERSTATION CHANGE START: BEEPSKY IS A DINOSAUR NOW. CAN'T SEE YOU IF YOU DON'T MOVE.
-		if(nearby_carbons.client) //We have a client. We're a player that uses move_delay.
-			if(nearby_carbons.client.move_delay + 4 SECONDS <= world.time)
-				continue
-		else if(nearby_carbons.next_move + 4 SECONDS <= world.time) //No client. We're a mob that uses next_move.
-			continue
-		//BUBBERSTATION CHANGE END: BEEPSKY IS A DINOSAUR NOW. CAN'T SEE YOU IF YOU DON'T MOVE.
-
 		threatlevel = nearby_carbons.assess_threat(judgement_criteria)
 
 		if(threatlevel < THREAT_ASSESS_DANGEROUS)


### PR DESCRIPTION
Reverts Bubberstation/Bubberstation#4216

This is ridiculous and makes Beepsky ineffective at his job. If I'm sitting at the bar Wanted, Beepsky and ED-209 will walk right by me without even glancing.

Officers who are talking to someone they aren't ready to arrest should be setting their target to Suspicious. Wanted is a very specific flag that means WANTED. If you haven't made the decision to arrest someone yet, don't set them to Wanted. Set them to Suspicious. You can freely set someone's security status by shift clicking them with HUDglasses and your security ID on.

Security being unwilling to properly use their tools is no reason to kneecap a perfectly functional mechanic.