### PR TITLE
speedmerge or something remove pillow implant from goodies because i forgor

### DIFF
--- a/modular_zubbers/code/modules/cargo/packs/goodies.dm
+++ b/modular_zubbers/code/modules/cargo/packs/goodies.dm
@@ -192,12 +192,6 @@
 	cost = PAYCHECK_CREW * 7
 	contains = list(/obj/item/organ/cyberimp/arm/toolkit/seclite)
 
-/datum/supply_pack/goody/pillow_implant
-	name = "Cyberpillow™ Implant"
-	desc = "A pack containing one Cyberpillow™ for those sudden locker naps and bouts of SSD."
-	cost = PAYCHECK_CREW * 3
-	contains = list(/obj/item/organ/cyberimp/arm/toolkit/pillow)
-
 /datum/supply_pack/goody/penfour_implant
 	name = "Fingertip Four Color Pen Implant"
 	desc = "An implanted four colour pen, replacing a fingertip. What more could you want?"


### PR DESCRIPTION

## About The Pull Request
i forgort to remove the fukken uhhhh pillwo thing from goodies so there's currently a broken implant you can buy
## Why It's Good For The Game
bugfix good
## Proof Of Testing
if it compiles it works it's removing a non-existent item from cargo
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: Remove broken implant from cargo goodies.
/:cl:
