### PR TITLE
Removes mapped in Plant DNA Manipulators on the two maps they existed on

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -39279,8 +39279,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/table/glass,
 /obj/effect/turf_decal/tile/green/fourcorners,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "hOM" = (
@@ -59589,9 +59589,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/table/glass,
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/tile/green/fourcorners,
+/obj/effect/decal/cleanable/food/plant_smudge,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "piX" = (

--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -45538,8 +45538,8 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "lHW" = (
-/obj/structure/table,
 /obj/item/radio/intercom/directional/west,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/terracotta,
 /area/station/service/hydroponics)
 "lIe" = (


### PR DESCRIPTION

## About The Pull Request
Does as the title suggests, removes the mapped in DNA manipulators on Box Station and Moon Station.
## Why It's Good For The Game
No other maps have them, this also makes the research web for it useless on these maps (unless they get destroyed) as botanists have an arguable upgrade from cross-pollination just given to them roundstart.
## Proof Of Testing
It was a simple map edit, it SHOULD work.
## Changelog
:cl:
map: Removed the roundstart Plant DNA Manipulators on Box Station and Moon Station.
/:cl:
