### PR TITLE
Fixes an exploit with the Paperwork Autosurgeon

### DIFF
--- a/modular_zubbers/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/modular_zubbers/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -6,8 +6,8 @@
 	. = ..()
 	new /obj/item/stamp/granted(src)
 	new /obj/item/stamp/denied(src)
-	new /obj/item/autosurgeon/paperwork(src)
+	new /obj/item/autosurgeon/paperwork/single_use(src)
 
 /obj/structure/closet/secure_closet/nanotrasen_consultant/PopulateContents()
 	. = ..()
-	new /obj/item/autosurgeon/paperwork(src)
+	new /obj/item/autosurgeon/paperwork/single_use(src)

--- a/modular_zubbers/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/modular_zubbers/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -6,8 +6,8 @@
 	. = ..()
 	new /obj/item/stamp/granted(src)
 	new /obj/item/stamp/denied(src)
-	new /obj/item/autosurgeon/paperwork/single_use(src)
+	new /obj/item/autosurgeon/paperwork(src)
 
 /obj/structure/closet/secure_closet/nanotrasen_consultant/PopulateContents()
 	. = ..()
-	new /obj/item/autosurgeon/paperwork/single_use(src)
+	new /obj/item/autosurgeon/paperwork(src)

--- a/modular_zubbers/code/modules/surgery/autosurgeon.dm
+++ b/modular_zubbers/code/modules/surgery/autosurgeon.dm
@@ -1,2 +1,5 @@
 /obj/item/autosurgeon/paperwork
 	starting_organ = /obj/item/organ/cyberimp/arm/toolkit/paperwork
+
+/obj/item/autosurgeon/paperwork/single_use
+	uses = 1

--- a/modular_zubbers/code/modules/surgery/autosurgeon.dm
+++ b/modular_zubbers/code/modules/surgery/autosurgeon.dm
@@ -1,5 +1,4 @@
 /obj/item/autosurgeon/paperwork
 	starting_organ = /obj/item/organ/cyberimp/arm/toolkit/paperwork
-
-/obj/item/autosurgeon/paperwork/single_use
+	desc = "A single use autosurgeon that contains a paperwork arm implant augment. A screwdriver can be used to remove it, but implants can't be placed back in."
 	uses = 1


### PR DESCRIPTION
## About The Pull Request

The HoP and NTC started with a REUSABLE autosurgeon in their lockers, instead of a single use one. Thankfully this had gone unnoticed until like, yesterday. Anyways quick fix to avoid people from abusing this

## Why It's Good For The Game

mfw NTC and HOP have free self-surgery

## Proof Of Testing

<img width="416" height="85" alt="image" src="https://github.com/user-attachments/assets/355a6cea-9504-446a-9c27-7fb26a44c593" />


</details>

## Changelog

:cl:
fix: Switched the reusable autosurgeon NTCs and HOPs had access to with a single use one.
/:cl:
