### PR TITLE
Re-adds the sleepy time bundle

### DIFF
--- a/modular_zubbers/code/modules/uplink/uplink_items/bundle.dm
+++ b/modular_zubbers/code/modules/uplink/uplink_items/bundle.dm
@@ -15,3 +15,11 @@
 	item = /obj/item/storage/box/syndibunny
 	cost = 8
 
+/datum/uplink_item/bundles_tc/tactical_naptime
+	name = "Sleepy Time Pajama Bundle"
+	desc = "Even soldiers need to get a good nights rest. Comes with blood-red pajamas, a blankie, a hot mug of cocoa and a fuzzy friend."
+	item = /obj/item/storage/box/syndie_kit/sleepytime
+	cost = 1
+	uplink_item_flags = NONE
+
+

--- a/modular_zubbers/code/modules/uplink/uplink_items/uplinkitems.dm
+++ b/modular_zubbers/code/modules/uplink/uplink_items/uplinkitems.dm
@@ -48,3 +48,10 @@
 	)
 	generate_items_inside(items_inside,src)
 
+/obj/item/storage/box/syndie_kit/sleepytime
+/obj/item/storage/box/syndie_kit/sleepytime/PopulateContents()
+	new /obj/item/clothing/under/syndicate/bloodred/sleepytime(src)
+	new /obj/item/reagent_containers/cup/glass/mug/coco(src)
+	new /obj/item/toy/plush/carpplushie(src)
+	new /obj/item/bedsheet/syndie(src)
+


### PR DESCRIPTION

## About The Pull Request

Re-adds the sleepy time bundle, for all your cozy operator needs. 

## Why It's Good For The Game
Someone asked, it's kinda a cute item. TG removed this for essentially no reason beyond "WE HATE FUN"
## Proof Of Testing
<img width="516" height="142" alt="image" src="https://github.com/user-attachments/assets/ce9f69a1-dda0-44b7-a11e-ede7663c8cb1" />
</details>

## Changelog
:cl:
add: the sleepy time bundle to uplinks
/:cl:
