### PR TITLE
All Uplink Items with limited stock now have their discount limited stock set to 1 because I observed a round once.

### DIFF
--- a/modular_zubbers/code/modules/uplink/uplink_items.dm
+++ b/modular_zubbers/code/modules/uplink/uplink_items.dm
@@ -1,0 +1,4 @@
+/datum/uplink_item/New()
+	. = ..()
+	if(limited_stock > 0)
+		limited_discount_stock = 1

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9775,6 +9775,7 @@
 #include "modular_zubbers\code\modules\tgui_input\color.dm"
 #include "modular_zubbers\code\modules\title_screen\code\title_screen_subsystem.dm"
 #include "modular_zubbers\code\modules\uplink\uplink_devices.dm"
+#include "modular_zubbers\code\modules\uplink\uplink_items.dm"
 #include "modular_zubbers\code\modules\uplink\uplink_items\badass.dm"
 #include "modular_zubbers\code\modules\uplink\uplink_items\job.dm"
 #include "modular_zubbers\code\modules\vehicles\mech_fabricator.dm"


### PR DESCRIPTION
## About The Pull Request

All Uplink Items with limited stock now have their discount limited stock set to 1.

Limited stock items typically include very powerful or spammy equipment, such as EMP bombs and Maxcaps.

This doesn't mean that you can only buy 1 of this item; it just means that you can only buy 1 of this item for the discount price.

## Why It's Good For The Game

Generally speaking if traitors see a very powerful item on sale, they will buy as many of it as possible even though they wouldn't normally buy it if it wasn't on sale. This usually results in one too many rounds where a traitor goes overboard with explosives or other spammable equipment, resulting in low-quality rounds.

Forcing the stock to 1 if it's a limited item should prevent spam from happening while still allowing traitors to benefit from sales.

## Proof Of Testing

If it compiles, it werks.

</details>

## Changelog

:cl: BurgerBB
balance: All Uplink Items with limited stock now have their discount limited stock set to 1.
/:cl:
