### PR TITLE
Fix quirk balances being broken

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -638,3 +638,5 @@ SPY_EASY_REWARD_TC_THRESHOLD 5
 ## Hard bounties grant uplink rewards that cost this much TC (or higher).
 ## Also functions as the upper end for medium bounties.
 SPY_HARD_REWARD_TC_THRESHOLD 15
+
+DEFAULT_QUIRK_POINTS 0

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/QuirksPage.tsx
@@ -325,8 +325,10 @@ function QuirkPage() {
     }
   });
 
-  const balance = -data.default_quirk_balance;
-  const positiveQuirks = 0;
+  // BUBBER EDIT START - Better Quirk Count Code
+  const balance = -data.quirks_balance;
+  const positiveQuirks = data.positive_quirk_count;
+  // BUBBER EDIT END - Better Quirk Count Code
 
   /* // BUBBER EDIT START - We handle this on the backend
   for (const selectedQuirkName of selectedQuirks) {


### PR DESCRIPTION

## About The Pull Request

A bit of our modular code was reverted that shouldn't have been, and upstream added a config for starting quirk points that defaults to -2 when we're currently set up for 0, so that is changed as well

## Why It's Good For The Game

The server borked

## Proof Of Testing

I tested and was able to add/remove quirks as normal

## Changelog
:cl:
fix: fixed quirk balances being broken
/:cl:
