### PR TITLE
Lowers taur laying recovery to 0.5 secs

### DIFF
--- a/modular_zubbers/modules/taur_mechanics/taur_body.dm
+++ b/modular_zubbers/modules/taur_mechanics/taur_body.dm
@@ -1,4 +1,4 @@
-#define LAYDOWN_COOLDOWN 0.5 SECONDS
+#define LAYDOWN_COOLDOWN 1 SECONDS
 
 /obj/item/organ/taur_body
 	name = "taur body"

--- a/modular_zubbers/modules/taur_mechanics/taur_body.dm
+++ b/modular_zubbers/modules/taur_mechanics/taur_body.dm
@@ -1,4 +1,4 @@
-#define LAYDOWN_COOLDOWN 2 SECONDS
+#define LAYDOWN_COOLDOWN 0.5 SECONDS
 
 /obj/item/organ/taur_body
 	name = "taur body"


### PR DESCRIPTION
## About The Pull Request

Title.
## Why It's Good For The Game

Two seconds is kind of ridiculous for regaining your mobility. Plus, what taur takes??? This long to get uo??
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
qol: Taur laying recovery: 2 secs -> 1 sec
/:cl:
