### PR TITLE
Fixes the spraycan renaming bug

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -213,10 +213,11 @@
 	dye_color = crayon_color
 
 	drawtype = pick(all_drawables)
-
 	AddElement(/datum/element/venue_price, FOOD_PRICE_EXOTIC)
-	AddElement(/datum/element/tool_renaming)
-	if(can_change_colour)
+
+	if(!can_change_colour)
+		AddElement(/datum/element/tool_renaming)
+	else
 		AddComponent(/datum/component/palette, AVAILABLE_SPRAYCAN_SPACE, paint_color)
 
 	refill()


### PR DESCRIPTION

## About The Pull Request
This fixes issue #4862, 
## Why It's Good For The Game
The stylists demand their colorable clothes and I will give it to them
## Proof Of Testing

You can see the screenshots below, spraycan left click now works as intended, crayon can still rename stuff.
Left click with spray can
<img width="65" height="62" alt="image" src="https://github.com/user-attachments/assets/1326d16e-47c0-4275-9901-3c69cb9d82c7" />

Right click with spray can 
<img width="58" height="54" alt="image" src="https://github.com/user-attachments/assets/b51642b9-383b-4cfa-90e4-6d23c6167acf" />

Left click with grayon
<img width="320" height="327" alt="image" src="https://github.com/user-attachments/assets/2c022570-01ae-47a6-a88b-09f34834034d" />




## Changelog
:cl:
fix: fixed the spraycan left click
/:cl:
