### PR TITLE
Fix drinks dispenser tier 2 upgrade

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -686,7 +686,7 @@
 		/datum/reagent/consumable/tonic,
 		/datum/reagent/water,
 	)
-	upgrade_reagents = null
+	// upgrade_reagents = null // BUBBER EDIT REMOVAL - Multi-tiered dispenser upgrades
 	/// The default list of emagged reagents dispensable by the soda dispenser
 	var/static/list/drink_emagged_reagents = list(
 		/datum/reagent/consumable/ethanol/thirteenloko,


### PR DESCRIPTION
## About The Pull Request

Fixes tier 2 upgrade of the drinks dispenser

## Why It's Good For The Game

I just want a Duplex! Is that so much to ask? God damn!

## Changelog

:cl: LT3
fix: Restored missing tier 2 reagents in drinks dispenser
/:cl: