### PR TITLE
[FUELED BY HOPIUM] Tackler Quirk

### DIFF
--- a/modular_zubbers/code/modules/quirks/positive_quirks/tackler.dm
+++ b/modular_zubbers/code/modules/quirks/positive_quirks/tackler.dm
@@ -1,0 +1,20 @@
+/datum/quirk/tackler
+	name = "Tackler"
+	desc = "You've spent years throwing yourself head-first into walls. You might be a little slow, but your football coach didn't mind."
+	medical_record_text = "Patient seems capable of explosive bursts of adrenaline."
+	value = 8
+	icon = FA_ICON_HAND_FIST
+	var/datum/component/tackler/tackle_comp
+
+/datum/quirk/tackler/add(client/client_source)
+	tackle_comp = quirk_holder.AddComponent(/datum/component/tackler, \
+		stamina_cost = 30, \
+		base_knockdown = 1 SECONDS, \
+		range = 5, \
+		speed = 1.5, \
+		skill_mod = 2, \
+		min_distance = 0, \
+	)
+
+/datum/quirk/tackler/remove()
+	QDEL_NULL(tackle_comp)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9748,6 +9748,7 @@
 #include "modular_zubbers\code\modules\quirks\neutral_quirks\body_temp.dm"
 #include "modular_zubbers\code\modules\quirks\neutral_quirks\unique_blood_color.dm"
 #include "modular_zubbers\code\modules\quirks\positive_quirks\robot_limb_detach.dm"
+#include "modular_zubbers\code\modules\quirks\positive_quirks\tackler.dm"
 #include "modular_zubbers\code\modules\quirks\positive_quirks\telepathy.dm"
 #include "modular_zubbers\code\modules\quote_of_the_round\config.dm"
 #include "modular_zubbers\code\modules\quote_of_the_round\debug_verbs.dm"


### PR DESCRIPTION
## About The Pull Request
This PR adds an 8 point positive quirk that adds component/tackler to the user.

## Why It's Balanced

I will admit, this is, if accepted, easily one of the most impactful positive quirks that Bubber has. My general feelings on the state of Bubber's game balancing are radical and I'll have to spare this PR body from it. 

Immediately, we are looking at a maximum +9 bonus to tackling upon spawn, up from +7 without this quirk. This is accomplished with a very precisely honed sort of minmaxing. This is who you're asking to have a +9 tackle bonus: <br>
<img width="611" height="277" alt="image" src="https://github.com/user-attachments/assets/3ca99354-7b2a-4678-9404-0e36e20f95dd" /> <br>
Achieving a maximum tackle bonus at spawn presents a lot of immediate drawbacks. You are forced into being a tajaran with a lizard's tail, wings, oversized, as well as the No Guns quirk. All of these things provide either a +1 or +2 bonus individually, as well as severely limit what a character can do in a round mechanically. Both oversized and No Guns makes security or Blueshield impossible roles to play. Oversized by itself experiences far too many drawbacks to be used for any sort of mechanical advantage in antagonist gameplay either, most damningly its malus to speed.

Visually, you have to be forced into an extremely distinct style. This restricts what sorts of blorbos are allowed to minmax tackle bonus because you **must** be a tajaran, have a lizard's tail, as well as have wings. For a majority of people, this isn't desirable. I would go as far as to call it a visual debuff. 

However, if someone does apply all of these factors at the same time, the chances of completing a successful tackle is indeed very high, if not additionally very taxing as well. The base stamina cost of a tackle is 30, which forces most people into stamcrit after just 4 attempted tackles. With oversized, this raises to 5 attempts. As stamina drops, so does a person's movespeed, incurring an additional malus on an already slow build.

This also includes one other important factor, which is that the stats on component/tackler do not stack with the addition of dedicated tackling gloves. In some cases, the stats inherent to the trait are strictly worse than those of gloves. The stamina cost of tackling without gloves equals the stamina cost of the most tiring gloves, the Gorilla Gloves. The knockdown time is also lower, being equal to the time of baseline enhanced retrieval gloves. The bonuses that gloveless tackling has over the variants is that there is a .5 higher speed mod compared to baseline in addition to the 2 skill_mod, but you would regardless be better off wearing dedicated gloves rather than without.

In reality, what we are looking at is a 8 quirk point buy-in compared to a 600 credit purchase from cargo with someone's roundstart wallet.
## Proof Of Testing

<img width="654" height="571" alt="image" src="https://github.com/user-attachments/assets/6efaf525-f513-4dee-ba21-a07af3388581" />


## Changelog

:cl:
add: Added new positive quirk: Tackler
/:cl: