### PR TITLE
(Non-Modular) (TM ONLY) Fixes an oversight in which dynamic was still being called

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -919,27 +919,27 @@ GLOBAL_VAR_INIT(cops_arrived, FALSE)
 	hacker.log_message("hacked a communications console, resulting in: [picked_option].", LOG_GAME, log_globally = TRUE)
 	switch(picked_option)
 		if(HACK_PIRATE) // Triggers pirates, which the crew may be able to pay off to prevent
-			var/list/pirate_rulesets = list(
+			/*var/list/pirate_rulesets = list( // BUBBER EDIT - REMOVAL - START
 				/datum/dynamic_ruleset/midround/pirates,
 				/datum/dynamic_ruleset/midround/pirates/heavy,
-			)
-			SSdynamic.force_run_midround(pick(pirate_rulesets))
+			)*/ // BUBBER EDIT - REMOVAL - END
+			SSgamemode.force_event(/datum/round_event_control/pirates) // BUBBER EDIT - PREVIOUS:			SSdynamic.force_run_midround(pick(pirate_rulesets))
 
 		if(HACK_FUGITIVES) // Triggers fugitives, which can cause confusion / chaos as the crew decides which side help
 			priority_announce(
 				"Attention crew: sector monitoring reports a jump-trace from an unidentified vessel destined for your system. Prepare for probable contact.",
 				"[command_name()] High-Priority Update",
 			)
-			SSdynamic.force_run_midround(/datum/dynamic_ruleset/midround/from_ghosts/fugitives)
+			SSgamemode.force_event(/datum/round_event_control/fugitives) // BUBBER EDIT - PREVIOUS:			SSdynamic.force_run_midround(/datum/dynamic_ruleset/midround/from_ghosts/fugitives)
 
 		if(HACK_SLEEPER) // Trigger one or multiple sleeper agents with the crew (or for latejoining crew)
 			priority_announce(
 				"Attention crew, it appears that someone on your station has hijacked your telecommunications and broadcasted an unknown signal.",
 				"[command_name()] High-Priority Update",
 			)
-			var/max_number_of_sleepers = clamp(round(length(GLOB.alive_player_list) / 40), 1, 3)
-			if(!SSdynamic.force_run_midround(/datum/dynamic_ruleset/midround/from_living/traitor, forced_max_cap = max_number_of_sleepers))
-				SSdynamic.queue_ruleset(/datum/dynamic_ruleset/latejoin/traitor)
+			/*var/max_number_of_sleepers = clamp(round(length(GLOB.alive_player_list) / 40), 1, 3) // BUBBER EDIT - REMOVAL - START
+			if(!SSdynamic.force_run_midround(/datum/dynamic_ruleset/midround/from_living/traitor, forced_max_cap = max_number_of_sleepers))*/ // BUBBER EDIT - REMOVAL - END
+			SSgamemode.force_event(/datum/round_event_control/antagonist/solo/traitor/midround) // BUBBER EDIT - PREVIOUS:				SSdynamic.queue_ruleset(/datum/dynamic_ruleset/latejoin/traitor)
 
 #undef HACK_PIRATE
 #undef HACK_FUGITIVES


### PR DESCRIPTION
## About The Pull Request
Does as the title suggests and makes it so that when ninjas hack communications consoles, the triggered events are run from `SSgamemode` (Storytellers) instead of `SSdynamic` (Dynamic).
## Why It's Good For The Game
Fixes https://github.com/Bubberstation/Bubberstation/issues/4576, which should help with people rolling antagonists without it being enabled by 'Be Antagonist'.
## Proof Of Testing
I had no runtimes when testing this and it seemed to work fine.

## Changelog
:cl:
fix: Fixed ninja hacked consoles using the /tg/ method of summoning antagonists
/:cl:
