### PR TITLE
Reversing BootKnife equip logic to actually check on equip rather than in-hand

### DIFF
--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -555,7 +555,7 @@ effective or pretty fucking useless.
 
 /obj/item/clothing/shoes/jackboots/dagger/equipped(mob/living/user, slot)
 	. = ..()
-	if(!(slot & ITEM_SLOT_FEET) || !istype(user))
+	if((slot & ITEM_SLOT_FEET) || !istype(user))
 		modified_bodyparts += user.get_bodypart(BODY_ZONE_L_LEG)
 		modified_bodyparts += user.get_bodypart(BODY_ZONE_R_LEG)
 		for(var/obj/item/bodypart/bodypart in modified_bodyparts)


### PR DESCRIPTION
## About The Pull Request

Makes the check for the spy BootKnife item actually check for when the boots are equipped, rather than held or removed.

## Why It's Good For The Game

Fixes: https://github.com/Bubberstation/Bubberstation/issues/5305

## Proof Of Testing

Previously, the boots would only 'modify' the limbs if held in hand (Which made zero sense)

Now, the boots when EQUIPPED properly modify the limbs and provide them with slash/sharpness as expected.

<details>
<summary>Screenshots/Videos</summary>
Equipped:

<img width="1262" height="630" alt="image" src="https://github.com/user-attachments/assets/08705e2c-f0bc-41a5-9692-9968b1a445a1" />


Unequipped:
<img width="1291" height="1150" alt="image" src="https://github.com/user-attachments/assets/342af4d2-b91b-4e47-942b-a83b756fc4dd" />

Combat detailing the slash procs:

<img width="827" height="624" alt="image" src="https://github.com/user-attachments/assets/1c91c8e0-b1bd-46a0-8e65-081244db18a0" />



</details>

## Changelog

:cl:
fix: Fixes spy's bootknife reward to actually work when equipped

/:cl:
