### PR TITLE
Adds new therapist Alt title "Anger Management"

### DIFF
--- a/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_skyrat/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -407,6 +407,7 @@
 		"Psychiatrist",
 		"Therapist",
 		"Shrink",
+		"Anger Management",
 	)
 
 /datum/job/quartermaster


### PR DESCRIPTION

## About The Pull Request
a while back i did a suggestion to add a alt title of anger management to the therapist role as it would be funny to have heads be able to sent employees who are being too agressive to anger management, and the people did agree with me, below is the link to the poll
https://discordapp.com/channels/1059199070016655462/1071095123145924679/1493318037955281089
the only change is i added inside the alt_job_titles.dm a line at line 410 to add the new job
## Why It's Good For The Game
it adds a new route for therapists to do rather then then dealing with tramadump timmy as they normaly would they can instead focus on teaching coping mechanisms
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
add: Adds new title to Psychologist "Anger Management"
/:cl:
