### PR TITLE
Fix chem dispenser remove/custom amount buttons

### DIFF
--- a/tgui/packages/tgui/interfaces/ChemDispenser.tsx
+++ b/tgui/packages/tgui/interfaces/ChemDispenser.tsx
@@ -283,14 +283,16 @@ export const ChemDispenser = (props) => {
                   </Box>
                 </Section>
               </Stack.Item>
+              {/* BUBBER EDIT ADDITION START - CUSTOM AMOUNTS*/}
               <Stack.Item textAlign="right" mb={-1} mr={1}>
-                <Button // SKYRAT EDIT ADDITION BEGIN - CHEMISTRY QOL
+                <Button
                   icon="pen"
                   iconPosition = "right"
                   content="Custom Amount"
                   onClick={() => act('custom_amount')}
                 />
                 </Stack.Item>
+              {/* BUBBER EDIT ADDITION END - CUSTOM AMOUNTS*/}
                 <Stack.Item>
                 <Section
                   title="Dispense"


### PR DESCRIPTION
## About The Pull Request

Fixes broken removing reagents/custom amount selection on chem dispenser

<img width="582" height="637" alt="image" src="https://github.com/user-attachments/assets/b47eb900-bf81-4c99-9944-d7abfaab8dd4" />

## Changelog

:cl: LT3
fix: Fixed chem dispenser remove reagent buttons
fix: Fixed chem dispenser custom amount button
/:cl: