### PR TITLE
Enables the larger sprite sizes for (alt) penises and balls

### DIFF
--- a/code/__DEFINES/~~bubber_defines/DNA.dm
+++ b/code/__DEFINES/~~bubber_defines/DNA.dm
@@ -78,7 +78,7 @@
 #define PENIS_DEFAULT_LENGTH 6 //still a lil long but not insane
 
 #define TESTICLES_MIN_SIZE 0
-#define TESTICLES_MAX_SIZE 6
+#define TESTICLES_MAX_SIZE 8
 
 #define SHEATH_NONE	"None"
 #define SHEATH_NORMAL "Sheath"

--- a/modular_skyrat/modules/customization/_globalvars/lists.dm
+++ b/modular_skyrat/modules/customization/_globalvars/lists.dm
@@ -54,7 +54,9 @@ GLOBAL_LIST_INIT(balls_size_translation, list(
 	"3" = "Very Big",
 	"4" = "Enormous",
 	"5" = "Immense",
-	"6" = "Gargantuan"
+	"6" = "Gargantuan",
+	"7" = "Colossal",
+	"8" = "Titanic"
 	))
 
 GLOBAL_LIST_INIT(marking_zone_to_bitflag, list(
@@ -86,7 +88,9 @@ GLOBAL_LIST_INIT(preference_balls_sizes, list(
 	"Very Big",
 	"Enormous",
 	"Immense",
-	"Gargantuan"
+	"Gargantuan",
+	"Colossal",
+	"Titanic"
 	))
 
 GLOBAL_LIST_INIT(robotic_styles_list, list(

--- a/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
@@ -311,7 +311,11 @@
 	layers = EXTERNAL_ADJACENT | EXTERNAL_BEHIND
 
 /obj/item/organ/genital/testicles/update_genital_icon_state()
-	var/measured_size = clamp(genital_size, 1, TESTICLES_MAX_SIZE)
+	var/measured_size = FLOOR(genital_size,1)
+	var/max_size = TESTICLES_MAX_SIZE
+	if(genital_name != "Pair (Alt)" && genital_name != "Sheathed Pair")
+		max_size -= 2
+	measured_size = clamp(measured_size, 1, max_size)
 	var/passed_string = "testicles_[genital_type]_[measured_size]"
 	if(uses_skintones)
 		passed_string += "_s"
@@ -335,7 +339,10 @@
 
 /obj/item/organ/genital/testicles/get_sprite_size_string()
 	var/measured_size = FLOOR(genital_size,1)
-	measured_size = clamp(measured_size, 0, TESTICLES_MAX_SIZE)
+	var/max_size = TESTICLES_MAX_SIZE
+	if(genital_name != "Pair (Alt)" && genital_name != "Sheathed Pair")
+		max_size -= 2
+	measured_size = clamp(measured_size, 0, max_size)
 	var/passed_string = "[genital_type]_[measured_size]"
 	if(uses_skintones)
 		passed_string += "_s"


### PR DESCRIPTION
## About The Pull Request
Very similarly to the (alt) breasts, the (alt) penises had larger sizes within the DMI, yet, they were not enabld. This enables them.

How to make the penis bigger:
Just turn it on!
Its a perfect joke.
## Why It's Good For The Game
I will copy-paste my reasoning from the breasts PR, because it is quite frankly the same thing.

More customization is good. Some players who left bubber have told me they'd come back to the server if we had more of splurt's customization because they don't like that server, but it has Better Character Creation Options Like Bigger Penis, so it's where they go. I was going to wait for a dedicated hyper pref to add this as it was stated to be a prerequisite, but that has been basically deemed impossible by the several people who have tried, so I'm pring it anyways in the hopes that it gets accepted.

I do not believe this to be a major issue either way as public nudity is already frowned upon within the server, as well as being an IC crime, and ooc enforced as "put that shit away if people LOOC it" even on smaller sizes. Underwear too, does exist, which the vast majority of characters have on. Especially with them already being in the code, I do not see much of a reason to not have them be enabled.
## Proof Of Testing
<img width="264" height="536" alt="afbeelding" src="https://github.com/user-attachments/assets/c586aead-55fc-4301-a28d-7a7628b76487" />
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
add: The (alt) sprites for penises now have 3 extra stages of size.
/:cl:
