### PR TITLE
People who have the maximum amount of antag tickets are chosen for antag before those who don't.

### DIFF
--- a/modular_zubbers/code/modules/zantag_tickets/candidate_setup.dm
+++ b/modular_zubbers/code/modules/zantag_tickets/candidate_setup.dm
@@ -1,21 +1,41 @@
 /datum/round_event/antagonist/candidate_setup(datum/round_event_control/antagonist/cast_control)
 
 	var/list/candidates_tickets = candidates_to_tickets(cast_control.get_candidates())
-
-	//Logging purposes.
+	var/total_candidates = length(candidates_tickets)
 	var/total_tickets = 0
-	for(var/candidate in candidates_tickets)
-		var/candidate_weight = candidates_tickets[candidate]
-		total_tickets += candidate_weight
-	var/average_tickets = round(total_tickets / length(candidates_tickets),1)
+	var/absolute_maximum = CONFIG_GET(number/antag_ticket_maximum)
 
-	for(var/i in 1 to antag_count)
-		if(!length(candidates_tickets)) //All out of options.
-			break
+	//Get people with max tickets and move them to another list.
+	var/list/candidates_with_max_tickets = list()
+	for(var/mob/candidate as anything in candidates_tickets)
+		var/ticket_count = candidates_tickets[candidate]
+		if(ticket_count >= absolute_maximum) //You have the max
+			//Move to the VIP list.
+			candidates_with_max_tickets += candidate
+			candidates_tickets -= candidate
+		else //Only include non-vip people for total ticket logging.
+			total_tickets += ticket_count
+
+	var/antag_spawns_left = antag_count
+
+	//These are the people who have the maximum amount of tickets.
+	while(antag_spawns_left > 0 && length(candidates_with_max_tickets) > 0) //Keep going until we have no antag spawns left or no one else who has max tickets.
+		antag_spawns_left--
+		var/mob/candidate = pick(candidates_with_max_tickets)
+		candidates_with_max_tickets -= candidate
+		setup_minds += candidate.mind
+		candidate_roles_setup(candidate)
+		log_antag_tickets("[key_name(candidate)] was made a(n) [cast_control.name] as they had the maximum number of tickets, beating [length(candidates_with_max_tickets)] others with maximum tickets.")
+
+	//These are the people who don't.
+	while(antag_spawns_left > 0 && length(candidates_tickets) > 0) //Keep going until we have no antag spawns left or no one else.
+		antag_spawns_left--
 		var/mob/candidate = pick_weight(candidates_tickets)
+		var/our_tickets = candidates_tickets[candidate]
+		var/chance_to_get = (our_tickets/total_tickets)*100
 		candidates_tickets -= candidate
 		setup_minds += candidate.mind
 		candidate_roles_setup(candidate)
-		var/our_weight = candidates_tickets[candidate]
-		var/percent_chance = round( (our_weight/total_tickets)*100, 1)
-		log_antag_tickets("[key_name(candidate)] was made an antagonist with a [percent_chance]% chance to roll (self tickets: [our_weight], total tickets: [total_tickets], average tickets: [average_tickets]).")
+		log_antag_tickets("[key_name(candidate)] was made a(n) [cast_control.name] with [our_tickets] tickets ([chance_to_get]% chance).")
+
+	log_antag_tickets("There were [total_candidates] people who wanted to be a(n) [cast_control.name], and [antag_count - antag_spawns_left] candidate(s) got the role.")


### PR DESCRIPTION
## About The Pull Request

People who have the maximum amount of antag tickets are chosen for antag before those who don't. This basically means that those who have gone the longest without getting antag will be chosen for antag first.

Even if you don't have the maximum amount of antag tickets, you can still roll antagonist if there are still slots left. This PR just means that people with the maximum are given priority.

## Why It's Good For The Game

I've been told that antag tickets are meaningless because John McAntag still gets antag after a round because of rng and the fact that not many people sign up as antag. This PR should fix that partially by making it so that people who have gone the longest without antag are chosen first.

## Proof Of Testing

Draft because untested. Will probably need to make a unit test or something.

## Changelog

:cl: BurgerBB
add: People who have the maximum amount of antag tickets are chosen for antag before those who don't.
/:cl:
