### PR TITLE
Disables heretic by setting its storyteller weight to 0

### DIFF
--- a/modular_zubbers/code/modules/storyteller/event_defines/crewset/heretic.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/crewset/heretic.dm
@@ -8,7 +8,6 @@
 	max_occurrences = 0
 	min_players = 30
 
-
 	maximum_antags_global = 2
 
 	tags = list(TAG_COMBAT, TAG_SPOOKY, TAG_CREW_ANTAG)


### PR DESCRIPTION
## About The Pull Request
Yep. It. Makes it not roll anymore.
## Why It's Good For The Game

To put it quite simply, it is an antagonist that does not facilitate roleplay, it has a kit designed around murdering efficiently in most paths, it gains more power by doing so, only has objectives revolving around it, and if admins are generous the endgame is a murderbone pass.

I will quote and elaborate on what I said in #contributor-discussion regarding this topic below.

Heretic is not conductive to roleplay within its current design. When I was asked about why I was asked if I thought if the main issues were sacrifice and the escape tools.

There's a lot of escape tools, yes. Sacrifice is a thing, yes. They do play a part in the equasion, but even without going for sacrifices the vast majority of tools are Strictly For Murder. Traitors have a lot of murder items, yes, but there's also a lot of gimmick material, and the total power budget is a lot lower. Outside of edge-case giga-god players they will never become a stationwide threat. Some paths have this issue more than others, lock, in my eyes, is primarily a nonissue. But if you look at void/rust/cosmic-ish/ash/moon, they're all tailor-made to murder as efficiently as possible.

If we look at void as our example, the main path abilities consist of a teleport/escape tool that also serves as an engage and does damage. An ability which removes someone from the fight for 10 seconds, working as an escape tool or crowd control, an escape tool armor, and void pulse which both spaces rooms you're in (if it has windows) as well as generally making your attacks more potent. The blade upgrade allows you to teleport to marked people. This is not even getting into the sidepaths.

It's designed solely for the intent of murder. When the majority of RP with heretics comes down to "lay on my rune or die" because the kit doesn't facilitate anything else, there is a major issue. 

People might say that changeling suffers from a lot of the same issues regarding their kit, which they do. The thing is that they do so a MUCH lesser extent due to the fact that they do not end up SCALING to be a "1 Vs Crew" threat. Whilst not ideal, it is far less of an issue than something that makes it everyone's problem. And whilst **_anecdotal_**, I think the lack of a scaling nature also causes ling players to... try(?) to roleplay more.

Adjusting weights has been tried in the past, it did not fix the issues with the antagonist, it only made them be seen less. You could buff counters to heretics, sure. But that would not solve the baseline issue of what their kits are designed for. It would require a full overhaul to get it within a state where the antag as a whole is conductive to roleplay and not solely to facilitate murdering as effectively as possible.

If people _**DO**_ still want to do roleplay gimmicks as heretic, the opfor feature exists, and if the idea is reasonable, staff can grant it to the players.

Also
<img width="593" height="304" alt="afbeelding" src="https://github.com/user-attachments/assets/92e986e6-e6d1-4474-85f2-126f469947b6" />

## Proof Of Testing
no
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
balance: Sets heretic's weight to 0 within the storyteller, disabling it.
/:cl:
