### PR TITLE
Changes the Nitrogen Breather quirk icon

### DIFF
--- a/modular_zubbers/code/datums/quirks/neutral_quirks/lungs.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/lungs.dm
@@ -67,7 +67,7 @@
 /datum/quirk/equipping/lungs/nitrogen
 	name = "Nitrogen Breather"
 	desc = "You breathe nitrogen, even if you might not normally breathe it. Oxygen is poisonous."
-	icon = FA_ICON_LUNGS_VIRUS
+	icon = FA_ICON_BIOHAZARD
 	medical_record_text = "Patient can only breathe nitrogen."
 	gain_text = "<span class='danger'>You suddenly have a hard time breathing anything but nitrogen."
 	lose_text = "<span class='notice'>You suddenly feel like you aren't bound to nitrogen anymore."


### PR DESCRIPTION

## About The Pull Request
Does as the title says. It's now the biohazard symbol.
## Why It's Good For The Game
It fixes CI.
## Proof Of Testing
N/A - One line change, it should work.
## Changelog
:cl:
image: The nitrogen breather quirk now has the biohazard icon.
/:cl:
