### PR TITLE
Fix a map warning for the interlink

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -14008,7 +14008,6 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/corporate,
-/obj/effect/mapping_helpers/airlock/access/any/cent_com/rep_or_captain,
 /obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/admin/interlink)
@@ -16898,7 +16897,6 @@
 /obj/structure/table/wood,
 /obj/machinery/fax{
 	fax_name = "Administrative Office";
-	pixel_x = 0;
 	pixel_y = 8
 	},
 /obj/effect/turf_decal/siding/wood/corner,


### PR DESCRIPTION

## About The Pull Request

Interlink admin office had two access helpers on one door which isn't allowed, removed one

## Why It's Good For The Game

<img width="839" height="35" alt="image" src="https://github.com/user-attachments/assets/6df3f877-f824-4ea5-91fc-0b98dae74417" />


## Proof Of Testing

No
