### PR TITLE
Ports "Adds Feedback for the Psionic Holding Quirk"

### DIFF
--- a/modular_zubbers/code/datums/quirks/positive_quirks/floating_items.dm
+++ b/modular_zubbers/code/datums/quirks/positive_quirks/floating_items.dm
@@ -44,9 +44,11 @@
 			if(ishuman(owner))
 				var/mob/living/carbon/human/owner_human = owner
 				owner_human.update_held_items()
+			to_chat(owner, span_notice("You stop focusing on moving objects with your mind."))
 		else
 			ADD_TRAIT(owner, TRAIT_FLOATING_HELD, QUIRK_TRAIT)
 			if(ishuman(owner))
 				var/mob/living/carbon/human/owner_human = owner
 				owner_human.update_held_items()
+			to_chat(owner, span_notice("You feel ready to move objects with your mind."))
 	return TRUE


### PR DESCRIPTION

## About The Pull Request

Title. Ports https://github.com/NovaSector/NovaSector/pull/5956 as I think it's a good PR. And also yknow.
## Why It's Good For The Game

"I have a hard time figuring something out if it's on or off without a chat message so this is more self serving than anything (and maybe those who have the same issue as me)"

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl: BasilTamaya
qol: Psionic Holding now tells you if you're holding something telekinetically or not.
/:cl:
