### PR TITLE
Renames All Storytellers in accordance with Staff Consensus

### DIFF
--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_0_extended.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_0_extended.dm
@@ -1,5 +1,5 @@
 /datum/storyteller/extended
-	name = "Extended (No Chaos)"
+	name = "Extended (No Event/Antag Rolls)"
 	desc = "Extended is the absence of a Storyteller. It will not spawn a single event of any sort, or run any Antagonists. Best for rounds where the population is so low that not even peaceful storytellers are low enough."
 	welcome_text = "How is dorms already full? The shift hasn't even started yet."
 	disable_distribution = TRUE

--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_1_chill.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_1_chill.dm
@@ -1,7 +1,7 @@
 /datum/storyteller/chill
-	name = "Chill (Low Chaos)"
-	desc = "The Chill will be light on events compared to other storytellers, especially so on ones involving combat, destruction, or chaos. \
-	The least hectic storyteller of all, while still having some spice. Best for RP-focused rounds with a few events sprinkled in."
+	name = "Low Event/Antag Rolls"
+	desc = "Formerly known as Chill, this storyteller will be light on events and antag rolls compared to other storytellers, especially so on ones involving combat, destruction, or chaos. \
+	The least hectic storyteller of all, while still having some spice. Best for RP-focused rounds with a few events and antags sprinkled in."
 	welcome_text = "If you vote for this storyteller on Ice Box, you have no originality."
 
 	track_data = /datum/storyteller_data/tracks/chill

--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_2_fragile.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_2_fragile.dm
@@ -1,6 +1,6 @@
 /datum/storyteller/fragile
-	name = "Fragile (Medium-Low Chaos)"
-	desc = "The Fragile will limit destructive, combat-focused, and chaotic events. \
+	name = "Mid-Low Event/Antag Rolls"
+	desc = "Formerly called Fragile, this storyteller will limit destructive, combat-focused, and chaotic events. \
 	Spawns more events and allows for more combat than the Chill, but remains lower in frequency than Default Andy. It will also repeat events less than the Chill."
 	welcome_text = "Handle with care!"
 

--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_3_default.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_3_default.dm
@@ -1,7 +1,7 @@
 /datum/storyteller/default
-	name = "Default Andy (Medium Chaos)"
-	desc = "Default Andy is the default Storyteller, and the comparison point for every other Storyteller. \
-	More frequent events than the Chill or the Fragile, but less frequent events than The Gamer or the Clown. Best for an average, varied experience."
+	name = "Default Event/Antag Rolls"
+	desc = "Formerly called Default Andy, this is the default Storyteller, and the comparison point for every other Storyteller. \
+	More frequent events than the lower intensity Chill or the Fragile, but less frequent events than Gamer or Enemy Within. Best for an average, varied experience."
 	welcome_text = "If I chopped you up in a meat grinder..."
 	antag_divisor = 8
 	storyteller_type = STORYTELLER_TYPE_ALWAYS_AVAILABLE

--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_4_bomb.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_4_bomb.dm
@@ -1,6 +1,6 @@
 /datum/storyteller/bomb
-	name = "Bomb (Medium-High Chaos)"
-	desc = "The Bomb will try to make more destructive events. For when you have a full engineering team. Or not, because they all cryo'd."
+	name = "Destructive Event/Antag Rolls"
+	desc = "Formerly known as Bomb, this storyteller will try to make more destructive events. For when you have a full engineering team. Or not, because they all cryo'd."
 	welcome_text = "Somebody set up us the bomb."
 	track_data = /datum/storyteller_data/tracks/bomb
 

--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_5_gamer.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_5_gamer.dm
@@ -1,6 +1,6 @@
 /datum/storyteller/gamer
-	name = "Gamer (High Chaos)"
-	desc = "The Gamer will try to create the most combat focused events, while trying to avoid purely destructive ones. \
+	name = "Combat/Higher Event/Antag Rolls"
+	desc = "Formerly known as Gamer, this storyteller will try to create the most combat focused events, while trying to avoid purely destructive ones. \
 	More combat-focused and frequent events than the Default, but stays ordered to avoid creating a hellshift, unlike the Clown."
 	welcome_text = "Welcome to the Gamer storyteller. Now with 50% more ahelps!"
 

--- a/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_6_enemy.dm
+++ b/modular_zubbers/code/modules/storyteller/storytellers/tellers/storyteller_6_enemy.dm
@@ -1,6 +1,6 @@
 /datum/storyteller/enemy
-	name = "Enemy Within (High Chaos)"
-	desc = "The Enemy Within aims to ensure that there are only crew antagonists while also prioritizing spawns for those antagonist types."
+	name = "Higher Crewset Antag/Event Rolls"
+	desc = "Formerly known as The Enemy Within, this storyteller aims to ensure that there are only crew antagonists while also prioritizing spawns for those antagonist types."
 	welcome_text = "Chat, I think there is an imposter among us on this Space Station 13. I have grown suspicious."
 
 	tag_multipliers = list(


### PR DESCRIPTION

## About The Pull Request

As stated, renames all storytellers due to repeated, constant confusion about the storyteller system.

`Low Event/Antag Rolls` (Chill)
`Mid-Low Event/Antag Rolls` (Fragile)
`Default Event/Antag Rolls` (Default)
`Destructive Event/Antag Rolls` (Bomb)
`Combat/Higher Event/Antag Rolls` (Gamer)
`Higher Crewset Antag/Event Rolls` (Enemy Within)
## Why It's Good For The Game

The storytellers now only contain flavor names in text. The votable titles and ones displayed during the round state their sole, mechanical logic - that is, higher, lower, or different types of event and antag rolls. The descriptions still contain flavor, as do the welcome messages.

This simplifies and will hopefully reduce the amount of "BUT THERE'S ANTAGS ON CHILL D;".
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
qol: Changed storyteller names to be more clear
/:cl:
