### PR TITLE
[SEMI-MODULAR] Oversized SAD Functionality

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -446,7 +446,7 @@
 				continue
 			if(isliving(current_atom))
 				var/mob/living/current_mob = atom
-				if(current_mob.buckled || current_mob.mob_size >= MOB_SIZE_LARGE)
+				if(current_mob.buckled || current_mob.mob_size >= MOB_SIZE_LARGE && !ignore_size) // BUBBER EDIT - ADDITION - "&& !ignore_size"
 					continue
 			target = atom
 

--- a/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
+++ b/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
@@ -31,6 +31,7 @@
 	density = TRUE
 	active_power_usage = 240 KILO WATTS
 	idle_power_usage = 24 KILO WATTS
+	ignore_size = TRUE
 	/// Is someone being processed inside of the machine?
 	var/processing = FALSE
 	/// How long does the machine take to work?

--- a/modular_zubbers/code/game/machinery/_machinery.dm
+++ b/modular_zubbers/code/game/machinery/_machinery.dm
@@ -1,0 +1,3 @@
+/obj/machinery
+	///If true, the machine will be able to close/function as normal regardless of mob size.
+	var/ignore_size = FALSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8994,6 +8994,7 @@
 #include "modular_zubbers\code\game\Items\nerdcrowbar.dm"
 #include "modular_zubbers\code\game\Items\plushes.dm"
 #include "modular_zubbers\code\game\Items\storage\backpack.dm"
+#include "modular_zubbers\code\game\machinery\_machinery.dm"
 #include "modular_zubbers\code\game\machinery\crew_monitor.dm"
 #include "modular_zubbers\code\game\machinery\department_balance.dm"
 #include "modular_zubbers\code\game\machinery\incident_display.dm"


### PR DESCRIPTION

## About The Pull Request
Adds a new variable on `/obj/machinery` called `ignore_size` it does as implied, ignores the size of a mob if the variable is set to true on a machine. So far, I only implemented this on the SAD so that oversized quirk users can finally use it, but it can be modularly added to pretty much any machine that opens/closes.
## Why It's Good For The Game
Oversized quirk users can finally use the SAD instead of being screwed and having to rely on getting a NIF (and being completely screwed in a few odd edge cases).
## Proof Of Testing
Parsed, compiled, and ran without any runtimes and worked as expected.
## Changelog
:cl:
qol: Oversized quirk users can now use SADs.
/:cl:
