### PR TITLE
[TM only]fix observers seeing not inlined emotes in runechat

### DIFF
--- a/code/modules/mob/dead/observer/observer_say.dm
+++ b/code/modules/mob/dead/observer/observer_say.dm
@@ -74,8 +74,6 @@
 	// Create map text prior to modifying message for goonchat
 	if (safe_read_pref(client, /datum/preference/toggle/enable_runechat) && (safe_read_pref(client, /datum/preference/toggle/enable_runechat_non_mobs) || ismob(speaker)))
 		is_custom_emote ? create_chat_message(speaker, null, message_mods[MODE_CUSTOM_SAY_EMOTE], spans, EMOTE_MESSAGE) : create_chat_message(speaker, message_language, raw_message, spans)
-
-		create_chat_message(speaker, message_language, raw_message, spans)
 	// Recompose the message, because it's scrambled by default
 	var/message = compose_message(speaker, message_language, raw_message, radio_freq, radio_freq_name, radio_freq_color, spans, message_mods)
 	to_chat(src,


### PR DESCRIPTION
## About The Pull Request
Testing to see if it works here, then I am going to TG to cleanup a few saycode issues
## Why It's Good For The Game

Makes it work as intended

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: observers no longer see "An interesting thing to say"
/:cl:
