### PR TITLE
Face scarf (Neck) and ranger poncho bug fixes!

### DIFF
--- a/modular_skyrat/modules/customization/modules/clothing/neck/_neck.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/neck/_neck.dm
@@ -104,14 +104,15 @@
 
 /obj/item/clothing/neck/face_scarf/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/toggle_icon, toggle_noun = "scarf")
+	AddComponent(/datum/component/toggle_clothes, "face_scarf_t")
 
-/obj/item/clothing/neck/face_scarf/click_alt(mob/user) //Make sure that toggling actually hides the snout so that it doesn't clip
+/obj/item/clothing/neck/face_scarf/update_icon(updates) //Make sure that toggling actually hides the snout so that it doesn't clip
+	. = ..()
 	if(icon_state != "face_scarf_t")
 		flags_inv = HIDEFACIALHAIR | HIDESNOUT
 	else
 		flags_inv = HIDEFACIALHAIR
-	return CLICK_ACTION_SUCCESS
+
 
 /obj/item/clothing/neck/maid_neck_cover
 	name = "maid neck cover"

--- a/modular_skyrat/modules/customization/modules/clothing/toggle_base.dm
+++ b/modular_skyrat/modules/customization/modules/clothing/toggle_base.dm
@@ -21,8 +21,11 @@
 /datum/component/toggle_clothes/proc/clothing_toggle(obj/item/clothing/source, mob/living/clicker)
 	SIGNAL_HANDLER
 
+	var/original_icon_state = initial(source.icon_state)
+	if(source.post_init_icon_state)
+		original_icon_state = initial(source.post_init_icon_state)
 	toggled = !toggled
-	source.icon_state = (toggled ? toggled_icon_state : initial(source.icon_state))
+	source.icon_state = (toggled ? toggled_icon_state : original_icon_state)
 	to_chat(clicker, "You toggle \the [source]!")
 	if(source.loc == clicker)
 		clicker.update_clothing(source.slot_flags)


### PR DESCRIPTION

## About The Pull Request

Pretty simple! Fixes two problems:
- Face scarf (Neck variant) wasn't updating the `flags_inv` because the `click_alt` proc wasn't being called, so I moved the toggle to a clothing one and then put the check on the `update_icon`
- Ranger poncho (And all clothing items with `toggle_clothing` component and a `post_init_icon_state`) would dissappear after being toggled twice, since it used the icon_state before being initialized.
## Why It's Good For The Game

Bug fixes!
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="696" height="431" alt="image" src="https://github.com/user-attachments/assets/9a167341-b7ff-4a84-8f54-d64afc990294" />
<img width="706" height="424" alt="image" src="https://github.com/user-attachments/assets/551330df-ffc4-4e4f-bdd7-e01b770c7bd7" />
<img width="708" height="444" alt="image" src="https://github.com/user-attachments/assets/1b64e0b1-70b3-4be4-9bb7-3b5c61b5fad4" />
<img width="689" height="426" alt="image" src="https://github.com/user-attachments/assets/ecc69f0e-5de5-4495-a126-8f5069e48386" />
<img width="691" height="430" alt="image" src="https://github.com/user-attachments/assets/278b18ee-98b1-4277-9400-73f54c355fe5" />

</details>

## Changelog
:cl:
fix: fixed toggling icon issues for neck-worn face scarfs an the ranger poncho (And other clothings too)
/:cl:
