### PR TITLE
Add server-side validation to alt job titles in save files

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences_savefile.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences_savefile.dm
@@ -31,6 +31,17 @@
 
 	return MODULAR_SAVEFILE_UP_TO_DATE
 
+/// Check that the alt job titles in the save data exist on the server side
+/datum/preferences/proc/validate_alt_jobs(list/job_titles)
+	. = list()
+	for(var/job in job_titles)
+		var/datum/job/job_datum = SSjob.get_job(job)
+		if(!istype(job_datum))
+			continue
+		var/alt_title = job_titles[job]
+		if(!alt_title || !(alt_title in job_datum.alt_titles))
+			continue
+		.[job] = alt_title
 
 /// Loads the modular customizations of a character from the savefile
 /datum/preferences/proc/load_character_skyrat(list/save_data)
@@ -50,7 +61,7 @@
 	mismatched_customization = save_data["mismatched_customization"]
 	allow_advanced_colors = save_data["allow_advanced_colors"]
 
-	alt_job_titles = save_data["alt_job_titles"]
+	alt_job_titles = validate_alt_jobs(SANITIZE_LIST(save_data["alt_job_titles"]))
 
 	general_record = sanitize_text(general_record)
 	security_record = sanitize_text(security_record)


### PR DESCRIPTION

## About The Pull Request

Incredibly funny that we went this long without but I'm tired of checking imported prefs manually, so this will ensure when a save file is loaded it runs through all the alt job titles and makes sure 1. the job exists and 2. the job has the title specified in the save
## Why It's Good For The Game

Job titles should be consistent

## Proof Of Testing

Hard to get screenshots of but yeah I edited my local save file to have valid job titles, valid jobs with non-existent titles, and non-existent jobs, and it properly sanitized the made up ones and kept the real ones

## Changelog
:cl:
server: alternate job titles in save files are now validated on load
/:cl:
