### PR TITLE
Reduces storyteller sec/antag cap to 1.15

### DIFF
--- a/modular_zubbers/code/modules/storyteller/gamemode.dm
+++ b/modular_zubbers/code/modules/storyteller/gamemode.dm
@@ -243,7 +243,7 @@ SUBSYSTEM_DEF(gamemode)
 		return 0
 	if(!storyteller.antag_divisor)
 		return 0
-	return round(max(min(get_correct_popcount() / storyteller.antag_divisor + sec_crew ,sec_crew * 1.5),ANTAG_CAP_FLAT))
+	return round(max(min(get_correct_popcount() / storyteller.antag_divisor + sec_crew ,sec_crew * storyteller.sec_antag_ratio),ANTAG_CAP_FLAT))
 
 /// Whether events can inject more antagonists into the round
 /datum/controller/subsystem/gamemode/proc/can_inject_antags()

--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/_storyteller.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/_storyteller.dm
@@ -42,6 +42,8 @@
 	var/population_max
 	/// The antag divisor, the higher it is the lower the antag cap gets. Basically means "for every antag_divisor crew, spawn 1 antag".
 	var/antag_divisor = 8
+	/// The ratio of sec/max antags. After the cap is determined with [antag_divisor], the antag cap is capped to sec_count/sec_antag_ratio.
+	var/sec_antag_ratio = 1.1
 
 	/// Two tellers of the same intensity group can't run in 2 consecutive rounds
 	var/storyteller_type = STORYTELLER_TYPE_ALWAYS_AVAILABLE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

From now on, each secoff will open one antag slot - with two opening once 8 total sec members are on.

The value is mostly arbitrary and taken from timsweeney's suggestion of something between 1-1.15.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

Sec's power is in numbers. As it stands, in the worst case scenario, sec will always be outnumbered 50%. This is, obviously, not ideal. We want antags to be outnumbered by sec, not the other way around.

Of course, some antags wont engage, which is why the number should still be on the higher side to account for more passive antags.

There was allegedly a discussion in staff chat about this, ending in the conclusion that reducing this might be a good idea.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Proof Of Testing

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->
<details>
<summary>Screenshots/Videos</summary>

<img width="1263" height="119" alt="image" src="https://github.com/user-attachments/assets/40f6dcad-51ef-423e-b364-c9e95938a784" />


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Storyteller antag/sec cap is now 1.15
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
