### PR TITLE
removes ashen passage from the draft + shop

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/ash_lore.dm
@@ -95,7 +95,7 @@
 
 	action_to_add = /datum/action/cooldown/spell/jaunt/ethereal_jaunt/ash
 	cost = 2
-    // drafting_tier = 5 BUBBER REMOVAL
+	// drafting_tier = 5 BUBBER REMOVAL
 
 /datum/heretic_knowledge/spell/fire_blast
 	name = "Volcano Blast"


### PR DESCRIPTION

## About The Pull Request
this removes ashen passage from the heretic shop and random drafts

## Why It's Good For The Game
apparently it was too much movement for all paths

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
balance: ashen passage is no longer in the shop/random drafts
/:cl:

