### PR TITLE
Teeny tiny Box Station fixes.

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -12106,11 +12106,26 @@
 	pixel_x = -23
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/item/stack/sheet/plasteel{
-	amount = 10;
-	pixel_x = -6;
+/obj/item/assembly/flash/handheld{
+	pixel_x = 10;
+	pixel_y = 12
+	},
+/obj/item/assembly/flash/handheld{
+	pixel_x = 10;
 	pixel_y = 4
+	},
+/obj/item/assembly/flash/handheld{
+	pixel_x = 10;
+	pixel_y = -4
+	},
+/obj/structure/table/glass,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/item/stack/sheet/plasteel/twenty{
+	pixel_y = 6;
+	pixel_x = -6
 	},
 /obj/item/stack/cable_coil{
 	pixel_x = -5;
@@ -12127,22 +12142,6 @@
 /obj/item/assembly/flash/handheld{
 	pixel_x = 2;
 	pixel_y = -4
-	},
-/obj/item/assembly/flash/handheld{
-	pixel_x = 10;
-	pixel_y = 12
-	},
-/obj/item/assembly/flash/handheld{
-	pixel_x = 10;
-	pixel_y = 4
-	},
-/obj/item/assembly/flash/handheld{
-	pixel_x = 10;
-	pixel_y = -4
-	},
-/obj/structure/table/glass,
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 1
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/robotics/lab)


### PR DESCRIPTION
## About The Pull Request

More Boxstation upkeep. This has various fixes that improve gameplay visually and mechanically. 

There was an intercom that used the wrong directional between the fitness room and service hall.
There was a wall in science maints that broke continuous wall rules.
Many airlocks in maints with the unrestricted airlock marker were given the new, default delayed variant from /tg/
Replaces some four glass-paned tiles with full tile glass windows to be consistent with other areas of the station.
Expands number of stowaway spawn locations.

## Why It's Good For The Game

Functional and visually appealing stations on our server are good 👍 

## Proof Of Testing

📦

## Changelog

:cl:
map: Some Box Station fixes: An intercom in the fitness room now faces right way. Made some glass and grass windows consistent with others. Some maintenance unrestricted access airlocks make sense now.
map: A few more spawn locations for stowaways were added on Box Station.
/:cl:

