### PR TITLE
Fixes oversight with borg expand/shrink modules

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -598,13 +598,6 @@
 		to_chat(usr, span_warning("This unit already has an expand module installed!"))
 		return FALSE
 
-	// SKYRAT EDIT ADDITION BEGIN
-	if(TRAIT_R_EXPANDER_BLOCKED in borg.model.model_features)
-		to_chat(usr, span_warning("This unit is unable to equip an expand module!"))
-		return FALSE
-
-	var/resize_amount = 1.6
-	// SKYRAT EDIT ADDITION END
 	ADD_TRAIT(borg, TRAIT_NO_TRANSFORM, REF(src))
 	var/prev_lockcharge = borg.lockcharge
 	borg.SetLockdown(TRUE)
@@ -627,7 +620,7 @@
 	borg.set_anchored(FALSE)
 	REMOVE_TRAIT(borg, TRAIT_NO_TRANSFORM, REF(src))
 	borg.hasExpanded = TRUE
-	borg.update_transform(resize_amount) // SKYRAT EDIT CHANGE - ORIGINAL: borg.update_transform(2)
+	borg.update_transform(1.6) // SKYRAT EDIT CHANGE - ORIGINAL: borg.update_transform(2)
 
 /obj/item/borg/upgrade/expand/deactivate(mob/living/silicon/robot/borg, mob/living/user = usr)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Bubberstation/Bubberstation/issues/4959 related to bypassing borg expand/shrink restrictions. Ensures the borg has a model selected before attempting to validate if it can be expanded/shrunk.

Also cleans up the code, making the shrink module consistent with expand and other TG upgrades.

## Why It's Good For The Game

Fix bug

## Changelog

:cl: LT3
fix: Fixed being able to expand/shrink borg models that are meant to have those upgrades unavailable
/:cl: