### PR TITLE
Re-"Clutters" the Settler quirk

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -24,8 +24,10 @@ GLOBAL_LIST_INIT_TYPED(quirk_blacklist, /list/datum/quirk, list(
 	list(/datum/quirk/mute, /datum/quirk/softspoken),
 	list(/datum/quirk/poor_aim, /datum/quirk/bighands),
 	list(/datum/quirk/bilingual, /datum/quirk/foreigner, /datum/quirk/csl),
+	//BUBBER EDIT (item_quirk)
 	list(/datum/quirk/spacer_born, /datum/quirk/item_quirk/settler),
 	list(/datum/quirk/photophobia, /datum/quirk/nyctophobia),
+	//BUBBER EDIT (item_quirk)
 	list(/datum/quirk/item_quirk/settler, /datum/quirk/freerunning),
 	list(/datum/quirk/numb, /datum/quirk/selfaware),
 	list(/datum/quirk/empath, /datum/quirk/evil),

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -24,9 +24,9 @@ GLOBAL_LIST_INIT_TYPED(quirk_blacklist, /list/datum/quirk, list(
 	list(/datum/quirk/mute, /datum/quirk/softspoken),
 	list(/datum/quirk/poor_aim, /datum/quirk/bighands),
 	list(/datum/quirk/bilingual, /datum/quirk/foreigner, /datum/quirk/csl),
-	list(/datum/quirk/spacer_born, /datum/quirk/settler),
+	list(/datum/quirk/spacer_born, /datum/quirk/item_quirk/settler),
 	list(/datum/quirk/photophobia, /datum/quirk/nyctophobia),
-	list(/datum/quirk/settler, /datum/quirk/freerunning),
+	list(/datum/quirk/item_quirk/settler, /datum/quirk/freerunning),
 	list(/datum/quirk/numb, /datum/quirk/selfaware),
 	list(/datum/quirk/empath, /datum/quirk/evil),
 	//SKYRAT EDIT ADDITION BEGIN

--- a/code/datums/quirks/positive_quirks/settler.dm
+++ b/code/datums/quirks/positive_quirks/settler.dm
@@ -34,7 +34,7 @@
 	//BUBBER EDIT REMOVAL END
 	//SKYRAT EDIT END
 	human_quirkholder.add_movespeed_modifier(/datum/movespeed_modifier/settler)
-	human_quirkholder.physiology.hunger_mod *= 0.75 //good for you, shortass, you don't get hungry nearly as often
+	human_quirkholder.physiology.hunger_mod *= 0.75 // BUBBER EDIT - ADDITION
 	human_quirkholder.add_traits(settler_traits, QUIRK_TRAIT)
 
 //BUBBER EDIT START

--- a/code/datums/quirks/positive_quirks/settler.dm
+++ b/code/datums/quirks/positive_quirks/settler.dm
@@ -1,3 +1,4 @@
+//BUBBER EDIT (item quirk)
 /datum/quirk/item_quirk/settler
 	name = "Settler"
 	//BUBBER EDIT (Changes text a bit)
@@ -23,6 +24,7 @@
 		TRAIT_STURDY_FRAME,
 	)
 
+//BUBBER EDIT (item quick)
 /datum/quirk/item_quirk/settler/add(client/client_source)
 	var/mob/living/carbon/human/human_quirkholder = quirk_holder
 	//SKYRAT EDIT BEGIN - This is so Teshari don't get the height decrease.
@@ -35,9 +37,11 @@
 	human_quirkholder.physiology.hunger_mod *= 0.75 //good for you, shortass, you don't get hungry nearly as often
 	human_quirkholder.add_traits(settler_traits, QUIRK_TRAIT)
 
+//BUBBER EDIT START
 /datum/quirk/item_quirk/settler/add_unique(client/client_source)
 	give_item_to_holder(/obj/item/storage/box/papersack/wheat, list(LOCATION_BACKPACK, LOCATION_HANDS))
 	give_item_to_holder(/obj/item/storage/toolbox/fishing/small, list(LOCATION_BACKPACK, LOCATION_HANDS))
+//BUBBER EDIT END
 
 /datum/quirk/item_quirk/settler/remove()
 	if(QDELING(quirk_holder))
@@ -47,5 +51,6 @@
 	//human_quirkholder.set_mob_height(HUMAN_HEIGHT_MEDIUM)
 	//BUBBER EDIT REMOVAL END
 	human_quirkholder.remove_movespeed_modifier(/datum/movespeed_modifier/settler)
+	//BUBBER EDIT
 	human_quirkholder.physiology.hunger_mod /= 0.75
 	human_quirkholder.remove_traits(settler_traits, QUIRK_TRAIT)

--- a/code/datums/quirks/positive_quirks/settler.dm
+++ b/code/datums/quirks/positive_quirks/settler.dm
@@ -1,4 +1,4 @@
-/datum/quirk/settler
+/datum/quirk/item_quirk/settler
 	name = "Settler"
 	//BUBBER EDIT (Changes text a bit)
 	desc = "You are from a lineage of the earliest space settlers!  You are much better at outdoorsmanship and \
@@ -23,7 +23,7 @@
 		TRAIT_STURDY_FRAME,
 	)
 
-/datum/quirk/settler/add(client/client_source)
+/datum/quirk/item_quirk/settler/add(client/client_source)
 	var/mob/living/carbon/human/human_quirkholder = quirk_holder
 	//SKYRAT EDIT BEGIN - This is so Teshari don't get the height decrease.
 	//BUBBER EDIT REMOVAL START - Lol, not any more.
@@ -32,9 +32,14 @@
 	//BUBBER EDIT REMOVAL END
 	//SKYRAT EDIT END
 	human_quirkholder.add_movespeed_modifier(/datum/movespeed_modifier/settler)
+	human_quirkholder.physiology.hunger_mod *= 0.75 //good for you, shortass, you don't get hungry nearly as often
 	human_quirkholder.add_traits(settler_traits, QUIRK_TRAIT)
 
-/datum/quirk/settler/remove()
+/datum/quirk/item_quirk/settler/add_unique(client/client_source)
+	give_item_to_holder(/obj/item/storage/box/papersack/wheat, list(LOCATION_BACKPACK, LOCATION_HANDS))
+	give_item_to_holder(/obj/item/storage/toolbox/fishing/small, list(LOCATION_BACKPACK, LOCATION_HANDS))
+
+/datum/quirk/item_quirk/settler/remove()
 	if(QDELING(quirk_holder))
 		return
 	var/mob/living/carbon/human/human_quirkholder = quirk_holder
@@ -42,4 +47,5 @@
 	//human_quirkholder.set_mob_height(HUMAN_HEIGHT_MEDIUM)
 	//BUBBER EDIT REMOVAL END
 	human_quirkholder.remove_movespeed_modifier(/datum/movespeed_modifier/settler)
+	human_quirkholder.physiology.hunger_mod /= 0.75
 	human_quirkholder.remove_traits(settler_traits, QUIRK_TRAIT)


### PR DESCRIPTION

## About The Pull Request
This is a reversion of [this](https://github.com/tgstation/tgstation/pull/92425) TG PR. 
## Why It's Good For The Game
If somebody considers the items to be "clutter", they can be tossed away; I, and other people who select this quirk, use it, at least partially, for the items.
## Proof Of Testing
Compiled, it works.
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl: sunnyaries
balance: re-clutters settler
/:cl:
