### PR TITLE
fixes alternate job titles not showing when a new head joins

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -201,7 +201,7 @@
 /// Note the joining mob has no client at this point.
 /datum/job/proc/announce_job(mob/living/joining_mob, job_title) // SKYRAT EDIT CHANGE - ALTERNATIVE_JOB_TITLES - Original: /datum/job/proc/announce_job(mob/living/joining_mob)
 	if(head_announce)
-		announce_head(joining_mob, list(head_announce))
+		announce_head(joining_mob, list(head_announce), job_title)	// BUBBER EDIT - fixes alternative job titles
 
 
 //Used for a special check of whether to allow a client to latejoin as this job.


### PR DESCRIPTION
## About The Pull Request

Fixes the departmental announcement of a new head joining.


Before:

<img width="580" height="54" alt="Image" src="https://github.com/user-attachments/assets/4d84b435-3924-466a-a62f-39d90afd41fc" />

After:

<img width="687" height="104" alt="image" src="https://github.com/user-attachments/assets/4af0d87a-8f7d-4c0f-860c-1f78ef143bf9" />


## Why It's Good For The Game

Fixes a bug.

## Proof Of Testing

<img width="687" height="104" alt="image" src="https://github.com/user-attachments/assets/4af0d87a-8f7d-4c0f-860c-1f78ef143bf9" />

## Changelog

:cl: Swan
fix: fixes the departmental head joining announcement
/:cl: