### PR TITLE
Removes pepperballs from non-swat crates.

### DIFF
--- a/modular_zubbers/code/modules/cargo/packs/goodies.dm
+++ b/modular_zubbers/code/modules/cargo/packs/goodies.dm
@@ -127,13 +127,6 @@
 	cost = PAYCHECK_CREW * 12
 	contains = list(/obj/item/organ/cyberimp/arm/toolkit/rope)
 
-/datum/supply_pack/goody/pepperball_gun
-	name = "Pepperball Gun Single-Pack"
-	desc = "Contains one pepperball gun, a non-lethal weapon that fires pepper-filled projectiles."
-	cost = PAYCHECK_CREW * 9
-	access = ACCESS_SECURITY
-	contains = list(/obj/item/storage/toolbox/guncase/skyrat/pistol/pepperball)
-
 /datum/supply_pack/goody/taser
 	name = "Taser Single-Pack"
 	desc = "Contains one hybrid taser, a non-lethal weapon that fires electric projectiles and features a secondary disabler."

--- a/modular_zubbers/code/modules/cargo/packs/security.dm
+++ b/modular_zubbers/code/modules/cargo/packs/security.dm
@@ -70,13 +70,6 @@
 	access_any = list(ACCESS_SECURITY, ACCESS_ROBOTICS)
 	access_view = FALSE
 
-/datum/supply_pack/security/pepperballguns
-	name = "Pepperball Gun Crate"
-	desc = "Contains three pepperball guns, a non-lethal weapon that fires pepper-filled projectiles."
-	cost = CARGO_CRATE_VALUE * 4.5
-	contains = list(/obj/item/storage/toolbox/guncase/skyrat/pistol/pepperball = 3)
-	access = ACCESS_SECURITY
-
 /datum/supply_pack/security/Tasers
 	name = "Taser Crate"
 	desc = "Contains three hybrid tasers, a non-lethal weapon that fires electric projectiles and features a secondary disabler."


### PR DESCRIPTION
## About The Pull Request
My intent was never to have pepperballs in any crate but swat. I was gone for awhile, so someone else had to finish a bit of my work, so I don't blame them for assuming!
## Why It's Good For The Game
Making pepperballs only available in the swat crate was for three primary reasons:
One, this locks them behind armory access, making them rarer. I didn't want everyone and their mother to have a pepperball gun. They should be occasional threats not constant ones.

Two, it was meant to buff the utility of the swat crate. Swat crates exist as multiple different pieces of equipment that focus on non-lethal tactical takedowns, I felt that pepperballs belonged perfectly in that category.

Three, a higher entry price point. Makes it more costly, and something you have to generally go out of your way for. It wasn't intended to be standard gear.

This being said, I haven't been here personally to observe how this being public effected balance too hard, so if I'm entirely wrong, do point it out.
## Proof Of Testing
Works on my machine.
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
balance: Pepper ball guns are now only obtainable through swat crates
/:cl:
