### PR TITLE
fixes emissive eyes 

### DIFF
--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -130,10 +130,10 @@
 	if(CONFIG_GET(flag/native_fov) && native_fov)
 		affected_human.add_fov_trait(type, native_fov)
 
-	// SKYRAT EDIT ADDITION - EMISSIVES
+	// BUBBER EDIT ADDITION - EMISSIVES
 	if (affected_human.emissive_eyes)
 		is_emissive = TRUE
-	// SKYRAT EDIT END
+	// BUBBER EDIT END
 
 	if(call_update)
 		affected_human.update_body()
@@ -169,7 +169,7 @@
 
 	organ_owner.update_tint()
 	organ_owner.update_sight()
-	is_emissive = FALSE // SKYRAT EDIT ADDITION
+	is_emissive = FALSE // BUBBER EDIT ADDITION
 	UnregisterSignal(organ_owner, list(
 		COMSIG_ATOM_BULLET_ACT,
 		COMSIG_COMPONENT_CLEAN_FACE_ACT,
@@ -328,14 +328,14 @@
 		left_scar.color = my_head.draw_color
 		overlays += left_scar
 
-	// SKYRAT EDIT START - Customization Emissives
+	// BUBBER EDIT START - Customization Emissives
 	if(is_emissive)
 		var/mutable_appearance/emissive_left = emissive_appearance_copy(eye_left, owner)
 		var/mutable_appearance/emissive_right = emissive_appearance_copy(eye_right, owner)
 
 		overlays += emissive_left
 		overlays += emissive_right
-	// SKYRAT EDIT END - Customization Emissives
+	// BUBBER EDIT END - Customization Emissives
 
 	if(my_head.worn_face_offset)
 		for (var/mutable_appearance/overlay as anything in overlays)


### PR DESCRIPTION
## About The Pull Request

This fixes emissive eyes not being emissive by re-adding some skyrat code that went missing after the upstream.

<img width="354" height="356" alt="Screenshot_229" src="https://github.com/user-attachments/assets/2ddf3dc2-8ed1-434d-8104-6b11d7976207" />


Note that there is a new(?) bug where the eyes are still emissive during blinking.
If this is not an issue it could probably be merged anyway.

How blinking should look:
<img width="110" height="142" alt="Screenshot_231" src="https://github.com/user-attachments/assets/be3c0ad8-751b-451c-8262-b635e309c502" />
How blinking currently looks:
<img width="141" height="136" alt="Screenshot_232" src="https://github.com/user-attachments/assets/4d6a3c80-9d1f-41f9-a98a-124476b49e38" />
## Why It's Good For The Game

Bugfix good
Fixes #5247

## Proof Of Testing

Runs of my machine.
<details>
<summary>Screenshots/Videos</summary>

<img width="631" height="348" alt="image" src="https://github.com/user-attachments/assets/4194d8a9-788a-446f-b658-895f1ba91328" />

</details>

## Changelog
:cl:
fix: emissive eyes are now emissive again
/:cl:
