### PR TITLE
Makes Black Market ruin always generate when possible

### DIFF
--- a/modular_skyrat/modules/mapping/code/space.dm
+++ b/modular_skyrat/modules/mapping/code/space.dm
@@ -83,6 +83,7 @@
 	suffix = "blackmarket.dmm"
 	name = "Space-Ruin Black Market"
 	description = "Market's open."
+	always_place = TRUE
 
 /datum/map_template/ruin/space/skyrat/shuttle8532
 	id = "shuttle8532"


### PR DESCRIPTION
Per my #suggestions post which received overwhelming support, adds the 'always_place' flag to the BMD ruin, forcing it to generate when possible. Like Tarkon!
## About The Pull Request
I literally changed one line to add the 'always_place' flag to `mapping/code/space.dmm` under the blackmarket ruin. The same flag that the Tarkon ruin uses to always generate when possible. 
## Why It's Good For The Game
BMD occupies a space that no other ghost role does; a small-scale off-station role with the sole purpose of making use of space ruins that would otherwise go ignored, **_WITH_** station interaction and RP _facilitated and encouraged._ 

It also hardly ever generates in favor of something like Charliestation or the Derelict Drone station-- Or Tarkon, which always generates and basically takes up an entire z-level. 

Making it always available would be healthy for RP, make the world feel larger than the confines of the station, and let people play non-NT or otherwise independent characters off of the main station without having to 1. be a Syndicate member, or 2. spend two hours setting up Tarkon on their own or with a metafriend.

Also it takes up very little space. I tested three times and saw no notable difference in how often other ghost role ruins generate  and how many other random space ruins generate.

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="330" height="61" alt="image" src="https://github.com/user-attachments/assets/467a46dc-8123-49e4-9cdc-4a1491ed250c" />
<img width="325" height="60" alt="image" src="https://github.com/user-attachments/assets/c497331f-1bc9-4a6c-90bb-e997226ddb6d" />
<img width="356" height="52" alt="image" src="https://github.com/user-attachments/assets/6883493e-7fe6-4965-9705-a0f3ef9eddd1" />

</details>

## Changelog
:cl:
map: Makes the Blackmarket ruin always generate when possible.
/:cl:
