### PR TITLE
Fix IPC Screens by setting eye icons to 'null' instead of 'none'

### DIFF
--- a/modular_skyrat/modules/synths/code/species/synthetic.dm
+++ b/modular_skyrat/modules/synths/code/species/synthetic.dm
@@ -121,7 +121,7 @@
 	if(!screen && screen_mutant_bodypart && screen_mutant_bodypart[MUTANT_INDEX_NAME] && screen_mutant_bodypart[MUTANT_INDEX_NAME] != "None")
 
 		if(eyes)
-			eyes.eye_icon_state = "None"
+			eyes.eye_icon_state = null
 
 		screen = new(human_who_gained_species)
 		screen.Grant(human_who_gained_species)


### PR DESCRIPTION
## About The Pull Request

The custom synth code will set eyes to none, but we have no icon state for that. But ontop of that, we already check if the eye state is null, and if it is, we just return (so we dont need to process eye animations/etc)

Fixes https://github.com/Bubberstation/Bubberstation/issues/5258

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>
No Screen:
<img width="336" height="519" alt="image" src="https://github.com/user-attachments/assets/cf89a921-dac1-41b3-8764-c0386f66bc13" />

With Screen:
<img width="323" height="539" alt="image" src="https://github.com/user-attachments/assets/8265413e-2466-4c3a-9edf-d46cc2bc4f27" />

(No error!)

</details>

## Changelog

:cl:
fix: IPC's no longer have an error when customizing their look with a screen.
/:cl:

