### PR TITLE
Re-Enables Mold

### DIFF
--- a/modular_zubbers/code/modules/storyteller/event_defines/moderate/moderate_overrides.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/moderate/moderate_overrides.dm
@@ -44,8 +44,6 @@
 
 /datum/round_event_control/mold
 	tags = list(TAG_COMMUNAL, TAG_COMBAT, TAG_CHAOTIC)
-	weight = 0
-	max_occurrences = 0
 
 /datum/round_event_control/obsessed
 	tags = list(TAG_TARGETED)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It brings mold back, removing an override that disabled mold from being spawned. 

## Why It's Good For The Game

With the (presumed) death of Fleshmind, Bubber is sorely lacking when it comes to external threats. Blob seems to be exceptionally rare, and spiders/xenos are eh. Bringing mold back would let us have a true PvE threat that people can fight (or not, I guess)

## Proof Of Testing

works on my machine 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Brings mold back

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
