### PR TITLE
Fixes the invisible icons on the VOKSHOD and HEV

### DIFF
--- a/modular_skyrat/modules/hev_suit/code/hev_suit.dm
+++ b/modular_skyrat/modules/hev_suit/code/hev_suit.dm
@@ -215,16 +215,16 @@
 /datum/action/item_action/hev_toggle
 	name = "Toggle HEV Suit"
 	button_icon = 'modular_skyrat/modules/hev_suit/icons/toggles.dmi'
-	background_icon_state = "bg_hl"
-	button_icon = 'modular_skyrat/modules/hev_suit/icons/toggles.dmi'
 	button_icon_state = "system_off"
+	background_icon = 'modular_skyrat/modules/hev_suit/icons/toggles.dmi'
+	background_icon_state = "bg_hl"
 
 /datum/action/item_action/hev_toggle_notifs
 	name = "Toggle HEV Suit Notifications"
 	button_icon = 'modular_skyrat/modules/hev_suit/icons/toggles.dmi'
-	background_icon_state = "bg_hl"
-	button_icon = 'modular_skyrat/modules/hev_suit/icons/toggles.dmi'
 	button_icon_state = "sound_VOICE_AND_TEXT"
+	background_icon = 'modular_skyrat/modules/hev_suit/icons/toggles.dmi'
+	background_icon_state = "bg_hl"
 
 /datum/action/item_action/hev_toggle_notifs/Trigger(trigger_flags)
 	var/obj/item/clothing/suit/space/hev_suit/my_suit = target

--- a/modular_skyrat/modules/novaya_ert/code/suit.dm
+++ b/modular_skyrat/modules/novaya_ert/code/suit.dm
@@ -68,16 +68,16 @@
 /datum/action/item_action/hev_toggle/nri
 	name = "Toggle VOSKHOD Suit"
 	button_icon = 'modular_skyrat/modules/novaya_ert/icons/toggles.dmi'
+	button_icon_state = "system_off"
+	background_icon = 'modular_skyrat/modules/novaya_ert/icons/toggles.dmi'
 	background_icon_state = "bg_nri"
-	button_icon = 'modular_skyrat/modules/novaya_ert/icons/toggles.dmi'
-	button_icon_state = "toggle"
 
 /datum/action/item_action/hev_toggle_notifs/nri
 	name = "Toggle VOSKHOD Suit Notifications"
 	button_icon = 'modular_skyrat/modules/novaya_ert/icons/toggles.dmi'
+	button_icon_state = "sound_VOICE_AND_TEXT"
+	background_icon = 'modular_skyrat/modules/novaya_ert/icons/toggles.dmi'
 	background_icon_state = "bg_nri"
-	button_icon = 'modular_skyrat/modules/novaya_ert/icons/toggles.dmi'
-	button_icon_state = "sound"
 
 /obj/item/clothing/suit/space/hev_suit/nri/captain
 	name = "\improper VOSKHOD-2 powered combat armor"


### PR DESCRIPTION
These never had the correct background_icon set. Also the VOKSHOD seems to have lacked the correct button_icon_state too. Both are now fixed :3

## Why It's Good For The Game

Bugfix good, plus I got this bountied and I need my estrogen money

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

<img width="281" height="99" alt="image" src="https://github.com/user-attachments/assets/22314223-8b01-4e6f-8431-4e63a3dbbc5a" />

</details>

## Changelog

:cl:
fix: The HEV and VOKSHOD suits now have the correct icon states for their item actions
/:cl:
