### PR TITLE
Updates the names of two flags in the loadouts to their modern lore names

### DIFF
--- a/modular_skyrat/master_files/code/modules/loadout/categories/inhands.dm
+++ b/modular_skyrat/master_files/code/modules/loadout/categories/inhands.dm
@@ -57,7 +57,7 @@
 	item_path = /obj/item/sign/flag/terragov
 
 /datum/loadout_item/inhand/flag_moghes
-	name = "Folded Republic Of Northern Moghes Flag"
+	name = "Folded Tiziran Empire Flag"
 	item_path = /obj/item/sign/flag/tizira
 
 /datum/loadout_item/inhand/flag_mothic
@@ -69,7 +69,7 @@
 	item_path = /obj/item/sign/flag/mars
 
 /datum/loadout_item/inhand/flag_nri
-	name = "Folded Novaya Rossiyskaya Imperiya Flag"
+	name = "Folded Pan-Slavic Commonwealth Flag"
 	item_path = /obj/item/sign/flag/nri
 
 /datum/loadout_item/inhand/flag_azulea


### PR DESCRIPTION

## About The Pull Request
Does as the title says
## Why It's Good For The Game
Lore
## Proof Of Testing
No
## Changelog
:cl:
spellcheck: The NRI flag is now the PSC flag in the loadout.
spellcheck: The Moghes flag is now the Tiziran Empire flag in the loadout.
/:cl:
