### PR TITLE
Forcibly removes Asynchronous Blinking in a semi-modular way because I became a lizard pirate once.

### DIFF
--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -514,7 +514,7 @@
 /obj/item/organ/eyes/proc/blink(duration = BLINK_DURATION, restart_animation = TRUE)
 	var/left_delayed = prob(50)
 	// Storing blink delay so mistimed blinks of lizards don't get cut short
-	var/sync_blinking = synchronized_blinking && (owner.get_organ_loss(ORGAN_SLOT_BRAIN) < BRAIN_DAMAGE_ASYNC_BLINKING)
+	var/sync_blinking = TRUE //BUBBERSTATION CHANGE: DISABLES SYNCED BLINKING UNTIL /TG/ AND/OR BYOND FIXES IT. OLD CODE: synchronized_blinking && (owner.get_organ_loss(ORGAN_SLOT_BRAIN) < BRAIN_DAMAGE_ASYNC_BLINKING)
 	var/blink_delay = sync_blinking ? 0 : rand(0, RAND_BLINKING_DELAY)
 	animate(eyelid_left, alpha = 0, time = 0)
 	if (!sync_blinking && left_delayed)
@@ -532,7 +532,7 @@
 		addtimer(CALLBACK(src, PROC_REF(animate_eyelids), owner), blink_delay + duration)
 
 /obj/item/organ/eyes/proc/animate_eyelids(mob/living/carbon/human/parent)
-	var/sync_blinking = synchronized_blinking && (parent.get_organ_loss(ORGAN_SLOT_BRAIN) < BRAIN_DAMAGE_ASYNC_BLINKING)
+	var/sync_blinking = TRUE //BUBBERSTATION CHANGE: DISABLES SYNCED BLINKING UNTIL /TG/ AND/OR BYOND FIXES IT. OLD CODE: synchronized_blinking && (parent.get_organ_loss(ORGAN_SLOT_BRAIN) < BRAIN_DAMAGE_ASYNC_BLINKING)
 	// Randomize order for unsynched animations
 	if (sync_blinking || prob(50))
 		var/list/anim_times = animate_eyelid(eyelid_left, parent, sync_blinking)


### PR DESCRIPTION
## About The Pull Request

Forcibly removes Asynchronous Blinking in a semi-modular way because I became a lizard pirate once.

## Why It's Good For The Game

There is a weird byond, or /tg/ (I suspect byond) issue where if your blinking is asynchronous, blinking breaks. This PR just forcibly disabled the code that runs it so it's just hard disabled.

## Proof Of Testing

It just works.

## Changelog

:cl: BurgerBB
del: Forcibly removes Asynchronous Blinking in a semi-modular way because I became a lizard pirate once.
/:cl:
