### PR TITLE
Slightly increases the fire rate of the Murphy because Obi-Wan Kenobi told me to once (also reduces AP).

### DIFF
--- a/modular_skyrat/modules/sec_haul/code/guns/bullets.dm
+++ b/modular_skyrat/modules/sec_haul/code/guns/bullets.dm
@@ -33,7 +33,7 @@
 	name = "9x19mm Murphy bullet"
 	damage = 20
 	wound_bonus = -20
-	armour_penetration = 20 //8 shots to crit a redsuit instead of 10.
+	armour_penetration = 10
 
 /obj/projectile/bullet/c9mm
 	damage = 25

--- a/modular_zubbers/code/modules/security/security_glock/gun.dm
+++ b/modular_zubbers/code/modules/security/security_glock/gun.dm
@@ -8,7 +8,7 @@
 	force = 10 //same as baton
 	accepted_magazine_type = /obj/item/ammo_box/magazine/security
 	fire_sound = 'modular_zubbers/sound/weapons/gun/lock/shot.ogg'
-	fire_delay = 5
+	fire_delay = 4
 	can_suppress = FALSE
 	projectile_damage_multiplier = 1
 	actions_types = list(/datum/action/item_action/toggle_mageject)


### PR DESCRIPTION

## About The Pull Request

Reduces the fire delay of the Murphy from 5 to 4
Reduces the AP of the Murphy bullets from 20AP to 10AP.

## Why It's Good For The Game

The gun honestly feels a little clunky, especially during lag. An increase in fire rate should help it. Hopefully this isn't too strong.

## Proof Of Testing

Untested. If it compiles, it works.

## Changelog

:cl: BurgerBB
balance: Reduces the fire delay of the Murphy from 5 to 4
/:cl:

