### PR TITLE
Prevents hypno lipsticks from randomly spawning in common containers because I noticed I spawned with one once.

### DIFF
--- a/modular_zubbers/code/game/Items/lipstick.dm
+++ b/modular_zubbers/code/game/Items/lipstick.dm
@@ -5,4 +5,4 @@
 	base_icon_state = "slipstick"
 	lipstick_color = COLOR_SYNDIE_RED
 	lipstick_trait = TRAIT_HYPNO_KISS
-
+	random_spawn = FALSE


### PR DESCRIPTION
## About The Pull Request

Prevents hypno lipsticks from randomly spawning in common containers because I noticed I spawned with one once.

## Why It's Good For The Game

Bugfixes good.

## Proof Of Testing

If it compiles, it werks.

## Changelog

:cl: BurgerBB
fix: Prevents hypno lipsticks from randomly spawning in common containers.
/:cl:

