### PR TITLE
fixes digi sprites not appearing for various syndicate clothes

### DIFF
--- a/modular_zubbers/code/modules/clothing/under/syndicate.dm
+++ b/modular_zubbers/code/modules/clothing/under/syndicate.dm
@@ -79,4 +79,4 @@
 /obj/item/clothing/under/syndicate/scrubs
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
 	// overrides an override
-	worn_icon_digi = 'modular_skyrat/master_files/icons/mob/clothing/under/medical.dmi'
+	worn_icon_digi = 'modular_skyrat/master_files/icons/mob/clothing/under/medical_digi.dmi'


### PR DESCRIPTION

## About The Pull Request

Fixes digitigrade leg sprites not appearing for the following 'syndicate' clothes:
- blood-red pajamas
- tactical turtleneck suit
- camouflage fatigues
- Ratnik 5 tracksuit
- combat uniform
- advanced military tracksuit
- tactical scrubs

<img width="464" height="100" alt="image" src="https://github.com/user-attachments/assets/0c462eac-ebfc-40ed-891d-4650ab3a5831" />


Digitigrade leg sprites existed for all of these items already, but did not appear due to "supports_variations_flags = NONE" being set for all of them. 
This fixes that by overriding it with "supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION". 
The medical scrubs also needed "worn_icon_digi" to be set to where the digi leg sprites for the medical scrubs are (it was pointing to the rest of the syndicate clothes).
## Why It's Good For The Game

Less missing digi sprites good!
Some of these clothes appear in persistence, and the chameleon kit.
## Proof Of Testing

Works on my machine.
<details>
<summary>Screenshots/Videos</summary>

- blood-red pajamas
<img width="126" height="143" alt="Screenshot_197" src="https://github.com/user-attachments/assets/55b952bd-9459-4a18-88e3-d2f674cb6b35" />

- tactical turtleneck suit
<img width="125" height="145" alt="Screenshot_198" src="https://github.com/user-attachments/assets/cd609346-13fa-4e1b-95fc-c89b04a6bdda" />

- camouflage fatigues
<img width="123" height="130" alt="Screenshot_199" src="https://github.com/user-attachments/assets/ef76a6f2-6a2d-4a8b-acd3-753a8eeba483" />

- Ratnik 5 tracksuit
<img width="138" height="150" alt="Screenshot_200" src="https://github.com/user-attachments/assets/48e2d234-a0e7-415e-91ac-44a6dfea021f" />

- combat uniform
<img width="156" height="141" alt="Screenshot_201" src="https://github.com/user-attachments/assets/c203df9c-5776-459a-a497-296be667c782" />

- advanced military tracksuit
<img width="142" height="163" alt="Screenshot_202" src="https://github.com/user-attachments/assets/a98100c3-3b49-4117-bd09-fe3a7655a412" />

- tactical scrubs
<img width="142" height="148" alt="Screenshot_203" src="https://github.com/user-attachments/assets/7d4a8ba4-d88e-4009-b270-27dd0f46ea21" />

</details>

## Changelog
:cl:
fix: fixed digi sprites for various syndicate/persistence clothes (blood-red pajamas, tactical turtleneck suit, camouflage fatigues, Ratnik 5 tracksuit, combat uniform, advanced military tracksuit, tactical scrubs) 
/:cl:
