### PR TITLE
Reworks how Voidwalker kidnapping works because I died to it once.

### DIFF
--- a/modular_zubbers/code/modules/antagonists/voidwalker/voidwalker_mob.dm
+++ b/modular_zubbers/code/modules/antagonists/voidwalker/voidwalker_mob.dm
@@ -1,0 +1,24 @@
+/mob/living/basic/voidwalker/take_them(mob/living/victim)
+
+	//Make the victim dark and husk them.
+	victim.reagents?.add_reagent(/datum/reagent/colorful_reagent/powder/black, 5)
+	victim.become_husk(BURN)
+
+	//Visual Effects.
+	victim.flash_act(5 SECONDS, override_blindness_check = TRUE, visual = TRUE, type = /atom/movable/screen/fullscreen/flash/black)
+	new /obj/effect/temp_visual/circle_wave/unsettle(get_turf(victim))
+
+	//Teleport to a nearby area.
+	var/turf/desired_turf = get_safe_lucky_player_turf(areas_to_exclude = list(get_area(src)))
+	if(!desired_turf) //Failsafe.
+		desired_turf = get_safe_random_station_turf()
+	if(!desired_turf) //Do nothing as a failsafe for a failsafe.
+		return
+	victim.forceMove(desired_turf)
+
+	//Paint the area they teleport to black.
+	var/list/valid_turfs = range(4,desired_turf)
+	var/datum/dimension_theme/chosen_theme = SSmaterials.dimensional_themes[/datum/dimension_theme/space]
+	chosen_theme.apply_theme_to_list_of_turfs(valid_turfs)
+
+	return TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9192,6 +9192,7 @@
 #include "modular_zubbers\code\modules\antagonists\malf\remove_malf.dm"
 #include "modular_zubbers\code\modules\antagonists\nightmare\nightmare_species.dm"
 #include "modular_zubbers\code\modules\antagonists\nukeop\equipment\nuclear_authentication_disk.dm"
+#include "modular_zubbers\code\modules\antagonists\voidwalker\voidwalker_mob.dm"
 #include "modular_zubbers\code\modules\antagonists\wizard\events_removal.dm"
 #include "modular_zubbers\code\modules\antagonists\wizard\events_rework.dm"
 #include "modular_zubbers\code\modules\antagonists\wizard\grand_finale_removal.dm"


### PR DESCRIPTION
## About The Pull Request

Voidwalker capture no longer gives you a space-fearing trauma that places you in gay baby jail when captured, or gives you blackface (It's 2026, blackface is bad!!!).

Voidwalker caputer now does the following:
- You die and get burn-husked.
- You get painted black (washable).
- You teleport to a safe station turf near someone (like how wizard dice works).
- The area near where you are teleported turns to fake space, similiar to how a dimensional anomaly works.

## Why It's Good For The Game

Voidwalker is a really really really bad antagonist type for Bubberstation. Not only are they (generally) treated friendly until they murder, but they're another /tg/ ambush antag on a sea of piss of ambush antags.

Instead of dedicating my New Years Eve fundamentally reworking how Void Walker works for a niche furry erp server, I'm just going to rework what happens when you get scrungled by one so losing to a void walker isn't as awful.

Also I'm pretty sure that there are unintentional bugs with voidwalker that existed for a while. You're intended to be alive during the dumb puzzle you're supposed to do, but what usually ends up happening is that you're just stuck in crit which means you have to either succumb or wait until you die, which is just dumb.

## Proof Of Testing

Draft because untested.

## Changelog

:cl: BurgerBB
balance: Reworks the consequences for getting captured by a voidwalker because I died to it once.
/:cl:
