### PR TITLE
Fix duplicate disabler SMG goody pack

### DIFF
--- a/modular_zubbers/code/modules/cargo/packs/goodies.dm
+++ b/modular_zubbers/code/modules/cargo/packs/goodies.dm
@@ -1,9 +1,6 @@
-/datum/supply_pack/goody/disablersmg_single
+/datum/supply_pack/goody/smg_single
 	name = "Disabler SMG Single-Pack"
-	desc = "Contains one disabler SMG, an automatic variant of the original workhorse."
 	cost = PAYCHECK_COMMAND * 3
-	access_view = ACCESS_WEAPONS
-	contains = list(/obj/item/gun/energy/disabler/smg)
 
 /datum/supply_pack/goody/lasercarbine_single
 	name = "Laser Carbine Single-Pack"


### PR DESCRIPTION
## About The Pull Request

Fixes duplicate entries for disabler SMG in cargo goodies.

</details>

## Changelog

:cl: LT3
fix: Fixed duplicate disabler SMG goody pack in cargo
/:cl: