### PR TITLE
Adds stoats to pet owner quirk!

### DIFF
--- a/modular_zubbers/code/datums/quirks/neutral_quirks/pet_owner.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/pet_owner.dm
@@ -95,6 +95,7 @@ GLOBAL_LIST_INIT(possible_player_pet, list(
 	"Sloth" = /mob/living/basic/sloth,
 	"Snake" = /mob/living/basic/snake,
 	"Spider" = /mob/living/basic/spider/maintenance,
+	"Stoat" = /mob/living/basic/stoat,
 	"Tegu" = /mob/living/basic/lizard/tegu,
 	"Tiger" = /mob/living/basic/pet/cat/tiger,
 )) //some of these are too big to be put back into the pet carrier once taken out, so I put a warning on the carrier.


### PR DESCRIPTION

## About The Pull Request
You can now take stoats as pets! Yippee!
## Why It's Good For The Game
Kinda sucks that the only mustelid mob in the game isn't available as part of the pet owner quirk.

Now they are!
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
It's literally just adding stoats to the pool of mobs for petowner. It works as intended.
</details>

## Changelog
:cl:
add: Stoats can now be taken as pets with the Pet Owner Quirk! Enjoy your little squirmy fella.
/:cl:
