### PR TITLE
Partial revert of #5082

### DIFF
--- a/modular_zubbers/code/modules/mob/living/basic/bots/firebot.dm
+++ b/modular_zubbers/code/modules/mob/living/basic/bots/firebot.dm
@@ -12,7 +12,7 @@
 	if(!COOLDOWN_FINISHED(src, foam_cooldown))
 		return
 	var/datum/effect_system/fluid_spread/foam/firefighting_freon/foam = new
-	foam.set_up(7, holder = src, location = loc)
+	foam.set_up(5, holder = src, location = loc)
 	foam.start()
 
 	COOLDOWN_START(src, foam_cooldown, 8 SECONDS)


### PR DESCRIPTION

## About The Pull Request
I forgot to slap a 'Do Not Merge' label on #5082 so it ended up getting merged before myself and the rest of the team were able to fully finish discussing the buff to the range, so I am reverting the buff done to the upgraded firebot's range for the time being.
## Why It's Good For The Game
Let me show you guys two videos taken of the upgraded firebots in the same exact environments with only one variable changed, the foam range.

### Foam Range 5

https://github.com/user-attachments/assets/8be3c694-acec-4a8f-af7b-36bfb1db0175

### Foam Range 7

https://github.com/user-attachments/assets/0bbafbd9-09cd-4450-9d07-e1e78e1845bb

Note that these fires don't get properly extinguished due to the type of fire I used (the canister fire), but if it was, say for instance, a plasma fire, the whole Thunderdome would have been extinguished from one foam shot with the buffed firebot meanwhile the one with the range of five only covers about 2/3 of the Thunderdome.
## Proof Of Testing
See the attached videos above.

## Changelog
:cl:
balance: Reduced the foam range of the upgraded firebots.
/:cl:
