### PR TITLE
Departamental Sec

### DIFF
--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -4,8 +4,8 @@
 		Procedure, eat donuts."
 	auto_deadmin_role_flags = DEADMIN_POSITION_SECURITY
 	faction = FACTION_STATION
-	total_positions = 8 //Handled in /datum/controller/occupations/proc/setup_officer_positions() //SKYRAT EDIT: SET TO 8, WAS 5
-	spawn_positions = 8 //Handled in /datum/controller/occupations/proc/setup_officer_positions() //SKYRAT EDIT: SEE ABOVE
+	total_positions = 5 //Handled in /datum/controller/occupations/proc/setup_officer_positions()
+	spawn_positions = 5 //Handled in /datum/controller/occupations/proc/setup_officer_positions()
 	supervisors = "the Head of Security, and the head of your assigned department (if applicable)"
 	minimal_player_age = 7
 	exp_requirements = 300
@@ -28,7 +28,7 @@
 		/datum/job_department/security,
 		)
 
-	family_heirlooms = list(/obj/item/book/manual/wiki/security_space_law, /obj/item/clothing/head/beret/sec/peacekeeper) //SKYRAT EDIT ADD - /peacekeeper
+	family_heirlooms = list(/obj/item/book/manual/wiki/security_space_law, /obj/item/clothing/head/beret/sec)
 
 	mail_goodies = list(
 		/obj/item/food/donut/caramel = 10,
@@ -57,27 +57,18 @@ GLOBAL_LIST_INIT(available_depts, list(SEC_DEPT_ENGINEERING, SEC_DEPT_MEDICAL, S
  */
 GLOBAL_LIST_EMPTY(security_officer_distribution)
 
-
 /datum/job/security_officer/after_roundstart_spawn(mob/living/spawning, client/player_client)
 	. = ..()
-	//SKYRAT EDIT REMOVAL
-	/*
 	if(ishuman(spawning))
 		setup_department(spawning, player_client, move_to = TRUE)
-	*/
-	//SKYRAT EDIT END
 
 
 /datum/job/security_officer/after_latejoin_spawn(mob/living/spawning)
 	. = ..()
-	//SKYRAT EDIT REMOVAL
-	/*
 	if(ishuman(spawning))
 		var/department = setup_department(spawning, spawning.client)
 		if(department)
 			announce_latejoin(spawning, department, GLOB.security_officer_distribution)
-	*/
-	//SKYRAT EDIT END
 
 
 /// Returns the department this mob was assigned to, if any.
@@ -227,17 +218,15 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 	id_trim = /datum/id_trim/job/security_officer
 	uniform = /obj/item/clothing/under/rank/security/officer
 	suit = /obj/item/clothing/suit/armor/vest/alt/sec
-	suit_store = /obj/item/gun/energy/e_gun/advtaser //BUBBER EDIT CHANGE - Original: /obj/item/gun/energy/disabler
+	suit_store = /obj/item/gun/energy/disabler
 	backpack_contents = list(
 		/obj/item/evidencebag = 1,
-		/obj/item/flashlight/seclite = 1, // BUBBER EDIT ADDITION
 		)
 	belt = /obj/item/modular_computer/pda/security
 	ears = /obj/item/radio/headset/headset_sec/alt
 	gloves = /obj/item/clothing/gloves/color/black/security
-	head = /obj/item/clothing/head/security_garrison //SKYRAT EDIT CHANGE - Original: /obj/item/clothing/head/helmet/sec
+	head = /obj/item/clothing/head/helmet/sec
 	shoes = /obj/item/clothing/shoes/jackboots/sec
-	glasses = /obj/item/clothing/glasses/hud/security //SKYRAT EDIT - ADDITION
 	l_pocket = /obj/item/restraints/handcuffs
 	r_pocket = /obj/item/assembly/flash/handheld
 

--- a/modular_zubbers/code/modules/jobs/job_types/security_officer.dm
+++ b/modular_zubbers/code/modules/jobs/job_types/security_officer.dm
@@ -1,0 +1,14 @@
+/datum/job/security_officer
+	total_positions = 8 //Handled in /datum/controller/occupations/proc/setup_officer_positions()
+	spawn_positions = 8 //Handled in /datum/controller/occupations/proc/setup_officer_positions()
+
+	family_heirlooms = list(/obj/item/book/manual/wiki/security_space_law, /obj/item/clothing/head/beret/sec/peacekeeper)
+
+
+/datum/outfit/job/security
+	head = /obj/item/clothing/head/security_garrison
+	suit_store = /obj/item/gun/energy/e_gun/advtaser
+	glasses = /obj/item/clothing/glasses/hud/security
+	backpack_contents = list(
+		/obj/item/evidencebag = 1,
+		/obj/item/flashlight/seclite = 1)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9447,6 +9447,7 @@
 #include "modular_zubbers\code\modules\jobs\job_types\nanotrasen_consultant.dm"
 #include "modular_zubbers\code\modules\jobs\job_types\quartermaster.dm"
 #include "modular_zubbers\code\modules\jobs\job_types\roboticist.dm"
+#include "modular_zubbers\code\modules\jobs\job_types\security_officer.dm"
 #include "modular_zubbers\code\modules\jobs\job_types\warden.dm"
 #include "modular_zubbers\code\modules\jobs\job_types\ghost_roles\blackmarket.dm"
 #include "modular_zubbers\code\modules\jobs\job_types\ghost_roles\ds2.dm"


### PR DESCRIPTION
# To be testmerged so we can see if players like it.

Readds departmental sec, assigning officers to departments of choice/at random with extra access, an armband, and a radio. This started because of a bug adding depguarsd with the voucher PR [woops] and then us getting good feedback on the gameplay during the bugged rounsd. 

**This does not remove departmental guards. They remain as individual lower-stakes entities.**

## Why It's Good For The Game
Allowing security access to the departments they are meant to protect reduces much of the frustration involved in actually doing their job. Dealing with people asking "why?" when screaming to let them in due to a changeling massacring people is potentially more frustrating for the security player than the part about getting killed 3 times and round removed by said ling. 

The RETA system, while helpful for letting swathes in, does not fulfill it's job if people inside are dead. How many people know the RETA system exists, even? 

A concern I am aware of is that the roles of sec and depguard might be blurred with sec having access. I believe they won't change in the slightest with this change. A couple examples of problems one might anticipate to be irrevocably altered by having department sec:

Ling in science, killing people!
Currently:
Sec bangs on the door and either hos, a worker, depguard or ai let them in to fight and die. The depguard can be there, too, as part of the mass of NT cannon fodder.
With this change:
A. The sci-assigned officer was in sci already, and the depguard and officer fight together until the current scenario happens all over again.
B. The sci-assigned officer was looking for the ling in maints. Proceed to current situation, but one can also wait on one of the 1-3 officers who should genuinely be keeping an eye out in that area. 

Sec patrols...
Currently: 
Depguards sit in departments, secoffs pace around maintenance and halls like they're high, gearing up in between. 
With change:
Depguards sit in departments, aware they might live a few seconds longer if something DOES come. 
Secoffs pace around maints AND their departments, however, there's a chance they engage with RP with non-sec and non-antags as they now actually cross paths with them other than when they die or need something, and there's also a rather low chance that a depguard's job is "taken" by having reinforcements. A secoff being there with the depguards helps them do it better, Barney would never take down the whole invasion himself.

Sec stealing things from departments
Currently:
A secoff has a harder time printing off, say, cells without permission from science. If they do it, they risk the wrath of the dep guard, which has the authority in their domain to stop it. As well as just being fired after anyone in said dept reports them. 
With change:
Sec might print off a few tools without asking, or take a medkit, at which point IC issue, conflict is created among non-antagonists, there's RP about corrupt cops now. 

I just do not see a possibility for this to do something that isn't a rather small amplification of a preexisting phenomenon in the game..

## Proof Of Testing

<img width="656" height="324" alt="AAAAAAAAAAA" src="https://github.com/user-attachments/assets/a81666df-d16d-47d1-93f9-f6d35645520d" />

:cl:
add: Sec now once more gets assigned to departments, granting bonus access
/:cl:

