### PR TITLE
Fix runtime with infiltrator modsuit

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/MOD_sprite_accessories/mod_accessory_handler.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/MOD_sprite_accessories/mod_accessory_handler.dm
@@ -40,7 +40,7 @@
 
 /datum/sprite_accessory/tails/get_custom_mod_icon(mob/living/carbon/human/wearer, mutable_appearance/appearance_to_use = null)
 	if(wearer?.wear_suit && istype(wearer.wear_suit, /obj/item/clothing/suit/mod))
-		var/obj/item/mod/control/modsuit_control = wearer.back
+		var/obj/item/mod/control/modsuit_control = locate() in wearer.get_equipped_items()
 		var/datum/mod_theme/mod_theme = modsuit_control.theme
 
 		if(!modsuit_control.active || !mod_theme.hardlight)
@@ -59,7 +59,7 @@
 
 /datum/sprite_accessory/ears/get_custom_mod_icon(mob/living/carbon/human/wearer, mutable_appearance/appearance_to_use = null)
 	if(wearer?.head && istype(wearer.head, /obj/item/clothing/head/mod))
-		var/obj/item/mod/control/modsuit_control = wearer.back
+		var/obj/item/mod/control/modsuit_control = locate() in wearer.get_equipped_items()
 		var/datum/mod_theme/mod_theme = modsuit_control.theme
 
 		if(!modsuit_control.active || !mod_theme.hardlight)
@@ -78,7 +78,7 @@
 
 /datum/sprite_accessory/wings/get_custom_mod_icon(mob/living/carbon/human/wearer, mutable_appearance/appearance_to_use = null)
 	if(wearer?.wear_suit && istype(wearer.wear_suit, /obj/item/clothing/suit/mod))
-		var/obj/item/mod/control/modsuit_control = wearer.back
+		var/obj/item/mod/control/modsuit_control = locate() in wearer.get_equipped_items()
 		var/datum/mod_theme/mod_theme = modsuit_control.theme
 
 		if(!modsuit_control.active || !mod_theme.hardlight)
@@ -97,7 +97,7 @@
 
 /datum/sprite_accessory/moth_antennae/get_custom_mod_icon(mob/living/carbon/human/wearer, mutable_appearance/appearance_to_use = null)
 	if(wearer?.head && istype(wearer.head, /obj/item/clothing/head/mod))
-		var/obj/item/mod/control/modsuit_control = wearer.back
+		var/obj/item/mod/control/modsuit_control = locate() in wearer.get_equipped_items()
 		var/datum/mod_theme/mod_theme = modsuit_control.theme
 
 		if(!modsuit_control.active || !mod_theme.hardlight)
@@ -116,7 +116,7 @@
 
 /datum/sprite_accessory/antenna/get_custom_mod_icon(mob/living/carbon/human/wearer, mutable_appearance/appearance_to_use = null)
 	if(wearer?.head && istype(wearer.head, /obj/item/clothing/head/mod))
-		var/obj/item/mod/control/modsuit_control = wearer.back
+		var/obj/item/mod/control/modsuit_control = locate() in wearer.get_equipped_items()
 		var/datum/mod_theme/mod_theme = modsuit_control.theme
 
 		if(!modsuit_control.active || !mod_theme.hardlight)
@@ -135,7 +135,7 @@
 
 /datum/sprite_accessory/horns/get_custom_mod_icon(mob/living/carbon/human/wearer, mutable_appearance/appearance_to_use = null)
 	if(wearer?.head && istype(wearer.head, /obj/item/clothing/head/mod))
-		var/obj/item/mod/control/modsuit_control = wearer.back
+		var/obj/item/mod/control/modsuit_control = locate() in wearer.get_equipped_items()
 		var/datum/mod_theme/mod_theme = modsuit_control.theme
 
 		if(!modsuit_control.active || !mod_theme.hardlight)
@@ -153,7 +153,7 @@
 
 /datum/sprite_accessory/taur/get_custom_mod_icon(mob/living/carbon/human/wearer, mutable_appearance/appearance_to_use = null)
 	if(wearer?.wear_suit && istype(wearer.wear_suit, /obj/item/clothing/suit/mod))
-		var/obj/item/mod/control/modsuit_control = wearer.back
+		var/obj/item/mod/control/modsuit_control = locate() in wearer.get_equipped_items()
 		var/datum/mod_theme/mod_theme = modsuit_control.theme
 
 		if(!modsuit_control.active || !mod_theme.hardlight)
@@ -171,7 +171,7 @@
 
 /datum/sprite_accessory/spines/get_custom_mod_icon(mob/living/carbon/human/wearer, mutable_appearance/appearance_to_use = null)
 	if(wearer?.wear_suit && istype(wearer.wear_suit, /obj/item/clothing/suit/mod))
-		var/obj/item/mod/control/modsuit_control = wearer.back
+		var/obj/item/mod/control/modsuit_control = locate() in wearer.get_equipped_items()
 		var/datum/mod_theme/mod_theme = modsuit_control.theme
 
 		if(!modsuit_control.active || !mod_theme.hardlight)
@@ -189,7 +189,7 @@
 
 /datum/sprite_accessory/xenodorsal/get_custom_mod_icon(mob/living/carbon/human/wearer, mutable_appearance/appearance_to_use = null)
 	if(wearer?.wear_suit && istype(wearer.wear_suit, /obj/item/clothing/suit/mod))
-		var/obj/item/mod/control/modsuit_control = wearer.back
+		var/obj/item/mod/control/modsuit_control = locate() in wearer.get_equipped_items()
 		var/datum/mod_theme/mod_theme = modsuit_control.theme
 
 		if(!modsuit_control.active || !mod_theme.hardlight)


### PR DESCRIPTION

## About The Pull Request

This code assumes the modsuit control unit is always on the back but infiltrator suits go on the belt and it runtimes

## Why It's Good For The Game

Runtime fix

## Proof Of Testing

Yes