### PR TITLE
Borg Gripper Update

### DIFF
--- a/modular_zubbers/code/game/objects/items/robot/items/storage.dm
+++ b/modular_zubbers/code/game/objects/items/robot/items/storage.dm
@@ -196,7 +196,7 @@
 //Engineering cyborg apparatus
 /obj/item/borg/apparatus/engineering
 	name = "Engineering manipulation gripper"
-	desc = "A simple grasping tool for interacting with various engineering related items, such as circuits, gas tanks, conveyer belts and more."
+	desc = "A simple grasping tool for interacting with various engineering related items, such as circuits, gas tanks, conveyor belts and more."
 	icon = 'modular_zubbers/icons/mob/silicon/robot_items.dmi'
 	icon_state = "gripper"
 	storable = list(
@@ -209,7 +209,8 @@
 					/obj/item/tank,
 					/obj/item/stock_parts,
 					/obj/item/assembly/control,
-					/obj/item/electronics/airlock
+					/obj/item/electronics,
+					/obj/item/circuitboard,
 					)
 
 //Mining cyborg apparatus


### PR DESCRIPTION
## About The Pull Request

Lets the engineering borg gripper pick up circuitboards and electronics again - for some reason they got massively nerfed compared to tg.

## Why It's Good For The Game

Engineering borgs should be able to do their job without having to get an upgrade roundstart.

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
add: lets engineering borgs pick up circuitboards and electronics other than airlock again, like on tg...
spellcheck: conveyer > conveyor
/:cl:
