### PR TITLE
Fixes the syndie cat ears (almost) always being on sale

### DIFF
--- a/modular_zubbers/code/modules/uplink/uplink_items/syndicat/_syndicat.dm
+++ b/modular_zubbers/code/modules/uplink/uplink_items/syndicat/_syndicat.dm
@@ -1,5 +1,5 @@
 //Just the ears alone
-/datum/uplink_item/implant/super_kitty_ears
+/datum/uplink_item/implants/super_kitty_ears
 	name = "Super Syndie-Kitty Ears"
 	desc = "Developed by several Interdyne Pharmaceutics scientists and Wizard Federation archmages during a record-breaking rager, \
 			this set of feline ears combines the finest of bio-engineering and thamaturgy to allow the user to transform to and from a genetically modified cat at will, \


### PR DESCRIPTION
## About The Pull Request
Discounts take one item from each category that it rolls. The ears were /datum/uplink_item/implant. All the other implants were /datum/uplink_item/implants. This caused it to be in its own category with noting else in the category and thus roll all the damn time.

## Why It's Good For The Game
Bug Fix

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
fix: Super Syndie-Kitty Ears are no longer on sale an unusual amount.
/:cl:

