### PR TITLE
adds medbay camera preset

### DIFF
--- a/modular_zubbers/code/game/machinery/camera/camera.dm
+++ b/modular_zubbers/code/game/machinery/camera/camera.dm
@@ -122,5 +122,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/autoname/turbine, 0)
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/autoname/rbmk, 0)
 
+// Medbay cameras
 
+/obj/machinery/camera/autoname/medbay
+	network = list("ss13","medbay")
 
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/autoname/medbay, 0)


### PR DESCRIPTION
## About The Pull Request

Adds medbay camera preset for mapping. I've noticed some maps use the medbay network, and yet it has no presets, so I decided to make one.

I haven't tested it, because it seems simple enough change to not require it, but I can do some testing if requested

## Why It's Good For The Game

Will make life of mappers easier

## Changelog

:cl: Swan
add: added medbay autoname camera preset for mappers
/:cl:
