### PR TITLE
Allows the quad (Alt) breasts to go up to stage 19 (S) instead of 5 (E)

### DIFF
--- a/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/genitals.dm
@@ -522,7 +522,7 @@
 	if(genital_type == "pair")
 		max_size = findtext(genital_name, "(Alt)") ? 19 : 16
 	if(genital_type == "quad")
-		max_size = findtext(genital_name, "(Alt)") ? 19 : 16
+		max_size = findtext(genital_name, "(Alt)") ? 19 : 5
 	var/current_size = FLOOR(genital_size, 1)
 	if(current_size < 0)
 		current_size = 0


### PR DESCRIPTION

## About The Pull Request
In the same vein of SapphoQueer's PR for pair (Alt) breasts, this just allows the larger sizes of quad (alt) breasts to be used, while keeping the default quad breasts at a max of size 5 (since there aren't actually sprites for higher sizes)

Only for quads, sextuple weren't touched.
## Why It's Good For The Game
More customisation is always good. I looked into this a while ago and was bothered by the fact that larger quad breasts weren't available. This fixes it! And honestly I'm using a lot of the same rationalisation as Sappho did here; if there was a dedicated hyper pref this'd be locked behind it, but since there isn't and thats apparently impossible I'm PRing it anyways.

Shouldn't be an issue because generally people don't rock around with their tits out in public (both being an IC crime and usually if people LOOC it they put it away). However, if the _max_ quad size is deemed too much I will reduce it down to either 16 or 17.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="270" height="276" alt="image" src="https://github.com/user-attachments/assets/6f68ed81-b63f-4c36-8c51-83b7b678cb8b" />

max of 19
<img width="271" height="274" alt="image" src="https://github.com/user-attachments/assets/4a777757-ebcc-4c0b-ac5e-df1392242bdb" />

max of 16
</details>

## Changelog
:cl:
add: The "quad (alt)" breasts now support sizes F-S.
/:cl:
