### PR TITLE
Reverts flipping CD back to TG version, unnerfing desword

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -137,10 +137,6 @@
 		return
 	if(!iscarbon(user))
 		return
-	// BUBBER EDIT ADDITION BEGIN - Freerunning Quirk
-	if(HAS_TRAIT(user, TRAIT_FREERUNNING))
-		return
-	// BUBBER EDIT ADDITION END
 
 	if(user.get_timed_status_effect_duration(/datum/status_effect/confusion) > BEYBLADE_PUKE_THRESHOLD)
 		user.vomit(VOMIT_CATEGORY_KNOCKDOWN, lost_nutrition = BEYBLADE_PUKE_NUTRIENT_LOSS, distance = 0)


### PR DESCRIPTION
## About The Pull Request
Using the double energy makes you spin. This spinning applies confusion due to anti-emote-spam code which comes from an override which doesn't check for whether it is a forced spin or an unforced spin, making using the desword ACTIVELY HINDER YOU. 

## Why It's Good For The Game

It's good because this is unintended behaviour and punishes using the item.

## Proof Of Testing

Compiled, the override has been deleted thats all. Tested ingame, bug appears on live bubber, doesn't appear on the test, spamming spin still kneecaps you on test.

## Changelog

:cl:
fix: Unintentionally spinning (which is anything but saying *spin) no longer apply a penalty for rapid use in short succession.
/:cl:
