### PR TITLE
Introduces a narrate verb

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/living_verbs.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/living_verbs.dm
@@ -107,7 +107,7 @@ GLOBAL_VAR_INIT(temporary_flavor_text_indicator, generate_temporary_flavor_text_
 		if(get_dist(user_mob_or_hologram.loc, target_mob.loc) > world.view)
 			to_chat(user, span_warning("Your narration was unable to be sent to your target: Too far away."))
 			return
-		target_mob.show_messageshow_message(span_cyan("[message] \n\ (Narration: [user])"), MSG_VISUAL)
+		target_mob.show_message(span_cyan("[message] \n\ (Narration: [user])"), MSG_VISUAL)
 
 #undef NARRATE_RANGE_MAX
 #undef NARRATE_RANGE_SAME_TILE


### PR DESCRIPTION
## About The Pull Request
Continuation of https://github.com/Bubberstation/Bubberstation/pull/2977
This PR introduces a narration verb that does not come from your character, instead being a description of things happening in the environment.

This PR is drafted as I learn how to give it a keybind, which I intend to be N.

## Why It's Good For The Game
This allows descriptions to describe environmental effects.

## Proof Of Testing
<img width="460" height="43" alt="image" src="https://github.com/user-attachments/assets/bc648ca1-3246-4f2f-9def-4d962408f7c9" />

## Changelog

:cl: ReturnToZender
add: New Narrate verb in the IC tab to bind. Allows you to narrate things going on from a third person perspective! I recommend Shift+N, personally.
/:cl:

