### PR TITLE
Makes reagent/blacksmithing spears function to the base crafted spear

### DIFF
--- a/modular_skyrat/modules/reagent_forging/code/forge_weapons.dm
+++ b/modular_skyrat/modules/reagent_forging/code/forge_weapons.dm
@@ -245,8 +245,14 @@
 	AddComponent(/datum/component/jousting, max_tile_charge = 9, min_tile_charge = 6)
 	AddComponent(/datum/component/butchering, speed = 10 SECONDS, effectiveness = 70)
 	AddComponent(/datum/component/two_handed, force_multiplier = 2)
-	AddComponent(/datum/component/two_hand_reach, unwield_reach = 1, wield_reach = 2)
+	AddComponent(/datum/component/two_hand_reach, unwield_reach = 2, wield_reach = 1)
 	AddComponent(/datum/component/mindless_killer, mindless_force_override = 0, mindless_multiplier_override = 2)
+
+/obj/item/forging/reagent_weapon/spear/proc/on_wield(obj/item/source, mob/living/carbon/user)
+	armour_penetration *= 2
+
+/obj/item/forging/reagent_weapon/spear/proc/on_unwield(obj/item/source, mob/living/carbon/user)
+	armour_penetration /= 2
 
 /obj/item/forging/reagent_weapon/axe
 	name = "reagent axe"


### PR DESCRIPTION

## About The Pull Request
Upstream sync changed how spears work, this adjusts the blacksmithing/reagent spears to work the same way. Which is - 2 tile range when one handed but less damage, 1 tile range when wielded but more damage + AP.
## Why It's Good For The Game
Partially consistency given normal spears work like that, partially so the reagent spears aren't just Better Than Regular Spears In Every Conceivable Scenario By Having Both Upsides At Once.

Also, this enables spear+shield properly.
## Proof Of Testing
It Works I Tested It
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
Balance: Reagent/Smithed spears now function similar to regular spears. 2 tiles of range when one-handed, 1 tile of range but double damage and AP when wielded. 
/:cl:
