### PR TITLE
Adds New Roleplay Title to Nanotrasen Representative

### DIFF
--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -358,13 +358,11 @@
 		"Nanotrasen Diplomat",
 		"Nanotrasen Representative",
 		"Nanotrasen Liason",
-		"Nanotrasen Idol",
 		"Central Command Consultant",
 		"Central Command Advisor",
 		"Central Command Diplomat",
 		"Central Command Representative",
 		"Central Command Liason",
-		"Central Command Idol",
 		"Corporate Liason",
 		"Corporate Consultant",
 	)

--- a/modular_zubbers/code/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_zubbers/code/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -77,3 +77,10 @@
 		"Body Retrieval Specialist",
 	)
 	. = ..()
+
+/datum/job/nanotrasen_consultant/New()
+	alt_titles |= list(
+				"Nanotrasen Idol",
+				"Central Command Idol",
+	)
+	. = ..()


### PR DESCRIPTION
## About The Pull Request
This PR adds an alternative and more casual title to Nanotrasen Representative, Nanotrasen/Central Command Idol.

The reasoning behind this change is NTR already has access to idol equipment, like the NT idol jumpskirt, which can be found in the loadout menu and NTR's closet.

The NT idol jumpskirt already exists and is within the game.

This PR does not add the NT idol jumpskirt, only an alt name to match.

Picture of NT idol jumpsuit within the game already:
<img width="129" height="145" alt="Screenshot 2025-11-10 131019" src="https://github.com/user-attachments/assets/1b57ee27-0953-4f9c-a4e2-c27ccea293d7" />
## Why It's Good For The Game
Adds another roleplay alternative to Nanotrasen Representative that can change the way you express your relationship with the company. Instead of being a hardened bureaucrat, you're one of the many faces to this very friendly company, *until someone crosses the line*. Be the manipulative parasocial idol of NT today!

If this PR gets accepted, I may expand the NTR's closet to include more generic idol clothing. Though, that will be its own PR. 

This PR is ready and is not awaiting any other changes.
## Proof Of Testing
It compiled and works locally. It's a really simple code change... ugh. It works.
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
add: New title to Nanotrasen Representative, Nanotrasen/Central Command Idol
/:cl:
