### PR TITLE
[PORT] Fixes Multi-cell charging racks have infinite range

### DIFF
--- a/modular_skyrat/modules/multicellcharger/code/multi_cell_charger.dm
+++ b/modular_skyrat/modules/multicellcharger/code/multi_cell_charger.dm
@@ -147,7 +147,7 @@
 /obj/machinery/cell_charger_multi/attack_ai(mob/user)
 	return
 
-/obj/machinery/cell_charger_multi/attack_hand(mob/user, list/modifiers)
+/obj/machinery/cell_charger_multi/attack_hand(mob/living/user, list/modifiers)
 	. = ..()
 	if(.)
 		return
@@ -162,7 +162,7 @@
 
 	user.visible_message(span_notice("[user] removes [charging] from [src]."), span_notice("You remove [charging] from [src]."))
 
-/obj/machinery/cell_charger_multi/proc/removecell(mob/user)
+/obj/machinery/cell_charger_multi/proc/removecell(mob/living/user)
 	if(!charging_batteries.len)
 		return FALSE
 	var/obj/item/stock_parts/power_store/cell/charging
@@ -175,6 +175,8 @@
 	else
 		charging = charging_batteries[1]
 	if(!charging)
+		return FALSE
+	if(!user.can_perform_action(src, NEED_HANDS)) // Prevents crew from grabbing a battery from a distance after interacting with the machine and running off before picking a battery from a distance.
 		return FALSE
 	charging.forceMove(drop_location())
 	charging.update_appearance()


### PR DESCRIPTION

## About The Pull Request
This PR pulls a PR from downstream to upstream in order to allow for proper merge on downstream without issues.
* https://github.com/SPLURT-Station/S.P.L.U.R.T-tg/pull/561

To quote the PR I'm pulling
There is apparently an issue on at least 2 other codebases which nobody has detected until recently.

To cut it short, people can grab power cells from a distance if they interact with the multi-cell recharger and walk away without grabbing anything, before finally pressing on a battery in the User Interface that appears.

This lets a person grab a battery from who knows how far away.

This PR aims to fix that problem, now requiring you to be adjacent (right next to the recharger) in order to grab it, OR have telekinesis.
## Why It's Good For The Game
Limits the crew's power of unintentional teleportation by fixing a bug.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

https://github.com/user-attachments/assets/c66a1640-85ce-4ed0-b2a8-80d41fd5db6c

</details>

## Changelog
:cl:
fix: Fixes an issue where people could grab Power cells from a multi-cell recharger from a distance.
/:cl:
