### PR TITLE
Lets the GMM sell materials again

### DIFF
--- a/code/modules/cargo/materials_market.dm
+++ b/code/modules/cargo/materials_market.dm
@@ -50,9 +50,6 @@
 	if(!isstack(exportable))
 		return
 
-	balloon_alert(user, "export not available!")
-	return ITEM_INTERACT_FAILURE
-
 	if(!is_operational)
 		balloon_alert(user, "no power!")
 		return ITEM_INTERACT_FAILURE

--- a/code/modules/cargo/materials_market.dm
+++ b/code/modules/cargo/materials_market.dm
@@ -50,13 +50,9 @@
 	if(!isstack(exportable))
 		return
 
-	// BUBBER EDIT ADDITION BEGIN - GMM can't sell materials
 	balloon_alert(user, "export not available!")
 	return ITEM_INTERACT_FAILURE
-	// BUBBER EDIT ADDITION END - GMM can't sell materials
 
-	// BUBBER EDIT REMOVAL BEGIN - GMM can't sell materials
-	/*
 	if(!is_operational)
 		balloon_alert(user, "no power!")
 		return ITEM_INTERACT_FAILURE
@@ -83,8 +79,6 @@
 	qdel(exportable)
 	use_energy(active_power_usage)
 	return ITEM_INTERACT_SUCCESS
-	*/
-	// BUBBER EDIT REMOVAL END - GMM can't sell materials
 
 /obj/machinery/materials_market/power_change()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Title. You can once again get material money cubes. Money is back on the menu.

## Why It's Good For The Game
People can already sell materials to the cargo budget as is by wrapping them up in a locker and shipping it off. If people want to cheese the system for Big Money, they might as well have access to the machine intended for this. 

There's a bazillion other ways of getting obscene amounts of credits (fish gen + powerator lol), it's a fun feature, and I don't see a reason for it to remain disabled entirely. 

## Proof Of Testing
Removed the comment which disabled it so if it compiles it works.

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
add: The GMM can sell materials once more.
/:cl:

