### PR TITLE
Updating wording of Liaison and adding Duchess titles

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -145,7 +145,7 @@
 // Off-Station
 #define JOB_SPACE_POLICE "Space Police"
 #define JOB_TERRAGOV "TerraGov"
-#define JOB_TERRAGOV_LIASON "TerraGov Liason"
+#define JOB_TERRAGOV_LIASON "TerraGov Liaison"
 // SKYRAT EDIT ADDITION END
 
 //Lost crew

--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -28,6 +28,7 @@
 		"Colonist",
 		"Contractor",
 		"Civilian",
+		"Duchess",
 		"Duke",
 		"Diplomat",
 		"Entertainer",
@@ -367,12 +368,12 @@
 		"Nanotrasen Advisor",
 		"Nanotrasen Diplomat",
 		"Nanotrasen Representative",
-		"Nanotrasen Liason",
+		"Nanotrasen Liaison",
 		"Command Consultant",
 		"Command Advisor",
 		"Corporate Diplomat",
 		"Corporate Representative",
-		"Corporate Liason",
+		"Corporate Liaison",
 		"Corporate Interest Officer",
 	)
 

--- a/modular_zubbers/code/datums/id_trim/jobs.dm
+++ b/modular_zubbers/code/datums/id_trim/jobs.dm
@@ -39,7 +39,7 @@
 
 /datum/id_trim/job/nanotrasen_consultant
 	job = /datum/job/nanotrasen_consultant
-	honorifics = list("Advisor", "Consultant", "Representative", "Rep.", "Interest Officer", "Liason")
+	honorifics = list("Advisor", "Consultant", "Representative", "Rep.", "Interest Officer", "Liaison")
 	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/captain/New()

--- a/modular_zubbers/maps/offstation/dauntless/areas.dm
+++ b/modular_zubbers/maps/offstation/dauntless/areas.dm
@@ -113,7 +113,7 @@
 	name = "Admirals Office"
 
 /area/ruin/space/has_grav/bubbers/dauntless/command/liason
-	name = "Syndicate Liason Office"
+	name = "Syndicate Liaison Office"
 
 /area/ruin/space/has_grav/bubbers/dauntless/command/vault
 	name = "High Security Vault"

--- a/modular_zubbers/maps/offstation/persistence/area.dm
+++ b/modular_zubbers/maps/offstation/persistence/area.dm
@@ -123,7 +123,7 @@
 	name = "Persistence Quarter Master Quarters"
 
 /area/ruin/space/has_grav/bubbers/persistance/service/dorms/liason
-	name = "Persistence Corporate Liason Quarters"
+	name = "Persistence Corporate Liaison Quarters"
 
 /area/ruin/space/has_grav/bubbers/persistance/service/dorms/assistant
 	name = "Persistence Assistant"
@@ -187,7 +187,7 @@
 	name = "Persistence Office"
 
 /area/ruin/space/has_grav/bubbers/persistance/command/liason
-	name = "Corporate Liason Office"
+	name = "Corporate Liaison Office"
 
 /area/ruin/space/has_grav/bubbers/persistance/command/vault
 	name = "High Security Vault"


### PR DESCRIPTION
## About The Pull Request

Updates non-code spelling of Liason -> Liaison
Adds new title for assistants "Duchess" which is a gender mirrored title of "Duke"

Addresses issue: https://github.com/Bubberstation/Bubberstation/issues/4463


## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>
<img width="335" height="200" alt="image" src="https://github.com/user-attachments/assets/c3a38a19-6499-4ce1-aa64-fe3e24a58bdb" />
<img width="775" height="153" alt="image" src="https://github.com/user-attachments/assets/e219cd72-a018-4835-b176-9e41e7572031" />
<img width="347" height="121" alt="image" src="https://github.com/user-attachments/assets/967827c1-1157-4b0b-acf0-7b8910809b74" />
<img width="1481" height="906" alt="image" src="https://github.com/user-attachments/assets/7706990e-b833-4196-9e2c-7d689cfc6592" />


</details>

## Changelog

:cl:
add: Added new assistant title "Duchess"
spellcheck: fixed the spelling of Liason to Liaison in various places
/:cl:
