### PR TITLE
Plant DNA Manip Board Changes

### DIFF
--- a/modular_zubbers/code/modules/research/designs/machine_board_designs.dm
+++ b/modular_zubbers/code/modules/research/designs/machine_board_designs.dm
@@ -1,10 +1,10 @@
 /datum/design/board/plantgenes
-	name = "Plant Gene Editor Board"
+	name = "Plant DNA Manipulator Board"
 	desc = "The circuit board for a plant gene editing machine."
 	id = "plantgene"
 	build_path = /obj/item/circuitboard/machine/plantgenes
 	category = list(
-		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_SERVICE
+		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_BOTANY
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SERVICE
 


### PR DESCRIPTION

## About The Pull Request

Some minor changes to the Plant DNA Manipulator board, moves it from the misc service machine boards to the botany specific machine boards tab in the service lathe, also changes the design datum name from Plant Gene Editor to Plant DNA Manipulator.
## Why It's Good For The Game

It's a botany specific machine also scientists have told me they can't find the dna manipulator research option because its called the plant gene editor.

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="440" height="199" alt="Screenshot 2025-09-06 115221" src="https://github.com/user-attachments/assets/fbca32ac-527c-476a-aed9-4bbe151bfcf1" />

</details>

## Changelog
:cl:
fix: move plant dna manipulator to botany machine board category, also updates name in r&d node
/:cl:
