### PR TITLE
Prevents light step/walk intent/bots from knocking down micros

### DIFF
--- a/code/datums/components/squashable.dm
+++ b/code/datums/components/squashable.dm
@@ -51,10 +51,10 @@
 		return
 
 	if((squash_flags & SQUASHED_SHOULD_BE_DOWN) && parent_as_living.body_position != LYING_DOWN)
-		//BUBBER EDIT - Light step doesnt knock down
+		//BUBBER EDIT - Light step/walk/bots dont knock down
 		if(isliving(crossing_movable))
 			var/mob/living/crossing_mob = crossing_movable
-			if((crossing_mob.move_intent == MOVE_INTENT_WALK) || HAS_TRAIT(crossing_mob, TRAIT_LIGHT_STEP))
+			if((crossing_mob.move_intent == MOVE_INTENT_WALK) || HAS_TRAIT(crossing_mob, TRAIT_LIGHT_STEP) || isbot(crossing_mob))
 				return
 		//BUBBER EDIT END
 		parent_as_living.Knockdown(1 SECONDS) // BUBBER EDIT - MICRO BALANCE


### PR DESCRIPTION
## About The Pull Request
Light step already prevented the damaging squash that happened, but still did the knockdown. I think it's thematically appropriate for people who watch their step to not accidentally throw people to the side. ESPECIALLY BEEPSKY AND MEDIBOTS AND JANIBOTS. THAT IS JUST HORRID.

## Why It's Good For The Game
I take the quirk because of me not wanting to hurt them over by accidentally walking into them. The knockdown is still annoying as hell even when I do play my micro and someone walks into me. Everything functions as normal when not having light step. Bots doing it is extra un-fun.

## Proof Of Testing
I tested it and it works

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
balance: Light step now prevents you from knocking down micros.
balance: Walking intent now prevents you from knocking down micros
balance: small bots (janibots, medibots, etc.) can no longer knock down micros.
/:cl:

