### PR TITLE
Makes overclocked volume pumps work in walls again, reverting #94007 from TG

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -75,13 +75,13 @@
 	var/output_starting_pressure = air2.return_pressure()
 	//BUBBER CHANGE START: Pumps work in walls again
 	// Requires being able to leak air in order to overclock.
-	//if(overclocked)
-	//	var/turf/turf = loc
-	//	if(isclosedturf(turf))
-	//		balloon_alert_to_viewers("jammed!")
-	//		overclocked = FALSE
-	//		update_appearance(UPDATE_ICON)
-	//BUBBER CHANGE END
+/* 	if(overclocked)
+		var/turf/turf = loc
+		if(isclosedturf(turf))
+			balloon_alert_to_viewers("jammed!")
+			overclocked = FALSE
+			update_appearance(UPDATE_ICON)
+	BUBBER CHANGE END */
 	if((input_starting_pressure < VOLUME_PUMP_MINIMUM_OUTPUT_PRESSURE) || ((output_starting_pressure > VOLUME_PUMP_MAX_OUTPUT_PRESSURE)) && !overclocked)
 		return
 


### PR DESCRIPTION
## About The Pull Request

Volume pumps work in walls again. I just removed the code added in [#94007](https://github.com/tgstation/tgstation/pull/94007)

## Why It's Good For The Game

The bug to place overclocked pumps in walls has been around for years at this point, long enough to become stable among atmosians for making compact setups by ignoring pressure limits. Only thing that changes with wall placement no longer working, is that atmos techs have to waste extra time. 

Removing floor from a tile surrounded by windows does effectivly exact same thing as placing pumps in walls, but takes extra time in a job that is already heavily time consuming, it's just an annoyance, it doesn't introduce any new problem to solve or workaround when solution is pretty straightforward. 

The loss of gas isn't relevant either, placing pumps in walls did not stop leaking, it just stopped it from spreading into air, the loss of gas is already at 0.1%, it's not enough to mess with efficiency of the setup.

Proper approach would be actually changing the way pumps work, make it engineering problem to solve instead of just adding annoying friction to playerbase of atmos techs that's already pretty small, which is why I believe it'd be best course to revert the change introduced by [#94007](https://github.com/tgstation/tgstation/pull/94007) until someone actually bothers to properly work on atmos content like this.

## Proof Of Testing

<img width="224" height="135" alt="image" src="https://github.com/user-attachments/assets/5a226421-070c-4691-98b5-c7d807da2de1" />

## Changelog

:cl:
balance: Overclocked volume pumps work in walls again
/:cl:
