### PR TITLE
Heretic targets now reroll on their penultimate sacrifice.

### DIFF
--- a/modular_zubbers/code/modules/antagonists/heretic/heretic.dm
+++ b/modular_zubbers/code/modules/antagonists/heretic/heretic.dm
@@ -15,7 +15,7 @@
 
 		// If they reach this stage, also reroll their targets, just in case they're attempting to double-sac to avoid the announcement.
 		to_chat(user, span_hypnophrase("Your heart beats with your new targets, the end draws near. A final chase will assure your ascension."))
-		user.balloon_alert(user, "Targets Rerolled!")
+		user.balloon_alert(user, "targets rerolled!")
 
 		for(var/mob/living/carbon/human/target as anything in heretic_datum.sac_targets)
 			heretic_datum.remove_sacrifice_target(target)


### PR DESCRIPTION

## About The Pull Request

This makes heretics automatically reroll their targets on their second-to-last ascension (when the relevant announcement pops up.)

## Why It's Good For The Game

The announcement exists as a way to tell the crew "It's bad, now's your chance to stop them, otherwise they'll ascend soon." However, it's currently able to be ignored entirely by carrying around or hiding a (dead) sacrifice until you can sacrifice 2 people in rapid succession, effectively ignoring the announcement as you'll be able to ascend soonafter.

This change simply aims to remove the double-sacrifice by rerolling targets when the announcement rings out, to give the crew their time to prepare and knowledge of the heretic.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="586" height="296" alt="image" src="https://github.com/user-attachments/assets/7c4e41d8-347c-48a0-ac62-174801e00779" />
</details>

## Changelog
:cl:
add: Heretics now reroll their sacrifices on their second to last sacrifice.
/:cl:
