### PR TITLE
Fixes the Black Mesa gateway's lighting

### DIFF
--- a/modular_skyrat/modules/mapping/code/areas/away_content.dm
+++ b/modular_skyrat/modules/mapping/code/areas/away_content.dm
@@ -5,6 +5,7 @@
 
 /area/awaymission/black_mesa
 	name = "Black Mesa Inside"
+	static_lighting = TRUE
 
 /area/awaymission/black_mesa/entrance
 	name = "Black Mesa Entrance"
@@ -265,7 +266,7 @@
 /area/awaymission/black_mesa/outside
 	name = "Black Mesa Outside"
 	static_lighting = FALSE
-	lighting
+	base_lighting_alpha = 255
 
 /area/awaymission/black_mesa/xen
 	name = "Black Mesa Xen"


### PR DESCRIPTION

## About The Pull Request
Does exactly as the title suggests. This makes it so the lighting works properly once again, or at least it did on my localhost.
## Why It's Good For The Game
People being able to see in areas where there is working lights and glowing plants is good for the game, yes.
## Proof Of Testing
Per usual, I forgot to take a screenshot. However, it worked fine locally.
## Changelog
:cl:
fix: The lighting in the Black Mesa gateway works again.
/:cl:
