### PR TITLE
robo-wardrobe purity seals

### DIFF
--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -248,7 +248,6 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 		/obj/item/clothing/under/costume/mech_suit = 2,
 		/obj/item/clothing/suit/hooded/techpriest = 2,
 		/obj/item/organ/tongue/robot = 2,
-		/obj/item/storage/box/purity_seal_box = 2,
 	)
 	refill_canister = /obj/item/vending_refill/wardrobe/robo_wardrobe
 	extra_price = PAYCHECK_COMMAND * 1.2

--- a/modular_zubbers/code/modules/vending/wardrobe.dm
+++ b/modular_zubbers/code/modules/vending/wardrobe.dm
@@ -109,6 +109,7 @@
 	)
 	zubbers_contraband = list(
 		/obj/item/organ/tongue/lizard/robot = 2,
+		/obj/item/storage/box/purity_seal_box = 2, // purity seals for any techpriests working in robotics!
 	)
 
 /obj/machinery/vending/wardrobe/gene_wardrobe


### PR DESCRIPTION
Adds 2 boxes of purity seals to the robo_wardrobe under the contraband category for any techpriests working there to make use of

## About The Pull Request

No further info needed its just adding a box that was already in the chaplain one

## Why It's Good For The Game

Cool sticker for the robo guys, gals and thems

## Proof Of Testing

It runs and works

## Changelog
:cl:
add: Adds 2 boxes of purity seals to the robo_wardrobe under the contraband category
/:cl:

