### PR TITLE
Removes LING ZOMBIE VIRUS FROM CARGO????

### DIFF
--- a/modular_zubbers/code/modules/changeling_zombies/event.dm
+++ b/modular_zubbers/code/modules/changeling_zombies/event.dm
@@ -23,7 +23,7 @@
 /datum/supply_pack/misc/changeling_zombie
 	name = "NT-CZV-1 Vials"
 	desc = "Contains a NT-CZV vials. Highly classified."
-	order_flags = ORDER_INVISIBLE // Hide this shit from everyone
+	order_flags = ORDER_SPECIAL // Can only be sent by admins
 	contains = list() //We don't put contents in this to do snowflake content in populate_contents
 	crate_type = /obj/structure/closet/crate/changeling_zombie
 


### PR DESCRIPTION
Someone didn't understand their cargo flags
## About The Pull Request

Due to an incorrect flag, you are currently able to order the changeling zombie virus from a cargo console that's had a multitool used on it
## Why It's Good For The Game

Needless to say, this is fucking stupid
## Proof Of Testing
</details>

## Changelog
:cl:
fix: Fixed an incorrect flag that allowed cargo to cause a zombie apocalypse
/:cl:
