### PR TITLE
Adds a new method of removing looping Immovable Rods

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/fleshlight.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/fleshlight.dm
@@ -144,3 +144,23 @@
 						'modular_skyrat/modules/modular_items/lewd_items/sounds/bang5.ogg',
 						'modular_skyrat/modules/modular_items/lewd_items/sounds/bang6.ogg'), 70, 1, -1)
 
+
+/obj/item/clothing/sextoy/fleshlight/bluespace
+	name = "bluespace fleshlight"
+	color_changed = TRUE
+	current_color = "teal"
+	desc = "Internal design based on the captain's mother."
+	custom_premium_price = PAYCHECK_COMMAND * 10
+
+/obj/item/clothing/sextoy/fleshlight/bluespace/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/effect_remover, \
+		tip_text = "Capture rod", \
+		on_clear_callback = CALLBACK(src, PROC_REF(rod_johnson)), \
+		effects_we_clear = list(/obj/effect/immovablerod)\
+	)
+
+/obj/item/clothing/sextoy/fleshlight/bluespace/proc/rod_johnson(obj/effect/immovablerod/target, mob/living/user)
+	user.throw_at(get_step(user,target.dir),12,4)
+	playsound(target, 'sound/effects/cartoon_sfx/cartoon_pop.ogg', 75, TRUE)
+	target.audible_message(span_danger("You hear a POP!"))

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_machinery/lustwish.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_machinery/lustwish.dm
@@ -187,7 +187,9 @@
 					/obj/item/reagent_containers/applicator/pill/pentacamphor = 5,
 					/obj/item/reagent_containers/cup/bottle/hexacrocin = 4,
 					/obj/item/reagent_containers/cup/bottle/pentacamphor = 2,
-					/obj/item/reagent_containers/cup/bottle/plushmium = 1)
+					/obj/item/reagent_containers/cup/bottle/plushmium = 1,
+					/obj/item/clothing/sextoy/fleshlight/bluespace = 1
+				)
 
 	refill_canister = /obj/item/vending_refill/lustwish
 	payment_department = ACCOUNT_SRV


### PR DESCRIPTION
## About The Pull Request

Adds a new method of removing looping Immovable Rods. You can purchase it in the contraband section of the Lustwish vendor.. It requires you to interact with the immovable rod, similar to an RD suplex.

## Why It's Good For The Game

Alternative way of removing immovable rods. It's expensive and a good alternative to having an RD.

## Proof Of Testing

Fully tested.

## Changelog

:cl: BurgerBB
add: Adds a new method of removing looping Immovable Rods. You can purchase it in the contraband section of the Lustwish vendor.. It requires you to interact with the immovable rod, similar to an RD suplex.
/:cl:
