### PR TITLE
Removes event-random near-uncurbable brain traumas because I got a brain trauma once.

### DIFF
--- a/code/modules/events/brain_trauma.dm
+++ b/code/modules/events/brain_trauma.dm
@@ -30,11 +30,15 @@
 		break
 
 /datum/round_event/brain_trauma/proc/traumatize(mob/living/carbon/human/H)
+	/* BUBBERSTATION CHANGE: CHANGES HOW RANDOM TRAUMAS WORK
 	var/resistance = pick(
 		50;TRAUMA_RESILIENCE_BASIC,
 		30;TRAUMA_RESILIENCE_SURGERY,
 		15;TRAUMA_RESILIENCE_LOBOTOMY,
 		5;TRAUMA_RESILIENCE_MAGIC)
+	BUBBERSTATION CHANGE END. */
+
+	var/resistance = TRAUMA_RESILIENCE_SURGERY //BUBBERSTATION CHANGE: CHANGES HOW RANDOM TRAUMAS WORK.
 
 	var/trauma_type = pick_weight(list(
 		BRAIN_TRAUMA_MILD = 60,


### PR DESCRIPTION
## About The Pull Request

All brain traumas from the spontaneous brain trauma event are now exclusively surgery curable. Note that this is a storyteller event, and not the random brain trauma roll from head injury/other sources.

## Why It's Good For The Game

It's probably not a good idea to add an event that just straight up has a chance to absolutely fuck you near-permanently without any sort of mitigation you can do because of RNG. I can't think of any other event that does something similar, other than maybe the planets aligning and an immovable rod hitting a fuel tank that launches you into a plasma lake on ice box.

## Proof Of Testing

If it compiles, it werks.

## Changelog

:cl: BurgerBB
balance: All brain traumas from the spontaneous brain trauma event are now exclusively surgery curable. Note that this is a storyteller event, and not the random brain trauma roll from head injury/other sources.
/:cl:
