### PR TITLE
Holotool fix 1

### DIFF
--- a/modular_zubbers/code/game/objects/items/holotool/modes.dm
+++ b/modular_zubbers/code/game/objects/items/holotool/modes.dm
@@ -3,7 +3,7 @@
 	var/sound
 	var/behavior
 	var/sharpness
-	var/speed = 2 // Better than normal, worse than upgraded.
+	var/speed = 0.5 // Better than normal (1), worse than upgraded(0.3).
 	var/requires_emag = FALSE
 
 /datum/holotool_mode/proc/on_set(obj/item/holotool/holotool)
@@ -58,11 +58,11 @@
 
 /datum/holotool_mode/welder/on_set(obj/item/holotool/holotool)
 	..()
-	holotool.AddElement(/datum/element/tool_flash, holotool.light_range)
+	holotool.AddElement(holotool.light_range)
 
 /datum/holotool_mode/welder/on_unset(obj/item/holotool/holotool)
 	..()
-	holotool.RemoveElement(/datum/element/tool_flash, holotool.light_range)
+	holotool.RemoveElement(holotool.light_range)
 
 ////////////////////////////////////////////////
 


### PR DESCRIPTION

## About The Pull Request
Fixes the holotool speed being backwards (toolspeed is not intuitive)
Fixes the holotool flashing you constantly through welding protection whoops
## Why It's Good For The Game
bug fix
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

worked, tested, compiled, its right this time.

</details>

## Changelog
:cl:
fix: Holotool has the correct speed and doesnt flash you through a welding mask.
/:cl:
