### PR TITLE
Allows oversized to fit within cryo cells

### DIFF
--- a/modular_zubbers/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/modular_zubbers/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -1,0 +1,2 @@
+/obj/machinery/cryo_cell
+	ignore_size = TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9250,6 +9250,7 @@
 #include "modular_zubbers\code\modules\asset_cache\assets\tgui.dm"
 #include "modular_zubbers\code\modules\atmospherics\gasmixtures\gas_types.dm"
 #include "modular_zubbers\code\modules\atmospherics\machinery\air_alarm\air_alarm_modes.dm"
+#include "modular_zubbers\code\modules\atmospherics\machinery\components\unary_devices\cryo.dm"
 #include "modular_zubbers\code\modules\atmospherics\machinery\portable\canister.dm"
 #include "modular_zubbers\code\modules\autolathe_components_adv\advpartdisks.dm"
 #include "modular_zubbers\code\modules\automapper\code\area_spawn_entries.dm"


### PR DESCRIPTION
## About The Pull Request
Title
## Why It's Good For The Game
burn wounds on oversized sucks to cure as medical. Let them use the tubes. Oversized is CBT enough as is.
## Proof Of Testing
<img width="849" height="714" alt="afbeelding" src="https://github.com/user-attachments/assets/dde2435d-04d6-44fe-a11c-087ced5dada7" />
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
qol: Oversized players now fit within cryo cells.
/:cl:
