### PR TITLE
Adds a general-purpose Miecz Goodie Pack for Glorious Comrade Defense

### DIFF
--- a/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/magazines.dm
+++ b/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/magazines.dm
@@ -29,7 +29,7 @@
 
 	ammo_type = /obj/item/ammo_casing/c27_54cesarzowa
 	caliber = CALIBER_CESARZOWA
-	max_ammo = 18
+	max_ammo = 20
 
 /obj/item/ammo_box/magazine/miecz/spawns_empty
 	start_empty = TRUE

--- a/modular_zubbers/code/modules/cargo/packs/goodies.dm
+++ b/modular_zubbers/code/modules/cargo/packs/goodies.dm
@@ -223,3 +223,15 @@
 	desc = "Donksoft's pop-up blaster is great for annoying coworkers. Pack contains one implant and a mini box of spare darts."
 	cost = PAYCHECK_CREW * 8
 	contains = list(/obj/item/organ/cyberimp/arm/toolkit/foamforce_implant, /obj/item/ammo_box/foambox/mini)
+
+/datum/supply_pack/goody/miecz
+	name = "Miecz Submachinegun Single-Pack"
+	desc = "Contains one Miecz Submachinegun, one of the newest guns to make it out of the PSC. Due to import fees and general rarity, this one's gonna be expensive. Contains two magazines, as well."
+	cost = PAYCHECK_COMMAND * 10
+	contains = list(/obj/item/gun/ballistic/automatic/miecz, /obj/item/ammo_box/magazine/miecz, /obj/item/ammo_box/magazine/miecz)
+
+/datum/supply_pack/goody/mieczmag
+	name = "Miecz Submachinegun Magazine Goodie Pack"
+	desc = "Contains a single magazine for the Miecz Submachinegun."
+	cost = PAYCHECK_COMMAND * 1.5
+	contains = list(/obj/item/ammo_box/magazine/miecz)

--- a/modular_zubbers/code/modules/cargo/packs/goodies.dm
+++ b/modular_zubbers/code/modules/cargo/packs/goodies.dm
@@ -228,6 +228,7 @@
 	name = "Miecz Submachinegun Single-Pack"
 	desc = "Contains one Miecz Submachinegun, one of the newest guns to make it out of the PSC. Due to import fees and general rarity, this one's gonna be expensive. Contains two magazines, as well."
 	cost = PAYCHECK_COMMAND * 10
+	access_view = ACCESS_WEAPONS
 	contains = list(/obj/item/gun/ballistic/automatic/miecz, /obj/item/ammo_box/magazine/miecz, /obj/item/ammo_box/magazine/miecz)
 
 /datum/supply_pack/goody/mieczmag

--- a/modular_zubbers/code/modules/cargo/packs/goodies.dm
+++ b/modular_zubbers/code/modules/cargo/packs/goodies.dm
@@ -227,7 +227,7 @@
 /datum/supply_pack/goody/miecz
 	name = "Miecz Submachinegun Single-Pack"
 	desc = "Contains one Miecz Submachinegun, one of the newest guns to make it out of the PSC. Due to import fees and general rarity, this one's gonna be expensive. Contains two magazines, as well."
-	cost = PAYCHECK_COMMAND * 10
+	cost = PAYCHECK_COMMAND * 10*1.25
 	access_view = ACCESS_WEAPONS
 	contains = list(/obj/item/gun/ballistic/automatic/miecz, /obj/item/ammo_box/magazine/miecz, /obj/item/ammo_box/magazine/miecz)
 

--- a/modular_zubbers/code/modules/cargo/packs/security.dm
+++ b/modular_zubbers/code/modules/cargo/packs/security.dm
@@ -132,11 +132,11 @@
 	crate_name = "nt22-hcs-mp crate"
 
 /datum/supply_pack/security/miecz
-	name = "Miecz Submachine Gun Single-Pack"
+	name = "Miecz Submachine Gun Crate"
 	crate_name = "Miecz submachine gun crate"
-	desc = "Contains a Miecz submachine gun and a spare magazine for it."
-	contains = list(/obj/item/gun/ballistic/automatic/miecz = 1,
-	/obj/item/ammo_box/magazine/miecz = 1)
+	desc = "Contains two Miecz submachine guns and a spare magazine for it."
+	contains = list(/obj/item/gun/ballistic/automatic/miecz = 2,
+	/obj/item/ammo_box/magazine/miecz = 2)
 	cost = CARGO_CRATE_VALUE * 10
 	access = ACCESS_SECURITY
 

--- a/modular_zubbers/code/modules/cargo/packs/security.dm
+++ b/modular_zubbers/code/modules/cargo/packs/security.dm
@@ -134,7 +134,7 @@
 /datum/supply_pack/security/miecz
 	name = "Miecz Submachine Gun Crate"
 	crate_name = "Miecz submachine gun crate"
-	desc = "Contains two Miecz submachine guns and a spare magazine for it."
+	desc = "Contains two Miecz submachine guns and a spare magazine for both."
 	contains = list(/obj/item/gun/ballistic/automatic/miecz = 2,
 	/obj/item/ammo_box/magazine/miecz = 2)
 	cost = CARGO_CRATE_VALUE * 10


### PR DESCRIPTION

## About The Pull Request

We're adding more balanced guns back bit by bit, but the Miecz, ever since the initial guncargo purge of the olden days, got relegated to security exclusivity. This makes no sense because it's a quirked up imported Space Polish SMG. This PR fixes that by adding it to cargo, for a price. Also, to differentiate the security order, the security SMG order now comes with two instead of just one. 

You can also buy magazine singlepacks. Waow. 

also gives it two more rounds per mag. Why was it 18 per? That was such a weird number.

## Why It's Good For The Game

more stuff to buy is funny and cool. 
## Proof Of Testing

<img width="429" height="394" alt="image" src="https://github.com/user-attachments/assets/741c4d33-386a-493d-95e4-aab26fbb6abd" />


<img width="418" height="192" alt="image" src="https://github.com/user-attachments/assets/7f25f15a-00ef-45c3-bb7d-79334f0fa557" />



</details>

## Changelog
:cl:
add: Added a Miecz goodie order, miecz mag goodie, and added an extra miecz to the sec order
add: two extra bullets to the miecz SMG mag 
/:cl:
