### PR TITLE
Adds two new goody packs (crew monitor/soap)

### DIFF
--- a/modular_zubbers/code/modules/cargo/packs/goodies.dm
+++ b/modular_zubbers/code/modules/cargo/packs/goodies.dm
@@ -181,3 +181,14 @@
 	cost = PAYCHECK_COMMAND
 	contains = list(/obj/item/mod/module/storage/large_capacity)
 
+/datum/supply_pack/goody/crew_monitor
+	name = "Handheld Crew Monitor Single-Pack"
+	desc = "A miniature machine that tracks suit sensors across the station."
+	cost = PAYCHECK_COMMAND * 4.5
+	contains = list(/obj/item/sensor_device)
+
+/datum/supply_pack/goody/soap
+	name = "Soap Single-Pack"
+	desc = "Recommended for emergency self-cleaning, passive-aggressive demonstrations, or reminding others that hygiene is, in fact, part of the job."
+	cost = PAYCHECK_LOWER * 3
+	contains = list(/obj/item/soap/deluxe)


### PR DESCRIPTION
## About The Pull Request

Adds two new goody packs to be ordered in cargo. Crew monitor and bar of soap.

## Why It's Good For The Game

Sometimes you want to purchase this without having to order an entire nanomed refill. Soap is available for free as a loadout item, so this makes it a bit more accessible.

## Changelog

:cl: LT3
add: Handheld crew monitor is now orderable via cargo
add: Soap is now orderable via cargo
/:cl: