### PR TITLE
Fixes "Wisteria Antennae" being unselectable

### DIFF
--- a/modular_zubbers/code/modules/customization/sprite_accessories/horns.dm
+++ b/modular_zubbers/code/modules/customization/sprite_accessories/horns.dm
@@ -116,6 +116,6 @@
 	name = "Cryptid Antlers"
 	icon_state = "cryptid"
 
-/datum/sprite_accessory/horns/bubber/antennae/wisteria
+/datum/sprite_accessory/horns/bubber/antennae/insectoidcrest
 	name = "Sharp Insectoid Crest"
 	icon_state = "sharp_crest"


### PR DESCRIPTION
## About The Pull Request
Title. Someone did an oopsie, and used "wisteria" as their horns name, meaning the wisteria antennae couldn't be used.
## Why It's Good For The Game
Please, my bug looks bald.
## Proof Of Testing
<img width="960" height="577" alt="image" src="https://github.com/user-attachments/assets/47239ff2-8bd8-41cc-a437-e5152bffc2a3" />
<details>
<summary>Screenshots/Videos
</summary>

</details>
