### PR TITLE
robotic wounds treat text short added and a small bugfix

### DIFF
--- a/modular_skyrat/modules/medical/code/wounds/synth/blunt/robotic_blunt_T1.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/blunt/robotic_blunt_T1.dm
@@ -11,6 +11,7 @@
 	homemade_treat_text = "In a pinch, <b>percussive maintenance</b> can reset the screws - the chance of which is increased if done by <b>someone else</b> or \
 	with a <b>diagnostic HUD</b>!"
 	status_effect_type = /datum/status_effect/wound/blunt/robotic/moderate
+	treat_text_short = "Apply screwdriver or percussive maintenance"
 	treatable_tools = list(TOOL_SCREWDRIVER)
 	interaction_efficiency_penalty = 1.2
 	limp_slowdown = 2.5

--- a/modular_skyrat/modules/medical/code/wounds/synth/blunt/robotic_blunt_T2.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/blunt/robotic_blunt_T2.dm
@@ -12,6 +12,7 @@
 	homemade_treat_text = "If <b>unable to screw/wrench</b>, <b>bone gel</b> can, over time, secure inner components at risk of <b>corrossion</b>. \
 	Alternatively, <b>crowbar</b> the limb open to expose the internals - this will make it <b>easier</b> to re-secure them, but has a <b>high risk</b> of <b>shocking</b> you, \
 	so use insulated gloves. This will <b>cripple the limb</b>, so use it only as a last resort!"
+	treat_text_short = "Use a screwdriver or wrench, and then a welder or cautery."
 
 	wound_flags = (ACCEPTS_GAUZE|MANGLES_EXTERIOR|SPLINT_OVERLAY|CAN_BE_GRASPED)
 	treatable_by = list(/obj/item/stack/medical/bone_gel)

--- a/modular_skyrat/modules/medical/code/wounds/synth/blunt/robotic_blunt_T3.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/blunt/robotic_blunt_T3.dm
@@ -7,7 +7,7 @@
 	occur_text = "caves in on itself, damaged solder and shrapnel flying out in a miniature explosion"
 	examine_desc = "has caved in, with internal components visible through gaps in the metal"
 	severity = WOUND_SEVERITY_CRITICAL
-
+	treat_text = "Use a rapid construction device."
 	disabling = TRUE
 
 	simple_treat_text = "If on the <b>chest</b>, <b>walk</b>, <b>grasp it</b>, <b>splint</b>, <b>rest</b> or <b>buckle yourself</b> to something to reduce movement effects. \

--- a/modular_skyrat/modules/medical/code/wounds/synth/robotic_burns.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/robotic_burns.dm
@@ -17,6 +17,7 @@
 	will quickly cool the limb, but <b>cause damage</b>. <b>Hercuri</b> is <b>especially effective</b> in quick cooling. \
 	<b>Clothing</b> reduces the water/hercuri that makes it to the metal, and <b>gauze</b> binds it and <b>reduces</b> the <b>damage</b> taken."
 	homemade_treat_text = "You can also splash <b>any liquid</b> on it for a rather <b>inefficient</b> and <b>damaging</b> coolant!"
+	treat_text_short = "Lower body temperature."
 
 	default_scar_file = METAL_SCAR_FILE
 
@@ -319,8 +320,8 @@
 	var/heat_fahrenheit = round(heating_threshold * 1.8-459.67, 0.1)
 
 	return "Its current temperature is [span_blue("[current_temp_celcius ] &deg;C ([current_temp_fahrenheit] &deg;F)")], \
-	and needs to cool to [span_nicegreen("[cool_celcius] &deg;C ([cool_fahrenheit] &deg;F)")], but \
-	will worsen if heated to [span_purple("[heat_celcius] &deg;C ([heat_fahrenheit] &deg;F)")]."
+	and needs to cool to [span_nicegreen("[cool_celcius] &deg;C ([cool_fahrenheit] &deg;F)")][(heating_threshold && heating_threshold != INFINITY) ?  ", but \
+	will worsen if heated to [span_purple("[heat_celcius] &deg;C ([heat_fahrenheit] &deg;F)")]" : ""]."
 
 /datum/wound/burn/robotic/overheat/get_scanner_description(mob/user)
 	. = ..()
@@ -343,6 +344,7 @@
 	occur_text = "lets out a slight groan as it turns a dull shade of thermal red"
 	examine_desc = "is glowing a dull thermal red and giving off heat"
 	treat_text = "Reduction of body temperature to expedite the passive heat dissipation - or, if thermal shock is to be risked, application of a fire extinguisher/shower."
+	treat_text_short = "Apply gauze or grasp limb before spraying the wound with coolant, lower body temperature, or wait."
 	severity = WOUND_SEVERITY_MODERATE
 
 	damage_multiplier_penalty = 1.15 //1.15x damage taken
@@ -393,6 +395,7 @@
 	examine_desc = "appears discolored and polychromatic, parts of it glowing a dull orange"
 	treat_text = "Isolation from physical hazards, and accommodation of passive heat dissipation - active cooling may be used, but temperature differentials significantly \
 		raise the risk of thermal shock."
+	treat_text_short = "Apply gauze and grasp limb before spraying the wound with coolant, or lower body temperature and wait."
 	severity = WOUND_SEVERITY_SEVERE
 
 	a_or_from = "from"
@@ -437,6 +440,7 @@
 	examine_desc = "is a blinding shade of white, almost melting from the heat"
 	treat_text = "Immediate confinement to cryogenics, as rapid overheating and physical vulnerability may occur. Active cooling is not advised, \
 		since the thermal shock may be lethal with such a temperature differential."
+	treat_text_short = "Apply cryogenics or lower body temperature without direct exposure to cold liquid."
 	severity = WOUND_SEVERITY_CRITICAL
 
 	a_or_from = "from"

--- a/modular_skyrat/modules/medical/code/wounds/synth/robotic_muscle.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/robotic_muscle.dm
@@ -10,6 +10,7 @@
 	treat_text = "A tight splint on the affected limb, as well as plenty of rest and sleep."
 	examine_desc = "appears to be moving sluggishly"
 	occur_text = "jitters for a moment before moving sluggishly"
+	treat_text_short = "Gauze and rest"
 	severity = WOUND_SEVERITY_MODERATE
 	interaction_efficiency_penalty = 1.5
 	limp_slowdown = 2
@@ -30,6 +31,7 @@
 	treat_text = "A tight splint on the affected limb, as well as plenty of rest and sleep."
 	examine_desc = "is stiffly limp, the extremities splayed out widely"
 	occur_text = "goes completely stiff, seeming to lock into position"
+	treat_text_short = "Gauze and rest"
 	severity = WOUND_SEVERITY_SEVERE
 	interaction_efficiency_penalty = 2
 	limp_slowdown = 5

--- a/modular_skyrat/modules/medical/code/wounds/synth/robotic_pierce.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/robotic_pierce.dm
@@ -20,6 +20,7 @@
 	examine_desc = "is shuddering gently, movements a little weak"
 	treat_text = "Replacing of damaged wiring, though repairs via wirecutting instruments or sutures may suffice, albeit at limited efficiency. In case of emergency, \
 				subject may be subjected to high temperatures to allow solder to reset."
+	treat_text_short = "Replace damaged wiring."
 
 	sound_effect = 'modular_skyrat/modules/medical/sound/robotic_slash_T1.ogg'
 
@@ -63,6 +64,7 @@
 	occur_text = "sputters and goes limp for a moment as it ejects a stream of sparks"
 	examine_desc = "is shuddering significantly, its servos briefly giving way in a rythmic pattern"
 	treat_text = "Containment of damaged wiring via gauze, then application of fresh wiring/sutures, or resetting of displaced wiring via wirecutter/retractor."
+	treat_text_short = "Apply gauze and replace wires."
 
 	sound_effect = 'modular_skyrat/modules/medical/sound/robotic_slash_T2.ogg'
 
@@ -107,6 +109,7 @@
 	examine_desc = "'s PSU is visible, with a sizable hole in the center"
 	treat_text = "Immediate securing via gauze, followed by emergency cable replacement and securing via wirecutters or hemostat. \
 		If the fault has become uncontrollable, extreme heat therapy is recommended."
+	treat_text_short = "Apply gauze, replace wires, and use wirecutters or a hemostat."
 
 	severity = WOUND_SEVERITY_CRITICAL
 	wound_flags = (ACCEPTS_GAUZE|MANGLES_EXTERIOR|CAN_BE_GRASPED|SPLINT_OVERLAY)

--- a/modular_skyrat/modules/medical/code/wounds/synth/robotic_slash.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/robotic_slash.dm
@@ -30,6 +30,7 @@
 	simple_treat_text = "<b>Replacing</b> of broken wiring, or <b>repairing</b> via a wirecutter. <b>Bandaging</b> binds the wiring and reduces intensity buildup, \
 	as does <b>firmly grasping</b> the limb - both the victim and someone else can do this. <b>Roboticists/Engineers</b> get a bonus to treatment, as do <b>diagnostic HUDs</b>."
 	homemade_treat_text = "<b>Sutures</b> can repair the wiring at reduced efficiency, as can <b>retractors</b>. In a pinch, <b>high temperatures</b> can repair the wiring!"
+	treat_text_short = "Replace wiring or apply wirecutters."
 
 	wound_flags = (ACCEPTS_GAUZE|CAN_BE_GRASPED|SPLINT_OVERLAY)
 
@@ -554,6 +555,7 @@
 	occur_text = "sends some electrical fiber in the direction of the blow, beginning to profusely spark"
 	examine_desc = "has multiple severed wires visible to the outside"
 	treat_text = "Containment of damaged wiring via gauze, then application of fresh wiring/sutures, or resetting of displaced wiring via wirecutter/retractor."
+	treat_text_short = "Apply gauze and replace wiring."
 
 	sound_effect = 'modular_skyrat/modules/medical/sound/robotic_slash_T2.ogg'
 
@@ -598,6 +600,7 @@
 	examine_desc = "has lots of mauled wires sticking out"
 	treat_text = "Immediate securing via gauze, followed by emergency cable replacement and securing via wirecutters or retractor. \
 		If the fault has become uncontrollable, extreme heat therapy is recommended."
+	treat_text_short = "Apply gauze, replace wires, and use wirecutters or a retractor."
 
 	severity = WOUND_SEVERITY_CRITICAL
 	wound_flags = (ACCEPTS_GAUZE|MANGLES_EXTERIOR|CAN_BE_GRASPED|SPLINT_OVERLAY)


### PR DESCRIPTION

## About The Pull Request
Adds a treat text short to each robotic limb so you can hover over the text on a health analyzer, and also makes the detailed info for burn wounds not display the amount of heat that'll escalate the wound if it's already critical, because then it would just show infinity and that's not possible.
## Why It's Good For The Game
bugfix and consistency stuff

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="432" height="112" alt="Screenshot 2026-01-29 200614" src="https://github.com/user-attachments/assets/0a916bab-c90f-4186-8126-398341104fdf" />
<img width="434" height="43" alt="image" src="https://github.com/user-attachments/assets/10051d0d-eddf-497d-87d9-cc1e9d8229da" />

</details>

## Changelog
:cl:
add: Added short treatment text to robotic limb wounds
fix: robotic burn wounds no longer show their heat threshold if it's null, 0, or infinity
/:cl:
