### PR TITLE
Adds Super Depression because I got slipped once (Removes mutual exclusivity of Depression and Hypersensitivity quirks)

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -8,7 +8,9 @@ GLOBAL_LIST_INIT_TYPED(quirk_blacklist, /list/datum/quirk, list(
 	list(/datum/quirk/item_quirk/blindness, /datum/quirk/item_quirk/scarred_eye),
 	list(/datum/quirk/item_quirk/blindness, /datum/quirk/item_quirk/fluoride_stare),
 	list(/datum/quirk/item_quirk/blindness, /datum/quirk/touchy),
-	list(/datum/quirk/jolly, /datum/quirk/depression, /datum/quirk/hypersensitive),
+	//list(/datum/quirk/jolly, /datum/quirk/depression, /datum/quirk/hypersensitive),
+	list(/datum/quirk/jolly, /datum/quirk/depression), // BUBBER EDIT ADD - no mood swings allowed
+	list(/datum/quirk/jolly, /datum/quirk/hypersensitive), // BUBBER EDIT ADD - we don't want players to be happy
 	list(/datum/quirk/no_taste, /datum/quirk/vegetarian, /datum/quirk/deviant_tastes, /datum/quirk/gamer),
 	list(/datum/quirk/pineapple_liker, /datum/quirk/pineapple_hater, /datum/quirk/gamer),
 	list(/datum/quirk/alcohol_tolerance, /datum/quirk/light_drinker),


### PR DESCRIPTION

## About The Pull Request
Removes mutual exclusivity of Hypersensitive and Depressed. Woe.

This is technically a SPLURT port but like
it's two lines and a commented out line so uh
yeah
## Why It's Good For The Game
### _**ULTRADEPRESSION UPON YE**_

(There's no reason these quirks should be mutually exclusive. They compound against one another, making the other worse. If you want to have super depression, you should be able to)
## Proof Of Testing
<img width="582" height="288" alt="image" src="https://github.com/user-attachments/assets/0549b2ee-cef3-4048-81df-2bc33923bd03" />
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
balance: Removes mutual exclusivity of "Depressed" and "Hypersensitive" quirks.
/:cl:
