### PR TITLE
Horror Form Code Cleanup + Fixes

### DIFF
--- a/modular_skyrat/modules/horrorform/code/horror_form.dm
+++ b/modular_skyrat/modules/horrorform/code/horror_form.dm
@@ -10,43 +10,43 @@
 	dna_cost = 4 //Tier 4
 	req_dna = 15
 	req_absorbs = 1
-	req_human = 1
+	req_human = TRUE
 	req_stat = UNCONSCIOUS
 
 /datum/action/changeling/horror_form/sting_action(mob/living/carbon/human/user)
 	..()
 	if(!user || HAS_TRAIT(user, TRAIT_NO_TRANSFORM))
-		return 0
+		return FALSE
 	user.visible_message(span_warning("[user] writhes and contorts, their body expanding to inhuman proportions!"), \
 						span_danger("We begin our transformation to our true form!"))
 	if(!do_after(user, 3 SECONDS, target = user, timed_action_flags = IGNORE_HELD_ITEM))
 		user.visible_message(span_warning("[user]'s transformation abruptly reverts itself!"), \
 							span_warning("Our transformation has been interrupted!"))
-		return 0
+		return FALSE
 	user.visible_message(span_warning("[user] grows into an abomination and lets out an awful scream!"), \
 						span_userdanger("We cast off our petty shell and enter our true form!"))
 	if(user.handcuffed)
-		var/obj/O = user.get_item_by_slot(ITEM_SLOT_HANDCUFFED)
-		if(istype(O))
-			qdel(O)
+		var/obj/handcuffs = user.get_item_by_slot(ITEM_SLOT_HANDCUFFED)
+		if(istype(handcuffs))
+			qdel(handcuffs)
 	if(user.legcuffed)
-		var/obj/O = user.get_item_by_slot(ITEM_SLOT_LEGCUFFED)
-		if(istype(O))
-			qdel(O)
+		var/obj/legcuffs = user.get_item_by_slot(ITEM_SLOT_LEGCUFFED)
+		if(istype(legcuffs))
+			qdel(legcuffs)
 	if(user.wear_suit && user.wear_suit.breakouttime)
-		var/obj/item/clothing/suit/S = user.get_item_by_slot(ITEM_SLOT_OCLOTHING)
-		if(istype(S))
-			qdel(S)
+		var/obj/item/clothing/suit/straightjacket = user.get_item_by_slot(ITEM_SLOT_OCLOTHING)
+		if(istype(straightjacket))
+			qdel(straightjacket)
 	if(istype(user.loc, /obj/structure/closet))
-		var/obj/structure/closet/C = user.loc
-		if(istype(C))
-			if(C && user.loc == C)
-				C.visible_message(span_warning("[C]'s door breaks and opens!"))
-				new /obj/effect/decal/cleanable/greenglow(C.drop_location())
-				C.welded = FALSE
-				C.locked = FALSE
-				C.broken = TRUE
-				C.open()
+		var/obj/structure/closet/closet = user.loc
+		if(istype(closet))
+			if(closet && user.loc == closet)
+				closet.visible_message(span_warning("[closet]'s door breaks and opens!"))
+				new /obj/effect/decal/cleanable/greenglow(closet.drop_location())
+				closet.welded = FALSE
+				closet.locked = FALSE
+				closet.broken = TRUE
+				closet.open()
 
 	var/mob/living/simple_animal/hostile/true_changeling/new_mob = new(get_turf(user))
 
@@ -69,4 +69,4 @@
 	user.mind.transfer_to(new_mob)
 	user.spawn_gibs()
 	//feedback_add_details("changeling_powers","HF")
-	return 1
+	return TRUE

--- a/modular_skyrat/modules/horrorform/code/horror_form.dm
+++ b/modular_skyrat/modules/horrorform/code/horror_form.dm
@@ -58,7 +58,7 @@
 	var/changeling_name = \
 		(user.gender == FEMALE) ? "Ms. " : \
 		(user.gender == MALE)   ? "Mr. " : \
-		(user.gender == NEUTER || PLURAL) ? "Mx. " :
+		(user.gender == NEUTER || PLURAL) ? "Mx. " : \
 	changeling_name += pick(GLOB.greek_letters)
 
 	new_mob.real_name = changeling_name

--- a/modular_skyrat/modules/horrorform/code/horror_form.dm
+++ b/modular_skyrat/modules/horrorform/code/horror_form.dm
@@ -5,6 +5,7 @@
 	button_icon = 'modular_skyrat/modules/horrorform/icons/actions_changeling.dmi'
 	button_icon_state = "horror_form"
 	background_icon_state = "bg_changeling"
+
 	chemical_cost = 50
 	dna_cost = 4 //Tier 4
 	req_dna = 15
@@ -16,56 +17,59 @@
 	..()
 	if(!user || HAS_TRAIT(user, TRAIT_NO_TRANSFORM))
 		return FALSE
-	user.visible_message(span_warning("[user] writhes and contorts, their body expanding to inhuman proportions!"), \
-						span_danger("We begin our transformation to our true form!"))
+
+	user.visible_message(
+		span_warning("[user] writhes and contorts, their body expanding to inhuman proportions!"), \
+		span_danger("We begin our transformation to our true form!")
+	)
+
 	if(!do_after(user, 3 SECONDS, target = user, timed_action_flags = IGNORE_HELD_ITEM))
-		user.visible_message(span_warning("[user]'s transformation abruptly reverts itself!"), \
-							span_warning("Our transformation has been interrupted!"))
+		user.visible_message(
+			span_warning("[user]'s transformation abruptly reverts itself!"), \
+			span_warning("Our transformation has been interrupted!")
+		)
 		return FALSE
-	user.visible_message(span_warning("[user] grows into an abomination and lets out an awful scream!"), \
-						span_userdanger("We cast off our petty shell and enter our true form!"))
+
+	user.visible_message(
+		span_warning("[user] grows into an abomination and lets out an awful scream!"), \
+		span_userdanger("We cast off our petty shell and enter our true form!")
+	)
+
 	if(user.handcuffed)
-		var/obj/handcuffs = user.get_item_by_slot(ITEM_SLOT_HANDCUFFED)
-		if(istype(handcuffs))
-			qdel(handcuffs)
+		qdel(user.get_item_by_slot(ITEM_SLOT_HANDCUFFED))
 	if(user.legcuffed)
-		var/obj/legcuffs = user.get_item_by_slot(ITEM_SLOT_LEGCUFFED)
-		if(istype(legcuffs))
-			qdel(legcuffs)
-	if(user.wear_suit && user.wear_suit.breakouttime)
-		var/obj/item/clothing/suit/straightjacket = user.get_item_by_slot(ITEM_SLOT_OCLOTHING)
-		if(istype(straightjacket))
-			qdel(straightjacket)
+		qdel(user.get_item_by_slot(ITEM_SLOT_LEGCUFFED))
+	if(user.wear_suit?.breakouttime)
+		qdel(user.get_item_by_slot(ITEM_SLOT_OCLOTHING))
+
 	if(istype(user.loc, /obj/structure/closet))
 		var/obj/structure/closet/closet = user.loc
-		if(istype(closet))
-			if(closet && user.loc == closet)
-				closet.visible_message(span_warning("[closet]'s door breaks and opens!"))
-				new /obj/effect/decal/cleanable/greenglow(closet.drop_location())
-				closet.welded = FALSE
-				closet.locked = FALSE
-				closet.broken = TRUE
-				closet.open()
+		closet.visible_message(span_warning("[closet]'s door breaks open!"))
+		new /obj/effect/decal/cleanable/greenglow(closet.drop_location())
+		closet.welded = FALSE
+		closet.locked = FALSE
+		closet.broken = TRUE
+		closet.open()
 
 	var/mob/living/simple_animal/hostile/true_changeling/new_mob = new(get_turf(user))
 
 	//Currently this is a thing as changeling ID's are not longer a thing
 	//Feel free to re-add them whomever wants to -Azarak
-	var/changeling_name
-	if(user.gender == FEMALE)
-		changeling_name = "Ms. "
-	else if(user.gender == MALE)
-		changeling_name = "Mr. "
-	else
-		changeling_name = "Mx. "
-	changeling_name += pick(GLOB.greek_letters) //Abductor suffixes are the same ones as changelings
+	var/changeling_name = \
+		(user.gender == FEMALE) ? "Ms. " : \
+		(user.gender == MALE)   ? "Mr. " : \
+		(user.gender == NEUTER || PLURAL) ? "Mx. " :
+	changeling_name += pick(GLOB.greek_letters)
 
 	new_mob.real_name = changeling_name
 	new_mob.name = new_mob.real_name
 	new_mob.stored_changeling = user
+
 	user.loc = new_mob
 	ADD_TRAIT(user, TRAIT_GODMODE, INNATE_TRAIT)
 	user.mind.transfer_to(new_mob)
 	user.spawn_gibs()
-	qdel(src) // Remove the old button as it is no longer needed.
+
+	qdel(src)
+
 	return TRUE

--- a/modular_skyrat/modules/horrorform/code/horror_form.dm
+++ b/modular_skyrat/modules/horrorform/code/horror_form.dm
@@ -73,4 +73,6 @@
 	user.mind.transfer_to(new_mob)
 	user.spawn_gibs()
 
+	qdel(src)
+
 	return TRUE

--- a/modular_skyrat/modules/horrorform/code/horror_form.dm
+++ b/modular_skyrat/modules/horrorform/code/horror_form.dm
@@ -55,10 +55,13 @@
 
 	//Currently this is a thing as changeling ID's are not longer a thing
 	//Feel free to re-add them whomever wants to -Azarak
-	var/changeling_name = \
-		(user.gender == FEMALE) ? "Ms. " : \
-		(user.gender == MALE)   ? "Mr. " : \
-		(user.gender == NEUTER || PLURAL) ? "Mx. " : \
+	var/changeling_name = ""
+	if(user.gender == FEMALE)
+		changeling_name = "Ms. "
+	else if(user.gender == MALE)
+		changeling_name = "Mr. "
+	else if(user.gender == NEUTER || user.gender == PLURAL)
+		changeling_name = "Mx. "
 	changeling_name += pick(GLOB.greek_letters)
 
 	new_mob.real_name = changeling_name

--- a/modular_skyrat/modules/horrorform/code/horror_form.dm
+++ b/modular_skyrat/modules/horrorform/code/horror_form.dm
@@ -3,7 +3,6 @@
 	desc = "We tear apart our human disguise, revealing our true form."
 	helptext = "We will become an unstoppable force of destruction. If we die in this form, we will reach equilibrium and explode into a shower of gore! We require the absorption of at least one other human, and 15 extracts of DNA."
 	button_icon = 'modular_skyrat/modules/horrorform/icons/actions_changeling.dmi'
-	button_icon = 'modular_skyrat/modules/horrorform/icons/actions_changeling.dmi'
 	button_icon_state = "horror_form"
 	background_icon_state = "bg_changeling"
 	chemical_cost = 50
@@ -68,5 +67,5 @@
 	ADD_TRAIT(user, TRAIT_GODMODE, INNATE_TRAIT)
 	user.mind.transfer_to(new_mob)
 	user.spawn_gibs()
-	//feedback_add_details("changeling_powers","HF")
+	qdel(src) // Remove the old button as it is no longer needed.
 	return TRUE

--- a/modular_skyrat/modules/horrorform/code/horror_form.dm
+++ b/modular_skyrat/modules/horrorform/code/horror_form.dm
@@ -73,6 +73,4 @@
 	user.mind.transfer_to(new_mob)
 	user.spawn_gibs()
 
-	qdel(src)
-
 	return TRUE

--- a/modular_skyrat/modules/horrorform/code/horror_form.dm
+++ b/modular_skyrat/modules/horrorform/code/horror_form.dm
@@ -55,12 +55,12 @@
 
 	//Currently this is a thing as changeling ID's are not longer a thing
 	//Feel free to re-add them whomever wants to -Azarak
-	var/changeling_name = ""
+	var/changeling_name
 	if(user.gender == FEMALE)
 		changeling_name = "Ms. "
 	else if(user.gender == MALE)
 		changeling_name = "Mr. "
-	else if(user.gender == NEUTER || user.gender == PLURAL)
+	else
 		changeling_name = "Mx. "
 	changeling_name += pick(GLOB.greek_letters)
 

--- a/modular_skyrat/modules/horrorform/code/true_changeling.dm
+++ b/modular_skyrat/modules/horrorform/code/true_changeling.dm
@@ -97,7 +97,7 @@
 			scream_hearer.playsound_local(src, 'modular_skyrat/modules/horrorform/sound/horror_scream_reverb.ogg', vol, 1, frequency)
 
 	for(var/mob/scream_hearer in range(35, src))
-		if(scream_hearer && scream_hearer.stat == DEAD && (scream_hearer.client.prefs.chat_toggles & CHAT_GHOSTSIGHT) && !(scream_hearer in viewers(get_turf(src), null)))
+		if(scream_hearer && scream_hearer.client && scream_hearer.stat == DEAD && (scream_hearer.client.prefs.chat_toggles & CHAT_GHOSTSIGHT) && !(scream_hearer in viewers(get_turf(src), null)))
 			scream_hearer.show_message(message)
 
 	audible_message(message)

--- a/modular_skyrat/modules/horrorform/code/true_changeling.dm
+++ b/modular_skyrat/modules/horrorform/code/true_changeling.dm
@@ -35,14 +35,7 @@
 	var/datum/action/innate/turn_to_human
 	var/transformed_time = 0
 
-	var/playstyle_string = span_infoplain(
-		"<b><font size=3 color='red'>We have entered our true form!\
-		</font> We are unbelievably powerful, and regenerate life at a steady rate. \
-		However, most of our abilities are useless in this form, and we must utilise the abilities that we have gained as a result \
-		of our transformation. Currently, we are incapable of returning to a human. \
-		After several minutes, we will once again be able to revert into a human. \
-		Taking too much damage will cause us to reach equilibrium and our cells will combust into a shower of gore, watch out!</b>"
-	)
+	var/playstyle_string = span_infoplain("<b><font size=3 color='red'>We have entered our true form!</font> We are unbelievably powerful, and regenerate life at a steady rate. However, most of our abilities are useless in this form, and we must utilise the abilities that we have gained as a result of our transformation. Currently, we are incapable of returning to a human. After several minutes, we will once again be able to revert into a human. Taking too much damage will cause us to reach equilibrium and our cells will combust into a shower of gore, watch out!</b>")
 	var/mob/living/carbon/human/stored_changeling = null
 	var/devouring = FALSE
 

--- a/modular_skyrat/modules/horrorform/code/true_changeling.dm
+++ b/modular_skyrat/modules/horrorform/code/true_changeling.dm
@@ -35,7 +35,12 @@
 	var/datum/action/innate/turn_to_human
 	var/transformed_time = 0
 
-	var/playstyle_string = span_infoplain("<b><font size=3 color='red'>We have entered our true form!</font> We are unbelievably powerful, and regenerate life at a steady rate. However, most of our abilities are useless in this form, and we must utilise the abilities that we have gained as a result of our transformation. Currently, we are incapable of returning to a human. After several minutes, we will once again be able to revert into a human. Taking too much damage will cause us to reach equilibrium and our cells will combust into a shower of gore, watch out!</b>")
+	var/playstyle_string = span_infoplain("<b><font size=3 color='red'>We have entered our true form!</font> \
+	We are unbelievably powerful, and regenerate life at a steady rate. \
+	However, most of our abilities are useless in this form, and we must utilise the abilities that we have gained as a result of our transformation. \
+	Currently, we are incapable of returning to a human. After several minutes, we will once again be able to revert into a human. \
+	Taking too much damage will cause us to reach equilibrium and our cells will combust into a shower of gore, watch out!</b>")
+
 	var/mob/living/carbon/human/stored_changeling = null
 	var/devouring = FALSE
 

--- a/modular_skyrat/modules/horrorform/code/true_changeling.dm
+++ b/modular_skyrat/modules/horrorform/code/true_changeling.dm
@@ -1,8 +1,5 @@
 #define TRUE_CHANGELING_REFORM_THRESHOLD (5 MINUTES)
-#define TRUE_CHANGELING_PASSIVE_HEAL 3 //Amount of brute damage restored per tick
-
-//Changelings in their true form.
-//Massive health and damage, but move slowly.
+#define TRUE_CHANGELING_PASSIVE_HEAL 3
 
 /mob/living/simple_animal/hostile/true_changeling
 	name = "true changeling"
@@ -20,7 +17,7 @@
 	status_flags = CANPUSH
 	atmos_requirements = null
 	minbodytemp = 0
-	maxHealth = 750 //Very durable
+	maxHealth = 750
 	health = 500
 	lighting_cutoff_red = 0
 	lighting_cutoff_green = 35
@@ -32,15 +29,22 @@
 	attack_verb_continuous = "rips into"
 	attack_verb_simple = "rip into"
 	attack_sound = 'sound/effects/blob/blobattack.ogg'
-	butcher_results = list(/obj/item/food/meat/slab/human = 15) //It's a pretty big dude. Actually killing one is a feat.
-	gold_core_spawnable = FALSE //Should stay exclusive to changelings tbh, otherwise makes it much less significant to sight one
+	butcher_results = list(/obj/item/food/meat/slab/human = 15)
+	gold_core_spawnable = FALSE
+
 	var/datum/action/innate/turn_to_human
 	var/transformed_time = 0
-	var/playstyle_string = span_infoplain("<b><font size=3 color='red'>We have entered our true form!</font> We are unbelievably powerful, and regenerate life at a steady rate. However, most of \
-	our abilities are useless in this form, and we must utilise the abilities that we have gained as a result of our transformation. Currently, we are incapable of returning to a human. \
-	After several minutes, we will once again be able to revert into a human. Taking too much damage will cause us to reach equilibrium and our cells will combust into a shower of gore, watch out!</b>")
-	var/mob/living/carbon/human/stored_changeling = null //The changeling that transformed
-	var/devouring = FALSE //If the true changeling is currently devouring a human
+
+	var/playstyle_string = span_infoplain(
+		"<b><font size=3 color='red'>We have entered our true form!\
+		</font> We are unbelievably powerful, and regenerate life at a steady rate. \
+		However, most of our abilities are useless in this form, and we must utilise the abilities that we have gained as a result \
+		of our transformation. Currently, we are incapable of returning to a human. \
+		After several minutes, we will once again be able to revert into a human. \
+		Taking too much damage will cause us to reach equilibrium and our cells will combust into a shower of gore, watch out!</b>"
+	)
+	var/mob/living/carbon/human/stored_changeling = null
+	var/devouring = FALSE
 
 /mob/living/simple_animal/hostile/true_changeling/New()
 	. = ..()
@@ -49,22 +53,24 @@
 
 /mob/living/simple_animal/hostile/true_changeling/Initialize(mapload)
 	. = ..()
+
 	to_chat(src, playstyle_string)
-	turn_to_human = new(src)
-	turn_to_human.Grant(src)
+
+	GRANT_ACTION(/datum/action/innate/turn_to_human)
 	GRANT_ACTION(/datum/action/innate/devour)
-	// ADD_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT) Bubbber change
 
 /mob/living/simple_animal/hostile/true_changeling/Life()
 	. = ..()
+
 	adjustBruteLoss(-TRUE_CHANGELING_PASSIVE_HEAL)
 
 /mob/living/simple_animal/hostile/true_changeling/AttackingTarget()
-	..()
+	. = ..()
+
 	if(prob(10))
 		emote("scream")
 
-/mob/living/simple_animal/hostile/true_changeling/emote(act, m_type=1, message = null, intentional = TRUE)
+/mob/living/simple_animal/hostile/true_changeling/emote(act, m_type = 1, message = null, intentional = TRUE)
 	if(stat)
 		return
 	if(act == "scream")
@@ -77,42 +83,53 @@
 /mob/living/simple_animal/hostile/true_changeling/proc/scream(message)
 	if(!message)
 		message = span_emote("<B>[src]</B> makes a loud, bone-chilling roar!")
-	var/frequency = get_rand_frequency() //so sound frequency is consistent
-	for(var/mob/M in range(35, src)) //You can hear the scream 7 screens away
-		// Double check for client
-		if(M && M.client)
-			var/turf/M_turf = get_turf(M)
-			if(M_turf && M_turf.z == src.z)
-				var/dist = get_dist(M_turf, src)
-				if(dist <= 7) //source of sound very close
-					M.playsound_local(src, 'modular_skyrat/modules/horrorform/sound/horror_scream.ogg', 80, 1, frequency)
-				else
-					var/vol = clamp(100-((dist-7)*5), 10, 100) //Every tile decreases sound volume by 5
-					M.playsound_local(src, 'modular_skyrat/modules/horrorform/sound/horror_scream_reverb.ogg', vol, 1, frequency)
-			if(M.stat == DEAD && (M.client.prefs.chat_toggles & CHAT_GHOSTSIGHT) && !(M in viewers(get_turf(src),null)))
-				M.show_message(message)
+	var/frequency = get_rand_frequency()
+
+	for(var/mob/scream_hearer in range(35, src))
+		if(!scream_hearer || !scream_hearer.client)
+			continue
+		var/turf/hearer_turf = get_turf(scream_hearer)
+		if(!hearer_turf || hearer_turf.z != src.z)
+			continue
+		var/dist = get_dist(hearer_turf, src)
+		if(dist <= 7)
+			scream_hearer.playsound_local(src, 'modular_skyrat/modules/horrorform/sound/horror_scream.ogg', 80, 1, frequency)
+		else
+			var/vol = clamp(100 - ((dist - 7) * 5), 10, 100)
+			scream_hearer.playsound_local(src, 'modular_skyrat/modules/horrorform/sound/horror_scream_reverb.ogg', vol, 1, frequency)
+
+	for(var/mob/scream_hearer in range(35, src))
+		if(scream_hearer && scream_hearer.stat == DEAD && (scream_hearer.client.prefs.chat_toggles & CHAT_GHOSTSIGHT) && !(scream_hearer in viewers(get_turf(src), null)))
+			scream_hearer.show_message(message)
+
 	audible_message(message)
 
 /mob/living/simple_animal/hostile/true_changeling/death()
 	. = ..()
+
 	scream()
 	spawn_gibs()
+
 	if(stored_changeling && mind)
 		visible_message(span_warning("[src] lets out a furious scream as it reaches equilibrium, as it starts exploding into a shower of gore!"), \
 						span_userdanger("We lack the power to maintain our mass, we have reached critic-..."))
 		anchored = TRUE
-		turn_to_human.Remove()
-		AddComponent(/datum/component/pellet_cloud, projectile_type=/obj/projectile/bullet/pellet/bone_fragment, magnitude=8)
+
+		if(istype(turn_to_human))
+			qdel(turn_to_human)
+
+		AddComponent(/datum/component/pellet_cloud, projectile_type=/obj/projectile/bullet/pellet/bone_fragment, magnitude = 8)
 		addtimer(CALLBACK(src, PROC_REF(real_death)), rand(3 SECONDS, 6 SECONDS))
 	else
 		visible_message(span_warning("[src] lets out a waning scream as it falls, twitching, to the floor."))
+
 		addtimer(CALLBACK(src, PROC_REF(revive_from_death)), 45 SECONDS)
 
 /mob/living/simple_animal/hostile/true_changeling/proc/revive_from_death()
 	if(!src)
 		return
 	visible_message(span_warning("[src] stumbles upright and begins to move!"))
-	revive() //Changelings can self-revive, and true changelings are no exception
+	revive()
 	scream()
 
 /mob/living/simple_animal/hostile/true_changeling/proc/real_death()
@@ -121,15 +138,19 @@
 	scream()
 	icon_state = "horror_dead"
 	visible_message(span_warning("[src] has surpassed equilibrium and can no longer support itself, exploding in a shower of bone and gore!"), \
-						span_userdanger("ARRRRRRGHHHH!!!"))
-	stored_changeling.loc = get_turf(src)
-	mind.transfer_to(stored_changeling)
-	stored_changeling.Paralyze(10 SECONDS) //Make them helpless for 10 seconds
-	stored_changeling.adjustBruteLoss(30, TRUE, TRUE)
-	REMOVE_TRAIT(stored_changeling, TRAIT_GODMODE, INNATE_TRAIT)
-	stored_changeling.emote("scream")
-	stored_changeling.gib()
-	stored_changeling = null
+					span_userdanger("ARRRRRRGHHHH!!!"))
+
+	if(stored_changeling)
+		stored_changeling.loc = get_turf(src)
+		if(mind)
+			mind.transfer_to(stored_changeling)
+		stored_changeling.Paralyze(10 SECONDS)
+		stored_changeling.adjustBruteLoss(30, TRUE, TRUE)
+		REMOVE_TRAIT(stored_changeling, TRAIT_GODMODE, INNATE_TRAIT)
+		stored_changeling.emote("scream")
+		stored_changeling.gib()
+		stored_changeling = null
+
 	SEND_SIGNAL(src, COMSIG_HORRORFORM_EXPLODE)
 	explosion(src, 0, 0, 5, 5)
 	qdel(src)
@@ -180,7 +201,6 @@
 	name = "Re-Form Human Shell"
 	desc = "We turn back into a human. This takes considerable effort and will stun us for some time afterwards."
 	button_icon = 'modular_skyrat/modules/horrorform/icons/actions_changeling.dmi'
-	button_icon = 'modular_skyrat/modules/horrorform/icons/actions_changeling.dmi'
 	background_icon_state = "bg_changeling"
 	button_icon_state = "change_to_human"
 
@@ -196,12 +216,15 @@
 		var/timeleft = (horrorform.transformed_time + TRUE_CHANGELING_REFORM_THRESHOLD) - world.time
 		horrorform.balloon_alert(horrorform, "wait [round(timeleft/600)+1] minutes!")
 		return FALSE
+
 	horrorform.visible_message(span_warning("[horrorform] suddenly crunches and twists into a smaller form!"), \
 						span_danger("We return to our lesser form."))
+
 	horrorform.stored_changeling.loc = get_turf(horrorform)
 	horrorform.mind.transfer_to(horrorform.stored_changeling)
 	horrorform.stored_changeling.Stun(2 SECONDS)
 	REMOVE_TRAIT(horrorform.stored_changeling, TRAIT_GODMODE, INNATE_TRAIT)
+
 	qdel(horrorform)
 	return TRUE
 
@@ -214,53 +237,71 @@
 
 /datum/action/innate/devour/Trigger(trigger_flags)
 	var/mob/living/simple_animal/hostile/true_changeling/horrorform = owner
+
 	if(horrorform.devouring)
 		horrorform.balloon_alert(horrorform, "already eating!")
 		return FALSE
+
 	var/list/potential_targets = list()
 	for(var/mob/living/carbon/human/victim in range(1, usr))
-		if(victim == horrorform.stored_changeling || (victim.mind && victim.mind.has_antag_datum(/datum/antagonist/changeling))) //You can't eat changelings in human form
+		if(!victim)
+			continue
+
+		if(victim == horrorform.stored_changeling || (victim.mind && victim.mind.has_antag_datum(/datum/antagonist/changeling)))
 			continue
 		potential_targets.Add(victim)
+
 	if(!length(potential_targets))
 		horrorform.balloon_alert(horrorform, "no carbons!")
 		return FALSE
+
 	var/mob/living/carbon/human/lunch
 	if(length(potential_targets) == 1)
 		lunch = potential_targets[1]
 	else
 		lunch = tgui_input_list(horrorform, "Choose a human to devour.", "Lunch", potential_targets)
-	if(!lunch && !ishuman(lunch))
+
+	if(!lunch || !ishuman(lunch))
 		return FALSE
-	if(lunch.getBruteLoss() + lunch.getFireLoss() >= 200) //Overall physical damage, basically
+
+	if(lunch.getBruteLoss() + lunch.getFireLoss() >= 200)
 		horrorform.visible_message(span_warning("[lunch] provides no further nutrients for [horrorform]!"), \
 						span_danger("[lunch] has no more useful flesh for us to consume!!"))
 		return FALSE
+
 	horrorform.devouring = TRUE
 	horrorform.visible_message(span_warning("[horrorform] begins ripping apart and feasting on [lunch]!"), \
 					span_danger("We begin to feast upon [lunch]..."))
-	if(!do_after(usr, 5 SECONDS, lunch))
+
+	if(!do_after(horrorform, 5 SECONDS, target = lunch))
 		horrorform.devouring = FALSE
 		return FALSE
+
 	horrorform.devouring = FALSE
 	lunch.adjustBruteLoss(60)
+
 	horrorform.visible_message(span_warning("[horrorform] tears a chunk from [lunch]'s flesh!"), \
 					span_danger("We tear a chunk of flesh from [lunch] and devour it!"))
 	to_chat(lunch, span_userdanger("[horrorform] takes a huge bite out of you!"))
 	lunch.spawn_gibs()
+
 	var/dismembered = FALSE
 	for(var/obj/item/bodypart/guts in lunch.bodyparts)
 		if(dismembered)
 			break
+		if(!guts)
+			continue
 		if(prob(60) || guts.body_part == CHEST || guts.body_part == HEAD)
 			continue
 		guts.dismember()
 		dismembered = TRUE
+
 	playsound(lunch, 'sound/effects/splat.ogg', 50, 1)
 	playsound(lunch, 'modular_skyrat/modules/horrorform/sound/tear.ogg', 50, 1)
 	lunch.emote("scream")
+
 	if(lunch.nutrition >= NUTRITION_LEVEL_FAT)
-		horrorform.adjustBruteLoss(-100) //Tasty leetle peegy
+		horrorform.adjustBruteLoss(-100)
 	else
 		horrorform.adjustBruteLoss(-50)
 


### PR DESCRIPTION

## About The Pull Request
Cleans up `modular_skyrat\modules\horrorform\code\true_changeling.dm` and `modular_skyrat\modules\horrorform\code\horror_form.dm` to make them significantly more readable. This also fixes https://github.com/Bubberstation/Bubberstation/issues/4656 by making the action get added correctly.
## Why It's Good For The Game
Readability + No Bugs = Good
## Proof Of Testing
It worked fine on my end, I was able to transform to horror form, then turn back into John Ling.
## Changelog
:cl:
fix: Fixed the horror form not being able to turn back into humanoid form
/:cl:
