### PR TITLE
Adjust the remaining alt PKAs 

### DIFF
--- a/modular_zubbers/code/game/objects/items/more_pkas.dm
+++ b/modular_zubbers/code/game/objects/items/more_pkas.dm
@@ -18,7 +18,7 @@
 	item_flags = NONE
 	obj_flags = UNIQUE_RENAME
 	weapon_weight = WEAPON_HEAVY
-	max_mod_capacity = 15 // A crumb of mod capacity as a treat
+	max_mod_capacity = 0
 	recoil = 3 //railgun go brrrrr
 	gun_flags = NOT_A_REAL_GUN
 
@@ -37,7 +37,8 @@
 	item_flags = NONE
 	obj_flags = UNIQUE_RENAME
 	weapon_weight = WEAPON_LIGHT
-	max_mod_capacity = 75
+	max_mod_capacity = 60
+	disabled_modkits = list(/obj/item/borg/upgrade/modkit/aoe) // Should cover all AOE variants
 
 /obj/item/gun/energy/recharge/kinetic_accelerator/shotgun
 	name = "proto-kinetic shotgun"


### PR DESCRIPTION

## About The Pull Request
Looking at the monkeystation github and checking both weapon in game myself, I've found that some of the alternate PKAs have been greatly buffed during their port from monkeystation. The railgun was never supposed to allow any modkit while the repeater was not supposed to be beyond 60 capacity.

Let's check them out with our current values:

Here's the railgun with the AOE mod (note: You can have one railgun on your belt and one railgun in your hand to reduce the cooldown massively from firing it (which I didn't have to do here since 3 goliath and 1 watcher got annihilated in one shot)

![railgun](https://github.com/user-attachments/assets/f51602f8-b909-4528-8081-5519491d1edd)

Then, we have the repeater, which you can dual wield and equip with damage and aoe

![repeater aoe](https://github.com/user-attachments/assets/4f42ed04-9742-4cde-8187-2dfd2669b5c1)


As a bonus, the repeater also have some funny use on station, dual wielding it and using the traitor modkits

![pka-repeater](https://github.com/user-attachments/assets/0d89fcc6-7082-4fbf-9a99-56a634b1e124)
## Why It's Good For The Game

These PKAs were rendered much stronger than their source material (monkeystation) and just like the last PR nerfing one of them stated, they break the mining cycle by allowing a solo miner to just clear every vents without breaking a sweat and in a record time. These should be the last cycle breakers unless I squint too hard at the PKA pistol.
I've put both of them with the same values as monkeystation did, and removed the AOE ability from the repeater (since it was just the shotgun all over again) 

The railgun is still a ranged crusher that deals lots of damage precisely (intended gimmick)
The repeater is still a better PKA if you manage to land your shots like the western movies enjoyer you are.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="648" height="307" alt="image" src="https://github.com/user-attachments/assets/0e2b3665-f8ea-4a42-8b2b-580b0a3d58fa" />

<img width="645" height="289" alt="image" src="https://github.com/user-attachments/assets/57e4eb08-7f53-42c9-b115-8503e90546a3" />

<img width="643" height="43" alt="image" src="https://github.com/user-attachments/assets/37035900-937e-4a45-94e7-810a25e5c7a0" />

<img width="442" height="21" alt="image" src="https://github.com/user-attachments/assets/17f78087-f053-43d1-9eaa-48d6b51130c7" />


</details>

## Changelog
:cl:
balance: Tweak the PKA railgun and repeater
/:cl:
