### PR TITLE
Cybernetic eyes techweb changes

### DIFF
--- a/code/__DEFINES/~skyrat_defines/techweb_nodes.dm
+++ b/code/__DEFINES/~skyrat_defines/techweb_nodes.dm
@@ -1,4 +1,3 @@
-#define TECHWEB_NODE_ADVANCED_VISION "adv_vision"
 #define TECHWEB_NODE_ANDROID_ORGANS "android_organs"
 #define TECHWEB_NODE_ANDROID_CHASSIS "android_chassis"
 #define TECHWEB_NODE_BORG_SHAPESHIFTER "borg_shapeshifter"
@@ -28,3 +27,5 @@
 #define TECHWEB_NODE_XENOARCH_STORAGE "xenoarch_storage"
 #define TECHWEB_NODE_AYY_CYBER_IMPLANTS "ayy_cyber_implants"
 #define TECHWEB_NODE_POWERATOR "powerator"
+#define TECHWEB_NODE_XRAY_VISION "xray_vision"
+#define TECHWEB_NODE_THERMAL_VISION "thermal_vision"

--- a/code/modules/research/techweb/nodes/cyborg_nodes.dm
+++ b/code/modules/research/techweb/nodes/cyborg_nodes.dm
@@ -249,11 +249,8 @@
 	design_ids = list(
 		"cybernetic_ears_xray",
 		"cybernetic_ears_xray_cat",
-		"ci-thermals",
-		"ci-xray",
-		"ci-thermals-moth",
-		"ci-xray-moth",
+		"ci-nv",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_5_POINTS)
-	discount_experiments = list(/datum/experiment/scanning/people/android = TECHWEB_TIER_5_POINTS)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_4_POINTS)
+	discount_experiments = list(/datum/experiment/scanning/people/android = TECHWEB_TIER_4_POINTS)
 	announce_channels = list(RADIO_CHANNEL_SCIENCE, RADIO_CHANNEL_MEDICAL)

--- a/modular_skyrat/master_files/code/modules/research/techweb/all_nodes.dm
+++ b/modular_skyrat/master_files/code/modules/research/techweb/all_nodes.dm
@@ -1,18 +1,29 @@
 
 // NEW NODES
 
-/datum/techweb_node/adv_vision
-	id = TECHWEB_NODE_ADVANCED_VISION
-	display_name = "Combat Cybernetic Eyes"
-	description = "Military grade combat implants to improve vision."
+/datum/techweb_node/xray_vision
+	id = TECHWEB_NODE_XRAY_VISION
+	display_name = "X-ray Cybernetic Eyes"
+	description = "Sensory organs utiziling technology reverse-engineered from the abductors."
 	prereq_ids = list(TECHWEB_NODE_COMBAT_IMPLANTS, TECHWEB_NODE_ALIEN_SURGERY)
 	design_ids = list(
-		"ci-thermals",
 		"ci-xray",
-		"ci-thermals-moth",
 		"ci-xray-moth",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_2_POINTS)
+	announce_channels = list(RADIO_CHANNEL_SCIENCE, RADIO_CHANNEL_MEDICAL)
+
+/datum/techweb_node/thermal_vision
+	id = TECHWEB_NODE_THERMAL_VISION
+	display_name = "Thermal Cybernetic Eyes"
+	description = "Military grade combat implants to improve vision."
+	prereq_ids = list(TECHWEB_NODE_COMBAT_IMPLANTS, TECHWEB_NODE_SYNDICATE_BASIC)
+	design_ids = list(
+		"ci-thermals",
+		"ci-thermals-moth",
+	)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_2_POINTS)
+	announce_channels = list(RADIO_CHANNEL_SCIENCE, RADIO_CHANNEL_MEDICAL)
 
 /datum/techweb_node/borg_shapeshifter
 	id = TECHWEB_NODE_BORG_SHAPESHIFTER

--- a/modular_skyrat/modules/implants/code/medical_nodes.dm
+++ b/modular_skyrat/modules/implants/code/medical_nodes.dm
@@ -33,13 +33,3 @@
 		"ci-antisleep",
 	)
 	return ..()
-
-/datum/techweb_node/cyber/night_vision_implants
-	id = TECHWEB_NODE_NIGHT_VISION_IMPLANTS
-	display_name = "Night vision implants"
-	description = "Now you can work all night, even if you lost your glasses!"
-	prereq_ids = list(TECHWEB_NODE_NIGHT_VISION, TECHWEB_NODE_CYBER_IMPLANTS)
-	design_ids = list(
-		"ci-nv",
-	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_1_POINTS)


### PR DESCRIPTION
## About The Pull Request
Changes the techweb around to make things a little more fair and balanced. 

Night vision eyes are now in advanced cybernetic organs and that node costs 120 instead of 200. It was only that expensive beacuse of x-ray and thermal eyes and it doesn't have those anymore. Also night vision eyes suck and aren't worth researching on their own.

Combat eyes have been split into two nodes. X-ray eyes and thermal eyes. Thermal eyes are unlocked with illegal tech, because thermal vision has always been more of a syndicate thing whereas x-rays remain locked behind alien surgery. Hopefully this makes thermal eyes more appealing, since x-rays kind of always overshadowed them.

## Why It's Good For The Game

It's more balanced and stuff. Also I'd like to see thermals actually get used.

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="611" height="152" alt="image" src="https://github.com/user-attachments/assets/9f60c198-9968-451c-b084-7b43e84088fb" />
<img width="611" height="148" alt="image" src="https://github.com/user-attachments/assets/ff45f737-ce49-437f-8fb8-268cee5566a2" />
<img width="612" height="187" alt="image" src="https://github.com/user-attachments/assets/d0b773ae-e7f4-420d-a035-a10c54c08419" />

</details>

## Changelog

:cl:
balance: Night vision implants techweb node merged into advanced cybernetic organs
balance: Advanced cybernetic organs are 80 research points cheaper
balance: Combat cybernetic eyes split into two different nodes, x-rays and thermals. Thermals are unlocked with illegal tech. Both nodes cost 80 points.
/:cl: