### PR TITLE
Reintroduces Phenol For Dispensers

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -93,6 +93,7 @@
 	/// The default list of reagents upgrade_reagents
 	var/static/list/default_upgrade_reagents = list(
 		/datum/reagent/acetone,
+		/datum/reagent/phenol,
 		/datum/reagent/ammonia,
 		/datum/reagent/ash,
 		/datum/reagent/diethylamine,


### PR DESCRIPTION
## About The Pull Request

Adds phenol back into the dispenser's upgraded chem list

## Why It's Good For The Game

The removal of this feature has been an unnecessary inconvenience and, possibly, unintentional 

## Proof Of Testing

<img width="553" height="484" alt="image" src="https://github.com/user-attachments/assets/fb0ddf3e-4afe-4e42-be3b-5137811ea3bc" />

## Changelog

:cl:
fix: Re-adds Phenol to Chem Dispensers
/:cl:
