### PR TITLE
Fix Void Raptor, Blueshift, Kilo telecomms dying at the start of the round

### DIFF
--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -16271,7 +16271,7 @@
 /area/station/medical/treatment_center)
 "dbY" = (
 /obj/effect/turf_decal/stripes/box,
-/obj/machinery/power/smes/engineering,
+/obj/machinery/power/smes/full,
 /obj/structure/cable,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -58364,9 +58364,7 @@
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "sLU" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/full,
 /obj/machinery/light/small/directional/north,
 /obj/structure/sign/warning/electric_shock/directional/north,
 /obj/structure/cable,

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -19047,9 +19047,7 @@
 "fBw" = (
 /obj/structure/sign/warning/electric_shock/directional/north,
 /obj/effect/turf_decal/bot,
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/full,
 /obj/structure/cable,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)


### PR DESCRIPTION
## About The Pull Request

Fixes improperly typed telecomms SMES mapped in these three. They were starting empty, thus dying instantly.

## Why It's Good For The Game

Telecomms doesn't die as soon as the round starts

## Changelog

:cl: LT3
fix: Telecomms on Void Raptor, Blueshift, and Kilo will no longer run out of power immediately after round start
/:cl: