### PR TITLE
[PORT] Fixes Assistants can punch their own punch cards with their PDAs

### DIFF
--- a/modular_skyrat/modules/cargo/code/items/gbp_punchcard.dm
+++ b/modular_skyrat/modules/cargo/code/items/gbp_punchcard.dm
@@ -13,6 +13,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	var/max_punches = 6
 	var/punches = 0
+	req_access = list(ACCESS_COMMAND) // Without this, assistants can punch the card that comes from the machine after they've turned in their roundstart card by using their own PDA.
 	COOLDOWN_DECLARE(gbp_punch_cooldown)
 
 /obj/item/gbp_punchcard/starting


### PR DESCRIPTION

## About The Pull Request
This PR pulls a PR from downstream to upstream in order to allow for proper merge on downstream without issues.
* https://github.com/SPLURT-Station/S.P.L.U.R.T-tg/pull/562

To quote that PR:
Long story short
Assistants could punch their punch cards by turning it in and then using their PDA on the newly created one, thus earning around 900 credits within 10 mins.

This PR fixes that problem.
## Why It's Good For The Game
Fixes an oversight that was made by the person coding this thing.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

https://github.com/user-attachments/assets/fc969ad8-b94d-4196-b1d1-4a4ce1a7d69b

</details>

## Changelog
:cl:
fix: Fixes an oversight made by a previous coder who created the punch card PDA system.
/:cl:
