### PR TITLE
removes the centdrobe and commdrobe at the interlink

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -15786,7 +15786,7 @@
 /obj/item/paper_bin,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/multitool,
-/turf/open/floor/wood/large,
+/turf/open/floor/carpet/executive,
 /area/centcom/central_command_areas/admin/interlink)
 "pFr" = (
 /obj/machinery/door/airlock/security{
@@ -16149,7 +16149,7 @@
 /area/centcom/interlink)
 "pVD" = (
 /obj/structure/dresser,
-/turf/open/floor/wood/large,
+/turf/open/floor/carpet/executive,
 /area/centcom/central_command_areas/admin/interlink)
 "pWH" = (
 /obj/structure/showcase/fakeid{
@@ -20360,7 +20360,7 @@
 "uAY" = (
 /obj/structure/bed/double,
 /obj/item/bedsheet/centcom/double,
-/turf/open/floor/wood/large,
+/turf/open/floor/carpet/executive,
 /area/centcom/central_command_areas/admin/interlink)
 "uCK" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -44416,8 +44416,8 @@ cAd
 cAd
 cAd
 oMF
-cAd
-cAd
+lFv
+lFv
 cAd
 cAd
 lEu
@@ -44675,7 +44675,7 @@ rPG
 lEu
 aXQ
 fIk
-lFv
+cAd
 uAY
 lEu
 aaa

--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -2035,16 +2035,13 @@
 /turf/open/floor/iron/dark,
 /area/centcom/interlink)
 "aXQ" = (
-/obj/machinery/vending/access/command{
-	pixel_x = 28;
-	density = 0;
-	shut_up = 1
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/item/clothing/neck/large_scarf/green,
+/obj/item/clothing/head/hats/intern{
+	pixel_y = 9
 	},
-/obj/machinery/vending/wardrobe/cent_wardrobe{
-	density = 0;
-	pixel_y = 31;
-	pixel_x = 6;
-	shut_up = 1
+/obj/item/clothing/under/rank/centcom/intern{
+	pixel_y = -3
 	},
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/admin/interlink)
@@ -4181,7 +4178,7 @@
 /obj/machinery/door/airlock/centcom{
 	name = "Administrative Office"
 	},
-/turf/open/floor/wood/large,
+/turf/closed/indestructible/fakedoor,
 /area/centcom/central_command_areas/admin/interlink)
 "dhg" = (
 /obj/effect/light_emitter/interlink,
@@ -12975,10 +12972,6 @@
 /area/centcom/interlink/dorm_rooms)
 "mEr" = (
 /obj/structure/table/wood,
-/obj/item/stamp/centcom{
-	pixel_x = -8;
-	pixel_y = 10
-	},
 /obj/item/stamp/denied{
 	pixel_x = 8;
 	pixel_y = 10
@@ -13008,6 +13001,10 @@
 	pixel_y = -3
 	},
 /obj/effect/mapping_helpers/requests_console/announcement,
+/obj/item/stamp/granted{
+	pixel_y = 10;
+	pixel_x = -4
+	},
 /turf/open/floor/carpet/executive,
 /area/centcom/central_command_areas/admin/interlink)
 "mEA" = (
@@ -14545,11 +14542,10 @@
 /turf/open/indestructible/plating,
 /area/centcom/holding/cafe/station/maint)
 "oeg" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/indestructible{
 	id = "admin_shutters"
 	},
-/turf/open/floor/wood/large,
+/turf/closed/indestructible/fakeglass,
 /area/centcom/central_command_areas/admin/interlink)
 "ogq" = (
 /obj/structure/chair/comfy/brown{
@@ -23095,10 +23091,6 @@
 /obj/item/pen/fourcolor{
 	pixel_x = -7;
 	pixel_y = 7
-	},
-/obj/item/pen/fountain/green{
-	pixel_x = -8;
-	pixel_y = 2
 	},
 /turf/open/floor/carpet/executive,
 /area/centcom/central_command_areas/admin/interlink)
@@ -44424,10 +44416,10 @@ cAd
 cAd
 cAd
 oMF
-lFv
-lFv
-lFv
-lFv
+cAd
+cAd
+cAd
+cAd
 lEu
 aaa
 vLx

--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -4178,7 +4178,7 @@
 /obj/machinery/door/airlock/centcom{
 	name = "Administrative Office"
 	},
-/turf/closed/indestructible/fakedoor,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/admin/interlink)
 "dhg" = (
 /obj/effect/light_emitter/interlink,


### PR DESCRIPTION

## About The Pull Request

Replaces the centdrobe and commdrobe in the interlink admin office with a simple intern uniform and hat and scarf because I saw someone grab centcom gear from that office once and use it on station. Also removes the centcom stamp from the interlink admin office.

## Why It's Good For The Game

Prevents people from getting and abusing the "free" centcom stuff.

## Proof Of Testing

loads properly upon building and running.
