### PR TITLE
Re-enables Clown Banana Shoes

### DIFF
--- a/code/modules/uplink/uplink_items/clownops.dm
+++ b/code/modules/uplink/uplink_items/clownops.dm
@@ -141,7 +141,6 @@
 	cost = 80
 	purchasable_from = UPLINK_CLOWN_OPS
 
-/* // SKYRAT EDIT REMOVAL START
 /datum/uplink_item/stealthy_tools/combatbananashoes
 	name = "Combat Banana Shoes"
 	desc = "While making the wearer immune to most slipping attacks like regular combat clown shoes, these shoes \
@@ -151,7 +150,6 @@
 	cost = 6
 	surplus = 0
 	purchasable_from = UPLINK_CLOWN_OPS
-*/ // SKYRAT EDIT REMOVAL END
 
 /datum/uplink_item/badass/clownopclumsinessinjector //clowns can buy this too, but it's in the role-restricted items section for them
 	name = "Clumsiness Injector"


### PR DESCRIPTION

## About The Pull Request

Another Skyrat I died removal getting put into a giant woodchipper labelled 'fun'. Everytime you revert a Skyrat change, Xyel's blood pressure goes up.

## Why It's Good For The Game

Why was this removed?

## Proof Of Testing

it work

## Changelog
:cl:
add: Clown Banana Shoes are buyable in the uplink again.
/:cl:
