### PR TITLE
Change examine TGUI not to reuse side maps for all viewers

### DIFF
--- a/modular_zubbers/code/modules/examine_tgui/examine_tgui.dm
+++ b/modular_zubbers/code/modules/examine_tgui/examine_tgui.dm
@@ -1,8 +1,19 @@
+/atom/movable/screen/map_view/examine_panel_screen/proc/update_character(mob/target)
+	var/mutable_appearance/current_mob_appearance = new(target.appearance)
+	current_mob_appearance.setDir(SOUTH)
+	current_mob_appearance.transform = matrix() // We reset their rotation, in case they're lying down.
+
+	// In case they're pixel-shifted, we bring 'em back!
+	current_mob_appearance.pixel_x = 0
+	current_mob_appearance.pixel_y = 0
+	cut_overlays()
+	add_overlay(current_mob_appearance)
+
 /datum/examine_panel
 	/// Mob that the examine panel belongs to.
 	var/mob/living/holder
-	/// The screen containing the appearance of the mob
-	var/atom/movable/screen/map_view/examine_panel_screen
+	/// Lazy assoc list of viewers to screens
+	var/list/viewer_screens
 
 
 /mob/living/carbon/human/Destroy()
@@ -17,37 +28,28 @@
 	return GLOB.always_state
 
 /datum/examine_panel/ui_close(mob/user)
-	examine_panel_screen.hide_from(user)
+	var/viewer_screen = LAZYACCESS(viewer_screens, user)
+	LAZYREMOVE(viewer_screens, user)
+	qdel(viewer_screen)
 
 /datum/examine_panel/Destroy(force)
 	holder = null
-	QDEL_NULL(examine_panel_screen)
+	QDEL_LIST_ASSOC_VAL(viewer_screens)
 	. = ..()
 
 /datum/examine_panel/ui_interact(mob/user, datum/tgui/ui)
-	if(!examine_panel_screen)
-		examine_panel_screen = new
-		examine_panel_screen.name = "screen"
-		examine_panel_screen.assigned_map = "examine_panel_[REF(holder)]_map"
-		examine_panel_screen.del_on_map_removal = FALSE
-		examine_panel_screen.screen_loc = "[examine_panel_screen.assigned_map]:1,1"
-
-	var/mutable_appearance/current_mob_appearance = new(holder)
-	current_mob_appearance.setDir(SOUTH)
-	current_mob_appearance.transform = matrix() // We reset their rotation, in case they're lying down.
-
-	// In case they're pixel-shifted, we bring 'em back!
-	current_mob_appearance.pixel_x = 0
-	current_mob_appearance.pixel_y = 0
-
-	examine_panel_screen.cut_overlays()
-	examine_panel_screen.add_overlay(current_mob_appearance)
+	var/atom/movable/screen/map_view/examine_panel_screen/viewer_screen = LAZYACCESS(viewer_screens, user)
+	if(isnull(viewer_screen))
+		viewer_screen = new
+		viewer_screen.generate_view("examine_panel_[REF(holder)]_[REF(user)]_map")
+		viewer_screen.update_character(holder)
+		LAZYSET(viewer_screens, user, viewer_screen)
 
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "ExaminePanel")
 		ui.open()
-		examine_panel_screen.display_to(user, ui.window)
+		viewer_screen.display_to(user, ui.window)
 
 
 /datum/examine_panel/ui_data(mob/user)
@@ -159,9 +161,11 @@
 			else
 				custom_species_lore = holder_human.dna.features["custom_species_lore"]
 
+	var/atom/movable/screen/map_view/examine_panel_screen/viewer_screen = LAZYACCESS(viewer_screens, user)
+
 	data["obscured"] = obscured ? TRUE : FALSE
 	data["character_name"] = name
-	data["assigned_map"] = examine_panel_screen.assigned_map
+	data["assigned_map"] = viewer_screen?.assigned_map
 	data["flavor_text"] = flavor_text
 	data["flavor_text_nsfw"] = flavor_text_nsfw
 	data["ooc_notes"] = ooc_notes


### PR DESCRIPTION

## About The Pull Request

Redo the examine TGUI code to maintain a separate map view for each viewer, and to dispose of it when the window is closed

Note: this alone will not fix the bug with the partially-invisible character previews in the examine TGUI

## Why It's Good For The Game

This changes it so there isn't one permanent constantly updating copy of the character view for all clients, this means that examining someone and keeping the window open won't show them talking and moving around and changing clothes, which is quite meta and can be abused. 

## Proof Of Testing

It worked

## Changelog
:cl:
code: the examine menu no longer recycles the same character preview
/:cl:
