### PR TITLE
Fixes Hypnovisor Display Issue

### DIFF
--- a/modular_zubbers/code/modules/mod/modules_lustwish.dm
+++ b/modular_zubbers/code/modules/mod/modules_lustwish.dm
@@ -79,8 +79,9 @@
 	return ..()
 
 /obj/item/mod/module/hypno_visor/on_part_activation()
+	overlay_state_inactive = null // Have you tried turning it off and back on again?
+	overlay_state_active = null
 	if(module_type == MODULE_PASSIVE)
-		overlay_state_inactive = null // Have you tried turning it off and back on again?
 		if(visor_effect)
 			overlay_state_inactive = "module_hypno_overlay"
 		apply_hypnosis()
@@ -90,8 +91,9 @@
 		mod.wearer.cure_trauma_type(/datum/brain_trauma/very_special/induced_hypnosis, TRAUMA_RESILIENCE_MAGIC)
 
 /obj/item/mod/module/hypno_visor/on_activation(mob/activator)
+	overlay_state_inactive = null // Have you tried turning it off and back on again?
+	overlay_state_active = null
 	if(module_type == MODULE_TOGGLE)
-		overlay_state_active = null // Have you tried turning it off and back on again?
 		if(visor_effect)
 			overlay_state_active = "module_hypno_overlay"
 		apply_hypnosis()

--- a/modular_zubbers/code/modules/mod/modules_lustwish.dm
+++ b/modular_zubbers/code/modules/mod/modules_lustwish.dm
@@ -14,13 +14,11 @@
 	required_slots = list(ITEM_SLOT_HEAD)
 	overlay_icon_file = 'modular_zubbers/icons/mob/clothing/modsuit/mod_modules.dmi'
 
-	module_type = MODULE_TOGGLE //These three are changed when the control wire is snipped
-	overlay_state_active = "module_hypno_overlay"
-	overlay_state_inactive = null
-
-	var/hypno_message = "Obey"
-		///Does the visor overlay show on the character sprite when installed? Only eligible with certain skins.
+	module_type = MODULE_TOGGLE //This is changed when the control wire is snipped
+	///Does the visor overlay show on the character sprite when installed? Only eligible with certain skins.
 	var/visor_effect = TRUE
+	var/hypno_message = "Obey"
+
 
 /obj/item/mod/module/hypno_visor/examine(mob/user)
 	. = ..()
@@ -50,12 +48,8 @@
 /obj/item/mod/module/hypno_visor/wirecutter_act(mob/living/user, obj/item/tool)
 	if(module_type == MODULE_TOGGLE) // If it's not toggle, make it so. If it is, make it passive.
 		module_type = MODULE_PASSIVE
-		overlay_state_active = null
-		overlay_state_inactive = "module_hypno_overlay"
 	else
 		module_type = MODULE_TOGGLE
-		overlay_state_active = "module_hypno_overlay"
-		overlay_state_inactive = null
 	playsound(src, 'sound/items/tools/wirecutter.ogg', 30, TRUE)
 	to_chat(user, span_notice("You [(module_type == MODULE_TOGGLE) ? "mend" : "snip"] the control wire on [src]."))
 	balloon_alert(user, "control wire [(module_type == MODULE_TOGGLE) ? "mend" : "snipp"]ed")
@@ -63,20 +57,12 @@
 
 /obj/item/mod/module/hypno_visor/on_install()
 	. = ..()
-	if(mod.skin != "lustwish")
-		overlay_state_inactive = null // Visual thing. Removes the overlay if it's not a part of the lustwish suit.
-		overlay_state_active = null
-		if(visor_effect == TRUE)
-			visor_effect = FALSE
-			addtimer(CALLBACK(src, PROC_REF(say_visor_no_worky), usr), 0.5 SECONDS)
+	if(mod.skin != "lustwish" && visor_effect == TRUE)
+		visor_effect = FALSE
+		addtimer(CALLBACK(src, PROC_REF(say_visor_no_worky), usr), 0.5 SECONDS)
 
 /obj/item/mod/module/hypno_visor/proc/say_visor_no_worky(user)
 		balloon_alert(user, "visor effect unavailable for this plating!")
-
-/obj/item/mod/module/hypno_visor/on_uninstall(deleting = FALSE)
-	. = ..()
-	overlay_state_inactive = initial(overlay_state_inactive) //This part only matters for visor/passive
-	overlay_state_active = initial(overlay_state_active) //This part only matters for visor/toggleable
 
 /obj/item/mod/module/hypno_visor/proc/apply_hypnosis()
 	if(!(mod.wearer.client?.prefs?.read_preference(/datum/preference/toggle/erp/hypnosis) && mod.wearer.client.prefs.read_preference(/datum/preference/toggle/erp/sex_toy)))
@@ -94,6 +80,9 @@
 
 /obj/item/mod/module/hypno_visor/on_part_activation()
 	if(module_type == MODULE_PASSIVE)
+		overlay_state_inactive = null // Have you tried turning it off and back on again?
+		if(visor_effect)
+			overlay_state_inactive = "module_hypno_overlay"
 		apply_hypnosis()
 
 /obj/item/mod/module/hypno_visor/on_part_deactivation(deleting = FALSE)
@@ -102,6 +91,9 @@
 
 /obj/item/mod/module/hypno_visor/on_activation(mob/activator)
 	if(module_type == MODULE_TOGGLE)
+		overlay_state_active = null // Have you tried turning it off and back on again?
+		if(visor_effect)
+			overlay_state_active = "module_hypno_overlay"
 		apply_hypnosis()
 
 /obj/item/mod/module/hypno_visor/on_deactivation(mob/activator, display_message = TRUE, deleting = FALSE)
@@ -124,7 +116,6 @@
 			if(mod.skin != "lustwish")
 				return balloon_alert(usr, "visor effect unavailable for this plating!")
 			visor_effect = text2num(value)
-			overlay_state_active = visor_effect ? "module_hypno_overlay" : null
 			if(active)
 				balloon_alert(usr, "restart to finalize changes")
 

--- a/modular_zubbers/code/modules/mod/modules_lustwish.dm
+++ b/modular_zubbers/code/modules/mod/modules_lustwish.dm
@@ -15,8 +15,8 @@
 	overlay_icon_file = 'modular_zubbers/icons/mob/clothing/modsuit/mod_modules.dmi'
 
 	module_type = MODULE_TOGGLE //These three are changed when the control wire is snipped
-	overlay_state_active = null
-	overlay_state_inactive = "module_hypno_overlay"
+	overlay_state_active = "module_hypno_overlay"
+	overlay_state_inactive = null
 
 	var/hypno_message = "Obey"
 		///Does the visor overlay show on the character sprite when installed? Only eligible with certain skins.


### PR DESCRIPTION
## About The Pull Request

Fixes a visual bug where the visual spiral on the hypnovisor sprite would act the opposite of the way you wanted, being always-on when it was in its default, untampered state. snipping the wires on the module twice fixed the issue. 

This is because the code I wrote for handling the overlay was terrible, constantly switching (or forgetting to switch) at several places throughout the code. To fix this, I've consolidated the overlay handling to only run before the module is activated, and have eliminated spots elsewhere in the code where it pops up.

## Why It's Good For The Game

The module's display behaves more intuitively, code is easier to read, and the world becomes a utopia the second this PR is merged (trust).

## Proof Of Testing

<img width="853" height="362" alt="image" src="https://github.com/user-attachments/assets/f00117f3-d7fb-4192-b253-0daf6cfe3b81" />
I know this doesn't really show much, my apologies.