### PR TITLE
Fixes various Skyrat/Bubbers runtimes

### DIFF
--- a/modular_skyrat/master_files/code/modules/paperwork/employment_contract.dm
+++ b/modular_skyrat/master_files/code/modules/paperwork/employment_contract.dm
@@ -53,5 +53,8 @@
 	<font size=1>Under Corporate Law section 201 subsection B.3. Defacement, publication, or theft of this document is punishable by demerit or immediate contractual termination. \
 	Central Command Representives are not responsible for possible loss of life, extermination, or bluespace occurances related to any sort of actions ordered to commit to."
 	)
+
 /obj/structure/filingcabinet/employment/addFile(mob/living/carbon/human/employee)
+	if(!employee || !employee.mind)
+		return
 	new /obj/item/paper/work_contract(src, employee.mind.name)

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/akula.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/akula.dm
@@ -160,7 +160,7 @@
 /// This proc is called after a mob with the TRAIT_SLIPPERY has its related timer run out
 /datum/species/akula/proc/dried(mob/living/carbon/akula)
 	// A moodlet which will not go away until the user gets wet
-	akula.add_mood_event("dry_skin", /datum/mood_event/dry_skin)
+	akula?.add_mood_event("dry_skin", /datum/mood_event/dry_skin)
 
 /// A simple overwrite which calls parent to listen to wet_stacks
 /datum/status_effect/fire_handler/wet_stacks/tick(delta_time)

--- a/modular_zubbers/code/game/machinery/computer/operating_computer.dm
+++ b/modular_zubbers/code/game/machinery/computer/operating_computer.dm
@@ -2,7 +2,7 @@
 	var/list/data = ..()
 	data["traumas"] = list()
 	var/mob/living/carbon/patient = table.patient
-	if(isnull(patient))
+	if(isnull(patient) | isnull(table))
 		return data
 
 	if(LAZYLEN(patient.get_traumas()))

--- a/modular_zubbers/code/modules/job_interns/job_interns.dm
+++ b/modular_zubbers/code/modules/job_interns/job_interns.dm
@@ -96,7 +96,7 @@
 		else
 			stack_trace("[src] client [player_client] checking for playtime resulted in null")
 		return FALSE
-	if(!required_time)
+	if(!required_time && SSjob.get_job(department_head[1])) //Jobs lacking a department head shouldn't runtime
 		stack_trace("[src] job failed to set intern time threshold")
 		return FALSE
 	if(playtime >= required_time)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR fixes runtimes in various parts of Bubber/Skyrat code

Fixes the employment contract so that it doesn't return in the absence of an employee or mind

The Akula mood event proc checks if an Akula is present

Operating tables no longer runtime if there is no table present

Nanotrasen Consultant no longer fails to set intern time threshold because it has no department head
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game
Less unnecessary runtimes in code, no player facing changes
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Proof Of Testing
It compiles
<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: ReturnToZender
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
