### PR TITLE
Fixes Multi-Cell Chargers working at range

### DIFF
--- a/modular_skyrat/modules/multicellcharger/code/multi_cell_charger.dm
+++ b/modular_skyrat/modules/multicellcharger/code/multi_cell_charger.dm
@@ -171,6 +171,8 @@
 		for(var/obj/item/stock_parts/power_store/cell/battery in charging_batteries)
 			buttons["[battery.name] ([round(battery.percent(), 1)]%)"] = battery
 		var/cell_name = tgui_input_list(user, "Please choose what cell you'd like to remove.", "Remove a cell", buttons)
+		if(!in_range(loc, user))
+			return FALSE
 		charging = buttons[cell_name]
 	else
 		charging = charging_batteries[1]


### PR DESCRIPTION

## About The Pull Request

Turns out you could take cells out of a multi-cell charger from range, this adds a check to stop that.
## Why It's Good For The Game

Minor bugfix 
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: Multi-Cell chargers can't be withdrawn from range anymore.
/:cl:
