### PR TITLE
Adds a modular digi flag override for clown suits

### DIFF
--- a/modular_zubbers/code/modules/clothing/under/jobs/civilian/clown_mime.dm
+++ b/modular_zubbers/code/modules/clothing/under/jobs/civilian/clown_mime.dm
@@ -1,0 +1,2 @@
+/obj/item/clothing/under/rank/civilian/clown
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9324,6 +9324,7 @@
 #include "modular_zubbers\code\modules\clothing\under\syndicate.dm"
 #include "modular_zubbers\code\modules\clothing\under\accessories\badges.dm"
 #include "modular_zubbers\code\modules\clothing\under\jobs\command.dm"
+#include "modular_zubbers\code\modules\clothing\under\jobs\civilian\clown_mime.dm"
 #include "modular_zubbers\code\modules\colony_fabricator\code\design_datums\fabricator_flag_additions\tools.dm"
 #include "modular_zubbers\code\modules\condos\condo_area.dm"
 #include "modular_zubbers\code\modules\condos\condo_doors.dm"


### PR DESCRIPTION

## About The Pull Request
We've had digitigrade sprites for the clown stuff all this time, but they haven't been used due to a flag on the base object being set as `supports_variations_flags = CLOTHING_NO_VARIATION` by /tg/. This PR sets that flag to `supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION`.
## Why It's Good For The Game
Digitigrade support is good.
## Proof Of Testing
It was a one line flag change. It compiled and ran.
## Changelog
:cl:
fix: Fixed clown jumpsuits and under clothing not having digitigrade sprites despite us having their icons.
/:cl:
