### PR TITLE
[BOUNTY] Allows family heirloom users to mark & rename items instead of getting a random one

### DIFF
--- a/code/datums/quirks/negative_quirks/family_heirloom.dm
+++ b/code/datums/quirks/negative_quirks/family_heirloom.dm
@@ -13,6 +13,12 @@
 /datum/quirk/item_quirk/family_heirloom/add_unique(client/client_source)
 	var/mob/living/carbon/human/human_holder = quirk_holder
 	var/obj/item/heirloom_type
+	// BUBBER EDIT ADDITION BEGIN - lets users manually designate heirlooms
+	if (!client_source?.prefs?.read_preference(/datum/preference/toggle/random_heirloom))
+		mark_action = new /datum/action/mark_family_heirloom(src)
+		mark_action.Grant(human_holder)
+		return
+	// BUBBER EDIT ADDITION END
 
 	// The quirk holder's species - we have a 50% chance, if we have a species with a set heirloom, to choose a species heirloom.
 	var/datum/species/holder_species = human_holder.dna?.species
@@ -44,6 +50,8 @@
 	)
 
 /datum/quirk/item_quirk/family_heirloom/post_add()
+	if (mark_action) // BUBBER EDIT ADDITION
+		return // BUBBER EDIT ADDITION
 	var/list/names = splittext(quirk_holder.real_name, " ")
 	var/family_name = names[names.len]
 

--- a/modular_zubbers/code/datums/quirks/negative_quirks/family_heirloom.dm
+++ b/modular_zubbers/code/datums/quirks/negative_quirks/family_heirloom.dm
@@ -1,9 +1,11 @@
+/// Typecache of types that cannot be marked as heirlooms.
 GLOBAL_LIST_INIT(invalid_heirloom_types, typecacheof(list(
 	/obj/item/card/id,
 	/obj/item/disk/nuclear,
 )))
 
 /datum/quirk/item_quirk/family_heirloom
+	/// The temporary mark action we give to users who have opted out of random items.
 	var/datum/action/mark_family_heirloom/mark_action
 
 /datum/quirk/item_quirk/family_heirloom/Destroy()

--- a/modular_zubbers/code/datums/quirks/negative_quirks/family_heirloom.dm
+++ b/modular_zubbers/code/datums/quirks/negative_quirks/family_heirloom.dm
@@ -1,0 +1,98 @@
+GLOBAL_LIST_INIT(invalid_heirloom_types, typecacheof(list(
+	/obj/item/card/id,
+	/obj/item/disk/nuclear,
+)))
+
+/datum/quirk/item_quirk/family_heirloom
+	var/datum/action/mark_family_heirloom/mark_action
+
+/datum/quirk/item_quirk/family_heirloom/Destroy()
+	. = ..()
+
+	QDEL_NULL(mark_action)
+
+/datum/quirk_constant_data/family_heirloom
+	associated_typepath = /datum/quirk/item_quirk/family_heirloom
+	customization_options = list(/datum/preference/toggle/random_heirloom)
+
+/datum/preference/toggle/random_heirloom
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "random_heirloom_toggle"
+	savefile_identifier = PREFERENCE_CHARACTER
+	can_randomize = FALSE
+	default_value = TRUE
+
+/datum/preference/toggle/random_heirloom/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	return FALSE
+
+/datum/action/mark_family_heirloom
+	name = "Mark Held Item As Heirloom"
+	desc = "Use to mark your held item as your family heirloom. Does not work on existing heirlooms."
+
+/datum/action/mark_family_heirloom/Trigger(mob/clicker, trigger_flags)
+	. = ..()
+
+	if (!.)
+		return FALSE
+
+	if (!isliving(owner))
+		return FALSE
+	var/mob/living/living_owner = owner
+
+	var/datum/quirk/item_quirk/family_heirloom/quirk = locate() in living_owner.quirks
+	if (isnull(quirk))
+		stack_trace("someone has the family heirloom action without the trait... wack. [owner]")
+		owner.balloon_alert(owner, "no quirk!")
+		return FALSE
+
+	var/obj/item/held_item = living_owner.get_active_held_item()
+
+	if (isnull(held_item))
+		living_owner.balloon_alert(living_owner, "no held item!")
+		return FALSE
+
+	if (GLOB.invalid_heirloom_types[held_item.type])
+		living_owner.balloon_alert(living_owner, "invalid item type!")
+		return FALSE
+
+	if (held_item.GetComponent(/datum/component/heirloom))
+		living_owner.balloon_alert(living_owner, "already a heirloom!")
+		return FALSE
+
+	// valid heirloom
+
+	var/new_name = tgui_input_text(
+		clicker,
+		"Enter the new name of [held_item]. (Leave blank for default name)",
+		"New name",
+		max_length = 50,
+		timeout = 60 SECONDS
+	)
+
+	var/new_desc = tgui_input_text(
+		clicker,
+		"Enter the new description of this [held_item]. (Leave blank for default desc)",
+		"New desc",
+		max_length = 256,
+		multiline = TRUE,
+		timeout = 60 SECONDS,
+	)
+
+	var/list/names = splittext(living_owner.real_name, " ")
+	var/family_name = names[names.len]
+
+	if (new_name)
+		held_item.name = "[new_name] ([held_item.name])"
+		ADD_TRAIT(held_item, TRAIT_WAS_RENAMED, REF(quirk))
+		held_item.AddElement(/datum/element/examined_when_worn)
+		SEND_SIGNAL(held_item, COMSIG_NAME_CHANGED)
+	if (new_desc)
+		held_item.desc = "[new_desc]"
+
+	held_item.AddComponent(/datum/component/heirloom, living_owner.mind, family_name)
+	living_owner.add_mob_memory(/datum/memory/key/quirk_heirloom, protagonist = living_owner, heirloom_name = initial(held_item.name))
+
+	owner.balloon_alert(owner, "heirloom set")
+	quirk.heirloom = WEAKREF(held_item)
+	quirk.mark_action = null
+	qdel(src)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9020,6 +9020,7 @@
 #include "modular_zubbers\code\datums\quirks\negative_quirks\bloodloss_dusting.dm"
 #include "modular_zubbers\code\datums\quirks\negative_quirks\brainproblems.dm"
 #include "modular_zubbers\code\datums\quirks\negative_quirks\dirty.dm"
+#include "modular_zubbers\code\datums\quirks\negative_quirks\family_heirloom.dm"
 #include "modular_zubbers\code\datums\quirks\negative_quirks\gifted.dm"
 #include "modular_zubbers\code\datums\quirks\negative_quirks\heavy_sleeper.dm"
 #include "modular_zubbers\code\datums\quirks\negative_quirks\loose_limbs.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/bubbers/family_heirloom.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/bubbers/family_heirloom.tsx
@@ -1,0 +1,8 @@
+import { CheckboxInput, type FeatureToggle } from '../../base';
+
+export const random_heirloom_toggle: FeatureToggle = {
+  name: 'Enable Random Heirlooms',
+  description:
+    'If enabled, you will recieve random heirlooms instead of being to mark your own.',
+  component: CheckboxInput,
+};


### PR DESCRIPTION

## About The Pull Request

Title. Bounty link: https://discord.com/channels/1059199070016655462/1398375166244819014

Adds a new pref option that, if disabled, gives you a one-use action that marks a held item as your heirloom and also gives a chance to rename and redescribe it (the original name is retained in parenthesis).
## Why It's Good For The Game

Gives wider variety for family heirloom users. I can finally break out the set of family jordans...
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="665" height="110" alt="image" src="https://github.com/user-attachments/assets/6a3a9c1c-676d-4daa-8031-bcf173779f50" />

https://github.com/user-attachments/assets/059c1a97-926e-4922-82b0-4fdd8aade9fd

</details>

## Changelog
:cl:
add: Family heirloom users can now use a quirk preference to, instead of getting a random item, mark an item inhand as an heirloom.
/:cl:
