### PR TITLE
Fixes liz fizz killing people with alcohol allergy

### DIFF
--- a/modular_skyrat/modules/customization/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/modular_skyrat/modules/customization/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -68,7 +68,7 @@
 	required_reagents = list(/datum/reagent/consumable/ethanol/painkiller = 2, /datum/reagent/consumable/grenadine = 1, /datum/reagent/consumable/orangejuice = 1, /datum/reagent/consumable/ice = 1)
 
 /datum/chemical_reaction/drink/liz_fizz
-	results = list(/datum/reagent/consumable/ethanol/liz_fizz = 5)
+	results = list(/datum/reagent/consumable/liz_fizz = 5)
 	required_reagents = list(/datum/reagent/consumable/triple_citrus = 3, /datum/reagent/consumable/ice = 1, /datum/reagent/consumable/cream = 1)
 
 /datum/chemical_reaction/drink/hotlime_miami

--- a/modular_skyrat/modules/customization/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/modular_skyrat/modules/customization/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -219,16 +219,8 @@
 	name = "glass of strawberry daiquiri"
 	desc = "Pink looking drink with flowers and a big straw to sip it. Looks sweet and refreshing, perfect for warm days."
 
-/datum/reagent/consumable/ethanol/liz_fizz
-	name = "Liz Fizz"
-	description = "Triple citrus layered with some ice and cream."
-	boozepwr = 0
-	color = "#D8FF59"
-	quality = DRINK_NICE
-	taste_description = "brain freezing sourness"
-
 /datum/glass_style/drinking_glass/liz_fizz
-	required_drink_type = /datum/reagent/consumable/ethanol/liz_fizz
+	required_drink_type = /datum/reagent/consumable/liz_fizz
 	icon = 'modular_skyrat/master_files/icons/obj/drinks.dmi'
 	icon_state = "liz_fizz"
 	name = "glass of liz fizz"

--- a/modular_skyrat/modules/customization/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/modular_skyrat/modules/customization/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -79,3 +79,10 @@
 	icon_state = "chocolatepudding"
 	name = "glass of beer batter"
 	desc = "Used in cooking, pure cholesterol, Scottish people eat it."
+
+/datum/reagent/consumable/liz_fizz
+	name = "Liz Fizz"
+	description = "Triple citrus layered with some ice and cream."
+	color = "#D8FF59"
+	quality = DRINK_NICE
+	taste_description = "brain freezing sourness"


### PR DESCRIPTION
## About The Pull Request

Fixes liz fizz, a non-alcoholic drink, being subtyped as ethanol.

## Why It's Good For The Game

Less people dropping dead at the bar, creating a murder mystery.

## Changelog

:cl: LT3
fix: Non-alcoholic liz fizz should no longer kill people who are allergic to alcohol
/:cl: