### PR TITLE
Allows the pair (Alt) breasts to go up to stage 19 (S) instead of 16 (P)

### DIFF
--- a/code/__DEFINES/~skyrat_defines/lewd_defines.dm
+++ b/code/__DEFINES/~skyrat_defines/lewd_defines.dm
@@ -29,6 +29,9 @@
 #define BREAST_SIZE_N "N"
 #define BREAST_SIZE_O "O"
 #define BREAST_SIZE_P "P"
+#define BREAST_SIZE_Q "Q"
+#define BREAST_SIZE_R "R"
+#define BREAST_SIZE_S "S"
 #define BREAST_SIZE_BEYOND_MEASUREMENT "beyond measurement"
 
 //ERP Size Areas

--- a/modular_skyrat/modules/customization/_globalvars/lists.dm
+++ b/modular_skyrat/modules/customization/_globalvars/lists.dm
@@ -19,6 +19,9 @@ GLOBAL_LIST_INIT(breast_size_translation, list(
 	"14" = BREAST_SIZE_N,
 	"15" = BREAST_SIZE_O,
 	"16" = BREAST_SIZE_P,
+	"17" = BREAST_SIZE_Q,
+	"18" = BREAST_SIZE_R,
+	"19" = BREAST_SIZE_S,
 	))
 
 GLOBAL_LIST_INIT(breast_size_to_number, list(
@@ -39,6 +42,9 @@ GLOBAL_LIST_INIT(breast_size_to_number, list(
 	BREAST_SIZE_N = 14,
 	BREAST_SIZE_O = 15,
 	BREAST_SIZE_P = 16,
+	BREAST_SIZE_Q = 17,
+	BREAST_SIZE_R = 18,
+	BREAST_SIZE_S = 19,
 	))
 
 GLOBAL_LIST_INIT(balls_size_translation, list(

--- a/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
@@ -475,7 +475,7 @@
 /obj/item/organ/genital/breasts/get_sprite_size_string()
 	var/max_size = 5
 	if(genital_type == "pair")
-		max_size = 16
+		max_size = findtext(genital_name, "(Alt)") ? 19 : 16
 	var/current_size = FLOOR(genital_size, 1)
 	if(current_size < 0)
 		current_size = 0


### PR DESCRIPTION
## About The Pull Request
We have had the bigger versions of the splurt boobs in the code for quite some time. They were not enabled. This enables them. It also clamps to 16 for the non-alt pair, so they are not affected.

This is ONLY for the pair boobs, quad/sextuple are not affected.

## Why It's Good For The Game
More customization is good. Some players who left bubber have told me they'd come back to the server if we had more of splurt's customization because they don't like that server, but it has Better Character Creation Options Like Bigger Boobs, so it's where they go. I was going to wait for a dedicated hyper pref to add this as it was stated to be a prerequisite, but that has been basically deemed impossible by the several people who have tried, so I'm pring it anyways in the hopes that it gets accepted. 

I do not believe this to be a major issue either way as public nudity is already frowned upon within the server, as well as being an IC crime, and ooc enforced as "put that shit away if people LOOC it" even on smaller sizes. Underwear too, does exist, which the vast majority of characters have on. Especially with them already being in the code, I do not see much of a reason to not have them be enabled.
## Proof Of Testing
<img width="271" height="348" alt="afbeelding" src="https://github.com/user-attachments/assets/ce86353a-f146-41a7-97bf-b5c11e3aacef" />
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
add: The "pair (alt)" breasts now support Q, R, and S sizes.
/:cl:
