### PR TITLE
Makes secmed grant medical and security hours, instead of just medical

### DIFF
--- a/modular_zubbers/code/modules/security/secmed/security_medic.dm
+++ b/modular_zubbers/code/modules/security/secmed/security_medic.dm
@@ -10,7 +10,7 @@
 	exp_requirements = 120
 	exp_required_type = EXP_TYPE_CREW
 	exp_required_type_department = EXP_TYPE_MEDICAL
-	exp_granted_type = EXP_TYPE_SECURITY
+	exp_granted_type = list(EXP_TYPE_SECURITY, EXP_TYPE_MEDICAL)
 	config_tag = "SECURITY_MEDIC"
 
 	outfit = /datum/outfit/job/security_medic

--- a/modular_zubbers/code/modules/security/secmed/security_medic.dm
+++ b/modular_zubbers/code/modules/security/secmed/security_medic.dm
@@ -10,7 +10,7 @@
 	exp_requirements = 120
 	exp_required_type = EXP_TYPE_CREW
 	exp_required_type_department = EXP_TYPE_MEDICAL
-	exp_granted_type = EXP_TYPE_SECURITY
+	exp_granted_type = EXP_TYPE_SECURITY, EXP_TYPE_MEDICAL
 	config_tag = "SECURITY_MEDIC"
 
 	outfit = /datum/outfit/job/security_medic
@@ -143,11 +143,3 @@
 	new /obj/item/storage/belt/security/medic/full(src)
 	new /obj/item/storage/bag/garment/secmed(src)
 
-//Prevents secmed hours from counting towards HoS
-/datum/controller/subsystem/job/setup_occupations()
-	. = ..()
-	var/list/sec_exp_list = experience_jobs_map[EXP_TYPE_SECURITY]
-	for(var/datum/job/job_type in sec_exp_list)
-		if(istype(job_type, /datum/job/security_medic))
-			LAZYREMOVE(sec_exp_list, job_type)
-			break

--- a/modular_zubbers/code/modules/security/secmed/security_medic.dm
+++ b/modular_zubbers/code/modules/security/secmed/security_medic.dm
@@ -10,7 +10,7 @@
 	exp_requirements = 120
 	exp_required_type = EXP_TYPE_CREW
 	exp_required_type_department = EXP_TYPE_MEDICAL
-	exp_granted_type = EXP_TYPE_SECURITY, EXP_TYPE_MEDICAL
+	exp_granted_type = EXP_TYPE_SECURITY, EXP_TYPE_MEDICAL,
 	config_tag = "SECURITY_MEDIC"
 
 	outfit = /datum/outfit/job/security_medic

--- a/modular_zubbers/code/modules/security/secmed/security_medic.dm
+++ b/modular_zubbers/code/modules/security/secmed/security_medic.dm
@@ -10,7 +10,7 @@
 	exp_requirements = 120
 	exp_required_type = EXP_TYPE_CREW
 	exp_required_type_department = EXP_TYPE_MEDICAL
-	exp_granted_type = EXP_TYPE_SECURITY, EXP_TYPE_MEDICAL,
+	exp_granted_type = EXP_TYPE_SECURITY
 	config_tag = "SECURITY_MEDIC"
 
 	outfit = /datum/outfit/job/security_medic


### PR DESCRIPTION

## About The Pull Request

As a secmed, you're supposed to do security work. It makes no sense that you don't get hour requirements done by playing it.

Upon further testing it appears it is not possible to provide two sets of hours. It now properly provides sec hours, however.  

## Why It's Good For The Game

secmeds dont get sec credit for playing it

## Proof Of Testing

should work

## Changelog
:cl:
add: Secmed now actually grants sec hours
/:cl:
