### PR TITLE
Airlocks/Grilles Stun You Instead of Knockdown (Skyrat Revert)

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -271,7 +271,7 @@
 	var/immediately_stun = should_stun && !(flags & SHOCK_DELAY_STUN)
 	if (immediately_stun)
 		if (paralyze)
-			StaminaKnockdown(stun_duration / 4) // SKYRAT EDIT CHANGE - ORIGINAL: Paralyze(40)
+			Paralyze(stun_duration)
 		else
 			Knockdown(stun_duration)
 	//Jitter and other fluff.
@@ -285,7 +285,7 @@
 ///Called slightly after electrocute act to apply a secondary stun.
 /mob/living/carbon/proc/secondary_shock(paralyze, stun_duration)
 	if (paralyze)
-		StaminaKnockdown(stun_duration / 6) // SKYRAT EDIT CHANGE - ORIGINAL: Paralyze(60)
+		Paralyze(stun_duration)
 	else
 		Knockdown(stun_duration)
 


### PR DESCRIPTION
## About The Pull Request

Reverts a skyrat change that caused shocks by default to knock you down instead of paralyze (stun).

Also reverts the secondary stuns stamina knockdown thing for secondary shocks as well.

Overall grille shocks and airlock shocks now paralyze (knockdown + stun) instead of knock you down and do stamina damage. Other shock sources generally already don't stun you by flags set from the shock source.

## Why It's Good For The Game

This change created an unintended consequence by making it so by not blocking movement with a stun you can just repeatedly move into the shocked airlock and grille and crit yourself/straight up die, similar to a conveyer grille shock trap but caused by not being able to react to the fact a grille is shocked, you continue moving into the grille or airlock and repeatedly get shocked over and over again (wow that's fun)

Shocks are a rather rare occurance anyways, touching a grille or shocked airlock stunning you isn't a major deal unless someone is actively there to punish you for getting stunned (most if not all direct player inflicted stuns and stuff like aoe shocks don't stun you and use a SHOCK_KNOCKDOWN or SHOCK_NOSTUN flag already, only grilles and shocked airlocks do)

I'd rather be stunned than repeatedly shock myself on a grille and die.

no one fixed this until now for some reason despite this being around for like 3-4 years.

this is mald after I got hit by this same exact thing again and it was never changed...

## Proof Of Testing

Video 1: Before
Video 2: After

Both tests use 1800 KW supply and 400 KW drawish for the station. Both tests held the W button down, simulating lag or simply not reacting in time. Before the changes, the amount of time you had to react to stop moving or change directions before being shocked again varied heavily. I was shocked 3 times in an almost instant span with basically no chance to react, taking triple the damage of video 2 (the third shock was from moving in soft crit).

<details>
<summary>Screenshots/Videos</summary>

Video 1: Before

https://github.com/user-attachments/assets/5c8a702f-221b-4d09-8327-8eaccce17651

Video 2: After

https://github.com/user-attachments/assets/b7a2f21a-32c8-4ce8-95e4-e08c6fd2b757

</details>

## Changelog

:cl:
balance: Shocked airlocks and grilles now stun you instead of just a knockdown and mild stamina damage.
fix: Fixed repeatedly shocking yourself to crit on airlocks and grilles due to not being stunned by airlocks/grilles. Should be less directly deadly now if you don't react to stop yourself.
/:cl:

