### PR TITLE
Improves hypnovisor code quality slightly

### DIFF
--- a/modular_zubbers/code/modules/mod/modules_lustwish.dm
+++ b/modular_zubbers/code/modules/mod/modules_lustwish.dm
@@ -14,7 +14,7 @@
 	required_slots = list(ITEM_SLOT_HEAD)
 	overlay_icon_file = 'modular_zubbers/icons/mob/clothing/modsuit/mod_modules.dmi'
 
-	module_type = MODULE_PASSIVE //These three are changed when the control wire is snipped
+	module_type = MODULE_TOGGLE //These three are changed when the control wire is snipped
 	overlay_state_active = null
 	overlay_state_inactive = "module_hypno_overlay"
 
@@ -25,7 +25,7 @@
 /obj/item/mod/module/hypno_visor/examine(mob/user)
 	. = ..()
 	. += span_info("It's currently programmed with the following directive: \"[hypno_message]\" Use it in-hand to rewrite it.")
-	. += span_info("Its visor will [visor_effect ? "" : "<b>not</b>"] display an external hypnotic effect. Use a screwdriver to toggle.")
+	. += span_info("Its visor will [visor_effect ? "" : "<b>not</b> "]display an external hypnotic effect. Use a screwdriver to toggle.")
 	. += span_info("Its control wire is currently [(module_type == MODULE_TOGGLE) ? \
 						"<b>intact,</b> allowing for on-the-fly configuration via the MOD UI." \
 						: \

--- a/modular_zubbers/code/modules/mod/modules_lustwish.dm
+++ b/modular_zubbers/code/modules/mod/modules_lustwish.dm
@@ -42,6 +42,7 @@
 
 /obj/item/mod/module/hypno_visor/screwdriver_act(mob/living/user, obj/item/tool)
 	visor_effect = !visor_effect
+	playsound(src, 'sound/machines/click.ogg', 30, TRUE)
 	to_chat(user, span_notice("You turn the visor display of [src] [visor_effect ? "on" : "off"]."))
 	return TRUE
 
@@ -54,7 +55,7 @@
 		module_type = MODULE_TOGGLE
 		overlay_state_active = "module_hypno_overlay"
 		overlay_state_inactive = null
-
+	playsound(src, 'sound/items/tools/wirecutter.ogg', 30, TRUE)
 	to_chat(user, span_notice("You [(module_type == MODULE_TOGGLE) ? "mend" : "snip"] the control wire on [src]."))
 	return TRUE
 
@@ -64,7 +65,10 @@
 		overlay_state_inactive = null // Visual thing. Removes the overlay if it's not a part of the lustwish suit.
 		overlay_state_active = null
 		visor_effect = FALSE
-		balloon_alert(usr, "visor effect unavailable for this plating!")
+		addtimer(CALLBACK(src, PROC_REF(say_visor_no_worky), usr), 0.5 SECONDS)
+
+/obj/item/mod/module/hypno_visor/proc/say_visor_no_worky(user)
+		balloon_alert(user, "visor effect unavailable for this plating!")
 
 /obj/item/mod/module/hypno_visor/on_uninstall(deleting = FALSE)
 	. = ..()

--- a/modular_zubbers/code/modules/mod/modules_lustwish.dm
+++ b/modular_zubbers/code/modules/mod/modules_lustwish.dm
@@ -63,11 +63,12 @@
 
 /obj/item/mod/module/hypno_visor/on_install()
 	. = ..()
-	if(mod.skin != "lustwish" && visor_effect == TRUE)
+	if(mod.skin != "lustwish")
 		overlay_state_inactive = null // Visual thing. Removes the overlay if it's not a part of the lustwish suit.
 		overlay_state_active = null
-		visor_effect = FALSE
-		addtimer(CALLBACK(src, PROC_REF(say_visor_no_worky), usr), 0.5 SECONDS)
+		if(visor_effect == TRUE)
+			visor_effect = FALSE
+			addtimer(CALLBACK(src, PROC_REF(say_visor_no_worky), usr), 0.5 SECONDS)
 
 /obj/item/mod/module/hypno_visor/proc/say_visor_no_worky(user)
 		balloon_alert(user, "visor effect unavailable for this plating!")

--- a/modular_zubbers/code/modules/mod/modules_lustwish.dm
+++ b/modular_zubbers/code/modules/mod/modules_lustwish.dm
@@ -44,6 +44,7 @@
 	visor_effect = !visor_effect
 	playsound(src, 'sound/machines/click.ogg', 30, TRUE)
 	to_chat(user, span_notice("You turn the visor display of [src] [visor_effect ? "on" : "off"]."))
+	balloon_alert(user, "visor effect [visor_effect ? "on" : "off"]")
 	return TRUE
 
 /obj/item/mod/module/hypno_visor/wirecutter_act(mob/living/user, obj/item/tool)
@@ -57,6 +58,7 @@
 		overlay_state_inactive = null
 	playsound(src, 'sound/items/tools/wirecutter.ogg', 30, TRUE)
 	to_chat(user, span_notice("You [(module_type == MODULE_TOGGLE) ? "mend" : "snip"] the control wire on [src]."))
+	balloon_alert(user, "control wire [(module_type == MODULE_TOGGLE) ? "mend" : "snipp"]ed")
 	return TRUE
 
 /obj/item/mod/module/hypno_visor/on_install()


### PR DESCRIPTION

## About The Pull Request

- Fixes an extra space in the description.
- Module starts with the control wire intact, not snipped.
- Adds sounds to module tampering.
- Fixed a bug where the visor effect would always show if the module was installed with it turned off.
- Fixes small issue with balloon alerts overlapping on install if visor effect is unavailable for plating.
## Why It's Good For The Game

Makes the hypnovisor texts look a little nicer and makes it not come out of the vendor pre-tampered. Extra feedback with sounds and the balloon alert polishing should make it feel much nicer to use, too. and we get a FREE bugfix!

## Proof Of Testing

<img width="635" height="110" alt="image" src="https://github.com/user-attachments/assets/042810d9-1148-4823-bdaf-fd243a4e4aaa" />