### PR TITLE
Fix all admin TGUI panels requiring the R_ADMIN permission

### DIFF
--- a/modular_zubbers/code/modules/admin/player_panel.dm
+++ b/modular_zubbers/code/modules/admin/player_panel.dm
@@ -9,11 +9,6 @@ GLOBAL_LIST_INIT(mute_bits, list(
 
 GLOBAL_DATUM_INIT(admin_state, /datum/ui_state/admin_state, new)
 
-/datum/ui_state/admin_state/can_use_topic(src_object, mob/user)
-	if(check_rights_for(user.client, R_ADMIN))
-		return UI_INTERACTIVE
-	return UI_CLOSE
-
 GLOBAL_LIST_INIT(pp_limbs, list(
 	"Head" 		= BODY_ZONE_HEAD,
 	"Left leg" 	= BODY_ZONE_L_LEG,


### PR DESCRIPTION
## About The Pull Request

In `modular_zubbers/code/modules/admin/player_panel.dm` there was an overwrite for the `/datum/ui_state/admin_state/can_use_topic(src_object, mob/user)` proc which was hard coded to check if the admin opening a TGUI window had a `R_ADMIN` permission. This is bad, because that permission gives access to like 90% of all permissions available in the admin panel - meaning that you cannot create admins with say, only the permission to spawn stuff using the `R_SPAWN` flag.

This PR fixes it by removing the overwrite - as this proc is also present in `code/modules/tgui/states/admin.dm` on line 24, and it does exactly the same thing, except that it checks the TGUI panels required perms, vs only the `R_ADMIN` flag.

## Why It's Good For The Game

Fixes most admin windows requiring the `R_ADMIN` flag to open - they will now require the flag set in `required_perms` (which is `R_ADMIN` by default).

## Proof Of Testing

<img width="1500" height="391" alt="image" src="https://github.com/user-attachments/assets/26da7eb7-2a94-4a88-86e6-ec61cd1e4e77" />

Spawn panel, requiring the `R_SPAWN` flag, open despite me not having the `R_ADMIN` flag.

## Changelog

:cl: Swan
fix: fixes some admin TGUI menus requiring the R_ADMIN flag instead of any other permission flag.
/:cl: