### PR TITLE
Fixes #4753 not actually woking and having the complete opposite effect intended.

### DIFF
--- a/modular_zubbers/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/modular_zubbers/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -1,3 +1,11 @@
+/obj/item/disk/nuclear/unsecured_process(last_move)
+
+	//If there is no assigned captain, then don't run the event.
+	if(!SSjob || !SSjob.assigned_captain)
+		return
+
+	. = ..()
+
 /obj/item/disk/nuclear/secured_process(last_move)
 
 	//If there is no assigned captain, then don't run the event.


### PR DESCRIPTION
## About The Pull Request

Fixes #4753 not actually working.

Because of a typo (unsecured vs secured), the acting captain check would only happen when reducing the weight of lone ops when the disk is secured, meaning that shifts with no captain could technically have a higher chance to occur since there was no way to reduce the weight.

## Why It's Good For The Game

Imagine making PRs that actually fucking work.

## Proof Of Testing

It actually works this time trust me bro one more pr to fix traffic trust me one more lane.

## Changelog

:cl: BurgerBB
fix: Fixes shifts with no captains having nuke ops.
/:cl:

