### PR TITLE
Matches the midround spawn weight of Malfunctioning AI to roundstart because I haven't died to it once

### DIFF
--- a/modular_zubbers/code/modules/storyteller/event_defines/crewset/malf.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/crewset/malf.dm
@@ -12,7 +12,7 @@
 
 	antag_datum = /datum/antagonist/malf_ai
 	antag_flag = ROLE_MALF
-	weight = 6
+	weight = 4
 	tags = list(TAG_CREW_ANTAG, TAG_COMBAT, TAG_CHAOTIC)
 	restricted_roles = list("Cyborg")
 


### PR DESCRIPTION
## About The Pull Request

Malfunctioning AI only has about a 2% spawn rate, this bumps it up to be the same as its' roundstart variant, on par with Bloodsucker or Heretic. Also removes the destructive trait, since Doomsday is admin only.

## Why It's Good For The Game

Even though it's a meme that Malfunction is a mostly dead gamemode on Bubberstation, it opens up great roleplaying opportunities and, while being underpowered, is still something that's fun to opt into. Because our pop is rarely above 20 at roundstart, we see very few malfunctioning AI's. 

## Changelog

:cl:
balance: Malf AI Midround now matches Malf AI roundstart weight.
/:cl: