### PR TITLE
Removing if statement check on NSFW examine panel tab

### DIFF
--- a/modular_zubbers/code/modules/examine_tgui/examine_tgui.dm
+++ b/modular_zubbers/code/modules/examine_tgui/examine_tgui.dm
@@ -140,9 +140,8 @@
 			flavor_text = holder_human.dna.features["flavor_text"]
 			art_ref = holder_human.dna.features["art_ref"]
 			name = holder.name
-			if(show_nsfw_flavor_text == "Always On" || (show_nsfw_flavor_text == "Nude Only" && !(holder_human.w_uniform)))
-				flavor_text_nsfw = holder_human.dna.features["flavor_text_nsfw"]
-				headshot_nsfw = holder_human.dna.features["headshot_nsfw"]
+			flavor_text_nsfw = holder_human.dna.features["flavor_text_nsfw"]
+			headshot_nsfw = holder_human.dna.features["headshot_nsfw"]
 
 		//Custom species handling. Reports the normal custom species if there is not one set.
 			if(holder_human.dna.species.lore_protected || holder_human.dna.features["custom_species"] == "")


### PR DESCRIPTION
## About The Pull Request

Previously, NSFW Examine Panel text and NSFW headshots were only shown if certain conditions were met:
1. When the examinee's examine NSFW text prefs were set to 'Always'
2. When the examinee's examin NSFW text prefs were set to 'Nude only' and the examinee has nothing worn in the chest slot

This removes that text, as we do not use any similar pref checks for the NSFW ref to be shown. (The one from the pink icon in the bottom right corner of the examine panel)

## Why It's Good For The Game

Fixes issue: https://github.com/Bubberstation/Bubberstation/issues/3252

## Proof Of Testing

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->
<details>
<summary>Screenshots/Videos</summary>

Before the fix:

With clothes on, and prefs set to 'nude only'
<img width="1537" height="991" alt="image" src="https://github.com/user-attachments/assets/d8f32c18-d18c-43e7-823b-f55030b4ca76" />

With clothes off, and prefs set to 'nude only'
<img width="1554" height="974" alt="image" src="https://github.com/user-attachments/assets/d7b5de1a-5073-44e4-98cd-8bec570ebdb8" />


**AFTER CHANGES:**

<img width="1557" height="960" alt="image" src="https://github.com/user-attachments/assets/d0ab7651-411f-4a73-a414-e3a2aeb64eaf" />
vs nude (they are the same) 
<img width="1612" height="983" alt="image" src="https://github.com/user-attachments/assets/1b6536ce-5fd2-45bb-bb79-338ab7c9a782" />



</details>

## Changelog

:cl:
fix: Fixed NSFW examine text and headshots not displaying when the tab is opened
/:cl: