### PR TITLE
The penalties for not securing a disk no longer occur if there is no captain (or acting) around because I heard people died to it once.

### DIFF
--- a/modular_zubbers/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/modular_zubbers/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -1,0 +1,7 @@
+/obj/item/disk/nuclear/secured_process(last_move)
+
+	//If there is no assigned captain, then don't run the event.
+	if(!SSJob || !SSJob.assigned_captain)
+		return
+
+	. = ..()

--- a/modular_zubbers/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/modular_zubbers/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -1,7 +1,7 @@
 /obj/item/disk/nuclear/secured_process(last_move)
 
 	//If there is no assigned captain, then don't run the event.
-	if(!SSJob || !SSJob.assigned_captain)
+	if(!SSjob || !SSjob.assigned_captain)
 		return
 
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

The penalties for not securing a disk no longer occur if there is no captain (or acting) around.

## Why It's Good For The Game

While securing the disk is a staple of Space Station 13, so is taking a stapler to the face.

This PR is meant to affect lowpop times when there is not even a captain assigned to secure the disk, which is pretty common. Players shouldn't be punished for playing on lowpop when 90% of the population are probably there to get their 3am gooning session in.

## Proof Of Testing

If it compiles, it works.

## Changelog

:cl: BurgerBB
balance: The penalties for not securing a disk no longer occur if there is no captain (or acting) around because I heard people died to it once.
/:cl:
