### PR TITLE
Allow free flipping unless it's a manually spammed emote

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -88,7 +88,7 @@
 /datum/emote/flip/run_emote(mob/user, params , type_override, intentional)
 	. = ..()
 	// BUBBER EDIT CHANGE BEGIN - Flip Cooldown
-	if(iscarbon(user))
+	if(iscarbon(user) && intentional)
 		var/mob/living/carbon/flippy_mcgee = user
 		flippy_mcgee.set_confusion_if_lower(FLIP_EMOTE_DURATION)
 		if(flippy_mcgee.get_timed_status_effect_duration(/datum/status_effect/confusion) > BEYBLADE_PUKE_THRESHOLD)


### PR DESCRIPTION

## About The Pull Request

inspired by (and by proxy) closes https://github.com/Bubberstation/Bubberstation/pull/5251

let's you flip freely from every source that calls the emote except manually spamming it via a bind
## Why It's Good For The Game

a few things force you to flip, this removes the nausea of it from that. 

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
https://cdn.discordapp.com/attachments/1097484328012886067/1472096985153798311/dreamseeker_KNP34fBxua.mp4?ex=699154a7&is=69900327&hm=d63bfc36b5da601d82fe1a3bae4c687ddbee7deda431fe1706d17fef2568ffc7&
</details>

## Changelog
:cl:
balance: forced flipping is now nausea free
/:cl:
