### PR TITLE
Removes the SM healing factor from the stamina emitter diode disk

### DIFF
--- a/modular_zubbers/code/modules/projectiles/beams.dm
+++ b/modular_zubbers/code/modules/projectiles/beams.dm
@@ -1,0 +1,2 @@
+/obj/projectile/beam/emitter/hitscan/bluelens
+	integrity_heal = 0

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9603,6 +9603,7 @@
 #include "modular_zubbers\code\modules\power\lighting\light_mapping_helpers.dm"
 #include "modular_zubbers\code\modules\power\supermatter\supermatter_delam.dm"
 #include "modular_zubbers\code\modules\power\supermatter\supermatter_gas.dm"
+#include "modular_zubbers\code\modules\projectiles\beams.dm"
 #include "modular_zubbers\code\modules\projectiles\ammunition\ballistic\rifle.dm"
 #include "modular_zubbers\code\modules\projectiles\ammunition\ballistic\smg.dm"
 #include "modular_zubbers\code\modules\projectiles\boxes_magazines\external\pistol.dm"


### PR DESCRIPTION

## About The Pull Request
Title
## Why It's Good For The Game
0.25% healing is kind of insane, there's almost nothing you can do to an SM that 4 emitters with this disk (in tier 1 research (very early game)) can't outheal. Removing the barrier to entry on mechanics is fine, removing any danger or risk sucks.
## Proof Of Testing
it works dude trust me :)
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
balance: removed SM healing from diode disk
/:cl:
