### PR TITLE
Ports beestation abductee overhaul

### DIFF
--- a/code/modules/antagonists/abductor/abductee/abductee.dm
+++ b/code/modules/antagonists/abductor/abductee/abductee.dm
@@ -22,17 +22,20 @@
 	play_stinger()
 
 /datum/antagonist/abductee/proc/give_objective()
-
-	// Give the base objective
+	// BUBBER EDIT START: OLD PROC IS JUST THE 3 LINES
+	// var/objtype = (prob(75) ? /datum/objective/abductee/random : pick(subtypesof(/datum/objective/abductee/) - /datum/objective/abductee/random))
+	// var/datum/objective/abductee/objective = new objtype()
+	// objectives += objective
 	var/datum/objective/abductee/base_objective = new()
 	base_objective.owner = owner
 
-	switch(rand(1,10))
-		if(6 to 10)
+	switch(rand(1, 10))
+		if(7 to 10)
 			base_objective = new /datum/objective/abductee/fearful()
-		if(3 to 5)
+		if(4 to 6)
 			base_objective = new /datum/objective/abductee/violent()
-		if(1 to 2)
+		if(1 to 3)
 			base_objective = new /datum/objective/abductee/paranoid()
 
 	objectives += base_objective
+		// BUBBER EDIT END

--- a/code/modules/antagonists/abductor/abductee/abductee_objectives.dm
+++ b/code/modules/antagonists/abductor/abductee/abductee_objectives.dm
@@ -1,7 +1,59 @@
 /datum/objective/abductee
 	completed = 1
-	explanation_text = "THEY took you... you can't remember...? The pale faces.. the hands... THEY control us now. You must protect yourself."
+	explanation_text = "THEY took you... you can't remember...? The pale faces.. the hands... THEY control us now. You must protect yourself." // BUBBER EDIT
 
+/* BUBBERSTATION EDIT START
+/datum/objective/abductee/random
+
+/datum/objective/abductee/random/New()
+	explanation_text = pick(world.file2list("strings/abductee_objectives.txt"))
+
+/datum/objective/abductee/steal
+	explanation_text = "Steal all"
+
+/datum/objective/abductee/steal/New()
+	var/target = pick(list("pets","lights","monkeys","fruits","shoes","bars of soap", "weapons", "computers", "organs"))
+	explanation_text+=" [target]."
+
+/datum/objective/abductee/paint
+	explanation_text = "The station is hideous. You must color it all"
+
+/datum/objective/abductee/paint/New()
+	var/color = pick(list("red", "blue", "green", "yellow", "orange", "purple", "black", "in rainbows", "in blood"))
+	explanation_text+= " [color]!"
+
+/datum/objective/abductee/speech
+	explanation_text = "Your brain is broken... you can only communicate in"
+
+/datum/objective/abductee/speech/New()
+	var/style = pick(list("pantomime", "rhyme", "haiku", "extended metaphors", "riddles", "extremely literal terms", "sound effects", "military jargon", "three word sentences"))
+	explanation_text+= " [style]."
+
+/datum/objective/abductee/capture
+	explanation_text = "Capture"
+
+/datum/objective/abductee/capture/New()
+	var/list/jobs = SSjob.joinable_occupations.Copy()
+	for(var/datum/job/job as anything in jobs)
+		if(job.current_positions < 1)
+			jobs -= job
+	if(length(jobs) > 0)
+		var/datum/job/target = pick(jobs)
+		explanation_text += " a [target.title]."
+	else
+		explanation_text += " someone."
+
+/datum/objective/abductee/calling/New()
+	var/mob/dead/D = pick(GLOB.dead_mob_list)
+	if(D)
+		explanation_text = "You know that [D] has perished. Hold a seance to call [D.p_them()] from the spirit realm."
+
+/datum/objective/abductee/forbiddennumber
+
+/datum/objective/abductee/forbiddennumber/New()
+	var/number = rand(2,10)
+	explanation_text = "Ignore anything in a set of [number], they don't exist."
+*/
 /datum/objective/abductee/fearful
 	explanation_text = "They're in league with THEM. You know their plans now. You must tell the others: "
 
@@ -18,7 +70,7 @@
 
 
 /datum/objective/abductee/violent
-	explanation_text = "You are filled with an otherworldly rage simmering within. Threatening to boil over at the slightest provocation: "
+	explanation_text = "You are filled with an otherworldly rage simmering within - threatening to boil over at the slightest provocation: "
 
 /datum/objective/abductee/violent/New()
 	// we use suit sensors because we really want to make sure that this person can be found by our little crackhead here
@@ -57,5 +109,5 @@
 		"They are sending cancer radio mindcontrol waves through the telecoms equipment. All of us are at risk. I must save the station by disabling every piece of radio equipment I can find.",
 		"This station is lost. We are all lost. It won't be long now, until THEY come to take us all away. They are our lords... The things I must do to serve them are cruel and vicious, but if I don't do this... Everything I know will end. I must give them a sacrifice.")
 
-	explanation_text += pick(your_poison)
+	explanation_text += pick(your_poison) //BUBBERSTATION EDIT END
 

--- a/code/modules/antagonists/abductor/equipment/gland.dm
+++ b/code/modules/antagonists/abductor/equipment/gland.dm
@@ -84,7 +84,6 @@
 /obj/item/organ/heart/gland/on_mob_remove(mob/living/carbon/gland_owner, special, movement_flags)
 	. = ..()
 	active = FALSE
-	gland_owner.say("yeowch")
 	if(initial(uses) == 1)
 		uses = initial(uses)
 	var/datum/atom_hud/abductor/hud = GLOB.huds[DATA_HUD_ABDUCTOR]

--- a/modular_zubbers/code/modules/antagonists/abductor/equipment/gland.dm
+++ b/modular_zubbers/code/modules/antagonists/abductor/equipment/gland.dm
@@ -1,11 +1,6 @@
 /obj/item/organ/heart/gland/Start()
-	active = 1
-
+	. = ..()
 	owner?.mind?.add_antag_datum(/datum/antagonist/abductee)
-
-	COOLDOWN_START(src, activation_cooldown, rand(cooldown_low, cooldown_high))
-
-
 	if(!ownerCheck() || !active_mind_control)
 		return
 	to_chat(owner, span_userdanger("You feel the compulsion fade, and you <i>completely forget</i> about your previous orders."))


### PR DESCRIPTION
## About The Pull Request

Didnt finish making this, go read code for more details

- Abductee, the antag, can be removed from a player by removing the organ
- Abductees get new objectives. All the old ones are gone. New objective selection works as follows:

4/10 Chance for a "fearful" type objective
3/10 for a "violent" type objective
4/10 for a "paranoid" type objective

the types are sets of possible, predetermined objectives. These flavours are spins on your typical crazy joe. While not as insanely creative as the current objectives, I'm sure nobody will miss the "you can only speak in haikus" ANTAGONIST objective. 

Truth is, there's a lot of stinkers, and these aren't impossible to RP with, are a good split of violent and nonviolent ones, and provide a good bit of entertainment I'd say. It's not perfect, it's better, for something as fucked as abductor content we can settle on "okay", for now.


## Why It's Good For The Game

Currently abductee status cannot be removed at all, objectives are too niche/chore-like at times and have little thematic consistency, New objectives are thematic and create the fabled low-stakes antag. 

Old objectives barely seemed like antag objectives at times, with speaking in haikus, for example, or being funnier than the clown being just round gimmicks anyone could do rather than a role designed to add spice. 

## Proof Of Testing

It works on my local

<img width="1920" height="1080" alt="obraz" src="https://github.com/user-attachments/assets/4aa8cd11-221d-4196-ae43-f4377195c66f" />


:cl:
qol: Abductee status is removed when the organ is taken out of somebody's chest
add: New abductee objectives, paranoid, aggressive and afraid - these tinfoil-hat-clad crewmates are out to stir a little ruckus! These replace the old ones
/:cl:

