### PR TITLE
Adds a borg obedience module

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_machinery/lustwish.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_machinery/lustwish.dm
@@ -44,6 +44,7 @@
 				/obj/item/spanking_pad = 4,
 				/obj/item/tickle_feather = 8,
 				/obj/item/borg/upgrade/dominatrixmodule = 5,
+				/obj/item/borg/upgrade/obediencemodule = 5,
 				/obj/item/reagent_containers/venom_milker = 5,
 			),
 		),

--- a/modular_zubbers/code/datums/quirks/negative_quirks/well_trained.dm
+++ b/modular_zubbers/code/datums/quirks/negative_quirks/well_trained.dm
@@ -7,7 +7,7 @@
 	value = -1
 	gain_text = "<span class='notice'>You feel like being someone's pet</span>"
 	lose_text = "<span class='notice'>You no longer feel like being a pet...</span>"
-	quirk_flags = QUIRK_HUMAN_ONLY | QUIRK_HIDE_FROM_SCAN | QUIRK_PROCESSES
+	quirk_flags = QUIRK_HIDE_FROM_SCAN | QUIRK_PROCESSES
 	erp_quirk = TRUE
 	var/mob/living/carbon/human/last_dom
 

--- a/modular_zubbers/code/datums/quirks/positive_quirks/dominant_aura.dm
+++ b/modular_zubbers/code/datums/quirks/positive_quirks/dominant_aura.dm
@@ -77,6 +77,44 @@
 				to_chat(sub, span_purple("You throw yourself on the floor like a pathetic beast and crawl towards <b>[quirk_holder]</b> like a good, submissive [good_x]."))
 
 		. = TRUE
+
+//Gotta check for borg module
+	for(var/mob/living/silicon/robot/borg_sub in hearers(world.view / 2, quirk_holder))
+		if(!borg_sub.has_quirk(/datum/quirk/well_trained) || (borg_sub == quirk_holder))
+			continue
+		if(borg_sub.stat == DEAD)
+			continue
+		var/good_x = "pet"
+		switch(borg_sub.gender)
+			if(MALE)
+				good_x = "boy"
+			if(FEMALE)
+				good_x = "girl"
+
+		switch(emote_args.key)
+			if("snap")
+				borg_sub.dir = get_dir(borg_sub, quirk_holder)
+				borg_sub.emote("me", 1, "faces towards <b>[quirk_holder]</b> at attention!", TRUE)
+				to_chat(borg_sub, span_purple("<b>[quirk_holder]</b>'s snap shoots down your spine and puts you at attention"))
+
+			if("snap2")
+				borg_sub.dir = get_dir(borg_sub, quirk_holder)
+				borg_sub.robot_lay_down()
+				borg_sub.Stun(0.3 SECONDS)
+				borg_sub.emote("me",1,"hunches down in response to <b>[quirk_holder]'s</b> snapping.", TRUE)
+				to_chat(borg_sub, span_purple("You hunch down and freeze in place in response to <b>[quirk_holder]</b> snapping their fingers"))
+
+			if("snap3")
+				step(borg_sub, get_dir(borg_sub, quirk_holder))
+				borg_sub.robot_lay_down()
+				borg_sub.Stun(0.3 SECONDS)
+				borg_sub.emote("me",1,"crawls closer to <b>[quirk_holder]</b> and lays down, following their command.",TRUE)
+				borg_sub.do_jitter_animation(0.1 SECONDS)
+				to_chat(borg_sub, span_purple("You crawl towards <b>[quirk_holder]</b> and lay down like a good, submissive [good_x]."))
+
+		. = TRUE
+
+
 	if(.)
 		TIMER_COOLDOWN_START(quirk_holder, DOMINANT_COOLDOWN_SNAP, 10 SECONDS) // 1/10th of a second knockdown with a 10 seconds cooldown on a neutral quirk.
 

--- a/modular_zubbers/code/datums/quirks/positive_quirks/dominant_aura.dm
+++ b/modular_zubbers/code/datums/quirks/positive_quirks/dominant_aura.dm
@@ -114,7 +114,6 @@
 
 		. = TRUE
 
-
 	if(.)
 		TIMER_COOLDOWN_START(quirk_holder, DOMINANT_COOLDOWN_SNAP, 10 SECONDS) // 1/10th of a second knockdown with a 10 seconds cooldown on a neutral quirk.
 

--- a/modular_zubbers/code/modules/research/designs/mechfab_designs.dm
+++ b/modular_zubbers/code/modules/research/designs/mechfab_designs.dm
@@ -82,7 +82,7 @@
 	)
 
 /datum/design/borg_obedience
-	name = "Cyborg obedience module"
+	name = "Cyborg Obedience Module"
 	id = "obediencemodule"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/obediencemodule

--- a/modular_zubbers/code/modules/research/designs/mechfab_designs.dm
+++ b/modular_zubbers/code/modules/research/designs/mechfab_designs.dm
@@ -81,6 +81,20 @@
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_ALL
 	)
 
+/datum/design/borg_obedience
+	name = "Cyborg obedience module"
+	id = "obediencemodule"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/obediencemodule
+	materials = list(
+		/datum/material/iron = SHEET_MATERIAL_AMOUNT,
+		/datum/material/glass = SHEET_MATERIAL_AMOUNT,
+	)
+	construction_time = 4 SECONDS
+	category = list(
+		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_ALL
+	)
+
 //so we have our own category
 /datum/design/borg_upgrade_surgical_processor_sci
 	name = "Research Surgical Processor"

--- a/modular_zubbers/code/modules/research/techweb/all_nodes.dm
+++ b/modular_zubbers/code/modules/research/techweb/all_nodes.dm
@@ -92,6 +92,7 @@
 	design_ids += list(
 		"blanksynth",
 		"dominatrixmodule",
+		"obediencemodule",
 		"borg_upgrade_expand",
 		"borg_upgrade_shrink",
 	)

--- a/modular_zubbers/code/modules/silicons/borgs/code/robot_upgrade.dm
+++ b/modular_zubbers/code/modules/silicons/borgs/code/robot_upgrade.dm
@@ -73,11 +73,20 @@
 // Borg Dom Aura :)
 /obj/item/borg/upgrade/dominatrixmodule/action(mob/living/silicon/robot/borg, mob/living/user)
 	. = ..()
-	borg.add_quirk(/datum/quirk/dominant_aura)
+	if(.)
+		if(borg.hasToys)
+			to_chat(usr, span_warning("This unit already has a 'recreational' module installed!"))
+			return FALSE
+
+		borg.hasToys = TRUE
+		borg.add_quirk(/datum/quirk/dominant_aura)
 
 /obj/item/borg/upgrade/dominatrixmodule/deactivate(mob/living/silicon/robot/borg, mob/living/user)
 	. = ..()
-	borg.remove_quirk(/datum/quirk/dominant_aura)
+	if(.)
+		if(borg.hasToys)
+			borg.hasToys = FALSE
+		borg.remove_quirk(/datum/quirk/dominant_aura)
 
 // Engineering RLD
 /obj/item/borg/upgrade/rld
@@ -111,3 +120,42 @@
 	model_type = list(/obj/item/robot_model/miner)
 	model_flags = BORG_MODEL_MINER
 	items_to_add = list(/obj/item/pinpointer/vent)
+
+
+/// "Good Borg" Obedience Training
+/mob/living/silicon/robot
+	var/hasToys = FALSE
+
+/obj/item/borg/upgrade/obediencemodule
+	name = "borg obedience module"
+	desc = "A module that greatly upgrades the ability of borgs to display affection."
+	icon = 'modular_skyrat/modules/borgs/icons/robot_items.dmi'
+	icon_state = "module_lust"
+	custom_price = 0
+
+	items_to_add = list(/obj/item/kinky_shocker,
+						/obj/item/clothing/mask/leatherwhip,
+						/obj/item/spanking_pad,
+						/obj/item/tickle_feather,
+						/obj/item/clothing/erp_leash,
+						)
+
+
+// WellTrained Obedience Behaviour
+/obj/item/borg/upgrade/obediencemodule/action(mob/living/silicon/robot/borg, mob/living/user)
+	. = ..()
+	if(.)
+		if(borg.hasToys)
+			to_chat(usr, span_warning("This unit already has a 'recreational' module installed!"))
+			return FALSE
+
+		borg.hasToys = TRUE
+		borg.add_quirk(/datum/quirk/well_trained)
+
+/obj/item/borg/upgrade/obediencemodule/deactivate(mob/living/silicon/robot/borg, mob/living/user)
+	. = ..()
+	if(.)
+		if(borg.hasToys)
+			borg.hasToys = FALSE
+
+		borg.remove_quirk(/datum/quirk/well_trained)

--- a/modular_zubbers/code/modules/silicons/borgs/code/robot_upgrade.dm
+++ b/modular_zubbers/code/modules/silicons/borgs/code/robot_upgrade.dm
@@ -125,7 +125,7 @@
 	var/hasToys = FALSE
 
 /obj/item/borg/upgrade/obediencemodule
-	name = "borg obedience module"
+	name = "Cyborg Obedience Module"
 	desc = "A module that greatly upgrades the ability of borgs to display affection."
 	icon = 'modular_skyrat/modules/borgs/icons/robot_items.dmi'
 	icon_state = "module_lust"

--- a/modular_zubbers/code/modules/silicons/borgs/code/robot_upgrade.dm
+++ b/modular_zubbers/code/modules/silicons/borgs/code/robot_upgrade.dm
@@ -72,14 +72,13 @@
 
 // Borg Dom Aura :)
 /obj/item/borg/upgrade/dominatrixmodule/action(mob/living/silicon/robot/borg, mob/living/user)
-	. = ..()
-	if(.)
-		if(borg.hasToys)
-			to_chat(usr, span_warning("This unit already has a 'recreational' module installed!"))
-			return FALSE
-
-		borg.hasToys = TRUE
-		borg.add_quirk(/datum/quirk/dominant_aura)
+    if(borg.hasToys)
+        to_chat(usr, span_warning("This unit already has a 'recreational' module installed!"))
+        return FALSE
+    . = ..()
+    if(.)
+        borg.hasToys = TRUE
+        borg.add_quirk(/datum/quirk/dominant_aura)
 
 /obj/item/borg/upgrade/dominatrixmodule/deactivate(mob/living/silicon/robot/borg, mob/living/user)
 	. = ..()
@@ -143,14 +142,13 @@
 
 // WellTrained Obedience Behaviour
 /obj/item/borg/upgrade/obediencemodule/action(mob/living/silicon/robot/borg, mob/living/user)
-	. = ..()
-	if(.)
-		if(borg.hasToys)
-			to_chat(usr, span_warning("This unit already has a 'recreational' module installed!"))
-			return FALSE
-
-		borg.hasToys = TRUE
-		borg.add_quirk(/datum/quirk/well_trained)
+    if(borg.hasToys)
+        to_chat(usr, span_warning("This unit already has a 'recreational' module installed!"))
+        return FALSE
+    . = ..()
+    if(.)
+        borg.hasToys = TRUE
+        borg.add_quirk(/datum/quirk/well_trained)
 
 /obj/item/borg/upgrade/obediencemodule/deactivate(mob/living/silicon/robot/borg, mob/living/user)
 	. = ..()

--- a/modular_zubbers/code/modules/silicons/borgs/code/robot_upgrade.dm
+++ b/modular_zubbers/code/modules/silicons/borgs/code/robot_upgrade.dm
@@ -73,12 +73,12 @@
 // Borg Dom Aura :)
 /obj/item/borg/upgrade/dominatrixmodule/action(mob/living/silicon/robot/borg, mob/living/user)
 	if(borg.hasToys)
-    	to_chat(usr, span_warning("This unit already has a 'recreational' module installed!"))
-    	return FALSE
-    . = ..()
+		to_chat(usr, span_warning("This unit already has a 'recreational' module installed!"))
+		return FALSE
+	. = ..()
 	if(.)
-    	borg.hasToys = TRUE
-    	borg.add_quirk(/datum/quirk/dominant_aura)
+		borg.hasToys = TRUE
+		borg.add_quirk(/datum/quirk/dominant_aura)
 
 /obj/item/borg/upgrade/dominatrixmodule/deactivate(mob/living/silicon/robot/borg, mob/living/user)
 	. = ..()
@@ -143,12 +143,12 @@
 // WellTrained Obedience Behaviour
 /obj/item/borg/upgrade/obediencemodule/action(mob/living/silicon/robot/borg, mob/living/user)
 	if(borg.hasToys)
-    	to_chat(usr, span_warning("This unit already has a 'recreational' module installed!"))
-    	return FALSE
+		to_chat(usr, span_warning("This unit already has a 'recreational' module installed!"))
+		return FALSE
 	. = ..()
 	if(.)
-    	borg.hasToys = TRUE
-    	borg.add_quirk(/datum/quirk/well_trained)
+		borg.hasToys = TRUE
+		borg.add_quirk(/datum/quirk/well_trained)
 
 /obj/item/borg/upgrade/obediencemodule/deactivate(mob/living/silicon/robot/borg, mob/living/user)
 	. = ..()

--- a/modular_zubbers/code/modules/silicons/borgs/code/robot_upgrade.dm
+++ b/modular_zubbers/code/modules/silicons/borgs/code/robot_upgrade.dm
@@ -120,7 +120,6 @@
 	model_flags = BORG_MODEL_MINER
 	items_to_add = list(/obj/item/pinpointer/vent)
 
-
 /// "Good Borg" Obedience Training
 /mob/living/silicon/robot
 	var/hasToys = FALSE
@@ -138,7 +137,6 @@
 						/obj/item/tickle_feather,
 						/obj/item/clothing/erp_leash,
 						)
-
 
 // WellTrained Obedience Behaviour
 /obj/item/borg/upgrade/obediencemodule/action(mob/living/silicon/robot/borg, mob/living/user)

--- a/modular_zubbers/code/modules/silicons/borgs/code/robot_upgrade.dm
+++ b/modular_zubbers/code/modules/silicons/borgs/code/robot_upgrade.dm
@@ -72,13 +72,13 @@
 
 // Borg Dom Aura :)
 /obj/item/borg/upgrade/dominatrixmodule/action(mob/living/silicon/robot/borg, mob/living/user)
-    if(borg.hasToys)
-        to_chat(usr, span_warning("This unit already has a 'recreational' module installed!"))
-        return FALSE
+	if(borg.hasToys)
+    	to_chat(usr, span_warning("This unit already has a 'recreational' module installed!"))
+    	return FALSE
     . = ..()
-    if(.)
-        borg.hasToys = TRUE
-        borg.add_quirk(/datum/quirk/dominant_aura)
+	if(.)
+    	borg.hasToys = TRUE
+    	borg.add_quirk(/datum/quirk/dominant_aura)
 
 /obj/item/borg/upgrade/dominatrixmodule/deactivate(mob/living/silicon/robot/borg, mob/living/user)
 	. = ..()
@@ -142,13 +142,13 @@
 
 // WellTrained Obedience Behaviour
 /obj/item/borg/upgrade/obediencemodule/action(mob/living/silicon/robot/borg, mob/living/user)
-    if(borg.hasToys)
-        to_chat(usr, span_warning("This unit already has a 'recreational' module installed!"))
-        return FALSE
-    . = ..()
-    if(.)
-        borg.hasToys = TRUE
-        borg.add_quirk(/datum/quirk/well_trained)
+	if(borg.hasToys)
+    	to_chat(usr, span_warning("This unit already has a 'recreational' module installed!"))
+    	return FALSE
+	. = ..()
+	if(.)
+    	borg.hasToys = TRUE
+    	borg.add_quirk(/datum/quirk/well_trained)
 
 /obj/item/borg/upgrade/obediencemodule/deactivate(mob/living/silicon/robot/borg, mob/living/user)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Adds a brand new cyborg module to the exofab and lustwish; the borg obedience module. As a sister module to the dominatrix module, it functions identically the same, but instead of applying the dominant aura trait, applies the well trained trait. This also makes it so the quirk functions on silicons properly.

## Why It's Good For The Game

Some borgs want to have the funny toys but not the dominant aura, or would prefer to just be able to have access to this trait, even if it may be a negative one on paper, not to mention it's a bit odd that only the one side of this two sided quirk is available.

## Proof Of Testing

It compiles, only one dominatrix or obedience module can properly be used at the same time, borgs react how they should with the quirk.
<details>

![submissable](https://github.com/user-attachments/assets/cee5476b-aa9f-4926-8256-605d33bfa123)
![snapsnap](https://github.com/user-attachments/assets/6a4b416a-d21f-4dff-aabd-d027bfc8292c)

<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
add: Obedience cyborg module added, a sister module to the dominatrix module that applies the well trained quirk
add: Obedience module available in the lustwish and exofab with the other utility borg modules
code: Updated the dominant aura quirk to work on well trained silicons
/:cl:
