### PR TITLE
Medical lobbies and shutters

### DIFF
--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -10975,6 +10975,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology/control)
+"cfi" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "cfj" = (
 /obj/structure/window/spawner/directional/north,
 /obj/structure/window/spawner/directional/west,
@@ -25840,12 +25847,12 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "eSV" = (
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
 /obj/machinery/firealarm/directional/east,
+/obj/structure/reagent_dispensers/water_cooler/punch_cooler,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "eSY" = (
@@ -65461,9 +65468,8 @@
 	},
 /area/station/service/theater)
 "mzN" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "meddoor";
-	name = "Medical Cell"
+/obj/machinery/door/airlock/security{
+	name = "Medbay Security Post"
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/blue/filled/warning,
@@ -66977,6 +66983,15 @@
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/mineral/plastitanium,
 /area/station/science/robotics/mechbay)
+"mOP" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "medsecprivacy";
+	name = "Privacy Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/medical)
 "mOS" = (
 /obj/machinery/atmospherics/components/binary/pump,
 /obj/structure/cable,
@@ -81763,6 +81778,12 @@
 	},
 /obj/machinery/light_switch/directional/north,
 /obj/machinery/light/directional/north,
+/obj/machinery/button/door/directional/north{
+	id = "medsecprivacy";
+	name = "Privacy Shutters Control";
+	req_access = list("security");
+	pixel_x = -14
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "pFN" = (
@@ -120654,6 +120675,11 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/wood,
 /area/station/security/prison/rec)
+"wUW" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/light/floor,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "wUX" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
@@ -226701,11 +226727,11 @@ dUv
 isi
 aZP
 qun
-ksY
+cfi
 vNX
 oYi
 vNX
-bst
+wUW
 bql
 exf
 frF
@@ -228998,7 +229024,7 @@ tEi
 axQ
 ext
 shb
-tCr
+mOP
 ksJ
 tYA
 smS
@@ -229512,7 +229538,7 @@ xRw
 tcL
 pHf
 kHj
-tCr
+mOP
 rXC
 vUt
 eSR

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -21763,6 +21763,13 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/depsec/medical,
+/obj/machinery/button/door/directional/north{
+	id = "medsecprivacy";
+	name = "Privacy Shutters Control";
+	req_access = list("security");
+	pixel_x = -8;
+	pixel_y = 22
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "bwH" = (
@@ -46794,8 +46801,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Office"
+/obj/machinery/door/airlock/security{
+	name = "Medbay Security Post"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
 /turf/open/floor/iron/dark,
@@ -57718,6 +57725,11 @@
 "lYP" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "medsecprivacy";
+	name = "Privacy Shutters"
+	},
 /turf/open/floor/plating,
 /area/station/medical/treatment_center)
 "lZo" = (
@@ -64726,6 +64738,7 @@
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 6
 	},
+/obj/structure/reagent_dispensers/water_cooler/punch_cooler,
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 1
 	},
@@ -70591,6 +70604,11 @@
 "rQe" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "medsecprivacy";
+	name = "Privacy Shutters"
+	},
 /turf/open/floor/plating,
 /area/station/security/checkpoint/medical)
 "rQi" = (
@@ -75623,6 +75641,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/security/processing)
+"uay" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id = "medsecprivacy";
+	name = "Privacy Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/medical)
 "uaA" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
@@ -120219,7 +120247,7 @@ bfF
 bfF
 vbw
 ruy
-rQe
+uay
 bvj
 bwG
 gGW
@@ -120733,7 +120761,7 @@ sdT
 ptB
 bpN
 bCS
-rQe
+uay
 btg
 bDR
 xjt

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -1738,15 +1738,11 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/locker)
 "aBN" = (
-/obj/structure/table,
-/obj/item/storage/box/bodybags{
-	pixel_y = 5
-	},
-/obj/item/pen,
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
+/obj/structure/reagent_dispensers/water_cooler/punch_cooler,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/lobby)
 "aCi" = (
@@ -18392,6 +18388,12 @@
 	dir = 4
 	},
 /obj/machinery/computer/security/telescreen/cmo/directional/south,
+/obj/machinery/button/door/directional/north{
+	id = "medsecprivacy";
+	name = "Privacy Shutters Control";
+	req_access = list("security");
+	pixel_x = -11
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "fZk" = (
@@ -26272,6 +26274,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/grass,
 /area/station/medical/psychology)
+"iue" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "medsecprivacy";
+	name = "Privacy Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/medical)
 "iug" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/plasma_input{
 	dir = 1
@@ -36117,7 +36128,7 @@
 "lAu" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/security/glass{
+/obj/machinery/door/airlock/security{
 	name = "Medbay Security Post"
 	},
 /obj/structure/cable,
@@ -38333,6 +38344,7 @@
 /obj/item/storage/box/bandages{
 	pixel_y = 5
 	},
+/obj/item/storage/box/bodybags,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/lobby)
 "mlB" = (
@@ -53177,6 +53189,15 @@
 /obj/effect/spawner/random/clothing/costume,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
+"rkb" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id = "medsecprivacy";
+	name = "Privacy Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/medical)
 "rkn" = (
 /obj/item/stack/cable_coil,
 /turf/open/misc/asteroid/airless,
@@ -58826,6 +58847,11 @@
 /area/station/medical/chemistry)
 "sSJ" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "medsecprivacy";
+	name = "Privacy Shutters"
+	},
 /turf/open/floor/plating,
 /area/station/security/checkpoint/medical)
 "sSN" = (
@@ -96503,9 +96529,9 @@ jTu
 wEJ
 kRu
 rFt
-sSJ
+iue
 lAu
-sSJ
+iue
 rFt
 owm
 jrs
@@ -97016,7 +97042,7 @@ xvW
 nbg
 mbc
 rUP
-sSJ
+rkb
 lfQ
 mHm
 rVp

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -10571,6 +10571,16 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
+"dgR" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "medsecprivacy";
+	name = "Privacy Shutters";
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/station/security/checkpoint/medical)
 "dhd" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Atmospherics - Plasma Cell";
@@ -29246,6 +29256,10 @@
 "ivR" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "medsecprivacy";
+	name = "Privacy Shutters"
+	},
 /turf/open/floor/plating/airless,
 /area/station/security/checkpoint/medical)
 "ivS" = (
@@ -39019,6 +39033,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "medsecprivacy";
+	name = "Privacy Shutters"
+	},
 /turf/open/floor/plating/airless,
 /area/station/security/checkpoint/medical)
 "lbM" = (
@@ -48501,10 +48519,10 @@
 /area/station/engineering/atmos/hfr_room)
 "nFV" = (
 /obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/status_display/ai/directional/north,
 /obj/effect/turf_decal/bot,
 /obj/machinery/computer/records/medical,
 /obj/machinery/light/cold/directional/north,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/freezer,
 /area/station/security/checkpoint/medical)
 "nGa" = (
@@ -55553,7 +55571,20 @@
 	pixel_x = 5;
 	pixel_y = 3
 	},
-/obj/machinery/airalarm/directional/east,
+/obj/machinery/button/door/directional/east{
+	icon_state = "button-warning";
+	id = "MedbayFoyer";
+	name = "Medbay Doors Control";
+	normaldoorcontrol = 1;
+	req_access = list("medical");
+	skin = "-warning"
+	},
+/obj/machinery/button/door/directional/east{
+	pixel_y = -9;
+	id = "medsecprivacy";
+	name = "Privacy Shutters Control";
+	req_access = list("security")
+	},
 /turf/open/floor/iron/freezer,
 /area/station/security/checkpoint/medical)
 "pzY" = (
@@ -61828,7 +61859,8 @@
 	id = "MedbayFoyer";
 	name = "Medbay Doors Control";
 	normaldoorcontrol = 1;
-	skin = "-warning"
+	skin = "-warning";
+	req_access = list("medical")
 	},
 /obj/machinery/duct,
 /turf/open/floor/iron/white/smooth_edge{
@@ -63183,10 +63215,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/structure/chair{
-	dir = 8
-	},
 /obj/effect/landmark/start/assistant,
+/obj/structure/reagent_dispensers/water_cooler/punch_cooler,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
 	},
@@ -116086,8 +116116,8 @@ cnC
 abF
 lZg
 qxO
-ivR
-ivR
+dgR
+dgR
 qxO
 ore
 uGJ

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -1097,7 +1097,7 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/fore/lesser)
 "asB" = (
-/obj/machinery/door/airlock/security/glass{
+/obj/machinery/door/airlock/security{
 	name = "Medbay Security Post"
 	},
 /obj/structure/cable,
@@ -6344,10 +6344,10 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/item/kirbyplants/random,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/west,
+/obj/structure/reagent_dispensers/water_cooler/punch_cooler,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "cin" = (
@@ -16243,6 +16243,11 @@
 /obj/structure/closet/secure_closet/security/med,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
+	},
+/obj/machinery/button/door/directional/north{
+	id = "medsecprivacy";
+	name = "Privacy Shutters Control";
+	req_access = list("security")
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/checkpoint/medical)
@@ -33545,6 +33550,10 @@
 "lym" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "medsecprivacy";
+	name = "Privacy Shutters"
+	},
 /turf/open/floor/plating,
 /area/station/medical/medbay/lobby)
 "lyp" = (
@@ -58306,6 +58315,11 @@
 "tPg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "medsecprivacy";
+	name = "Privacy Shutters"
+	},
 /turf/open/floor/plating,
 /area/station/security/checkpoint/medical)
 "tPt" = (

--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -2438,6 +2438,11 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
 	},
+/obj/machinery/button/door/directional/north{
+	id = "medsecprivacy";
+	name = "Privacy Shutters Control";
+	req_access = list("security")
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "aGa" = (
@@ -3152,6 +3157,15 @@
 /obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/engine)
+"aPS" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "medsecprivacy";
+	name = "Privacy Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/medical)
 "aPT" = (
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
@@ -8970,8 +8984,8 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/library/abandoned)
 "cyf" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Post - Medbay"
+/obj/machinery/door/airlock/security{
+	name = "Medbay Security Post"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/orderly,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -52788,6 +52802,11 @@
 /area/station/commons/dorms/room1)
 "oeJ" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "medsecprivacy";
+	name = "Privacy Shutters";
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/security/checkpoint/medical)
 "oeL" = (
@@ -55199,10 +55218,10 @@
 /turf/open/floor/iron/large,
 /area/station/engineering/atmos/hallway)
 "oKG" = (
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
+/obj/structure/reagent_dispensers/water_cooler/punch_cooler,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
@@ -256668,9 +256687,9 @@ hfe
 frd
 frd
 xgq
-oeJ
-oeJ
-oeJ
+aPS
+aPS
+aPS
 xAV
 xAV
 xAV


### PR DESCRIPTION
## About The Pull Request

Adds shutters and consistent naming to medical security posts on Bubber maps.
Adds a pair of missing lights on Blueshift
Adds a missing button on Void Raptor
Gives medical lobbies a water cooler

## Changelog

:cl: LT3
map: Fixed missing lights in Blueshift medical lobby
map: Fixed missing door button in Void Raptor medical
map: Added some water coolers to medical lobbies
/:cl: