### PR TITLE
Makes .310 AP Unprintable

### DIFF
--- a/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/xhihao_light_arms/ammo.dm
+++ b/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/xhihao_light_arms/ammo.dm
@@ -13,7 +13,7 @@
 
 	projectile_type = /obj/projectile/bullet/strilka310/ap
 	custom_materials = AMMO_MATS_AP
-	advanced_print_req = TRUE
+	can_be_printed = FALSE
 
 /obj/projectile/bullet/strilka310/ap
 	name = ".310 armor-piercing bullet"


### PR DESCRIPTION

## About The Pull Request
This ammo does 25 damage per shot to a redsuit. The other maintainers agreed that this probably shouldn't be printable from the reloading bench.
## Why It's Good For The Game
This ammo probably shouldn't be able to be easily printed, and saved as an OPFOR only item instead.
## Proof Of Testing
I didn't have time to test it but if CI passes it works. One line change.
## Changelog
:cl:
balance: .310 AP ammo is no longer printable from the ammo bench.
/:cl:
