### PR TITLE
Modified jaws of recovery crafting removal

### DIFF
--- a/modular_zubbers/code/datums/components/crafting/tools.dm
+++ b/modular_zubbers/code/datums/components/crafting/tools.dm
@@ -21,3 +21,7 @@
 	reqs = list(/obj/item/weldingtool/experimental = 1,
 	/obj/item/grenade/gas_crystal/proto_nitrate_crystal = 1)
 	category = CAT_TOOLS
+
+/datum/crafting_recipe/jaws_of_recovery
+	category = null
+	crafting_flags = CRAFT_MUST_BE_LEARNED


### PR DESCRIPTION

## About The Pull Request

Modifies the recipe for the modified jaws of recovery to delist it from the crafting menu.

## Why It's Good For The Game

The recipe can be easily abused by people who know how the game works, allowing certain individuals to get easy and free jaws of life in an unintended way.
This PR removes the ability to use the recipe.
## Proof Of Testing

Recipe isn't present and doesn't appear when the correct materials are gathered.
<img width="877" height="514" alt="image" src="https://github.com/user-attachments/assets/af803dc3-15ec-423c-acb1-ad2149c6e989" />

## Changelog
:cl:
del: Removes the weird recipe to craft modified Jaws of Recovery
/:cl:
