### PR TITLE
Add radio coverage to arrivals shuttle

### DIFF
--- a/_maps/shuttles/skyrat/arrivals_skyrat.dmm
+++ b/_maps/shuttles/skyrat/arrivals_skyrat.dmm
@@ -114,6 +114,7 @@
 	},
 /area/shuttle/arrival)
 "w" = (
+/obj/machinery/telecomms/relay/preset/shuttle,
 /turf/closed/wall/mineral/titanium/shuttle_wall/arrivals{
 	icon_state = "11,3"
 	},

--- a/modular_zubbers/code/game/machinery/telecomms/machines/relay.dm
+++ b/modular_zubbers/code/game/machinery/telecomms/machines/relay.dm
@@ -1,0 +1,13 @@
+/obj/machinery/telecomms/relay/preset/shuttle
+	id = "Shuttle Relay"
+	autolinkers = list("s_relay")
+	icon = 'icons/obj/tram/tram_controllers.dmi'
+	icon_state = "tram-controller"
+	pixel_x = -2
+	pixel_y = -3
+
+/obj/machinery/telecomms/relay/preset/shuttle/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
+	return // no changing this one's configuration
+
+/obj/machinery/telecomms/relay/preset/shuttle/ui_interact(mob/user, datum/tgui/ui)
+	return // no changing this one's configuration

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9067,6 +9067,7 @@
 #include "modular_zubbers\code\game\machinery\doors\door.dm"
 #include "modular_zubbers\code\game\machinery\doors\firedoor.dm"
 #include "modular_zubbers\code\game\machinery\pipe\construction.dm"
+#include "modular_zubbers\code\game\machinery\telecomms\machines\relay.dm"
 #include "modular_zubbers\code\game\objects\effects\landmarks.dm"
 #include "modular_zubbers\code\game\objects\effects\overlays.dm"
 #include "modular_zubbers\code\game\objects\effects\shark_infested_waters.dm"


### PR DESCRIPTION
## About The Pull Request

Adds radio coverage to the Interlink arrivals shuttle.

## Why It's Good For The Game

Player request, no longer live in FOMO that you missed something in the 30 seconds you were travelling on the shuttle towards the station.

## Changelog

:cl: LT3
qol: FOMO no more, the Interlink arrivals shuttle now has radio coverage
/:cl: