### PR TITLE
fixes flae typo

### DIFF
--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -216,7 +216,7 @@
 	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
 
 /datum/design/c38_flare_mag
-	name = "Magazine (.38 Flae) (VERY Lethal)"
+	name = "Magazine (.38 Flare) (VERY Lethal)"
 	desc = "Designed to tactically reload a NT BR-38 Battle Rifle. Flare casings launch a concentrated particle beam towards a target, lighting them up for everyone to see."
 	id = "c38_flare_mag"
 	build_type = PROTOLATHE | AWAY_LATHE


### PR DESCRIPTION
## About The Pull Request
Skyrat gun removal pr somehow made a typo from FLARE to FLAE

## Why It's Good For The Game
Flae

## Proof Of Testing
no

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
fix: Fixed a typo in the .38 flare ammo, no longer will it be Flae ammo.
/:cl:

