### PR TITLE
Adds crafting recipe for the surgery mask that also muffles speech

### DIFF
--- a/modular_zubbers/code/datums/components/crafting/tailoring.dm
+++ b/modular_zubbers/code/datums/components/crafting/tailoring.dm
@@ -63,6 +63,19 @@
 	..()
 	blacklist += subtypesof(/obj/item/clothing/mask/gas)
 
+/datum/crafting_recipe/muzzle_medical_mask
+	name = "Surgery Mask"
+	result = /obj/item/clothing/mask/breath/muzzle
+	reqs = list(/obj/item/clothing/mask/breath = 1,
+				/obj/item/clothing/mask/muzzle = 1)
+	time = 3 SECONDS
+	category = CAT_CLOTHING
+
+/datum/crafting_recipe/muzzle_medical_mask/New()
+	..()
+	blacklist += /obj/item/clothing/mask/breath/muzzle
+	blacklist += subtypesof(/obj/item/clothing/mask/muzzle)
+
 /datum/crafting_recipe/hudsunciv
 	name = "Civilian HUDsunglasses"
 	result = /obj/item/clothing/glasses/hud/civilian/sunglasses

--- a/modular_zubbers/code/datums/components/crafting/tailoring.dm
+++ b/modular_zubbers/code/datums/components/crafting/tailoring.dm
@@ -73,7 +73,7 @@
 
 /datum/crafting_recipe/muzzle_medical_mask/New()
 	..()
-	blacklist += /obj/item/clothing/mask/breath/muzzle
+	blacklist += typesof(/obj/item/clothing/mask/breath/muzzle)
 	blacklist += subtypesof(/obj/item/clothing/mask/muzzle)
 
 /datum/crafting_recipe/hudsunciv


### PR DESCRIPTION

## About The Pull Request

Adds a recipe for this thing. Works with every subtype of breath mask except itself and some weird rare ones. Only works with the default muzzle, not any of the tape strip muzzles or anything.
<img width="732" height="228" alt="image" src="https://github.com/user-attachments/assets/948ccbdf-9504-43c1-87f2-a38c25b3448d" />

## Why It's Good For The Game

it's a little freakayyyy aha... also it can silence screams from doing robotic surgery

## Proof Of Testing

<img width="477" height="98" alt="image" src="https://github.com/user-attachments/assets/becf340e-34d1-46f1-8704-fca26ae40466" />

## Changelog

:cl:
add: Added a crafting recipe for the Surgery Mask, the breath mask that muffles its wearer.
/:cl:
