### PR TITLE
Fixes a flaky test relating to the engorged cortical borer organ

### DIFF
--- a/modular_skyrat/modules/cortical_borer/code/cortical_borer.dm
+++ b/modular_skyrat/modules/cortical_borer/code/cortical_borer.dm
@@ -46,9 +46,12 @@ GLOBAL_LIST_EMPTY(cortical_borers)
 
 /obj/item/organ/borer_body/on_mob_insert(mob/living/carbon/carbon_target, special, movement_flags)
 	. = ..()
+	carbon_target.apply_status_effect(/datum/status_effect/grouped/screwy_hud/fake_healthy, type)
+	if (isnull(borer))
+		return
+	
 	for(var/datum/borer_focus/body_focus as anything in borer.body_focuses)
 		body_focus.on_add()
-	carbon_target.apply_status_effect(/datum/status_effect/grouped/screwy_hud/fake_healthy, type)
 
 //on removal, force the borer out
 /obj/item/organ/borer_body/on_mob_remove(mob/living/carbon/carbon_target, special, movement_flags)


### PR DESCRIPTION
## About The Pull Request

#5495 had a flaky CI fail due to the `/obj/item/organ/borer_body` organ, caused by it's `var/mob/living/basic/cortical_borer/borer` var being set to null. As can be seen by the stack trace, this was because that organ has a chance to be spawned by a bioscrambler anomaly, which obviously doesn't spawn a borer alongside the organ. This PR fixes this behavior.

<img width="927" height="386" alt="image" src="https://github.com/user-attachments/assets/63022c2d-27f8-462e-8f3f-570fd69a9210" />

The only reason I fix this is because the gateway test CI check has failed me a few too many times because of it and I was losing my mind.

## Why It's Good For The Game

Fixes #5321 
Fixes #5373 