### PR TITLE
Adds a Quirk: "Loose Limbs" That Causes Your Limbs To Fall Off On Death!

### DIFF
--- a/code/datums/components/omen.dm
+++ b/code/datums/components/omen.dm
@@ -298,6 +298,35 @@
 
 	return
 
+// Variant of the quirk omen, also permanent, but only causes the limbs to be removed on death.
+/datum/component/omen/loose_limbs
+	incidents_left = INFINITY
+	luck_mod = 0 // 0% chance of bad things happening
+	damage_mod = 0 // 0% of normal damage
+	//luck and damage modifiers set to 0%, to ensure the other cursed effects are disabled.
+/datum/component/omen/loose_limbs/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_LIVING_DEATH, PROC_REF(check_death))
+
+/datum/component/omen/loose_limbs/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_LIVING_DEATH)
+
+/datum/component/omen/loose_limbs/check_death(mob/living/our_guy)
+	if(!iscarbon(our_guy))
+		our_guy.gib(DROP_ALL_REMAINS)
+		return
+
+	// Don't explode if buckled to a stasis bed
+	if(our_guy.buckled)
+		var/obj/machinery/stasis/stasis_bed = our_guy.buckled
+		if(istype(stasis_bed))
+			return
+
+	death_explode(our_guy)
+	var/mob/living/carbon/player = our_guy
+	player.spread_bodyparts()
+	//causes minor explosion and removes limbs, does not spawn gibs.
+	return
+
 /**
  * The bible omen.
  * While it lasts, parent gets a cursed aura filter.

--- a/modular_zubbers/code/datums/quirks/negative_quirks/loose_limbs.dm
+++ b/modular_zubbers/code/datums/quirks/negative_quirks/loose_limbs.dm
@@ -1,0 +1,12 @@
+/datum/quirk/loose_limbs
+	name = "Loose Limbs"
+	desc = "Your limbs aren't as resilient as others! When you die, they are likely to fall off."
+	icon = FA_ICON_USER_INJURED
+	value = -2
+	gain_text = span_danger("Your joints feel weak.")
+	lose_text = span_notice("Your joints feel strengthened.")
+	medical_record_text = "Patient's joints are quite weak and may fall off."
+	hardcore_value = 2
+
+/datum/quirk/loose_limbs/add(client/client_source)
+	quirk_holder.AddComponent(/datum/component/omen/loose_limbs)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8932,6 +8932,7 @@
 #include "modular_zubbers\code\datums\quirks\negative_quirks\brainproblems.dm"
 #include "modular_zubbers\code\datums\quirks\negative_quirks\gifted.dm"
 #include "modular_zubbers\code\datums\quirks\negative_quirks\heavy_sleeper.dm"
+#include "modular_zubbers\code\datums\quirks\negative_quirks\loose_limbs.dm"
 #include "modular_zubbers\code\datums\quirks\negative_quirks\micro.dm"
 #include "modular_zubbers\code\datums\quirks\negative_quirks\monophobia.dm"
 #include "modular_zubbers\code\datums\quirks\negative_quirks\narcolepsy.dm"


### PR DESCRIPTION

## About The Pull Request
Full disclosure: This is a PR commissioned by CodeRedAlert on the discord for 20 USD.

Adds a quirk which causes your limbs (arms and legs) to fall off on death. This is a feature from the "Cursed" quirk that the commissioner wanted to see isolated. We agreed that -2 seems like a fair point value to give it, but this can be open to change, either making it worth more or less points if the maintainers agree on it.
Tested locally, as far as I know, there are no bugs with it, and it should not inherit any other of the Cursed quirk.
## Why It's Good For The Game
Adds extra flavor to players who want characters with weak limbs, such as a piñata character, or a doll.

## Proof Of Testing
<img width="158" height="161" alt="image" src="https://github.com/user-attachments/assets/f768ffe5-acd0-4861-99ed-d2dab83173fa" />

Those limbs sure do come off! Tested locally in a variety of circumstances to ensure it functions as expected.

## Changelog
:cl:
add: New quirk- Loose Limbs!
/:cl:
