### PR TITLE
Fix character voice dropdown showing IDs instead of names

### DIFF
--- a/modular_zubbers/code/modules/blooper/bark.dm
+++ b/modular_zubbers/code/modules/blooper/bark.dm
@@ -61,6 +61,15 @@ GLOBAL_VAR_INIT(blooper_allowed, TRUE) // For administrators
 /datum/preference/choiced/blooper/apply_to_human(mob/living/carbon/human/target, value)
 	target.set_blooper(value)
 
+/datum/preference/choiced/blooper/compile_constant_data()
+	var/list/data = ..()
+	var/list/display_names = list()
+	for(var/id in GLOB.blooper_list)
+		var/datum/blooper/blooper_path = GLOB.blooper_list[id]
+		display_names[id] = blooper_path::name
+	data[CHOICED_PREFERENCE_DISPLAY_NAMES] = display_names
+	return data
+
 /datum/preference_middleware/blooper
 	/// Cooldown on requesting a Blooper preview.
 	COOLDOWN_DECLARE(blooper_cooldown)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The dropdown where you pick a vocal bark for your character displays the internal ids of the barks, instead of the less ugly names that are supposed to be used

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

Looks less like shit

## Proof Of Testing

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->
<details>
<summary>Screenshots/Videos</summary>
<img width="643" height="470" alt="voices" src="https://github.com/user-attachments/assets/1d5a85eb-188e-474e-8da5-28a83a3b415d" />

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed vocal bark list using ids instead of names
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
