### PR TITLE
Removes Hot Potato from maintenance loot because I died to it once.

### DIFF
--- a/modular_zubbers/code/_globalvars/lists/maintenance_loot_one_of_a_kind.dm
+++ b/modular_zubbers/code/_globalvars/lists/maintenance_loot_one_of_a_kind.dm
@@ -5,7 +5,6 @@ GLOBAL_LIST_INIT(one_of_a_kind_loot, list(
 	/obj/item/dice/d20/teleporting_die_of_fate,
 	/obj/item/modular_computer/pda/clear,
 	/obj/item/gun/energy/meteorgun/pen,
-	/obj/item/hot_potato,
 	/obj/item/clothing/shoes/gunboots/disabler,
 	/obj/item/spear/grey_tide,
 	/obj/item/shadowcloak,


### PR DESCRIPTION

## About The Pull Request

Removes Hot Potato from maintenance loot because I died to it once.

## Why It's Good For The Game

When I initially added this to the maintenance loot list, I thought it just blew you up. I didn't think it would gib.

## Proof Of Testing

If it compiles, it werks.

## Changelog

:cl: BurgerBB
del: Removes Hot Potato from maintenance loot because I died to it once.
/:cl: