### PR TITLE
Mining Equipment that requires low pressure to work now works in areas with water vapor in it.

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -258,6 +258,10 @@
 	var/pressure = environment.return_pressure()
 	if(pressure <= LAVALAND_EQUIPMENT_EFFECT_PRESSURE)
 		. = TRUE
+	//BUBBERSTATION ADDITION MOONSTATION COMPATIBILITY
+	else if(environment.gases[/datum/gas/water_vapor] && environment.gases[/datum/gas/water_vapor][MOLES] >= 1)
+		. = TRUE
+	//BUBBERSTATION ADDITION MOONSTATION COMPATIBILITY END.
 
 ///Find an obstruction free turf that's within the range of the center. Can also condition on if it is of a certain area type.
 /proc/find_obstruction_free_location(range, atom/center, area/specific_area)


### PR DESCRIPTION
## About The Pull Request

Mining Equipment that requires low pressure to work now works in areas with water vapor in it. The specific threshold is 1 mole of water vapor. For reference, Moon Station's external atmos has 1.1 moles.

## Why It's Good For The Game

So miners can mine on the middle level of Moon Station if they choose.

This affects:
- Berserk Armor
- Grapple Gun
- Resonators
- Space Crawling for Heretics
- Ripley Stuff
- Raptors
- Cyborg Mining Shields
- Kinetic Accelerators
- Brimdust Sacs
- Sphere Modsuit Modules
- Rush Glands
- Mining Pens
- Mining Drones

## Proof Of Testing

Untested. If it compiles, it werks.

## Changelog

:cl: BurgerBB
balance: Mining Equipment that requires low pressure to work now works in areas with water vapor in it.
/:cl:
