### PR TITLE
Changes Civillian HUD implant cost to 2 in augs+

### DIFF
--- a/modular_skyrat/modules/customization/modules/client/augment/implants.dm
+++ b/modular_skyrat/modules/customization/modules/client/augment/implants.dm
@@ -59,7 +59,7 @@
 
 /datum/augment_item/implant/eyes/civhud
 	name = "Civilian HUD Implant"
-	cost = 4
+	cost = 2
 	path = /obj/item/organ/cyberimp/eyes/hud/civilian
 
 //MOUTH IMPLANTS


### PR DESCRIPTION

## About The Pull Request
Title. Reduces cost of the civ hud implant from 4 points to 2.
## Why It's Good For The Game
4 points for a job indicator HUD icon seems a bit much, considering razor claws are also 4 points. Some people use the HUD for accessibility reasons as well, such as poor eyesight. Reducing the cost makes it a little easier to grab if one wants it.
## Proof Of Testing
if it compiles it works, simple value change
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
balance: Reduces quirk cost of the Civillian HUD implant in Augs+ from 4 to 2
/:cl:
