### PR TITLE
Fix ticket tab capitalization bug

### DIFF
--- a/modular_skyrat/modules/opposing_force/code/opposing_force_datum.dm
+++ b/modular_skyrat/modules/opposing_force/code/opposing_force_datum.dm
@@ -546,7 +546,7 @@
 	to_chat(mind_reference.current, custom_boxed_message("red_box", span_redtext("Your OPFOR application has been denied by [denier ? get_admin_ckey(denier) : "the OPFOR subsystem"]!")))
 	send_system_message(get_admin_ckey(denier) + " has denied the application with the following reason: [reason]")
 	send_admins_opfor_message("[span_red("DENIED")]: [ADMIN_LOOKUPFLW(denier)] has denied [ckey]'s application([reason ? reason : "No reason specified"])")
-	ticket_counter_add_handled(denier.key, 1)
+	ticket_counter_add_handled(denier.ckey, 1)
 
 /datum/opposing_force/proc/approve(mob/approver)
 	if(status == OPFOR_STATUS_APPROVED)
@@ -565,7 +565,7 @@
 	to_chat(mind_reference.current, custom_boxed_message("green_box", span_greentext("Your OPFOR application has been [objective_denied ? span_bold("partially approved (please view your OPFOR for details)") : span_bold("fully approved")] by [approver ? get_admin_ckey(approver) : "the OPFOR subsystem"]!")))
 	send_system_message("[approver ? get_admin_ckey(approver) : "The OPFOR subsystem"] has approved the application")
 	send_admins_opfor_message("[span_green("APPROVED")]: [ADMIN_LOOKUPFLW(approver)] has approved [ckey]'s application")
-	ticket_counter_add_handled(approver.key, 1)
+	ticket_counter_add_handled(approver.ckey, 1)
 
 /datum/opposing_force/proc/close_application(mob/user)
 	if(status == OPFOR_STATUS_NOT_SUBMITTED)

--- a/modular_skyrat/modules/ticket_counter/code/counter.dm
+++ b/modular_skyrat/modules/ticket_counter/code/counter.dm
@@ -30,25 +30,25 @@ GLOBAL_LIST_INIT(ticket_counter, list())
 /datum/admin_help/Close(key_name = key_name_admin(usr), silent = FALSE)
 	. = ..()
 	if(!previously_closed)
-		ticket_counter_add_handled(usr.key, 1)
+		ticket_counter_add_handled(usr.ckey, 1)
 		previously_closed = TRUE
 
 /datum/admin_help/Resolve(key_name = key_name_admin(usr), silent = FALSE)
 	. = ..()
 	if(!previously_closed)
-		ticket_counter_add_handled(usr.key, 1)
+		ticket_counter_add_handled(usr.ckey, 1)
 		previously_closed = TRUE
 
 /datum/admin_help/Reject(key_name = key_name_admin(usr))
 	. = ..()
 	if(!previously_closed)
-		ticket_counter_add_handled(usr.key, 1)
+		ticket_counter_add_handled(usr.ckey, 1)
 		previously_closed = TRUE
 
 /datum/admin_help/ICIssue(key_name = key_name_admin(usr))
 	. = ..()
 	if(!previously_closed)
-		ticket_counter_add_handled(usr.key, 1)
+		ticket_counter_add_handled(usr.ckey, 1)
 		previously_closed = TRUE
 
 /obj/effect/statclick/opfor_list


### PR DESCRIPTION

## About The Pull Request

The menu that shows tickets handled count used key instead of ckey so sometimes it would be capitalized and list the same admin in two separate entries with the number split

## Why It's Good For The Game

It annoys me

## Proof Of Testing

Yes
