### PR TITLE
Adds Bridge Assistant to Chain of Succession

### DIFF
--- a/modular_zubbers/code/controllers/subsystem/job.dm
+++ b/modular_zubbers/code/controllers/subsystem/job.dm
@@ -8,7 +8,8 @@
 			JOB_QUARTERMASTER = 6,
 			JOB_NT_REP = 7,
 			JOB_HEAD_OF_SECURITY = 8,
-			JOB_BLUESHIELD = 9
+			JOB_BLUESHIELD = 9,
+			JOB_BRIDGE_ASSISTANT = 10
 		)
 
 /datum/controller/subsystem/job/proc/get_pda_type_by_job(job_name)


### PR DESCRIPTION
Per a conversation in staff, Bridge Assistant should be the lowest level on the chain of succession, given the bridge is their workspace and they're technically command. Wiki will be updated to reflect this upon merge.

🆑
add: Bridge assistant added to chain of succession, at the very lowest level.
/:cl: