### PR TITLE
nosferatu can ventcrawl with a backpack again

### DIFF
--- a/modular_zubbers/code/modules/antagonists/bloodsucker/clans/clan_nosferatu.dm
+++ b/modular_zubbers/code/modules/antagonists/bloodsucker/clans/clan_nosferatu.dm
@@ -35,11 +35,6 @@
 
 /datum/bloodsucker_clan/nosferatu/proc/can_ventcrawl(mob/living/carbon/human/owner_mob, atom/vent, provide_feedback)
 	SIGNAL_HANDLER
-	var/obj/back_slot = owner_mob.get_item_by_slot(ITEM_SLOT_BACK)
-	if(back_slot && !istype(back_slot, /obj/item/storage/backpack/satchel/flat))
-		if(provide_feedback)
-			to_chat(owner_mob, span_warning("You cannot ventcrawl with [back_slot] on your back!"))
-		return FALSE
 	for(var/item in owner_mob.held_items)
 		if(isnull(item))
 			continue


### PR DESCRIPTION

## About The Pull Request
nosferatu can ventcrawl with a backpack again

## Why It's Good For The Game
it was probably too rough a nerf given the other changes

## Proof Of Testing
it compiles

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
balance: Nosferatu can ventcral with a non-smuggling satchel now, no limitations on their back slot
/:cl:

