### PR TITLE
Fix armor on some modular jumpsuits

### DIFF
--- a/modular_skyrat/master_files/code/modules/clothing/under/syndicate.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/under/syndicate.dm
@@ -31,7 +31,7 @@
 	inhand_icon_state = "b_suit"
 	can_adjust = TRUE
 	has_sensor = HAS_SENSORS
-	armor_type = /datum/armor/clothing_under/standard
+	armor_type = /datum/armor/clothing_under
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
 	unique_reskin = list(
 		RESKIN_NT = "tactifool_blue",
@@ -49,7 +49,7 @@
 	name = "tacticool skirtleneck"
 	desc = "A snug skirtleneck, in fabulous Nanotrasen-blue. Just looking at it makes you want to buy a NT-certifed coffee, go into the office, and -work-."
 	icon_state = "tactifool_blue_skirt"
-	armor_type = /datum/armor/clothing_under/standard
+	armor_type = /datum/armor/clothing_under
 	body_parts_covered = CHEST|GROIN|ARMS
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	dying_key = DYE_REGISTRY_JUMPSKIRT
@@ -61,7 +61,7 @@
 
 /obj/item/clothing/under/syndicate/bloodred/sleepytime/sensors //Halloween-only
 	has_sensor = HAS_SENSORS
-	armor_type = /datum/armor/clothing_under/standard
+	armor_type = /datum/armor/clothing_under
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
 
 /obj/item/clothing/under/syndicate/skyrat/baseball
@@ -121,7 +121,7 @@
 	desc = "Throughout the stars, rumors of mad scientists and angry drill sergeants run rampant; of creatures in armor black as night, being led by men or women wearing this uniform. They share one thing: a deep, natonalistic zeal of the dream of America."
 	icon_state = "enclave"
 	can_adjust = TRUE
-	armor_type = /datum/armor/clothing_under/standard
+	armor_type = /datum/armor/clothing_under
 
 /obj/item/clothing/under/syndicate/skyrat/enclave/officer
 	name = "neo-American officer uniform"

--- a/modular_skyrat/modules/customization/modules/clothing/~donator/donator_clothing.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/~donator/donator_clothing.dm
@@ -219,7 +219,7 @@
 	icon_state = "black_turtleneck"
 	worn_icon = 'modular_skyrat/master_files/icons/donator/mob/clothing/uniform.dmi'
 	supports_variations_flags = NONE
-	armor_type = /datum/armor/clothing_under/standard
+	armor_type = /datum/armor/clothing_under
 	can_adjust = FALSE //There wasnt an adjustable sprite anyways
 	has_sensor = HAS_SENSORS	//Actually has sensors, to balance the new lack of armor
 

--- a/modular_skyrat/modules/syndie_edits/code/syndie_edits.dm
+++ b/modular_skyrat/modules/syndie_edits/code/syndie_edits.dm
@@ -164,7 +164,7 @@
 	name = "tactical maid outfit"
 	desc = "A 'tactical' skirtleneck fashioned to the likeness of a maid outfit. Why the Syndicate has these, you'll never know."
 	icon_state = "syndimaid"
-	armor_type = /datum/armor/clothing_under/standard
+	armor_type = /datum/armor/clothing_under
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	dying_key = DYE_REGISTRY_JUMPSKIRT
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON

--- a/modular_zubbers/code/modules/clothing/under/_under.dm
+++ b/modular_zubbers/code/modules/clothing/under/_under.dm
@@ -1,7 +1,3 @@
-/datum/armor/clothing_under/standard
-	bio = 10
-	wound = 5
-
 /obj/item/clothing/under/emp_act(severity)
 	. = ..()
 	if(. & EMP_PROTECT_SELF)

--- a/modular_zubbers/code/modules/clothing/under/misc.dm
+++ b/modular_zubbers/code/modules/clothing/under/misc.dm
@@ -37,7 +37,7 @@
 	body_parts_covered = CHEST|GROIN|LEGS
 
 /obj/item/clothing/under/syndicate/syndibunny/fake
-	armor_type = /datum/armor/clothing_under/standard
+	armor_type = /datum/armor/clothing_under
 
 /obj/item/clothing/under/costume/playbunny/magician
 	name = "magician's bunny suit"

--- a/modular_zubbers/code/modules/clothing/under/syndicate.dm
+++ b/modular_zubbers/code/modules/clothing/under/syndicate.dm
@@ -27,7 +27,7 @@
 	name = "utility overalls turtleneck"
 	desc = "A pair of spiffy overalls with a turtleneck underneath, useful for both engineering and botanical work."
 	icon_state = "syndicate_overalls"
-	armor_type = /datum/armor/clothing_under/standard
+	armor_type = /datum/armor/clothing_under
 	has_sensor = HAS_SENSORS
 	can_adjust = TRUE
 

--- a/modular_zubbers/code/modules/security/sec_clothing_overrides.dm
+++ b/modular_zubbers/code/modules/security/sec_clothing_overrides.dm
@@ -1099,7 +1099,7 @@
 	can_adjust = FALSE
 
 /obj/item/clothing/under/rank/security/detective/cowboy/armorless //Donator variant, just uses the sprite.
-	armor_type = /datum/armor/clothing_under/standard
+	armor_type = /datum/armor/clothing_under
 
 /obj/item/clothing/under/rank/security/detective/runner
 	name = "runner sweater"


### PR DESCRIPTION
## About The Pull Request

Someone made /datum/armor/clothing_under/none as an attempt to provide no armor to a subtyped item, such as defanged syndie clothing.

However, a blank subtype just inherits from the parent.

Changes it to be an explicit definition of the expected armor value

## Why It's Good For The Game

Things don't inadvertently get armor they're not supposed to

## Changelog

:cl: LT3
fix: Fixed a few under clothing items inheriting incorrect armor values
/:cl: