### PR TITLE
Fixes the murphy's balloon alerts always being "unloaded" upon manual reload

### DIFF
--- a/modular_zubbers/code/modules/security/security_glock/gun.dm
+++ b/modular_zubbers/code/modules/security/security_glock/gun.dm
@@ -155,7 +155,8 @@
 
 	if (!internal_magazine && istype(tool, /obj/item/ammo_box/magazine))
 		if (tac_reloads)
-			eject_magazine(user)
-			insert_magazine(user, tool)
+			eject_magazine(user, display_message = FALSE)
+			insert_magazine(user, tool, display_message = FALSE)
+			balloon_alert(user, "[src.magazine_wording] loaded")
 			return ITEM_INTERACT_SUCCESS
 	..()


### PR DESCRIPTION

## About The Pull Request
It is in fact not unloading when you put a mag in
## Why It's Good For The Game
bug fix
## Proof Of Testing

https://github.com/user-attachments/assets/ba64b79c-27b8-4716-a5f2-52e8dd05304b
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
Fix: Balloon alerts for the murphy now function properly.
/:cl:
