### PR TITLE
Fixes Moonstation Wiring

### DIFF
--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -932,6 +932,7 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/tcommsat/computer)
 "amt" = (
@@ -4701,6 +4702,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "blw" = (
@@ -11704,6 +11706,7 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/east,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/tcommsat/computer)
 "djc" = (
@@ -14822,6 +14825,7 @@
 /obj/machinery/door/airlock/engineering/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "ecP" = (
@@ -15453,6 +15457,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/assistant,
+/obj/structure/cable,
 /turf/open/floor/iron/large,
 /area/station/commons/storage/tools)
 "ekH" = (
@@ -18349,6 +18354,7 @@
 /area/station/maintenance/starboard/aft)
 "eXq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/engineering/break_room)
 "eXt" = (
@@ -21129,6 +21135,7 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/terminal/maintenance/fore)
 "fHC" = (
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "fHE" = (
@@ -22631,8 +22638,8 @@
 /area/station/security/prison/work)
 "gcc" = (
 /obj/machinery/power/smes/full,
-/obj/structure/cable,
 /obj/structure/sign/warning/gas_mask/directional/west,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/tcommsat/computer)
 "gcl" = (
@@ -25160,7 +25167,6 @@
 /area/station/cargo/storage)
 "gOK" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -26166,6 +26172,7 @@
 "hcY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/iron/large,
 /area/station/commons/storage/tools)
 "hdk" = (
@@ -28837,6 +28844,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
 "hLn" = (
@@ -29991,7 +29999,6 @@
 /area/station/maintenance/department/prison)
 "ibs" = (
 /obj/machinery/door/airlock/maintenance_hatch,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
@@ -38158,6 +38165,7 @@
 /area/moonstation/surface)
 "kmZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/large,
 /area/station/commons/storage/tools)
 "knc" = (
@@ -43703,7 +43711,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/tcommsat/computer)
 "lIT" = (
@@ -47411,6 +47418,7 @@
 /obj/effect/landmark/navigate_destination/autoname,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/door/airlock/engineering/glass,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "mIo" = (
@@ -52038,6 +52046,7 @@
 "nXF" = (
 /obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/large,
 /area/station/commons/storage/tools)
 "nXH" = (
@@ -57616,6 +57625,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "psB" = (
@@ -67169,6 +67179,11 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark/corner,
 /area/station/common/wrestling/arena)
+"rXq" = (
+/obj/item/kirbyplants/random,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/tcommsat/computer)
 "rXs" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -249063,7 +249078,7 @@ gWY
 kbe
 diP
 amq
-jik
+rXq
 fqU
 pND
 jik


### PR DESCRIPTION
## About The Pull Request

Fixes one (1) misplaced wire that caused Moonstation to not have power to the eastern side of the staiton.
Fixes one(1) misplaced wire in telecomms that caused telecomms not to use its emergency backup power.
Adds some redundant wires that I felt were needed to remove deadends.

## Why It's Good For The Game

AAAAAAAAAAAAAAAA

## Proof Of Testing

Tested

## Changelog


:cl: BurgerBB
fix: Fixes Moonstation Wiring
/:cl:

