### PR TITLE
Restores Per-Map Shuttles

### DIFF
--- a/_maps/boxstation.json
+++ b/_maps/boxstation.json
@@ -6,7 +6,7 @@
 	"shuttles": {
 		"emergency": "emergency_box",
 		"ferry": "ferry_fancy",
-		"cargo": "cargo_skyrat",
+		"cargo": "cargo_box",
 		"whiteship": "whiteship_box"
 	},
 	"job_changes": {

--- a/_maps/deltastation.json
+++ b/_maps/deltastation.json
@@ -6,7 +6,7 @@
 	"shuttles": {
 		"emergency": "emergency_delta",
 		"ferry": "ferry_fancy",
-		"cargo": "cargo_delta_skyrat",
+		"cargo": "cargo_delta",
 		"whiteship": "whiteship_delta"
 	},
 	"job_changes": {

--- a/_maps/icebox.json
+++ b/_maps/icebox.json
@@ -9,7 +9,7 @@
 	"planetary": 1,
 	"give_players_hooks": 1,
 	"shuttles": {
-		"cargo": "cargo_skyrat",
+		"cargo": "cargo_box",
 		"ferry": "ferry_fancy",
 		"whiteship": "whiteship_box",
 		"emergency": "emergency_box"

--- a/_maps/tramstation.json
+++ b/_maps/tramstation.json
@@ -5,7 +5,7 @@
 	"map_file": "tramstation.dmm",
 	"give_players_hooks": 1,
 	"shuttles": {
-		"cargo": "cargo_skyrat",
+		"cargo": "cargo_box",
 		"ferry": "ferry_fancy",
 		"whiteship": "whiteship_tram",
 		"emergency": "emergency_tram"

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -44,10 +44,10 @@
 
 	var/allow_custom_shuttles = TRUE
 	var/shuttles = list(
-		"cargo" = "cargo_skyrat",
+		"cargo" = "cargo_box",
 		"ferry" = "ferry_fancy",
 		"whiteship" = "whiteship_meta",
-		"emergency" = "emergency_skyrat", //SKYRAT EDIT CHANGE
+		"emergency" = "emergency_meta",
 	)
 
 	/// Dictionary of job sub-typepath to template changes dictionary


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game
<img width="981" height="881" alt="image" src="https://github.com/user-attachments/assets/c98b3fe8-a5f3-43bb-9cbf-c53e38141e0d" />

<img width="535" height="777" alt="image" src="https://github.com/user-attachments/assets/107b0004-f878-4c9f-9f7f-0658bd067195" />


TG maps typically have per-map shuttles which is very cool. Meaning that even if buying a shuttle slips the mind, you'd still have one different from the previous map.



## Proof Of Testing

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Per-Map shuttles are back.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
