### PR TITLE
Bring balance to the shotgun pka

### DIFF
--- a/modular_zubbers/code/game/objects/items/more_pkas.dm
+++ b/modular_zubbers/code/game/objects/items/more_pkas.dm
@@ -55,7 +55,8 @@
 	item_flags = NONE
 	obj_flags = UNIQUE_RENAME
 	weapon_weight = WEAPON_HEAVY
-	max_mod_capacity = 75
+	max_mod_capacity = 60
+	disabled_modkits = list(/obj/item/borg/upgrade/modkit/aoe) // Should cover all AOE variants
 
 /obj/item/gun/energy/recharge/kinetic_accelerator/glock
 	name = "proto-kinetic pistol"


### PR DESCRIPTION

## About The Pull Request
Protokinetic accelerators (PKAs) modkits were never balanced to fire multiple kinetic shots at once. This overlook from our unique alternative PKAs made it so some of them outshine all other tools. The shockwave was recently fixed, but the shotgun (which has the exact same problem) was forgotten.

What makes the ability to fire multiple blast at once so dreadful is that the explosion modkit (balanced for one projectile) uses each pellets to create an explosion, meaning that each pellet becomes a 3x3 aoe.

Here's a demonstration of how broken it is:

**Clearing a legion tendril like it's nothing**
![legions](https://github.com/user-attachments/assets/175fb6d3-0c97-47f1-8498-96871b9f43e8)

**Clearing a watcher tendril like it's nothing**
![watchers](https://github.com/user-attachments/assets/b7d784b1-ab8d-4cb6-a110-c61076439d7f)

**Two goliaths that looked at me**
![goliaths](https://github.com/user-attachments/assets/16abf427-032b-4f3b-a849-544dff822a18)

This by itself renders vent mining a joke, and brings the same problem the shockwave did (clearing lavaland in under 30mins solo)

Another thing that wasn't considered, is that by pointblanking someone, the 3 kinetic pellets are a guaranteed hit. This means that by having a shotgun and equipping it with a damage modkit and a traitor modkit (1 for 5tc) you get this funny result:

![shotgunblast](https://github.com/user-attachments/assets/d1c7cd7b-2f8b-4de2-a6a5-23e1cd14c201)

This is 50 damage.
Now if we get a bit spicier by getting another shotgun with the same setup (you can buy another traitor modkit for 5tc) and by doing the minimal item swapping, you get...
![shotgundouble](https://github.com/user-attachments/assets/228bd7ed-de46-4f28-9814-c0d5e75fefd1)

Which is 100 damage in less than one second from a weapon that has 3 tiles reach, can be mounted with explosive modkit for even less chances of missing. Two normal PKAs with the same mods do half of that

My solution to that is to give it the same treatment the shockwave got, and to nerf the mod capacity so that you cannot shove 1 damage mod and 1 traitor mod at the same time, which is better than just deleting it. This bring the mod capacity to 60 (the railgun gets 15) 
## Why It's Good For The Game
Having a tool that outshine all others is bad, mining is not supposed to be a walk in the park. With this PR, the PKA shotgun still can pointblank for three guaranteed hit + get two damage mods for a serious punch, which makes it still a decent gimmick. 
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

**Me trying to equip the explosion modkit + the new capacity**
<img width="453" height="19" alt="cantinstall" src="https://github.com/user-attachments/assets/76e5f74a-3cd6-4e2c-bec7-6e4dce1eb04e" />
<img width="634" height="293" alt="shotgun nerf" src="https://github.com/user-attachments/assets/711f98f6-1f36-4ad3-aae9-4767d989faa4" />

The new shotgun damage with the traitor kit only
![shotgun no dam mod](https://github.com/user-attachments/assets/9298a675-7dc8-40b8-b26e-e49616be3aa8)

I can show a video of my clearing a large vent with only the shotgun if needed, but the small gifs should already be putting a decent picture

</details>

## Changelog
:cl:
balance: Tweak the PKA shotgun
/:cl:
