### PR TITLE
Prevents the nukeop plushie from giving illegal tech

### DIFF
--- a/modular_zubbers/code/modules/uplink/uplink_items/badass.dm
+++ b/modular_zubbers/code/modules/uplink/uplink_items/badass.dm
@@ -3,6 +3,7 @@
 	desc = "For agents in the field requiring urgent emotional support."
 	item = /obj/item/toy/plush/nukeplushie
 	cost = 1
+	uplink_item_flags = NONE
 
 /datum/uplink_item/badass/medalbox
 	name = "Syndicate Medal Box"


### PR DESCRIPTION
## About The Pull Request
someone added it to the uplink a year ago and forgot to give the uplink_item_flags = NONE flag
## Why It's Good For The Game
bug fix
## Proof Of Testing
<img width="400" height="260" alt="afbeelding" src="https://github.com/user-attachments/assets/f807417a-f39a-4039-bd93-c9f554689a5c" />
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: nukeop plushies are no longer capable of giving illegal tech
/:cl:
