### PR TITLE
Fixes the camera name on kilo station medical outpost- DO NOT MERGE AS THIS IS GETTING CLOSED

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -36610,7 +36610,10 @@
 	name = "Security Requests Console"
 	},
 /obj/structure/filingcabinet,
-/obj/machinery/camera/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Medical Checkpoint Post";
+	name = "medical camera"
+	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
@@ -48088,6 +48091,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/machinery/camera/directional/south{
+	c_tag = "Cargo Checkpoint Post";
+	name = "cargo camera";
+	network = list("ss13","qm")
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
 "pAx" = (


### PR DESCRIPTION

## About The Pull Request
Changes the name on a camera so it can be found by medical security orderly on kilo station
## Why It's Good For The Game
Camera can be used to watch people from the security outpost in medical on kilo station with the correct name

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: Fixed camera name so it can be found in the medical outpost on kilo station
/:cl:
