### PR TITLE
Locks the warden's campaign hat to warden in loadout

### DIFF
--- a/modular_zubbers/code/modules/loadout/categories/heads.dm
+++ b/modular_zubbers/code/modules/loadout/categories/heads.dm
@@ -25,6 +25,7 @@
 /datum/loadout_item/head/hats/warden/drill
 	name = "Warden's Campaign Hat"
 	item_path = /obj/item/clothing/head/hats/warden/drill
+	restricted_roles = list(JOB_WARDEN)
 
 /datum/loadout_item/head/hats/warden/police/patrol
 	name = "Police Patrol Cap"


### PR DESCRIPTION

## About The Pull Request
It should've probably been already the case

## Why It's Good For The Game
Oversight fix good

## Proof Of Testing
no

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
fix: The warden's hat can now only be selected by wardens within the loadout.
/:cl:

