### PR TITLE
Fixed bug with powerator?

### DIFF
--- a/modular_zubbers/code/modules/power/powerator.dm
+++ b/modular_zubbers/code/modules/power/powerator.dm
@@ -178,7 +178,7 @@
 		return
 
 	if(!attached_cable.avail(current_power))
-		if(!attached_cable.avail())
+		if(!attached_cable.newavail())
 			return
 		current_power = min(max_power, attached_cable.newavail())
 	attached_cable.add_delayedload(current_power)


### PR DESCRIPTION
## About The Pull Request
Should fix [Powerator selling over it's limit #4788](https://github.com/Bubberstation/Bubberstation/issues/4788)
All simple. If power in grid bigger than max_power, it will use max_power value. If lower - it gonna use power in grid value. Looks sane.
## Why It's Good For The Game
## Proof Of Testing
Uhhhh... I tried to reproduce it, but I kinda struggled to fall into this condition with attached_cable.newavail() > max_power.
I think it will work though!
Update: These screenshots should do I think
<details>
<summary>Screenshots/Videos</summary>
<img width="1406" height="372" alt="image" src="https://github.com/user-attachments/assets/e4422d58-9d48-4d67-bb7e-b3a1b713a79b" />
<img width="1520" height="423" alt="image" src="https://github.com/user-attachments/assets/d616dfce-6f41-413d-94d0-2faa0dbc3ee2" />

</details>

## Changelog
:cl:
fix: Fixed powerator being able to sell more power than it supposed to
/:cl:
