### PR TITLE
Crew antagonists cannot spawn after the 2 hour mark because I died on the shuttle once.

### DIFF
--- a/config/bubbers/storyteller.txt
+++ b/config/bubbers/storyteller.txt
@@ -48,3 +48,5 @@ MAJOR_POP_SCALE_PENALTY 30
 ROLESET_POP_SCALE_PENALTY 30
 OBJECTIVES_POP_SCALE_PENALTY 30
 
+## Disable storyteller crew antagonist creation after this many minutes. Values less than 0 means don't disable.
+DISALLOW_CREW_ANTAGS_TIME_THRESHOLD -1

--- a/modular_zubbers/code/modules/storyteller/config.dm
+++ b/modular_zubbers/code/modules/storyteller/config.dm
@@ -147,3 +147,8 @@
 	default = GHOSTSET_POP_SCALE_PENALTY
 	integer = TRUE
 	min_val = 0
+
+/datum/config_entry/number/disallow_crew_antags_time_threshold
+	default = -1
+	integer = TRUE
+	min_val = -1

--- a/modular_zubbers/code/modules/storyteller/event_defines/crewset/_antagonist_event.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/crewset/_antagonist_event.dm
@@ -70,8 +70,10 @@
 	. = ..()
 	if(!.)
 		return
-	if(world.time-SSticker.round_start_time >= (2 HOURS))
-		return FALSE
+	var/crew_antag_time_maximum = CONFIG_GET(number/disallow_crew_antags_time_threshold)
+	if(crew_antag_time_maximum >= 0)
+		if( (world.time-SSticker.round_start_time) >= (crew_antag_time_maximum MINUTES))
+			return FALSE
 	if(!roundstart && !SSgamemode.can_inject_antags())
 		return FALSE
 	if(!get_antag_amount())


### PR DESCRIPTION
## About The Pull Request

Crew antagonists cannot spawn after the 2 hour mark. This does not stop things like space changelings and lone infiltrators from spawning.

## Why It's Good For The Game

This prevents the issue of server pop dying because someone got antagonist while the shuttle was coming and they decided it would be best to go tits out because there isn't time to roleplay and they might as well make the best of it.

A common concern I've seen with this PR is that if people extend, it means that more antagonists could've spawned after the 2 hour mark, but generally speaking people extend the round because an antagonist is already doing something interesting or something else is going on in the round. Generally, no one votes continue because "oh antags haven't done anything yet, something might happen".
## Proof Of Testing

If it compiles, it werks.

## Changelog

:cl: BurgerBB
config: Added a configurable setting for where crew antagonists cannot spawn after a set time period because I died on the shuttle once. This does not stop things like space changelings and lone infiltrators from spawning.
/:cl:

