### PR TITLE
Infinite (Water) Showers.

### DIFF
--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -337,7 +337,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/shower, (-16))
 		update_actually_on(intended_on)
 
 	// Reclaim water
-//	if(!actually_on) BUBBERS CHANGE. Unlimited water for showers.
+//if(!actually_on) BUBBER EDIT CHANGE - Unlimited water for showers
 		if(has_water_reclaimer && reagents.total_volume < reagents.maximum_volume)
 			reagents.add_reagent(reagent_id, refill_rate * seconds_per_tick)
 			return 0


### PR DESCRIPTION

## About The Pull Request

Comments out the portion of code that makes it so water recyclers can't charge while the shower is on.

## Why It's Good For The Game

Shower RP, they can now run for more than 30-60 seconds.

## Proof Of Testing

I have been listening to shower noises for like 11 minutes, I think it works.
<img width="343" height="336" alt="image" src="https://github.com/user-attachments/assets/bb510713-8843-4d3b-94c4-eb2e94482ecc" />
<img width="662" height="143" alt="image" src="https://github.com/user-attachments/assets/475d33bf-af44-4a34-93cf-cf2fd00eb585" />

</details>

## Changelog
:cl:
qol: Showers with recyclers have infinite water.
/:cl:
