### PR TITLE
Buffs the murphy a little bit because I didn't die to it once

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/guns/bullets.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/bullets.dm
@@ -33,7 +33,7 @@
 	name = "9x19mm Murphy bullet"
 	damage = 20
 	wound_bonus = -20
-	armour_penetration = 40
+	armour_penetration = 40 // Sounds like a lot, isn't. Means it does 15 damage against a redsuit instead of 10.
 
 /obj/projectile/bullet/c9mm
 	damage = 25

--- a/modular_skyrat/modules/sec_haul/code/guns/bullets.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/bullets.dm
@@ -33,7 +33,7 @@
 	name = "9x19mm Murphy bullet"
 	damage = 20
 	wound_bonus = -20
-	armour_penetration = 40 // Sounds like a lot, isn't. Means it does 15 damage against a redsuit instead of 10.
+	armour_penetration = 20 //8 shots to crit a redsuit instead of 10.
 
 /obj/projectile/bullet/c9mm
 	damage = 25

--- a/modular_skyrat/modules/sec_haul/code/guns/bullets.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/bullets.dm
@@ -33,6 +33,7 @@
 	name = "9x19mm Murphy bullet"
 	damage = 20
 	wound_bonus = -20
+	armour_penetration = 40
 
 /obj/projectile/bullet/c9mm
 	damage = 25

--- a/modular_zubbers/code/modules/projectiles/boxes_magazines/external/pistol.dm
+++ b/modular_zubbers/code/modules/projectiles/boxes_magazines/external/pistol.dm
@@ -6,7 +6,7 @@
 	base_icon_state = "9x19p"
 	ammo_type = /obj/item/ammo_casing/security
 	caliber = CALIBER_9MM_SEC
-	max_ammo = 10
+	max_ammo = 14
 	ammo_band_color = null
 	multiple_sprites = AMMO_BOX_PER_BULLET
 	multiple_sprite_use_base = TRUE
@@ -17,7 +17,7 @@
 	name = "pistol magazine (9mm Murphy Rocket Eject)"
 	desc = parent_type::desc + "With a small charge inside that sparks on ejection, this one has less room for ammo and a lethal velocity to it's ejections."
 	ammo_type = /obj/item/ammo_casing/security
-	max_ammo = 8
+	max_ammo = 10
 	base_icon_state = "9x19pI"
 	murphy_eject_sound = 'sound/items/weapons/gun/general/rocket_launch.ogg'
 


### PR DESCRIPTION

## About The Pull Request
Buffs the murphy mag to 14 shots, up from 10
Buffs the murphy rocket mags to 10 shots, up from 8.
Gives the murphy bullets Twenty AP.

## Why It's Good For The Game
The murphy, as it stands, is not good. It is relegated to being a dedicated "Simplemobs And Tider Repellant Gun" (which admittedly is its original purpose). This is all fine in its own right, however, nowhere does it state this outright. What this leads to is either it being replaced for better options off the bat, or new and clueless security players being unaware of just how weak it is, and then dying because of it as it is their standard-issue pistol. In its current state it takes 10 shots to crit a redsuit. That is One Full Magazine.

After this PR? It's 8 shots whilst you have a magazine size of 14. Still quite a few shots to crit and it means almost every other security weapon is better at being lethal especially due to the murphys slow firerrate, but it at least gives you more of a chance, as well as being able to miss any shots at all. This will not suddenly turn the gun into The Meta. These are some minor adjustements to hopefully have it feel good to use in the slightest.

## Proof Of Testing
numbers changes

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
balance: Murphy bullets now have a twenty AP.
balance: Murphy magazines now fit 14 bullets, up from 10. Murphy rocket mags fit 10, up from 8.
/:cl:

