### PR TITLE
Adds GPS to all Crew cyborg models

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -397,6 +397,7 @@
 		/obj/item/picket_sign/cyborg,
 		/obj/item/reagent_containers/borghypo/clown,
 		/obj/item/extinguisher/mini,
+		/obj/item/gps/cyborg, // Bubber Addition
 	)
 	emag_modules = list(
 		/obj/item/reagent_containers/borghypo/clown/hacked,
@@ -442,6 +443,7 @@
 		/obj/item/construction/rtd/borg,
 		/obj/item/stack/cable_coil,
 		/obj/item/airlock_painter/decal/cyborg,
+		/obj/item/gps/cyborg, // Bubber Addition
 	)
 	radio_channels = list(RADIO_CHANNEL_ENGINEERING)
 	emag_modules = list(
@@ -497,6 +499,7 @@
 		/obj/item/reagent_containers/spray/cyborg_drying,
 		/obj/item/wirebrush,
 		/obj/item/pushbroom, // Bubber Addition
+		/obj/item/gps/cyborg, // Bubber Addition
 	)
 	radio_channels = list(RADIO_CHANNEL_SERVICE)
 	emag_modules = list(
@@ -767,6 +770,7 @@
 		/obj/item/borg/apparatus/organ_storage,
 		/obj/item/borg/lollipop,
 		/obj/item/storage/bag/chemistry,
+		/obj/item/gps/cyborg, // Bubber Addition
 
 	)
 	radio_channels = list(RADIO_CHANNEL_MEDICAL)
@@ -836,6 +840,7 @@
 		/obj/item/borg/cyborghug/peacekeeper,
 		/obj/item/extinguisher,
 		/obj/item/borg/projectile_dampen,
+		/obj/item/gps/cyborg, // Bubber Addition
 	)
 	emag_modules = list(
 		/obj/item/reagent_containers/borghypo/peace/hacked,
@@ -859,6 +864,7 @@
 		/obj/item/gun/energy/disabler/cyborg,
 		/obj/item/clothing/mask/gas/sechailer/cyborg,
 		/obj/item/extinguisher/mini,
+		/obj/item/gps/cyborg, // Bubber Addition
 	)
 	radio_channels = list(RADIO_CHANNEL_SECURITY)
 	emag_modules = list(
@@ -906,6 +912,7 @@
 		/obj/item/rsf,
 		/obj/item/storage/bag/tray,
 		/obj/item/storage/bag/tray, // SKYRAT EDIT: Moves the second tray up to be near the default one
+		/obj/item/gps/cyborg, // Bubber Addition
 		// SKYRAT EDIT START - COMMENTS OUT STUFF, MOVING IT TO SPECIALIZED MODULES
 		/*
 		// Moved to artistic module

--- a/modular_skyrat/modules/borgs/code/robot_model.dm
+++ b/modular_skyrat/modules/borgs/code/robot_model.dm
@@ -328,6 +328,7 @@
 		/obj/item/crowbar/cyborg,
 		/obj/item/extinguisher,
 		/obj/item/universal_scanner,
+		/obj/item/gps/cyborg, // Bubber Addition
 	)
 	radio_channels = list(RADIO_CHANNEL_SUPPLY)
 	emag_modules = list(

--- a/modular_zubbers/code/modules/silicons/borgs/code/robot_model.dm
+++ b/modular_zubbers/code/modules/silicons/borgs/code/robot_model.dm
@@ -25,6 +25,7 @@
 		/obj/item/crowbar/cyborg,
 		/obj/item/picket_sign/cyborg,
 		/obj/item/borg/stun,
+		/obj/item/gps/cyborg,
 	)
 	radio_channels = list(RADIO_CHANNEL_CENTCOM, RADIO_CHANNEL_COMMAND)
 	model_traits = list(TRAIT_PUSHIMMUNE, TRAIT_NOFLASH)
@@ -103,6 +104,7 @@
 		/obj/item/experi_scanner,
 		/obj/item/stack/medical/gauze,
 		/obj/item/borg/apparatus/tank_manipulator,
+		/obj/item/gps/cyborg,
 	)
 	radio_channels = list(RADIO_CHANNEL_SCIENCE)
 


### PR DESCRIPTION
Also adds them to Centcom and Security borgs which, despite being Admin Only, are still crew-sided
## About The Pull Request
Adds a cyborg GPS module to all the following cyborgs:
* Clown
* Engineer
* Janitor
* Medical
* Peacekeeper
* Service
* Science
* Cargo
* Centcom
* Security
## Why It's Good For The Game

As mentioned in a suggestion on discord, and in following discussion, this will allow for damaged borgs to be rescued slightly easier when killed, and will assist in un-upgraded borgs in finding dead miners. It's an equivalent to crew suit sensors, in that they're useless unless turned on/renamed. @SapphoQueer has already given me the go-ahead to make this change.

## Proof Of Testing

Testing hasn't happened as of this PR being made, I'll update with a comment in a few hours when I can do so.

</details>

## Changelog
:cl:
add: All Crew cyborg models now come equipped a built in GPS
/:cl:
