### PR TITLE
Makes voidwalkers more common

### DIFF
--- a/modular_zubbers/code/modules/storyteller/event_defines/ghostset/voidwalker.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/ghostset/voidwalker.dm
@@ -4,9 +4,9 @@
 	name = "Spawn Void Walker"
 	typepath = /datum/round_event/ghost_role/void_walker
 	max_occurrences = 1
-	weight = 3
+	weight = 5
 	earliest_start = 20 MINUTES
-	min_players = 30
+	min_players = 25
 	category = EVENT_CATEGORY_ENTITIES
 	description = "A Void Walker that drags people out of the station and into the abyss"
 	map_flags = EVENT_SPACE_ONLY


### PR DESCRIPTION
## About The Pull Request
Makes voidwalkers more common by increasing the spawn weight and lowering the minimum population requirements
minimum players are still higher than other ghostset antags
## Why It's Good For The Game
Voidwalkers are extremely rare, as they have a weight of 3 with minimum 30 population on a space map. While it gives them novelty, they do not nearly have the amount of impact to justify this rarity.
Many of the space maps are not made with voidwalkers in mind, meaning they often have a hard time, rarely getting a chance to strike. Not to mention that the many synthetics we have are immune to their main attack, which deals oxyloss damage.
Making them more common and giving people at least more chances to go up against these unfavorable odds.

## Proof Of Testing
I didn't test anything, but I'd be very surprised if it didn't work

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
balance: Increased Voidwalker spawn weight to 5 (was 3)
balance: Decrease minimum population requirement for Voidwalker to 25 (was 30)
/:cl:
