### PR TITLE
Makes ash accretion module inseperable from mining modsuits once more

### DIFF
--- a/code/modules/mod/modules/modules_supply.dm
+++ b/code/modules/mod/modules/modules_supply.dm
@@ -369,7 +369,7 @@
 	desc = "A module that collects ash from the terrain, covering the suit in a protective layer, this layer is \
 		lost when moving across standard terrain."
 	icon_state = "ash_accretion"
-	removable = TRUE // BUBBER EDIT CHANGE - ORIGINAL: removable = FALSE
+	removable = FALSE
 	incompatible_modules = list(/obj/item/mod/module/ash_accretion)
 	overlay_state_inactive = "module_ash"
 	use_mod_colors = TRUE


### PR DESCRIPTION

## About The Pull Request
title, can't crowbar it out of the mining mod anymore.

## Why It's Good For The Game
The ash accretion module gives a major speedboost + armor buff on lavaland... but also on the surface of maps like icebox and moonstation. Being able to get a methspeed syndicatemod with 80-90% melee resist as long as you're outside in the process. As it turns out, this may not be fun to fight against, or intended for that matter. 

## Proof Of Testing
 1 line change

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
balance: Makes the ash accretion module unable to be removed from mining modsuits.
/:cl:

