### PR TITLE
fixed exception with ghost species

### DIFF
--- a/modular_zubbers/code/modules/mob/living/carbon/human/species_types/ghost.dm
+++ b/modular_zubbers/code/modules/mob/living/carbon/human/species_types/ghost.dm
@@ -1,0 +1,2 @@
+/datum/species/ghost/get_species_description()
+	return list("Spirits are spirits of long-dead creatures whom, for one reason or another, still roam around.")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9518,6 +9518,7 @@
 #include "modular_zubbers\code\modules\mob\living\carbon\human\species_types\ethereal.dm"
 #include "modular_zubbers\code\modules\mob\living\carbon\human\species_types\felinid.dm"
 #include "modular_zubbers\code\modules\mob\living\carbon\human\species_types\flypeople.dm"
+#include "modular_zubbers\code\modules\mob\living\carbon\human\species_types\ghost.dm"
 #include "modular_zubbers\code\modules\mob\living\carbon\human\species_types\golems.dm"
 #include "modular_zubbers\code\modules\mob\living\carbon\human\species_types\hemophage_species.dm"
 #include "modular_zubbers\code\modules\mob\living\carbon\human\species_types\humanoid.dm"


### PR DESCRIPTION
## About The Pull Request
Fixes exception when choosing Ghost species.
Most of species have overrides in
modular_zubbers\code\modules\mob\living\carbon\human\species_types
which returning lists instead of strings.
https://github.com/Bubberstation/Bubberstation/issues/4785
## Why It's Good For The Game
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="1006" height="768" alt="image" src="https://github.com/user-attachments/assets/057d682b-264a-4285-a5ea-842c53ea0afe" />
<img width="1023" height="823" alt="image" src="https://github.com/user-attachments/assets/8fda32d5-e4c6-4c33-a70a-299d25021186" />
</details>

## Changelog
:cl:
fix: Fixed ghost species crashing character preferences menu
/:cl:
