### PR TITLE
adjusts tram controller code to work properly without bypasses

### DIFF
--- a/code/modules/transport/tram/tram_controller.dm
+++ b/code/modules/transport/tram/tram_controller.dm
@@ -1205,4 +1205,4 @@
 		balloon_alert(user, "needs tram!")
 		return FALSE
 
-	return ..()
+	return TRUE


### PR DESCRIPTION

## About The Pull Request

Changes a single line of code to make it so the tram controller only does the proper tram checks instead of all the normal wall-mounted checks, which will always fail in tram circumstances without bypasses.
## Why It's Good For The Game

Without the fix, the tram controller cannot be reattached and in thus, the tram will cease functioning.

## Proof Of Testing

Runs and works as intended

## Changelog
:cl:
fix: The tram controller can now be mounted to trams.
/:cl:
