### PR TITLE
Fixes forge SFX ignoring ambience preference

### DIFF
--- a/modular_skyrat/modules/colony_fabricator/code/appliances/recycler.dm
+++ b/modular_skyrat/modules/colony_fabricator/code/appliances/recycler.dm
@@ -60,7 +60,7 @@
 	SIGNAL_HANDLER
 
 	flick("recycler_grind", src)
-	playsound(src, item_recycle_sound, 50, TRUE)
+	conditional_pref_sound(src, item_recycle_sound, vol = 50, vary = TRUE, extrarange = MEDIUM_RANGE_SOUND_EXTRARANGE, ignore_walls = FALSE, pref_to_check = /datum/preference/numeric/volume/sound_ambience_volume)
 	use_energy(min(active_power_usage * 0.25, amount_inserted / 100))
 
 	if(amount_inserted)

--- a/modular_skyrat/modules/reagent_forging/code/anvil.dm
+++ b/modular_skyrat/modules/reagent_forging/code/anvil.dm
@@ -79,7 +79,7 @@
 		return ITEM_INTERACT_SUCCESS
 
 /obj/structure/reagent_anvil/hammer_act(mob/living/user, obj/item/tool)
-	conditional_pref_sound(src, 'modular_skyrat/modules/reagent_forging/sound/forge.ogg', vol = 50, vary = TRUE, extrarange = MEDIUM_RANGE_SOUND_EXTRARANGE, ignore_walls = FALSE, pref_to_check = /datum/preference/numeric/volume/sound_ambience_volume)
+	conditional_pref_sound(src, 'modular_skyrat/modules/reagent_forging/sound/forge.ogg', vol = 35, vary = TRUE, extrarange = MEDIUM_RANGE_SOUND_EXTRARANGE, ignore_walls = FALSE, pref_to_check = /datum/preference/numeric/volume/sound_ambience_volume)
 
 	//do we have an incomplete item to hammer out? if so, here is our block of code
 	var/obj/item/forging/incomplete/locate_incomplete = locate() in contents
@@ -148,7 +148,7 @@
 
 			locate_obj.repair_damage(locate_obj.get_integrity() + 10)
 			user.mind.adjust_experience(/datum/skill/smithing, 5) //repairing does give some experience
-			playsound(src, 'modular_skyrat/modules/reagent_forging/sound/forge.ogg', 50, TRUE, ignore_walls = FALSE)
+			conditional_pref_sound(src, 'modular_skyrat/modules/reagent_forging/sound/forge.ogg', vol = 35, vary = TRUE, extrarange = MEDIUM_RANGE_SOUND_EXTRARANGE, ignore_walls = FALSE, pref_to_check = /datum/preference/numeric/volume/sound_ambience_volume)
 
 	return ITEM_INTERACT_SUCCESS
 

--- a/modular_skyrat/modules/reagent_forging/code/crafting_bench.dm
+++ b/modular_skyrat/modules/reagent_forging/code/crafting_bench.dm
@@ -182,7 +182,7 @@
 	return ITEM_INTERACT_SUCCESS
 
 /obj/structure/reagent_crafting_bench/hammer_act(mob/living/user, obj/item/tool)
-	playsound(src, 'modular_skyrat/modules/reagent_forging/sound/forge.ogg', 50, TRUE)
+	conditional_pref_sound(src, 'modular_skyrat/modules/reagent_forging/sound/forge.ogg', vol = 35, vary = TRUE, extrarange = MEDIUM_RANGE_SOUND_EXTRARANGE, ignore_walls = FALSE, pref_to_check = /datum/preference/numeric/volume/sound_ambience_volume)
 	if(length(contents))
 		if(!istype(contents[1], /obj/item/forging/complete))
 			balloon_alert(user, "invalid item")


### PR DESCRIPTION
## About The Pull Request

Fixes some occurrences where forge.ogg is allowed to play while skipping the ambient volume preferences check.

## Why It's Good For The Game

Having this sound playing regularly without a method to mute it is a war crime

## Changelog

:cl: LT3
fix: All sources of forge noise will now respect your ambient volume preference settings
/:cl:
