### PR TITLE
[MODULAR] Expands the Chain of Command for Acting Captainship to include Security, Guards, Medical, and Engineering to fix lowpop access issues.

### DIFF
--- a/modular_zubbers/code/controllers/subsystem/job.dm
+++ b/modular_zubbers/code/controllers/subsystem/job.dm
@@ -8,7 +8,31 @@
 			JOB_QUARTERMASTER = 6,
 			JOB_NT_REP = 7,
 			JOB_HEAD_OF_SECURITY = 8,
-			JOB_BLUESHIELD = 9
+			JOB_BLUESHIELD = 9,
+			JOB_BRIDGE_ASSISTANT = 10,
+			JOB_VETERAN_ADVISOR = 11,
+			// Security, as they're the most "responsible" due to their inability to roll antag and general need to get into places to do things like secure the disk or call the emergency shuttle.
+			JOB_WARDEN = 12,
+			JOB_SECURITY_OFFICER = 13,
+			JOB_DETECTIVE = 15,
+			JOB_SECURITY_MEDIC = 16,
+			JOB_CORRECTIONS_OFFICER = 17,
+			// Departmental Guards, as they're already trusted with head-level access to their departments, with a priority matching the head of staff they work for.
+			JOB_BOUNCER = 18,
+			JOB_SCIENCE_GUARD = 19,
+			JOB_ORDERLY = 20,
+			JOB_ENGINEERING_GUARD = 21,
+			JOB_CUSTOMS_AGENT = 22,
+			// Medical, as a member of the emergency services aboard the station, may need to get into departments to pick up bodies.
+			JOB_MEDICAL_DOCTOR = 23,
+			JOB_PARAMEDIC = 24,
+			JOB_CHEMIST = 25,
+			JOB_CORONER = 26,
+			JOB_PSYCHOLOGIST = 27,
+			// Engineering, as a member of the emergency services aboard the station, may need to get into departments to repair hull breaches.
+			JOB_STATION_ENGINEER = 28,
+			JOB_ATMOSPHERIC_TECHNICIAN = 29,
+			JOB_TELECOMMS_SPECIALIST = 30,
 		)
 
 /datum/controller/subsystem/job/proc/get_pda_type_by_job(job_name)


### PR DESCRIPTION
## About The Pull Request

Expands the Chain of Command for Acting Captainship to include Security, Guards, Medical, and Engineering to fix lowpop access issues.

I haven't tested this locally but it's a simple change. Easy enough to test on a localhost, but my local repo is tied up right now.

## Why It's Good For The Game

Lowpop is rearing it's ugly head at nights again due to a combination of college starting back up, work hours getting longer for employed individuals, and college exams kicking into high gear. People just can't stay up all night anymore and it's causing issues with lowpop rounds where nobody has access to critical sections of the station without committing some light breaking and entering into secure areas to do things like set up the engine, revive dead crew, and get weapons to fend off carps and threats.

As such, the following priority is now in effect for acting captainship:
1. The existing heads of staff, as they're authority figures who can't roll antag and are the existing chain of command.
2. Security, as they're authority figures who can't roll antag, are already targets for antags, and thus not worried about the additional risk of carrying the Captain's Spare ID and/or the nuclear authentication disk.
3. Departmental Guards,, as they're authority figures who can't roll antag, are already targets for antags, and thus not worried about the additional risk of carrying the Captain's Spare ID and/or the nuclear authentication disk. Their priority is equivalent to the priority of their heads of staff in the pecking order.
4. Medical, as they're part of the emergency services on the station alongside Security and Engineering, and need into places to rescue dead crew and revive them.
5. Engineering, as they're part of the emergency services on the station alongside Medical and Security, and need into places to fix hull breaches and stop disasters from unfolding.

Non-essential crew like Service, Assistants, and Clown are not included in the chain of command and thus aren't eligible for acting captainship.

Players in these new groups have already volunteered to contribute to the stability of the station and the wellbeing and safety of the crew, with a pre-existing expectation to respond to threats both crew-wise and structure-wise, so complaints about having responsibility is null and void; if you didn't want responsibility, don't sign up for emergency services staffing.

## Proof Of Testing

I haven't tested this locally but it's a simple change. Easy enough to test on a localhost, but my local repo is tied up right now.

## Changelog
:cl:
balance: Expands the Chain of Command for Acting Captainship to include Security, Guards, Medical, and Engineering to fix lowpop access issues.
/:cl:
