### PR TITLE
Nerfs the Persistence interdyne suit

### DIFF
--- a/_maps/bubber/automapper/templates/IceBoxStation/iceboxstation_persistence.dmm
+++ b/_maps/bubber/automapper/templates/IceBoxStation/iceboxstation_persistence.dmm
@@ -25093,13 +25093,13 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/space/has_grav/bubbers/persistance/service/dorms/morale)
 "YP" = (
-/obj/machinery/suit_storage_unit/interdyne,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/mapping_helpers/apc/syndicate_access,
 /obj/effect/mapping_helpers/apc/full_charge,
 /obj/effect/mapping_helpers/apc/cut_AI_wire,
 /obj/structure/cable,
 /obj/machinery/light/directional/north,
+/obj/machinery/suit_storage_unit/industrial/syndicatemed,
 /turf/open/floor/wood/large,
 /area/ruin/space/has_grav/bubbers/persistance/service/dorms/medical)
 "YQ" = (

--- a/_maps/bubber/automapper/templates/lavaland/lavaland_persistence.dmm
+++ b/_maps/bubber/automapper/templates/lavaland/lavaland_persistence.dmm
@@ -10167,13 +10167,13 @@
 /turf/closed/wall/r_wall/plastitanium/syndicate/cruiser,
 /area/ruin/space/has_grav/bubbers/persistance/service/salon)
 "uB" = (
-/obj/machinery/suit_storage_unit/interdyne,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/mapping_helpers/apc/syndicate_access,
 /obj/effect/mapping_helpers/apc/full_charge,
 /obj/effect/mapping_helpers/apc/cut_AI_wire,
 /obj/structure/cable,
 /obj/machinery/light/directional/north,
+/obj/machinery/suit_storage_unit/industrial/syndicatemed,
 /turf/open/floor/wood/large,
 /area/ruin/space/has_grav/bubbers/persistance/service/dorms/medical)
 "uC" = (

--- a/modular_zubbers/code/modules/syndicate_offstation/equipment_items/mod_types.dm
+++ b/modular_zubbers/code/modules/syndicate_offstation/equipment_items/mod_types.dm
@@ -19,3 +19,7 @@
 		/obj/item/melee/energy/sword,
 		/obj/item/shield/energy,
 	)
+
+//added so persistence interdyne mod isn't stupid fast
+/datum/mod_theme/interdyne/persistence
+	slowdown_deployed = 0

--- a/modular_zubbers/code/modules/syndicate_offstation/equipment_items/suitstorage.dm
+++ b/modular_zubbers/code/modules/syndicate_offstation/equipment_items/suitstorage.dm
@@ -25,6 +25,11 @@
 	storage_type = /obj/item/tank/internals/emergency_oxygen/double
 	mask_type = /obj/item/clothing/mask/gas/syndicate
 
+/obj/machinery/suit_storage_unit/industrial/syndicatemed
+	mod_type = /obj/item/mod/control/pre_equipped/interdyne/persistence
+	storage_type = /obj/item/tank/internals/emergency_oxygen/double
+	mask_type = /obj/item/clothing/mask/gas/syndicate
+
 //Modsuit loadouts
 
 //morale officer suit
@@ -71,3 +76,5 @@
 	inbuilt_modules = list()
 	slot_flags = ITEM_SLOT_BACK
 
+/obj/item/mod/control/pre_equipped/interdyne/persistence
+	theme = /datum/mod_theme/interdyne/persistence


### PR DESCRIPTION

## About The Pull Request

The interdyne modsuit goes REALLY fast. This PR makes it go less fast.
## Why It's Good For The Game

Maintainer told me too. Also this is a prerequisite for another project I am working on.

<img width="446" height="532" alt="image" src="https://github.com/user-attachments/assets/0a2f0936-a3f7-40f3-896b-3bbdfd7d787c" />
## Proof Of Testing

<img width="649" height="620" alt="image" src="https://github.com/user-attachments/assets/7a3117f7-982d-4c23-9d69-120c50b8fcde" />
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
balance: The persistence interdyne mod is slower.
/:cl:
