### PR TITLE
Adds the Tacticool Energy Gun, a "New" gun to sec and cargo.

### DIFF
--- a/modular_zubbers/code/modules/cargo/packs/goodies.dm
+++ b/modular_zubbers/code/modules/cargo/packs/goodies.dm
@@ -166,7 +166,7 @@
 
 /datum/supply_pack/goody/tacticool_laser
 	name = "Tacticool Energy Gun Single-Pack"
-	desc = "Contains one tacticool energy gun, for all your francophile and operator needs."
+	desc = "Contains one tacticool energy gun, for all your operator needs."
 	cost = PAYCHECK_COMMAND * 6
 	contains = list(/obj/item/gun/energy/tacticool)
 

--- a/modular_zubbers/code/modules/cargo/packs/goodies.dm
+++ b/modular_zubbers/code/modules/cargo/packs/goodies.dm
@@ -168,5 +168,6 @@
 	name = "Tacticool Energy Gun Single-Pack"
 	desc = "Contains one tacticool energy gun, for all your operator needs."
 	cost = PAYCHECK_COMMAND * 6
+	access_view = ACCESS_WEAPONS
 	contains = list(/obj/item/gun/energy/tacticool)
 

--- a/modular_zubbers/code/modules/cargo/packs/goodies.dm
+++ b/modular_zubbers/code/modules/cargo/packs/goodies.dm
@@ -163,3 +163,10 @@
 	desc = "Recommended for emergency self-cleaning, passive-aggressive demonstrations, or reminding others that hygiene is, in fact, part of the job."
 	cost = PAYCHECK_LOWER * 3
 	contains = list(/obj/item/soap/deluxe)
+
+/datum/supply_pack/goody/tacticool_laser
+	name = "Tacticool Energy Gun Single-Pack"
+	desc = "Contains one tacticool energy gun, for all your francophile and operator needs."
+	cost = PAYCHECK_COMMAND * 6
+	contains = list(/obj/item/gun/energy/tacticool)
+

--- a/modular_zubbers/code/modules/cargo/packs/security.dm
+++ b/modular_zubbers/code/modules/cargo/packs/security.dm
@@ -176,3 +176,13 @@
 	to_spawn[pick_weight(bonus_items)] = 1
 
 	generate_items_inside(to_spawn, src)
+
+/datum/supply_pack/security/armory/tacticool_laser_crate
+	name = "Tacticool energy gun crate"
+	desc = "Three tacticool energy guns to express your individuality compared to all those other energy gun users!"
+	cost = CARGO_CRATE_VALUE * 8
+	contains = list(
+		/obj/item/gun/energy/tacticool,
+		/obj/item/gun/energy/tacticool,
+		/obj/item/gun/energy/tacticool,
+	)

--- a/modular_zubbers/code/modules/projectiles/guns/energy/energyguns.dm
+++ b/modular_zubbers/code/modules/projectiles/guns/energy/energyguns.dm
@@ -6,8 +6,8 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode/sec/tacticool, /obj/item/ammo_casing/energy/disabler/tacticool, /obj/item/ammo_casing/energy/laser/tacticool)
 
 /obj/item/ammo_casing/energy/disabler/tacticool
-  e_cost = LASER_SHOTS(10, STANDARD_CELL_CHARGE)
+	e_cost = LASER_SHOTS(10, STANDARD_CELL_CHARGE)
 /obj/item/ammo_casing/energy/electrode/sec/tacticool
-  e_cost = LASER_SHOTS(2, STANDARD_CELL_CHARGE)
+	e_cost = LASER_SHOTS(2, STANDARD_CELL_CHARGE)
 /obj/item/ammo_casing/energy/laser/tacticool
-  e_cost = LASER_SHOTS(10, STANDARD_CELL_CHARGE)
+	e_cost = LASER_SHOTS(10, STANDARD_CELL_CHARGE)

--- a/modular_zubbers/code/modules/projectiles/guns/energy/energyguns.dm
+++ b/modular_zubbers/code/modules/projectiles/guns/energy/energyguns.dm
@@ -1,0 +1,7 @@
+/obj/item/gun/energy/tacticool
+	name = "tacticool energy gun"
+	desc = "A defanged variant of a more militarized energy gun, missing the taser equipment for private security purchasers."
+	icon_state = "energytac"
+	ammo_x_offset = 2
+	ammo_type = list(/obj/item/ammo_casing/energy/disabler, /obj/item/ammo_casing/energy/laser)
+// De-Tasered tactical energy gun!

--- a/modular_zubbers/code/modules/projectiles/guns/energy/energyguns.dm
+++ b/modular_zubbers/code/modules/projectiles/guns/energy/energyguns.dm
@@ -1,7 +1,13 @@
 /obj/item/gun/energy/tacticool
 	name = "tacticool energy gun"
-	desc = "A defanged variant of a more militarized energy gun, missing the taser equipment for private security purchasers."
+	desc = "An older edition of a tactical energy gun, clearly having not been maintained very well. The weapon's cell seems to be stressed extremely by it's taser."
 	icon_state = "energytac"
 	ammo_x_offset = 2
-	ammo_type = list(/obj/item/ammo_casing/energy/disabler, /obj/item/ammo_casing/energy/laser)
-// De-Tasered tactical energy gun!
+	ammo_type = list(/obj/item/ammo_casing/energy/electrode/sec/tacticool, /obj/item/ammo_casing/energy/disabler/tacticool, /obj/item/ammo_casing/energy/laser/tacticool)
+
+/obj/item/ammo_casing/energy/disabler/tacticool
+  e_cost = LASER_SHOTS(10, STANDARD_CELL_CHARGE)
+/obj/item/ammo_casing/energy/electrode/sec/tacticool
+  e_cost = LASER_SHOTS(2, STANDARD_CELL_CHARGE)
+/obj/item/ammo_casing/energy/laser/tacticool
+  e_cost = LASER_SHOTS(10, STANDARD_CELL_CHARGE)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9806,6 +9806,7 @@
 #include "modular_zubbers\code\modules\projectiles\guns\ballistic\bow.dm"
 #include "modular_zubbers\code\modules\projectiles\guns\ballistic\pistol.dm"
 #include "modular_zubbers\code\modules\projectiles\guns\ballistic\rifle.dm"
+#include "modular_zubbers\code\modules\projectiles\guns\energy\energyguns.dm"
 #include "modular_zubbers\code\modules\projectiles\guns\energy\pulse.dm"
 #include "modular_zubbers\code\modules\projectiles\projectile\bullets\lmg.dm"
 #include "modular_zubbers\code\modules\projectiles\projectile\bullets\smg.dm"


### PR DESCRIPTION

## About The Pull Request

People have been clamoring for new firearms to be given to the people, and with the recent re-use of axed weapons, I figured I'd take a crack at pulling something out that seemingly even /tg/ forgot. 

This PR adds an energy gun with a built-in taser to orders. 

You may ask "But wait, can't you stunlock and kill someone?" In fact, you cannot. Swapping weapons, or changing the mode, removes the taser. 

The taser mode also drains half the cell, and appears to have caused increased drain on the other two options. (10% drain per shot compared to 6%)

## Why It's Good For The Game

More gun variety is kinda neato! 

## Proof Of Testing

<img width="192" height="183" alt="image" src="https://github.com/user-attachments/assets/93dafeb9-867b-4c5a-9d27-b1f7f0b67012" />

Works on my machine. 

## Changelog
:cl:
add: Adds the Tacticool Energy Gun, a seemingly poorly maintained variant of the tactical energy gun, to cargo! 
/:cl:
