### PR TITLE
Allows MOD modules to activate in a partially-deployed MODsuit

### DIFF
--- a/code/modules/mod/modules/_module.dm
+++ b/code/modules/mod/modules/_module.dm
@@ -149,14 +149,6 @@
 	if(((!mod.active || mod.activating) && !(allow_flags & MODULE_ALLOW_INACTIVE)) || !mod.get_charge()) // SKYRAT EDIT ADDITION: INACTIVE USE
 		balloon_alert(activator, "unpowered!")
 		return FALSE
-
-	// SKYRAT EDIT START - No using modules when not all parts are deployed.
-	if(!(allow_flags & MODULE_ALLOW_INACTIVE))
-		for(var/obj/item/part as anything in mod.get_parts())
-			if(part.loc == mod)
-				balloon_alert(mod.wearer, "deploy all parts first!")
-				return FALSE
-	// SKYRAT EDIT END
 	if(!(allow_flags & MODULE_ALLOW_PHASEOUT) && istype(mod.wearer.loc, /obj/effect/dummy/phased_mob))
 		//specifically a to_chat because the user is phased out.
 		to_chat(activator, span_warning("You cannot activate this right now."))


### PR DESCRIPTION

## About The Pull Request

This PR reverts part of a Skyrat-Era PR, https://github.com/Skyrat-SS13/Skyrat-tg/pull/15950. The PR as a whole was intended to fix an exploit where a retracted MODsuit's modules could still be used, but did so by preventing any modules from being activated at all if the MODsuit was not fully deployed and active, in addition to deactivating them when the associated part was retracted.

TG eventually fixed retraction not deactivating modules, and the Skyrat fix for that part is no longer in our codebase. The part preventing modules from being activated unless the suit is fully deployed, however, lingered, and nowadays it inconveniences me when I am trying to have hot MODsuit sex. _This is unacceptable._

This change will bring MODsuit behavior closer to how TG has it, where players don't need to wait for all 4 parts of the suit to activate before using something that only needs the gloves deployed. There may be some mild balance implications there, but given that it's moving to how TG does it I'm not too concerned.

## Why It's Good For The Game

Keeps us closer to parity with TG, and allows for greater flexibility in MODsuit use, rewarding players who are knowledgeable in their modules' required parts with faster access to those modules' abilities.

## Proof Of Testing
<img width="853" height="449" alt="image" src="https://github.com/user-attachments/assets/8acbb0ca-5852-4a65-acd8-80f9a2e92c58" />

## Changelog

:cl:
del: Removed a Skyrat restriction on activating MOD modules with a partially-deployed suit.
/:cl:
