### PR TITLE
Heretic now requires a chaplain in order to roll because I saw someone die to it once.

### DIFF
--- a/modular_zubbers/code/modules/storyteller/event_defines/crewset/heretic.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/crewset/heretic.dm
@@ -18,3 +18,11 @@
 /datum/round_event_control/antagonist/solo/heretic/midround
 	name = "Midround Heretics"
 	roundstart = FALSE
+
+/datum/round_event_control/antagonist/solo/heretic/can_spawn_event(players_amt, allow_magic = FALSE)
+	. = ..()
+	if(!.) //if we can't spawn it normally, then don't bother checking below
+		return .
+	var/datum/job/chaplain_job = SSjob.get_job(JOB_CHAPLAIN)
+	if(chaplain_job.current_positions <= 0) //Current positions is the amount of people in this job.
+		return FALSE


### PR DESCRIPTION
## About The Pull Request

Heretic now requires a chaplain in order to roll. There must be at least 1 chaplain present in order for heretic to roll.

## Why It's Good For The Game

Heretic's design is very balance dependent on a chaplain existing, much like how blob is very dependent on engineers existing (blob requires engineers to roll) and how virus events are dependent on medical existing (viruses require medical to roll).

While holy water/null rods can be obtained by breaking into the chapel, it is very easy for a heretic to just steal the null rod.

## Proof Of Testing

Untested. I can't really test this solo.

## Changelog

:cl: BurgerBB
add: Heretic now requires a chaplain in order to roll. There must be at least 1 chaplain present in order for heretic to roll.
/:cl:

