### PR TITLE
Increases security rocket launcher explosion damage from 30 to 50 because I got shot by it once and was like "wait that's it"

### DIFF
--- a/modular_zubbers/code/modules/security_rocket_launcher/projectile.dm
+++ b/modular_zubbers/code/modules/security_rocket_launcher/projectile.dm
@@ -15,7 +15,7 @@
 	range = 100
 	can_hit_turfs = FALSE
 
-	var/explosion_damage = 30 //Same as a light explosion.
+	var/explosion_damage = 50 //A light explosion is 30.
 	var/ignition_speed = 1 //Speed is set to this value after meeting minimium range.
 	var/minimum_range = 2
 	var/cached_range = 0 //Cheaper than calling initial(range) constantly.


### PR DESCRIPTION
## About The Pull Request

Increases security rocket launcher explosion damage from 30 to 50 because I got shot by it once and was like "wait that's it"

## Why It's Good For The Game

The weapon is super weak and no one uses it. Hopefully a numbers change gets people to use it.

## Proof Of Testing

If it compiles, it werks.

</details>

## Changelog

:cl: BurgerBB
balance: Increases security rocket launcher explosion damage from 30 to 50
/:cl:
