### PR TITLE
Fixes Radiation Storms affecting lavaland + ruins.

### DIFF
--- a/modular_zubbers/code/datums/weather/weather_types/radiation_storm.dm
+++ b/modular_zubbers/code/datums/weather/weather_types/radiation_storm.dm
@@ -7,6 +7,7 @@
 	LAZYOR(protected_areas, list(
 		/area/station/terminal,
 		/area/lavaland,
+		/area/ruin,
 		/area/moonstation/underground,
 		/area/station/cargo/miningelevators,
 		/area/station/cargo/miningfoundry/event_protected,


### PR DESCRIPTION
## About The Pull Request

Radiation Storms no longer affect Lavaland or ruins of all types (Space, Ice, Lavaland, etc).

## Why It's Good For The Game

Prevents fuckery.

## Proof Of Testing

Untested.

## Changelog

:cl: BurgerBB
add: Radiation Storms no longer affect Lavaland or ruins of all types (Space, Ice, Lavaland, etc).
/:cl:
