### PR TITLE
unrigs the wizard die

### DIFF
--- a/modular_zubbers/code/modules/wizard_dize/wizard_dice_object.dm
+++ b/modular_zubbers/code/modules/wizard_dize/wizard_dice_object.dm
@@ -12,10 +12,6 @@
 
 	var/teleport_delay = 10 MINUTES
 	var/teleport_delay_pickup = 5 MINUTES
-
-	rigged = DICE_BASICALLY_RIGGED
-	rigged_value = 1
-
 	var/uses_left = 20 //The dice will still get consumed if someone gets wizard. Set to a value already less than 0 and it will be infinite.
 
 /obj/item/dice/d20/teleporting_die_of_fate/no_teleport


### PR DESCRIPTION

## About The Pull Request
unrigs the wizard die
## Why It's Good For The Game
it's kinda ass that it's super hard to roll the wizard die even if it spawns near people now, and it has limited uses now, considering to reduce the uses as a fallback so wizard isn't too common
## Proof Of Testing
it builds
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
balance: wizard die isn't rigged
/:cl:
