### PR TITLE
Fixing Golden NTRep Coat missing Texture

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/~donator/donator_clothing.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/~donator/donator_clothing.dm
@@ -1551,6 +1551,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/contraband/korpstech, 32)
 	icon = 'modular_skyrat/master_files/icons/donator/obj/clothing/suits.dmi'
 	worn_icon = 'modular_skyrat/master_files/icons/donator/mob/clothing/suit.dmi'
 	icon_state = "razurath_coat"
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 
 // Donation reward for MaSvedish
 /obj/item/holocigarette/masvedishcigar


### PR DESCRIPTION
## About The Pull Request
In response to https://github.com/Bubberstation/Bubberstation/issues/4620 this fixes the broken Texture on the Golden NTRep Coat.
## Why It's Good For The Game
It's just a minor bug fix.
## Proof Of Testing
Tested it on local, it works fine now.
<details>
<summary>Screenshots/Videos</summary>
<img width="92" height="87" alt="image_2025-09-06_203007606" src="https://github.com/user-attachments/assets/3072fdda-1667-413f-9780-4fbf93683ce1" />

</details>

## Changelog

:cl:
fix: Fixed Golden NTRep Coats missing Texture on Digitigrade mobs
/:cl:

