### PR TITLE
Brings the Proto-Kinetic shotgun back to 20 damage per pellet as opposed to 15

### DIFF
--- a/modular_zubbers/code/game/objects/items/more_pkas.dm
+++ b/modular_zubbers/code/game/objects/items/more_pkas.dm
@@ -189,6 +189,10 @@
 	range = 3
 	log_override = TRUE
 
+/obj/item/borg/upgrade/modkit/indoors/modify_projectile(obj/projectile/kinetic/shotgun/K)
+	..()
+	K.pressure_decrease = min(K.pressure_decrease, 0.5)
+
 /obj/projectile/kinetic/glock
 	name = "light kinetic force"
 	icon_state = null


### PR DESCRIPTION

## About The Pull Request
It got nerfed due to stacking damage with the AOE kit which was the real issue. The actual pellets themselves doing 20 damage was not the issue. It can no longer hold the AOE kit. Thus it's reasonable to be at 20 to prevent it from being actually useless

also less damage with the traitor modkit to prevent super fast 2shots
## Why It's Good For The Game
Read the above
## Proof Of Testing
numbers change
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
balance: The proto-kinetic shotgun now does 20 damage per pellet instead of 15.
balance: The proto-kinectic shotgun does less total damage with the traitor modkit, doing a maximum of 10 damage per pellet.
/:cl:
