### PR TITLE
Lets the goodies tab actually show up

### DIFF
--- a/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
@@ -147,7 +147,7 @@ function CatalogTabs(props: CatalogTabsProps & Props) {
                 setActiveSupplyName(supply.name);
                 setSearchText('');
               }}
-              style={supply.name === "Goodies" ? {display: 'none'} : undefined}
+              //style={supply.name === "Goodies" ? {display: 'none'} : undefined} //BUBBER EDIT REMOVAL - We want the goodies tab thanks.
             >
               <Stack justify="space-between">
                 <span>{supply.name}</span>

--- a/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
+++ b/tgui/packages/tgui/interfaces/Cargo/CargoCatalog.tsx
@@ -147,7 +147,7 @@ function CatalogTabs(props: CatalogTabsProps & Props) {
                 setActiveSupplyName(supply.name);
                 setSearchText('');
               }}
-              //style={supply.name === "Goodies" ? {display: 'none'} : undefined} //BUBBER EDIT REMOVAL - We want the goodies tab thanks.
+              //style={supply.name === "Goodies" ? {display: 'none'} : undefined} //BUBBER EDIT - We want the goodies tab thanks.
             >
               <Stack justify="space-between">
                 <span>{supply.name}</span>


### PR DESCRIPTION

## About The Pull Request
Upstream sync broke this, tg fixed it with https://github.com/tgstation/tgstation/pull/95478. Doing the exact same shit here to fix it.

## Why It's Good For The Game
Bug fix 

## Proof Of Testing
<img width="208" height="80" alt="afbeelding" src="https://github.com/user-attachments/assets/edc9d73e-3ddf-4078-b4e6-7bc25204193e" />

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
Fix: The goodies tab exists once more.
/:cl:

