### PR TITLE
Fixes mislabeled evac sign on Moonstation

### DIFF
--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -20912,6 +20912,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/garden)
+"fEJ" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/hallway/primary/starboard)
 "fEK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -30523,6 +30532,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/machinery/door/airlock/public/glass,
+/obj/structure/sign/departments/evac/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hallway)
 "ikg" = (
@@ -37620,6 +37630,7 @@
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 1
 	},
+/obj/structure/sign/departments/evac/directional/east,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/starboard)
 "kfB" = (
@@ -38914,6 +38925,13 @@
 /obj/effect/decal/cleanable/confetti,
 /turf/open/floor/eighties,
 /area/station/maintenance/abandon_arcade)
+"kwB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark/corner,
+/area/station/hallway/secondary/exit)
 "kwC" = (
 /obj/machinery/computer/atmos_control/mix_tank{
 	dir = 1;
@@ -39578,6 +39596,16 @@
 /obj/effect/spawner/random/burgerstation/power,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai/satellite/service)
+"kFt" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/station/engineering/atmos/hallway)
 "kFz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -55965,8 +55993,9 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/obj/structure/flora/tree/palm/style_random{
-	pixel_y = 12
+/obj/structure/fluff/beach_umbrella/science{
+	pixel_y = 7;
+	pixel_x = -4
 	},
 /turf/open/misc/beach/sand,
 /area/station/science/genetics)
@@ -264779,7 +264808,7 @@ iRL
 dPP
 dPP
 gLd
-xaX
+fEJ
 xMC
 cDa
 rLN
@@ -264796,7 +264825,7 @@ fYw
 fYw
 lyJ
 mCr
-fYw
+kFt
 lSM
 ejo
 pvF
@@ -265812,7 +265841,7 @@ lSy
 big
 oDq
 xXg
-hXM
+kwB
 tke
 oXD
 pwX


### PR DESCRIPTION
## About The Pull Request

Fixes mislabeled evac sign on Moonstation.
Adds some extra detail and missing wall stuff in the evac hallway.

## Why It's Good For The Game

Fixes good.

## Proof Of Testing

If it compiles, it werks.

## Changelog

:cl: BurgerBB
fix: Fixes mislabeled evac sign on Moonstation
/:cl:

