### PR TITLE
Let ethereals wear underwear, as god intended

### DIFF
--- a/code/modules/surgery/bodyparts/species_parts/ethereal_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/ethereal_bodyparts.dm
@@ -23,6 +23,7 @@
 	dmg_overlay_type = null
 	brute_modifier = 1.25 //ethereal are weak to brute damages
 	wing_types = null
+	// bodypart_traits = list(TRAIT_NO_UNDERWEAR) BUBBER EDIT - let them wear underwear
 
 /obj/item/bodypart/chest/ethereal/update_limb(dropping_limb, is_creating)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Removing one line of code lets ethereals wear underwear. God bless!
## Why It's Good For The Game
This is intended. In the ethereal species module, NO_UNDERWEAR is already commented out, but coders forgot to remove the same trait assignment in the surgery module. Also, I need to put my ethereal in the neko bikini.
## Proof Of Testing
Works locally, compiles and runs fine. Ethereals can wear underclothes.
<details>
<summary>Screenshots/Videos</summary>
<img width="212" height="324" alt="image" src="https://github.com/user-attachments/assets/3189bb3d-5377-4885-bbc1-9eedaa32a8aa" />
</details>

## Changelog
:cl:
fix: Lets ethereals wear underwear again.
/:cl:
