### PR TITLE
FIx: murphy (and double barrelled shotgun) need a weapons permit like every other gun in the game

### DIFF
--- a/modular_zubbers/code/modules/cargo/packs/goodies.dm
+++ b/modular_zubbers/code/modules/cargo/packs/goodies.dm
@@ -48,6 +48,7 @@
 
 /datum/supply_pack/goody/double_barrel
 	cost = PAYCHECK_COMMAND * 10 //1400 is too much considering the combat shotgun is 1500 for 1
+	access_view = ACCESS_WEAPONS
 
 /datum/supply_pack/goody/plasma_marksman
 	name = "Gwiazda Plasma Sharpshooters Single-pack"

--- a/modular_zubbers/code/modules/security/security_glock/cargo.dm
+++ b/modular_zubbers/code/modules/security/security_glock/cargo.dm
@@ -10,6 +10,7 @@
 	cost = CARGO_CRATE_VALUE * 6
 	contains = list(/obj/item/gun/ballistic/automatic/pistol/sec_glock = 3)
 	crate_name = "'Murphy' service pistol crate"
+	access_view = ACCESS_WEAPONS
 
 /datum/supply_pack/security/armory/sec_glock_ammo
 	name = "'Murphy' Service Pistol Ammo Crate"
@@ -17,6 +18,7 @@
 	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/ammo_box/magazine/security = 4)
 	crate_name = "'Murphy' service pistol ammo crate"
+	access_view = ACCESS_WEAPONS
 
 /datum/supply_pack/security/armory/alert_level_firing_pin
 	name = "Alert Level Firing Pin Crate"
@@ -24,15 +26,18 @@
 	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/obj/item/firing_pin/alert_level = 4)
 	crate_name = "alert level firing pin crate"
+	access_view = ACCESS_WEAPONS
 
 /datum/supply_pack/goody/murphy_single
 	name = "'Murphy' Service Pistol Single-Pack"
 	desc = "A rugged, law-enforcement-grade service pistol, once famously sold for just a dollar. Comes as a single-pack with one 'Murphy' pistol ready for action."
 	cost = PAYCHECK_COMMAND * 5
 	contains = list(/obj/item/gun/ballistic/automatic/pistol/sec_glock = 1)
+	access_view = ACCESS_WEAPONS
 
 /datum/supply_pack/goody/murphy_ammo
 	name = "'Murphy' Service Pistol Magazine Single-Pack"
 	desc = "Full magazine with an extra-robust ejection spring. Fits into the Murphy Service Pistol."
 	cost = PAYCHECK_COMMAND * 2
 	contains = list(/obj/item/ammo_box/magazine/security = 1)
+	access_view = ACCESS_WEAPONS


### PR DESCRIPTION

## About The Pull Request

To order murphy ammo or pistols you now need a weapons permit. Same thing goes for the DB shotgun. Just like you would for a disabler. 

## Why It's Good For The Game

Fixing a mistake
## Proof Of Testing


</details>

## Changelog

:cl:
fix: fixed missing weapons restrictions on buying some guns from cargo
/:cl: