### PR TITLE
Removes the negative movespeed in the light from shadekin

### DIFF
--- a/modular_zubbers/code/modules/mob/living/carbon/human/species_types/shadekin.dm
+++ b/modular_zubbers/code/modules/mob/living/carbon/human/species_types/shadekin.dm
@@ -140,8 +140,10 @@
 		return
 	var/light_amount = owner_turf.get_lumcount()
 
-	if (light_amount < SHADOW_SPECIES_LIGHT_THRESHOLD) //heal in the dark
+	if (light_amount < SHADOW_SPECIES_LIGHT_THRESHOLD) // heal in the dark
 		owner.apply_status_effect(applied_status)
+	else
+		return
 
 /datum/status_effect/shadekin_regeneration
 	id = "shadekin_regeneration"


### PR DESCRIPTION

## About The Pull Request
Title

## Why It's Good For The Game
Shadekin already have a fair few downsides, 20% more damage taken is a LOT. The main benefits are healing in the dark and nobreath. I do not believe these warrant a borderline-permanent slower movespeed when 90% of the time the station will be bright. 

## Proof Of Testing
no

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
balance: Shadekin no longer suffer a movespeed debuff in the light.
/:cl:

