### PR TITLE
fix some unintentional DNR bugs

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1075,6 +1075,10 @@
 /mob/living/proc/can_be_revived()
 	if(health <= HEALTH_THRESHOLD_DEAD)
 		return FALSE
+		// BUBBER EDIT BEGIN - DNR FAILS REVIVE CHECK
+	if(HAS_TRAIT(src, TRAIT_DNR))
+		return FALSE
+		// BUBBER EDIT END
 	return TRUE
 
 /mob/living/proc/update_damage_overlays()

--- a/modular_zubbers/code/modules/changeling_zombies/infection.dm
+++ b/modular_zubbers/code/modules/changeling_zombies/infection.dm
@@ -13,6 +13,9 @@ GLOBAL_VAR_INIT(changeling_zombies_detected,FALSE)
 	if(!host.dna)
 		return FALSE
 
+	if(HAS_TRAIT(host, TRAIT_DNR))
+		return FALSE
+
 	var/datum/species/host_species = host.dna.species
 
 	if(host_species.no_equip_flags & ITEM_SLOT_OCLOTHING)


### PR DESCRIPTION

## About The Pull Request

Changeling Zombie and Medical Revival techniques should no longer bypass DNR

a future PR should be made to make changeling zombies offer to ghosts, when the zombie dies the mob is fully finished
## Why It's Good For The Game

bug fix

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: changelings can no longer make zombies out of DNR victims
/:cl:
