### PR TITLE
Changes the combat shotgun's weight class from bulky to huge.

### DIFF
--- a/modular_skyrat/modules/aesthetics/guns/code/guns.dm
+++ b/modular_skyrat/modules/aesthetics/guns/code/guns.dm
@@ -34,7 +34,6 @@
 	inhand_icon_state = "shotgun_combat"
 	inhand_x_dimension = 32
 	inhand_y_dimension = 32
-	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/gun/ballistic/shotgun/automatic/combat/compact
 	name = "\improper Peacekeeper compact combat shotgun"


### PR DESCRIPTION

## About The Pull Request
Title. It was bulky because of a skyrat override.
## Why It's Good For The Game
The combat shotgun is unique in that it has a 1.5x damage multiplier, its original upstream behavior is that it did so at the drawback of not fitting in any storage. You lug it around in your hands, risk it dropping if you get knocked down or slipped, but you do more damage. Skyrat implemented an override to this, which made it Bulky instead. Bulky means it fits on armor and the like. What this effectively did was remove any REAL reason to use other shotguns other than maybe... a few extra shells before having to reload. This is far too little of a tradeoff to justify the 1.5x damage. 

This change reverts that, carry it around like a real spaceman if you want that extra damage.
## Proof Of Testing
1 line override removal it'll work.
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
Balance: The combat shotgun that does 1.5x damage has been moved from bulky weight, to huge weight.
/:cl:
