### PR TITLE
metalh2quickfix

### DIFF
--- a/modular_zubbers/code/modules/clothing/head/helmet.dm
+++ b/modular_zubbers/code/modules/clothing/head/helmet.dm
@@ -667,6 +667,7 @@
 	worn_icon = 'modular_zubbers/icons/mob/clothing/head/helmet.dmi'
 	worn_icon_teshari = 'modular_zubbers/icons/mob/clothing/head/helmet_teshari.dmi'
 	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL | BLOCK_GAS_SMOKE_EFFECT | STACKABLE_HELMET_EXEMPT | SNUG_FIT | HEADINTERNALS
+	material_flags = NONE
 	heat_protection = HEAD
 	cold_protection = HEAD
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT

--- a/modular_zubbers/code/modules/clothing/suits/armor.dm
+++ b/modular_zubbers/code/modules/clothing/suits/armor.dm
@@ -112,6 +112,7 @@
 	worn_icon = 'modular_zubbers/icons/mob/clothing/suits/armor.dmi'
 	worn_icon_digi = 'modular_zubbers/icons/mob/clothing/suits/armor_digi.dmi'
 	worn_icon_teshari = 'modular_zubbers/icons/mob/clothing/suits/armor_teshari.dmi'
+	material_flags = NONE
 	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL | BLOCK_GAS_SMOKE_EFFECT
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixed a small bug with material flagging on the metal h2 armor set.

## Why It's Good For The Game

Because the metal h2 armor is currently functionless

## Proof Of Testing

Tested on a localhost.

## Changelog

:cl:

fix: fixed metal hydrogen armor having no stats due to a material conflict

/:cl: