### PR TITLE
Adds modular jobs to Orbit Menu department sorting

### DIFF
--- a/tgui/packages/tgui/interfaces/Orbit/constants.ts
+++ b/tgui/packages/tgui/interfaces/Orbit/constants.ts
@@ -21,15 +21,18 @@ type Department = {
 export const DEPARTMENT2COLOR: Record<string, Department> = {
   cargo: {
     color: 'brown',
-    trims: ['Bitrunner', 'Cargo Technician', 'Shaft Miner', 'Quartermaster'],
+    trims: ['Bitrunner', 'Cargo Technician', 'Shaft Miner', 'Quartermaster', 'Blacksmith', 'Customs Agent' ],
+    // BUBBER EDIT ADDITION - Blacksmith, Customs Agent
   },
   command: {
     color: 'blue',
-    trims: ['Captain', 'Head of Personnel'],
+    trims: ['Captain', 'Head of Personnel', 'Nanotrasen Consultant', 'Blueshield', 'Bridge Assistant'],
+    // BUBBER EDIT ADDITION - Nanotrasen Consultant, Blueshield, Bridge Assistant
   },
   engineering: {
     color: 'orange',
-    trims: ['Atmospheric Technician', 'Chief Engineer', 'Station Engineer'],
+    trims: ['Atmospheric Technician', 'Chief Engineer', 'Station Engineer', 'Telecomms Specialist', 'Engineering Guard'],
+    // BUBBER EDIT ADDITION - Telecomms Specialist, Engineering Guard
   },
   medical: {
     color: 'teal',
@@ -39,15 +42,18 @@ export const DEPARTMENT2COLOR: Record<string, Department> = {
       'Coroner',
       'Medical Doctor',
       'Paramedic',
+      'Orderly',  // BUBBER EDIT ADDITION
     ],
   },
   science: {
     color: 'pink',
-    trims: ['Geneticist', 'Research Director', 'Roboticist', 'Scientist'],
+    trims: ['Geneticist', 'Research Director', 'Roboticist', 'Scientist', 'Science Guard'],
+    // BUBBER EDIT ADDITION - Science Guard
   },
   security: {
     color: 'red',
-    trims: ['Detective', 'Head of Security', 'Security Officer', 'Warden'],
+    trims: ['Detective', 'Head of Security', 'Security Officer', 'Warden', 'Security Medic', 'Corrections Officer'],
+    // BUBBER EDIT ADDITION - Security Medic, Corrections Officer
   },
   service: {
     color: 'green',
@@ -63,6 +69,8 @@ export const DEPARTMENT2COLOR: Record<string, Department> = {
       'Lawyer',
       'Mime',
       'Psychologist',
+      'Barber',  // BUBBER EDIT ADDITION
+      'Bouncer',  // BUBBER EDIT ADDITION
     ],
   },
 };


### PR DESCRIPTION

## About The Pull Request
Exactly as the title says - adds modular jobs to their relevant department's DEPARTMENT2COLOR, making the orbit menu sort them alongside their coworkers.

<h5>Any that aren't sorted, are TG jobs that should be sorted upstream - namely the Veteran Advisor, Big Brother, and 'Busser' (monkey-day).</h5>
<h5>Technically Bridge Assistant is too, and could probably just be sorted up there too. But since it's actually common, I figured it's best just included here.</h5>

<h6>This is my first Bubber PR so I hope I did this right 🙏 I don't know that this can be fully modularized because of this being a .js file but I did the comments</h6>

## Why It's Good For The Game

Consistency - keeps coworkers sorted with coworkers. Makes the whole thing actually work as advertised.

## Proof Of Testing

Couldn't test with color because I don't have 50something clients, but it's still sorted. (Minus TG jobs that need sorting)

<details>
<summary>Screenshots/Videos</summary>
<img width="797" height="389" alt="image" src="https://github.com/user-attachments/assets/d422c82e-ad4b-4d54-80ae-e9cadc81e832" />

</details>

## Changelog
:cl:
qol: Modular jobs are now sorted within their departments in the Orbit menu!
/:cl:
