### PR TITLE
Fix missing cargo granted stamps [MDB IGNORE]

### DIFF
--- a/_maps/bubber/automapper/templates/IceBoxStation/iceboxstation_persistence.dmm
+++ b/_maps/bubber/automapper/templates/IceBoxStation/iceboxstation_persistence.dmm
@@ -11399,7 +11399,7 @@
 	pixel_x = 8;
 	pixel_y = 6
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = 8;
 	pixel_y = 1
 	},
@@ -19152,7 +19152,7 @@
 	pixel_x = 8;
 	pixel_y = 9
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = 8;
 	pixel_y = 2
 	},

--- a/_maps/bubber/automapper/templates/lavaland/lavaland_persistence.dmm
+++ b/_maps/bubber/automapper/templates/lavaland/lavaland_persistence.dmm
@@ -5549,7 +5549,7 @@
 	pixel_x = 8;
 	pixel_y = 6
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = 8;
 	pixel_y = 1
 	},
@@ -6098,7 +6098,7 @@
 	pixel_x = 8;
 	pixel_y = 9
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = 8;
 	pixel_y = 2
 	},

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -30139,7 +30139,7 @@
 	pixel_x = 7;
 	pixel_y = 4
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = 7;
 	pixel_y = 9
 	},
@@ -73778,7 +73778,7 @@
 	pixel_x = 7;
 	pixel_y = 3
 	},
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = -6;
 	pixel_y = 9
 	},

--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -85109,7 +85109,7 @@
 /area/station/security/checkpoint/science)
 "vXN" = (
 /obj/structure/table/wood,
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = 7;
 	pixel_y = 9
 	},
@@ -88164,7 +88164,7 @@
 	},
 /obj/item/dest_tagger,
 /obj/item/stack/package_wrap,
-/obj/item/stamp{
+/obj/item/stamp/granted{
 	pixel_x = 7;
 	pixel_y = 9
 	},


### PR DESCRIPTION
## About The Pull Request

Fixes missed UpdatePaths for PR 94139, repathing cargo GRANTED stamps

## Changelog

:cl: LT3
fix: Fixed cargo granted stamps from being invisible
/:cl:
