### PR TITLE
Temporary fix for flaky gateway CI

### DIFF
--- a/_maps/gateway_test.json
+++ b/_maps/gateway_test.json
@@ -14,6 +14,7 @@
 		"/datum/unit_test/space_dragon_expiration",
 		"/datum/unit_test/spy_bounty",
 		"/datum/unit_test/traitor",
-		"/datum/unit_test/lungs/lungs_sanity_ashwalker"
+		"/datum/unit_test/lungs/lungs_sanity_ashwalker",
+		"/datum/unit_test/breath/breath_sanity_ashwalker"
 	]
 }


### PR DESCRIPTION
## About The Pull Request

Gateway test CI seems to be running out of memory often now, this was fixed in https://github.com/tgstation/tgstation/pull/94771 but given how behind we are in upstreams I just want to selectively apply this and it can be overwritten once upstream syncs have caught up.

**The changes to `space_ruin_levels` and `minetype` can safely be overwritten once https://github.com/tgstation/tgstation/pull/94771 is pulled, and the additions to `ignored_unit_tests` should be removed once https://github.com/tgstation/tgstation/pull/94821 is pulled (as it provides a better fix).**

## Why It's Good For The Game

Gateway_test is failing a lot