### PR TITLE
Makes MOD hypnovisor module toggleable, editable in-suit

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_machinery/lustwish.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_machinery/lustwish.dm
@@ -148,7 +148,8 @@
 			"icon" = FA_ICON_USER_ASTRONAUT,
 			"products" = list(
 				/obj/item/mod/construction/plating/lustwish = 5,
-				/obj/item/mod/module/hypno_visor = 5,
+				/obj/item/mod/module/hypno_visor/passive = 5,
+				/obj/item/mod/module/hypno_visor/toggleable = 5,
 				/obj/item/mod/module/remote_control = 5,
 			)
 		),

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_machinery/lustwish.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_machinery/lustwish.dm
@@ -148,8 +148,7 @@
 			"icon" = FA_ICON_USER_ASTRONAUT,
 			"products" = list(
 				/obj/item/mod/construction/plating/lustwish = 5,
-				/obj/item/mod/module/hypno_visor/passive = 5,
-				/obj/item/mod/module/hypno_visor/toggleable = 5,
+				/obj/item/mod/module/hypno_visor = 5,
 				/obj/item/mod/module/remote_control = 5,
 			)
 		),

--- a/modular_zubbers/code/modules/mod/modules_lustwish.dm
+++ b/modular_zubbers/code/modules/mod/modules_lustwish.dm
@@ -15,6 +15,8 @@
 	required_slots = list(ITEM_SLOT_HEAD)
 	overlay_icon_file = 'modular_zubbers/icons/mob/clothing/modsuit/mod_modules.dmi'
 	var/hypno_message = "Obey"
+		///Does the visor overlay show on the character sprite when installed?
+	var/visor_effect = TRUE
 
 /obj/item/mod/module/hypno_visor/proc/apply_hypnosis()
 	if(!(mod.wearer.client?.prefs?.read_preference(/datum/preference/toggle/erp/hypnosis) && mod.wearer.client.prefs.read_preference(/datum/preference/toggle/erp/sex_toy)))
@@ -31,6 +33,8 @@
 	. = ..()
 	if(mod.skin != "lustwish")
 		overlay_state_inactive = null // Visual thing. Removes the overlay if it's not a part of the lustwish suit.
+		overlay_state_active = null
+		balloon_alert(mod.wearer, "visor effect unavailable for this plating!")
 
 /obj/item/mod/module/hypno_visor/on_uninstall(deleting = FALSE)
 	. = ..()
@@ -41,7 +45,8 @@
 /obj/item/mod/module/hypno_visor/passive
 	name = "MOD passive hypnosis module"
 	desc = "A module inserted into the visor of a suit in which commands can be processed. \
-			Enables automatically when visor is activated. Use on self to set directives."
+			Enables automatically when visor is activated. Use on self to set directives. \
+			Screwdriver to toggle visor effects."
 	module_type = MODULE_PASSIVE
 	overlay_state_inactive = "module_hypno_overlay"
 
@@ -72,10 +77,9 @@
 	icon = 'modular_zubbers/icons/mob/clothing/modsuit/mod_modules.dmi'
 	icon_state = "module_hypno"
 	module_type = MODULE_TOGGLE
-	overlay_state_active = "module_hypno_overlay"
+	overlay_state_active = null
 	overlay_icon_file = 'modular_zubbers/icons/mob/clothing/modsuit/mod_modules.dmi'
-	///Does the visor overlay show on the character sprite when installed? Disabled due to the checkbox not working.
-	//var/visor_effect = FALSE
+	visor_effect = FALSE
 
 /obj/item/mod/module/hypno_visor/toggleable/Destroy()
 	if(!mod)
@@ -93,7 +97,7 @@
 /obj/item/mod/module/hypno_visor/toggleable/get_configuration()
 	. = ..()
 	.["hypno_message"] = add_ui_configuration("Hypnotic Message", "button", "list")
-	//.["visor_effect"] = add_ui_configuration("Visor Effect", "bool", visor_effect)
+	.["visor_effect"] = add_ui_configuration("Visor Effect", "bool", visor_effect)
 
 /obj/item/mod/module/hypno_visor/toggleable/configure_edit(key, value)
 	switch(key)
@@ -102,8 +106,13 @@
 			if(active)
 				balloon_alert(mod.wearer, "restart to finalize changes")
 			// restart module for change to take effect. ALSO NEEDS TO FIX SO IT'S THE BUTTON PRESSER AND NOT THE WEARER!
-		//if("visor_effect")
-		//	overlay_state_active = visor_effect ? "module_hypno_overlay" : null
+		if("visor_effect")
+			if(mod.skin != "lustwish")
+				return balloon_alert(mod.wearer, "visor effect unavailable for this plating!")
+			visor_effect = text2num(value)
+			overlay_state_active = visor_effect ? "module_hypno_overlay" : null
+			if(active)
+				balloon_alert(mod.wearer, "restart to finalize changes")
 
 
 /datum/storage/pockets/small/remote_module

--- a/modular_zubbers/code/modules/mod/modules_lustwish.dm
+++ b/modular_zubbers/code/modules/mod/modules_lustwish.dm
@@ -107,17 +107,16 @@
 /obj/item/mod/module/hypno_visor/toggleable/configure_edit(key, value)
 	switch(key)
 		if("hypno_message")
-			hypno_message = tgui_input_text(mod.wearer, "Change the hypnotic phrase.", default = hypno_message, max_length = MAX_MESSAGE_LEN)
+			hypno_message = tgui_input_text(usr, "Change the hypnotic phrase.", default = hypno_message, max_length = MAX_MESSAGE_LEN)
 			if(active)
-				balloon_alert(mod.wearer, "restart to finalize changes")
-			// ALSO NEEDS TO FIX SO IT'S THE BUTTON PRESSER AND NOT THE WEARER!
+				balloon_alert(usr, "restart to finalize changes")
 		if("visor_effect")
 			if(mod.skin != "lustwish")
-				return balloon_alert(mod.wearer, "visor effect unavailable for this plating!")
+				return balloon_alert(usr, "visor effect unavailable for this plating!")
 			visor_effect = text2num(value)
 			overlay_state_active = visor_effect ? "module_hypno_overlay" : null
 			if(active)
-				balloon_alert(mod.wearer, "restart to finalize changes")
+				balloon_alert(usr, "restart to finalize changes")
 
 
 /datum/storage/pockets/small/remote_module

--- a/modular_zubbers/code/modules/mod/modules_lustwish.dm
+++ b/modular_zubbers/code/modules/mod/modules_lustwish.dm
@@ -29,12 +29,18 @@
 	. = ..()
 	hypno_message = tgui_input_text(user, "Change the hypnotic phrase.", default = hypno_message, max_length = MAX_MESSAGE_LEN)
 
+/obj/item/mod/module/hypno_visor/screwdriver_act(mob/living/user, obj/item/tool)
+	visor_effect = !visor_effect
+	to_chat(user, span_notice("You turn the hypnosis module's visor display [visor_effect ? "on" : "off"]."))
+	return TRUE
+
 /obj/item/mod/module/hypno_visor/on_install()
 	. = ..()
 	if(mod.skin != "lustwish")
 		overlay_state_inactive = null // Visual thing. Removes the overlay if it's not a part of the lustwish suit.
 		overlay_state_active = null
-		balloon_alert(mod.wearer, "visor effect unavailable for this plating!")
+		visor_effect = FALSE
+		//balloon_alert(SOMEONE??? IDK how to track the person installing, "visor effect unavailable for this plating!")
 
 /obj/item/mod/module/hypno_visor/on_uninstall(deleting = FALSE)
 	. = ..()
@@ -73,13 +79,12 @@
 	name = "MOD toggleable hypnosis module"
 	desc = "A module inserted into the visor of a suit in which commands can be processed. \
 		    Directives can be edited on-the-fly, but the module must be manually activated. \
-			Use on self or check the MOD UI to set directives."
+			Use on self or check the MOD UI to set directives. Screwdriver to toggle visor effects."
 	icon = 'modular_zubbers/icons/mob/clothing/modsuit/mod_modules.dmi'
 	icon_state = "module_hypno"
 	module_type = MODULE_TOGGLE
 	overlay_state_active = null
 	overlay_icon_file = 'modular_zubbers/icons/mob/clothing/modsuit/mod_modules.dmi'
-	visor_effect = FALSE
 
 /obj/item/mod/module/hypno_visor/toggleable/Destroy()
 	if(!mod)
@@ -105,7 +110,7 @@
 			hypno_message = tgui_input_text(mod.wearer, "Change the hypnotic phrase.", default = hypno_message, max_length = MAX_MESSAGE_LEN)
 			if(active)
 				balloon_alert(mod.wearer, "restart to finalize changes")
-			// restart module for change to take effect. ALSO NEEDS TO FIX SO IT'S THE BUTTON PRESSER AND NOT THE WEARER!
+			// ALSO NEEDS TO FIX SO IT'S THE BUTTON PRESSER AND NOT THE WEARER!
 		if("visor_effect")
 			if(mod.skin != "lustwish")
 				return balloon_alert(mod.wearer, "visor effect unavailable for this plating!")

--- a/modular_zubbers/code/modules/mod/modules_lustwish.dm
+++ b/modular_zubbers/code/modules/mod/modules_lustwish.dm
@@ -77,7 +77,7 @@
 /obj/item/mod/module/hypno_visor/Destroy()
 	if(!mod)
 		return ..()
-	if(module_type = ((module_type == MODULE_PASSIVE && part_activated) || (module_type == MODULE_TOGGLE && active)) && mod.wearer)
+	if(module_type == ((module_type == MODULE_PASSIVE && part_activated) || (module_type == MODULE_TOGGLE && active)) && mod.wearer)
 		mod.wearer.cure_trauma_type(/datum/brain_trauma/very_special/induced_hypnosis, TRAUMA_RESILIENCE_MAGIC)
 	return ..()
 

--- a/modular_zubbers/code/modules/mod/modules_lustwish.dm
+++ b/modular_zubbers/code/modules/mod/modules_lustwish.dm
@@ -56,7 +56,7 @@
 
 /obj/item/mod/module/hypno_visor/on_install()
 	. = ..()
-	if(mod.skin != "lustwish")
+	if(mod.skin != "lustwish" && visor_effect == TRUE)
 		overlay_state_inactive = null // Visual thing. Removes the overlay if it's not a part of the lustwish suit.
 		overlay_state_active = null
 		visor_effect = FALSE

--- a/modular_zubbers/code/modules/mod/modules_lustwish.dm
+++ b/modular_zubbers/code/modules/mod/modules_lustwish.dm
@@ -4,7 +4,7 @@
 	theme = /datum/mod_theme/lustwish
 
 /obj/item/mod/module/hypno_visor
-	name = "MOD hypnotic visor module"
+	name = "\improper MOD hypnotic visor module"
 	desc = "A module inserted into the visor of a suit in which commands can be processed."
 	icon = 'modular_zubbers/icons/mob/clothing/modsuit/mod_modules.dmi'
 	icon_state = "module_hypno"
@@ -24,9 +24,9 @@
 
 /obj/item/mod/module/hypno_visor/examine(mob/user)
 	. = ..()
-	. += span_info("It's currently programmed with the following directive: \"[hypno_message]\" Use it in-hand to rewrite it.\n\
-					Its visor will [visor_effect ? "" : "<b>not</b>"] display an external hypnotic effect. Use a screwdriver to toggle.\n\
-					Its control wire is currently [(module_type == MODULE_TOGGLE) ? \
+	. += span_info("It's currently programmed with the following directive: \"[hypno_message]\" Use it in-hand to rewrite it.")
+	. += span_info("Its visor will [visor_effect ? "" : "<b>not</b>"] display an external hypnotic effect. Use a screwdriver to toggle.")
+	. += span_info("Its control wire is currently [(module_type == MODULE_TOGGLE) ? \
 						"<b>intact,</b> allowing for on-the-fly configuration via the MOD UI." \
 						: \
 						"<b>snipped,</b> forcing the module to be always-on when the helmet is activated."] \
@@ -34,11 +34,15 @@
 
 /obj/item/mod/module/hypno_visor/attack_self(mob/user)
 	. = ..()
-	hypno_message = tgui_input_text(user, "Change the hypnotic phrase.", default = hypno_message, max_length = MAX_MESSAGE_LEN)
+	var/message_input = tgui_input_text(user, "Change the hypnotic phrase.", default = hypno_message, max_length = MAX_MESSAGE_LEN)
+	if(message_input)
+		hypno_message = message_input
+	else
+		hypno_message = "Obey"
 
 /obj/item/mod/module/hypno_visor/screwdriver_act(mob/living/user, obj/item/tool)
 	visor_effect = !visor_effect
-	to_chat(user, span_notice("You turn the visor display of the [src] [visor_effect ? "on" : "off"]."))
+	to_chat(user, span_notice("You turn the visor display of [src] [visor_effect ? "on" : "off"]."))
 	return TRUE
 
 /obj/item/mod/module/hypno_visor/wirecutter_act(mob/living/user, obj/item/tool)
@@ -51,7 +55,7 @@
 		overlay_state_active = "module_hypno_overlay"
 		overlay_state_inactive = null
 
-	to_chat(user, span_notice("You [(module_type == MODULE_TOGGLE) ? "mend" : "snip"] the control wire on the [src]."))
+	to_chat(user, span_notice("You [(module_type == MODULE_TOGGLE) ? "mend" : "snip"] the control wire on [src]."))
 	return TRUE
 
 /obj/item/mod/module/hypno_visor/on_install()


### PR DESCRIPTION
## About The Pull Request

Changes the hypnovisor significantly:
- Renames it (hypnosis module --> MOD hypnotic visor module) to be similar to normal modules
- Changing the directive now fills the text box with the previously selected directive.
- Use a screwdriver on the module to toggle its visor effects, so nobody will suspect you're doing something lewd while you walk around in your fully-deployed Lustwish modsuit.
- Use wirecutters on the module to cut its control wire, switching between toggleable mode and passive mode.
-- Passive mode retains current hypnovisor functionality, which means it is always-on, and cannot be configured while installed.
-- Toggleable mode can be switched on/off and configured via the MOD UI (including via remote control), with changes to the directive and display taking effect upon restart.
- Tutorial text added for the module's examine text, explaining the interactions, what they do, and also what the module is currently configured to.

No other changes to functionality are intended for this module.

If someone is willing to sprite them, I'd be happy to add support for additional spiral visor overlays for other MOD platings (Standard, Engineering, Loader, Medical, Corpsman, etc.?) that have big enough visors for it...

## Why It's Good For The Game

Adding additional functionalities to the lewder modules makes them more attractive to use and ultimately will lead to me seeing more of the content I like in the game. Being able to edit directives on-the-fly also makes use of this module much less clunky.

## Proof Of Testing
<details>
<summary>
<img width="967" height="351" alt="image" src="https://github.com/user-attachments/assets/124b807d-49f3-470c-83bf-2e5c18dc3b24" />
</summary>

</details>

## Changelog

:cl:
add: MOD hypnosis module is now configurable via the MOD UI... including remote control.
/:cl: