### PR TITLE
[BOUNTY] Adds Gender And Action Filter To Dom/Sub Quirks

### DIFF
--- a/modular_zubbers/code/datums/quirks/neutral_quirks/dominant_aura.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/dominant_aura.dm
@@ -8,8 +8,87 @@
 	lose_text = span_notice("You feel less assertive than before.")
 	quirk_flags = QUIRK_HIDE_FROM_SCAN
 	erp_quirk = TRUE // Disables on ERP config.
-	/// Subs will only be affected by this quirk if both the dom and sub prefer each others' gender.
-	var/list/preferred_genders_to_dom = list(MALE, FEMALE, PLURAL, NEUTER)
+
+/datum/quirk_constant_data/dominant_aura
+	associated_typepath = /datum/quirk/dominant_aura
+	customization_options = list(
+		/datum/preference/toggle/dominant_aura/gender_pref/male,
+		/datum/preference/toggle/dominant_aura/gender_pref/female,
+		/datum/preference/toggle/dominant_aura/gender_pref/plural,
+		/datum/preference/toggle/dominant_aura/gender_pref/neuter,
+		/datum/preference/toggle/dominant_aura/gender_pref/other,
+		/datum/preference/toggle/dominant_aura/snap,
+		/datum/preference/toggle/dominant_aura/snap2,
+		/datum/preference/toggle/dominant_aura/snap3,
+		/datum/preference/toggle/dominant_aura/clicker,
+		/datum/preference/toggle/dominant_aura/sub_inspect_dom,
+		/datum/preference/toggle/dominant_aura/sub_sense_dom,
+	)
+
+/// This next section is for quirk preferences, which is how personalization of the quirk is saved to the character slot.
+/datum/preference/toggle/dominant_aura
+	abstract_type = /datum/preference/toggle/dominant_aura
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_identifier = PREFERENCE_CHARACTER
+
+	default_value = TRUE
+
+/datum/preference/toggle/dominant_aura/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences) //Unsure what this does. Revisit later
+	return FALSE
+
+/// Most of the functionalities of Dominant Aura and Well-Trained require both the dom and sub to share a preference for each other. Gender preferences are selected via the quirk menu and stored as character prefs.
+/datum/preference/toggle/dominant_aura/gender_pref
+	abstract_type = /datum/preference/toggle/dominant_aura/gender_pref
+
+/datum/preference/toggle/dominant_aura/gender_pref/male
+	savefile_key = "dom_aura__prefers_males"
+/datum/preference/toggle/dominant_aura/gender_pref/female
+	savefile_key = "dom_aura__prefers_females"
+/datum/preference/toggle/dominant_aura/gender_pref/plural
+	savefile_key = "dom_aura__prefers_plurals"
+/datum/preference/toggle/dominant_aura/gender_pref/neuter
+	savefile_key = "dom_aura__prefers_neuters"
+/datum/preference/toggle/dominant_aura/gender_pref/other ///This was not coded with any specific use case in mind. Just figured it'd be a good idea.
+	savefile_key = "dom_aura__prefers_other"
+
+/// Players can also opt-out of most interactions even if all other requirements are met.
+/datum/preference/toggle/dominant_aura/sub_sense_dom
+	savefile_key = "dom_aura__sub_sense_dom"
+/datum/preference/toggle/dominant_aura/snap
+	savefile_key = "dom_aura__snap"
+/datum/preference/toggle/dominant_aura/snap2
+	savefile_key = "dom_aura__snap2"
+/datum/preference/toggle/dominant_aura/snap3
+	savefile_key = "dom_aura__snap3"
+/datum/preference/toggle/dominant_aura/clicker
+	savefile_key = "dom_aura__clicker"
+/datum/preference/toggle/dominant_aura/sub_inspect_dom
+	savefile_key = "dom_aura__sub_inspect_dom"
+
+
+/datum/quirk/dominant_aura/proc/check_if_sub_is_preferred(mob/living/carbon/human/sub)
+	if(!quirk_holder.client) //sanity
+		return
+	switch(sub.gender)
+		if(MALE)
+			return quirk_holder.client.prefs.read_preference(/datum/preference/toggle/dominant_aura/gender_pref/male)
+		if(FEMALE)
+			return quirk_holder.client.prefs.read_preference(/datum/preference/toggle/dominant_aura/gender_pref/female)
+		if(PLURAL)
+			return quirk_holder.client.prefs.read_preference(/datum/preference/toggle/dominant_aura/gender_pref/plural)
+		if(NEUTER)
+			return quirk_holder.client.prefs.read_preference(/datum/preference/toggle/dominant_aura/gender_pref/neuter)
+		else
+			return quirk_holder.client.prefs.read_preference(/datum/preference/toggle/dominant_aura/gender_pref/other)
+
+/datum/quirk/dominant_aura/proc/check_if_dom_sub_mutually_preferred(mob/living/carbon/human/sub)
+	if(!check_if_sub_is_preferred(sub))
+		return FALSE
+	var/datum/quirk/well_trained/sub_quirk = sub.get_quirk(/datum/quirk/well_trained)
+	if(!sub_quirk.check_if_dom_is_preferred(quirk_holder))
+		return FALSE
+	else
+		return TRUE
 
 /datum/quirk/dominant_aura/add(client/client_source)
 	. = ..()
@@ -21,16 +100,6 @@
 	UnregisterSignal(quirk_holder, COMSIG_MOB_EXAMINING)
 	UnregisterSignal(quirk_holder, COMSIG_MOB_EMOTE)
 
-/datum/quirk/dominant_aura/proc/check_if_sub_is_preferred(mob/living/carbon/human/sub)
-	for(var/checked_gender in preferred_genders_to_dom)
-		if(sub.gender == checked_gender)
-			return TRUE
-
-/datum/quirk/dominant_aura/proc/check_if_dom_sub_mutually_preferred(mob/living/carbon/human/sub)
-	if(!check_if_sub_is_preferred(sub))
-		return FALSE
-	if(!sub.(insert sub preference check here))
-
 /datum/quirk/dominant_aura/proc/on_sub_examine(atom/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 
@@ -39,7 +108,7 @@
 	var/mob/living/carbon/human/sub = user
 	if(!sub.has_quirk(/datum/quirk/well_trained))
 		return
-	if(!check_if_sub_is_preferred(sub))
+	if(!check_if_dom_sub_mutually_preferred(sub))
 		return
 	if(sub.stat == DEAD)
 		return
@@ -60,10 +129,12 @@
 		return
 
 	for(var/mob/living/carbon/human/sub in hearers(world.view / 2, quirk_holder))
-		if(!sub.has_quirk(/datum/quirk/well_trained) || (sub == quirk_holder))
+		if(sub == quirk_holder || sub.stat == DEAD)
 			continue
-		if(sub.stat == DEAD)
+		if(!sub.has_quirk(/datum/quirk/well_trained))
 			continue
+		if(!check_if_dom_sub_mutually_preferred(sub))
+			return
 		var/good_x = "pet"
 		switch(sub.gender)
 			if(MALE)
@@ -73,24 +144,29 @@
 
 		switch(emote_args.key)
 			if("snap")
-				sub.dir = get_dir(sub, quirk_holder)
-				sub.emote("me", 1, "faces towards <b>[quirk_holder]</b> at attention!", TRUE)
-				to_chat(sub, span_purple("<b>[quirk_holder]</b>'s snap shoots down your spine and puts you at attention"))
+				if(quirk_holder.client.prefs.read_preference(/datum/preference/toggle/dominant_aura/snap) && sub.client.prefs.read_preference(/datum/preference/toggle/well_trained/snap))
+					sub.dir = get_dir(sub, quirk_holder)
+					sub.emote("me", 1, "faces towards <b>[quirk_holder]</b> at attention!", TRUE)
+					to_chat(sub, span_purple("<b>[quirk_holder]</b>'s snap shoots down your spine and puts you at attention."))
+					. = TRUE
 
 			if("snap2")
-				sub.dir = get_dir(sub, quirk_holder)
-				sub.Immobilize(0.3 SECONDS)
-				sub.emote("me",1,"hunches down in response to <b>[quirk_holder]'s</b> snapping.", TRUE)
-				to_chat(sub, span_purple("You hunch down and freeze in place in response to <b>[quirk_holder]</b> snapping their fingers"))
+				if(quirk_holder.client.prefs.read_preference(/datum/preference/toggle/dominant_aura/snap2) && sub.client.prefs.read_preference(/datum/preference/toggle/well_trained/snap2))
+					sub.dir = get_dir(sub, quirk_holder)
+					sub.Immobilize(0.3 SECONDS)
+					sub.emote("me",1,"hunches down in response to <b>[quirk_holder]'s</b> snapping.", TRUE)
+					to_chat(sub, span_purple("You hunch down and freeze in place in response to <b>[quirk_holder]</b> snapping their fingers."))
+					. = TRUE
 
 			if("snap3")
-				sub.KnockToFloor(knockdown_amt = 0.1 SECONDS)
-				step(sub, get_dir(sub, quirk_holder))
-				sub.emote("me",1,"falls to the floor and crawls closer to <b>[quirk_holder]</b>, following their command.",TRUE)
-				sub.do_jitter_animation(0.1 SECONDS)
-				to_chat(sub, span_purple("You throw yourself on the floor like a pathetic beast and crawl towards <b>[quirk_holder]</b> like a good, submissive [good_x]."))
+				if(quirk_holder.client.prefs.read_preference(/datum/preference/toggle/dominant_aura/snap3) && sub.client.prefs.read_preference(/datum/preference/toggle/well_trained/snap3))
+					sub.KnockToFloor(knockdown_amt = 0.1 SECONDS)
+					step(sub, get_dir(sub, quirk_holder))
+					sub.emote("me",1,"falls to the floor and crawls closer to <b>[quirk_holder]</b>, following their command.",TRUE)
+					sub.do_jitter_animation(0.1 SECONDS)
+					to_chat(sub, span_purple("You throw yourself on the floor like a pathetic beast and crawl towards <b>[quirk_holder]</b> like a good, submissive [good_x]."))
+					. = TRUE
 
-		. = TRUE
 
 //Gotta check for borg module
 	for(var/mob/living/silicon/robot/borg_sub in hearers(world.view / 2, quirk_holder))
@@ -107,26 +183,30 @@
 
 		switch(emote_args.key)
 			if("snap")
-				borg_sub.dir = get_dir(borg_sub, quirk_holder)
-				borg_sub.emote("me", 1, "faces towards <b>[quirk_holder]</b> at attention!", TRUE)
-				to_chat(borg_sub, span_purple("<b>[quirk_holder]</b>'s snap shoots down your spine and puts you at attention"))
+				if(quirk_holder.client.prefs.read_preference(/datum/preference/toggle/dominant_aura/snap) && borg_sub.client.prefs.read_preference(/datum/preference/toggle/well_trained/snap))
+					borg_sub.dir = get_dir(borg_sub, quirk_holder)
+					borg_sub.emote("me", 1, "faces towards <b>[quirk_holder]</b> at attention!", TRUE)
+					to_chat(borg_sub, span_purple("<b>[quirk_holder]</b>'s snap shoots down your spine and puts you at attention."))
+					. = TRUE
 
 			if("snap2")
-				borg_sub.dir = get_dir(borg_sub, quirk_holder)
-				borg_sub.robot_lay_down()
-				borg_sub.Stun(0.3 SECONDS)
-				borg_sub.emote("me",1,"hunches down in response to <b>[quirk_holder]'s</b> snapping.", TRUE)
-				to_chat(borg_sub, span_purple("You hunch down and freeze in place in response to <b>[quirk_holder]</b> snapping their fingers"))
+				if(quirk_holder.client.prefs.read_preference(/datum/preference/toggle/dominant_aura/snap2) && borg_sub.client.prefs.read_preference(/datum/preference/toggle/well_trained/snap2))
+					borg_sub.dir = get_dir(borg_sub, quirk_holder)
+					borg_sub.robot_lay_down()
+					borg_sub.Stun(0.3 SECONDS)
+					borg_sub.emote("me",1,"hunches down in response to <b>[quirk_holder]'s</b> snapping.", TRUE)
+					to_chat(borg_sub, span_purple("You hunch down and freeze in place in response to <b>[quirk_holder]</b> snapping their fingers."))
+					. = TRUE
 
 			if("snap3")
-				step(borg_sub, get_dir(borg_sub, quirk_holder))
-				borg_sub.robot_lay_down()
-				borg_sub.Stun(0.3 SECONDS)
-				borg_sub.emote("me",1,"crawls closer to <b>[quirk_holder]</b> and lays down, following their command.",TRUE)
-				borg_sub.do_jitter_animation(0.1 SECONDS)
-				to_chat(borg_sub, span_purple("You crawl towards <b>[quirk_holder]</b> and lay down like a good, submissive [good_x]."))
-
-		. = TRUE
+				if(quirk_holder.client.prefs.read_preference(/datum/preference/toggle/dominant_aura/snap3) && borg_sub.client.prefs.read_preference(/datum/preference/toggle/well_trained/snap3))
+					step(borg_sub, get_dir(borg_sub, quirk_holder))
+					borg_sub.robot_lay_down()
+					borg_sub.Stun(0.3 SECONDS)
+					borg_sub.emote("me",1,"crawls closer to <b>[quirk_holder]</b> and lays down, following their command.",TRUE)
+					borg_sub.do_jitter_animation(0.1 SECONDS)
+					to_chat(borg_sub, span_purple("You crawl towards <b>[quirk_holder]</b> and lay down like a good, submissive [good_x]."))
+					. = TRUE
 
 	if(.)
 		TIMER_COOLDOWN_START(quirk_holder, DOMINANT_COOLDOWN_SNAP, 10 SECONDS) // 1/10th of a second knockdown with a 10 seconds cooldown on a neutral quirk.

--- a/modular_zubbers/code/datums/quirks/neutral_quirks/dominant_aura.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/dominant_aura.dm
@@ -1,13 +1,15 @@
 /datum/quirk/dominant_aura
 	name = "Dominant Aura"
-	desc = "Your personality is assertive enough to appear as powerful to other people, so much in fact that the weaker kind can't help but throw themselves at your feet on command."
+	desc = "You are assertive enough to command your more obedient cohorts. At a snap of your fingers, you can compel their attention-- or send them to the floor."
 	icon = "fa-sort-up"
-	medical_record_text = "Patient displays a high level of assertiveness within their personality."
+	medical_record_text = "Patient displays a highly assertive personality."
 	value = 0
 	gain_text = span_notice("You feel like making someone your pet.")
-	lose_text = span_notice("You feel less assertive than before")
+	lose_text = span_notice("You feel less assertive than before.")
 	quirk_flags = QUIRK_HIDE_FROM_SCAN
 	erp_quirk = TRUE // Disables on ERP config.
+	/// Subs will only be affected by this quirk if both the dom and sub prefer each others' gender.
+	var/list/preferred_genders_to_dom = list(MALE, FEMALE, PLURAL, NEUTER)
 
 /datum/quirk/dominant_aura/add(client/client_source)
 	. = ..()
@@ -19,6 +21,11 @@
 	UnregisterSignal(quirk_holder, COMSIG_MOB_EXAMINING)
 	UnregisterSignal(quirk_holder, COMSIG_MOB_EMOTE)
 
+/datum/quirk/dominant_aura/proc/check_if_sub_is_preferred(mob/living/carbon/human/sub)
+	for(var/checked_gender in preferred_genders_to_dom)
+		if(sub.gender == checked_gender)
+			return TRUE
+
 /datum/quirk/dominant_aura/proc/on_sub_examine(atom/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 
@@ -27,9 +34,11 @@
 	var/mob/living/carbon/human/sub = user
 	if(!sub.has_quirk(/datum/quirk/well_trained))
 		return
+	if(!check_if_sub_is_preferred(sub))
+		return
 	if(sub.stat == DEAD)
 		return
-	examine_list += span_purple("You sense an aura of submissiveness radiating from them.")
+	examine_list += span_purple("[%PRONOUN_They] seem[%PRONOUN_s] submissive towards you.")
 
 /datum/quirk/dominant_aura/proc/on_snap(atom/source, datum/emote/emote_args)
 	SIGNAL_HANDLER

--- a/modular_zubbers/code/datums/quirks/neutral_quirks/dominant_aura.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/dominant_aura.dm
@@ -29,7 +29,7 @@
 		return
 	if(sub.stat == DEAD)
 		return
-	examine_list += span_purple("You can sense submissiveness irradiating from them.")
+	examine_list += span_purple("You sense an aura of submissiveness radiating from them.")
 
 /datum/quirk/dominant_aura/proc/on_snap(atom/source, datum/emote/emote_args)
 	SIGNAL_HANDLER

--- a/modular_zubbers/code/datums/quirks/neutral_quirks/dominant_aura.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/dominant_aura.dm
@@ -26,6 +26,11 @@
 		if(sub.gender == checked_gender)
 			return TRUE
 
+/datum/quirk/dominant_aura/proc/check_if_dom_sub_mutually_preferred(mob/living/carbon/human/sub)
+	if(!check_if_sub_is_preferred(sub))
+		return FALSE
+	if(!sub.(insert sub preference check here))
+
 /datum/quirk/dominant_aura/proc/on_sub_examine(atom/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 
@@ -38,7 +43,7 @@
 		return
 	if(sub.stat == DEAD)
 		return
-	examine_list += span_purple("[%PRONOUN_They] seem[%PRONOUN_s] submissive towards you.")
+	examine_list += span_purple("[sub.p_They()] seem[sub.p_s()] submissive towards you.")
 
 /datum/quirk/dominant_aura/proc/on_snap(atom/source, datum/emote/emote_args)
 	SIGNAL_HANDLER

--- a/modular_zubbers/code/datums/quirks/neutral_quirks/well_trained.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/well_trained.dm
@@ -8,7 +8,7 @@
 	lose_text = "<span class='notice'>You no longer feel like being a pet...</span>"
 	quirk_flags = QUIRK_HIDE_FROM_SCAN | QUIRK_PROCESSES
 	erp_quirk = TRUE
-	var/mob/living/carbon/human/last_dom
+	var/mob/living/last_dom
 
 /datum/quirk_constant_data/well_trained
 	associated_typepath = /datum/quirk/well_trained
@@ -127,13 +127,17 @@
 		return
 	if(!quirk_holder)
 		return
+	if(!quirk_holder.client.prefs.read_preference(/datum/preference/toggle/well_trained/sub_sense_dom))
+		return //otherwise subs that disable this effect will be permanently mood debuffed
 	. = FALSE
 	// handles calculating nearby dominant quirk holders.
-	var/list/mob/living/carbon/human/doms = viewers(world.view / 2, quirk_holder)
+	var/list/mob/living/carbon/human/humandoms = viewers(world.view / 2, quirk_holder)
+	var/list/mob/living/silicon/robot/robodoms = viewers(world.view / 2, quirk_holder)
+	var/list/mob/living/doms = humandoms + robodoms
 	var/closest_distance
-	for(var/mob/living/carbon/human/dom in doms)
+	for(var/mob/living/dom in doms)
 		if(dom != quirk_holder && dom.has_quirk(/datum/quirk/dominant_aura)) // Does the detected players have dom aura quirk and is not src player
-			if(check_if_sub_dom_mutually_preferred(dom) && (quirk_holder.client.prefs.read_preference(/datum/preference/toggle/well_trained/sub_sense_dom) && dom.client.prefs.read_preference(/datum/preference/toggle/dominant_aura/sub_sense_dom))) // Do we like each others' genders, and do we both want the aura mechanic
+			if(check_if_sub_dom_mutually_preferred(dom) && dom.client.prefs.read_preference(/datum/preference/toggle/dominant_aura/sub_sense_dom)) // Do we like each others' genders, and does the dom want the aura mechanic
 				if(!closest_distance || get_dist(quirk_holder, dom) <= closest_distance) // If original dom is not closest, set a new one
 					. = dom // set parent to new dom.
 					closest_distance = get_dist(quirk_holder, dom) // set new closest distance.

--- a/modular_zubbers/code/datums/quirks/neutral_quirks/well_trained.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/well_trained.dm
@@ -2,9 +2,9 @@
 	name = "Well-Trained"
 	desc = "You absolutely love being dominated. The thought of someone with a stronger character than yours is enough to make you act up. They can snap their fingers to send you to the floor."
 	icon = "fa-sort-down"
-	medical_record_text = "Patient can be easily swayed by a sufficiently assertive individual"
+	medical_record_text = "Patient can be easily swayed by a sufficiently assertive individual."
 	value = 0
-	gain_text = "<span class='notice'>You feel like being someone's pet</span>"
+	gain_text = "<span class='notice'>You feel like being someone's pet.</span>"
 	lose_text = "<span class='notice'>You no longer feel like being a pet...</span>"
 	quirk_flags = QUIRK_HIDE_FROM_SCAN | QUIRK_PROCESSES
 	erp_quirk = TRUE

--- a/modular_zubbers/code/datums/quirks/neutral_quirks/well_trained.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/well_trained.dm
@@ -10,6 +10,87 @@
 	erp_quirk = TRUE
 	var/mob/living/carbon/human/last_dom
 
+/datum/quirk_constant_data/well_trained
+	associated_typepath = /datum/quirk/well_trained
+	customization_options = list(
+		/datum/preference/toggle/well_trained/gender_pref/male,
+		/datum/preference/toggle/well_trained/gender_pref/female,
+		/datum/preference/toggle/well_trained/gender_pref/plural,
+		/datum/preference/toggle/well_trained/gender_pref/neuter,
+		/datum/preference/toggle/well_trained/gender_pref/other,
+		/datum/preference/toggle/well_trained/snap,
+		/datum/preference/toggle/well_trained/snap2,
+		/datum/preference/toggle/well_trained/snap3,
+		/datum/preference/toggle/well_trained/clicker,
+		/datum/preference/toggle/well_trained/sub_inspect_dom,
+		/datum/preference/toggle/well_trained/sub_sense_dom,
+	)
+
+/// This next section is for quirk preferences, which is how personalization of the quirk is saved to the character slot.
+/datum/preference/toggle/well_trained
+	abstract_type = /datum/preference/toggle/well_trained
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_identifier = PREFERENCE_CHARACTER
+
+	default_value = TRUE
+
+/datum/preference/toggle/well_trained/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences) //Unsure what this does. Revisit later
+	return FALSE
+
+/// Most of the functionalities of Dominant Aura and Well-Trained require both the dom and sub to share a preference for each other. Gender preferences are selected via the quirk menu and stored as character prefs.
+/datum/preference/toggle/well_trained/gender_pref
+	abstract_type = /datum/preference/toggle/well_trained/gender_pref
+
+/datum/preference/toggle/well_trained/gender_pref/male
+	savefile_key = "well_trained__prefers_males"
+/datum/preference/toggle/well_trained/gender_pref/female
+	savefile_key = "well_trained__prefers_females"
+/datum/preference/toggle/well_trained/gender_pref/plural
+	savefile_key = "well_trained__prefers_plurals"
+/datum/preference/toggle/well_trained/gender_pref/neuter
+	savefile_key = "well_trained__prefers_neuters"
+/datum/preference/toggle/well_trained/gender_pref/other ///This was not coded with any specific use case in mind. Just figured it'd be a good idea.
+	savefile_key = "well_trained__prefers_other"
+
+/// Players can also opt-out of most interactions even if all other requirements are met.
+/datum/preference/toggle/well_trained/sub_sense_dom
+	savefile_key = "well_trained__sub_sense_dom"
+/datum/preference/toggle/well_trained/snap
+	savefile_key = "well_trained__snap"
+/datum/preference/toggle/well_trained/snap2
+	savefile_key = "well_trained__snap2"
+/datum/preference/toggle/well_trained/snap3
+	savefile_key = "well_trained__snap3"
+/datum/preference/toggle/well_trained/clicker
+	savefile_key = "well_trained__clicker"
+/datum/preference/toggle/well_trained/sub_inspect_dom
+	savefile_key = "well_trained__sub_inspect_dom"
+
+
+/datum/quirk/well_trained/proc/check_if_dom_is_preferred(mob/living/carbon/human/dom)
+	if(!quirk_holder.client) //sanity
+		return
+	switch(dom.gender)
+		if(MALE)
+			return quirk_holder.client.prefs.read_preference(/datum/preference/toggle/well_trained/gender_pref/male)
+		if(FEMALE)
+			return quirk_holder.client.prefs.read_preference(/datum/preference/toggle/well_trained/gender_pref/female)
+		if(PLURAL)
+			return quirk_holder.client.prefs.read_preference(/datum/preference/toggle/well_trained/gender_pref/plural)
+		if(NEUTER)
+			return quirk_holder.client.prefs.read_preference(/datum/preference/toggle/well_trained/gender_pref/neuter)
+		else
+			return quirk_holder.client.prefs.read_preference(/datum/preference/toggle/well_trained/gender_pref/other)
+
+/datum/quirk/well_trained/proc/check_if_sub_dom_mutually_preferred(mob/living/carbon/human/dom)
+	if(!check_if_dom_is_preferred(dom))
+		return FALSE
+	var/datum/quirk/dominant_aura/dom_quirk = dom.get_quirk(/datum/quirk/dominant_aura)
+	if(!dom_quirk.check_if_sub_is_preferred(quirk_holder))
+		return FALSE
+	else
+		return TRUE
+
 /datum/quirk/well_trained/add(client/client_source)
 	. = ..()
 	RegisterSignal(quirk_holder, COMSIG_MOB_EXAMINING, PROC_REF(on_dom_examine))
@@ -25,9 +106,13 @@
 		return
 	if(!dom.has_quirk(/datum/quirk/dominant_aura) || (dom == quirk_holder))
 		return
+	if(!check_if_sub_dom_mutually_preferred(dom))
+		return
+	if(!(quirk_holder.client.prefs.read_preference(/datum/preference/toggle/well_trained/sub_inspect_dom) && dom.client.prefs.read_preference(/datum/preference/toggle/dominant_aura/sub_inspect_dom)))
+		return
 	if(dom.stat == DEAD)
 		return
-	examine_list += span_purple("You can't look at <b>[dom]</b> for long before flustering away")
+	examine_list += span_purple("You can't look at <b>[dom]</b> for long before flustering away.")
 
 	if(TIMER_COOLDOWN_FINISHED(dom, DOMINANT_COOLDOWN_EXAMINE))
 		to_chat(dom, span_purple("<b>[source]</b> tries to look at you but immediately looks away with a red face..."))
@@ -48,9 +133,10 @@
 	var/closest_distance
 	for(var/mob/living/carbon/human/dom in doms)
 		if(dom != quirk_holder && dom.has_quirk(/datum/quirk/dominant_aura)) // Does the detected players have dom aura quirk and is not src player
-			if(!closest_distance || get_dist(quirk_holder, dom) <= closest_distance) // If original dom is not closest, set a new one
-				. = dom // set parent to new dom.
-				closest_distance = get_dist(quirk_holder, dom) // set new closest distance.
+			if(check_if_sub_dom_mutually_preferred(dom) && (quirk_holder.client.prefs.read_preference(/datum/preference/toggle/well_trained/sub_sense_dom) && dom.client.prefs.read_preference(/datum/preference/toggle/dominant_aura/sub_sense_dom))) // Do we like each others' genders, and do we both want the aura mechanic
+				if(!closest_distance || get_dist(quirk_holder, dom) <= closest_distance) // If original dom is not closest, set a new one
+					. = dom // set parent to new dom.
+					closest_distance = get_dist(quirk_holder, dom) // set new closest distance.
 	if(!.) // If there's no dom nearby.
 		last_dom = null
 		quirk_holder.add_mood_event(DOMINANT_MOOD, /datum/mood_event/dominant/need)

--- a/modular_zubbers/code/modules/lewd_machinery/clicker.dm
+++ b/modular_zubbers/code/modules/lewd_machinery/clicker.dm
@@ -37,7 +37,10 @@
 			for(var/mob/living/carbon/human/sub in hearers(world.view / 2, living_user))
 				if(!sub.has_quirk(/datum/quirk/well_trained) || sub == living_user || sub.stat == DEAD)
 					continue
-
+// Check for matching gender preference on sub and dom, as well as if they both want the clicker interaction
+				var/datum/quirk/well_trained/sub_quirk = sub.get_quirk(/datum/quirk/well_trained)
+				if(!sub_quirk.check_if_sub_dom_mutually_preferred(living_user) || !(sub.client.prefs.read_preference(/datum/preference/toggle/well_trained/clicker) && living_user.client.prefs.read_preference(/datum/preference/toggle/dominant_aura/clicker)))
+					continue
 				if(get_dist(sub, living_user) > world.view / 2)
 					continue
 				sub.dir = get_dir(sub, living_user)
@@ -56,6 +59,11 @@
 			for(var/mob/living/silicon/robot/borg_sub in hearers(world.view / 2, living_user))
 				if(!borg_sub.has_quirk(/datum/quirk/well_trained) || borg_sub == living_user || borg_sub.stat == DEAD)
 					continue
+// Check for matching gender preference on sub and dom, as well as if they both want the clicker interaction
+				var/datum/quirk/well_trained/sub_quirk = borg_sub.get_quirk(/datum/quirk/well_trained)
+				if(!sub_quirk.check_if_sub_dom_mutually_preferred(living_user) || !(borg_sub.client.prefs.read_preference(/datum/preference/toggle/well_trained/clicker) && living_user.client.prefs.read_preference(/datum/preference/toggle/dominant_aura/clicker)))
+					continue
+
 				borg_sub.dir = get_dir(borg_sub, living_user)
 				borg_sub.emote("me", 1, "suddenly perks up in attention!", TRUE)
 				to_chat(borg_sub, span_purple("You perk up in attention hearing <b>[living_user]</b>'s click!"))

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/bubbers/dominant_aura.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/bubbers/dominant_aura.tsx
@@ -1,0 +1,61 @@
+// THIS IS A BUBBER UI FILE #BUBBERGANG😝
+import { CheckboxInput, type Feature } from '../../base';
+
+export const dom_aura__prefers_males: Feature<boolean> = {
+  name: 'Is Dom To He/Him',
+  component: CheckboxInput,
+};
+
+export const dom_aura__prefers_females: Feature<boolean> = {
+  name: 'Is Dom To She/Her',
+  component: CheckboxInput,
+};
+
+export const dom_aura__prefers_plurals: Feature<boolean> = {
+  name: 'Is Dom To They/Them',
+  component: CheckboxInput,
+};
+
+export const dom_aura__prefers_neuters: Feature<boolean> = {
+  name: 'Is Dom To It/Its',
+  component: CheckboxInput,
+};
+
+export const dom_aura__prefers_other: Feature<boolean> = {
+  name: 'Is Dom To Any Other Genders',
+  component: CheckboxInput,
+};
+
+export const dom_aura__snap: Feature<boolean> = {
+  name: 'Command Subs With *snap',
+  component: CheckboxInput,
+};
+
+export const dom_aura__snap2: Feature<boolean> = {
+  name: 'Command Subs With *snap2',
+  component: CheckboxInput,
+};
+
+export const dom_aura__snap3: Feature<boolean> = {
+  name: 'Command Subs With *snap3',
+  component: CheckboxInput,
+};
+
+export const dom_aura__clicker: Feature<boolean> = {
+  name: 'Command Subs With Clicker',
+  component: CheckboxInput,
+};
+
+export const dom_aura__sub_inspect_dom: Feature<boolean> = {
+  name: 'Embarass Subs If They Examine You',
+  component: CheckboxInput,
+  description:
+    'If unchecked, compatible subs will not blush and turn when inspecting you. ',
+};
+
+export const dom_aura__sub_sense_dom: Feature<boolean> = {
+  name: 'Aura',
+  component: CheckboxInput,
+  description:
+    'If unchecked, compatible subs will not be alerted to your presence automatically, and will not recieve a positive moodlet for being near you. ',
+};

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/bubbers/well_trained.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/bubbers/well_trained.tsx
@@ -1,0 +1,61 @@
+// THIS IS A BUBBER UI FILE #BUBBERGANG😝
+import { CheckboxInput, type Feature } from '../../base';
+
+export const well_trained__prefers_males: Feature<boolean> = {
+  name: 'Subs To He/Him',
+  component: CheckboxInput,
+};
+
+export const well_trained__prefers_females: Feature<boolean> = {
+  name: 'Subs To She/Her',
+  component: CheckboxInput,
+};
+
+export const well_trained__prefers_plurals: Feature<boolean> = {
+  name: 'Subs To They/Them',
+  component: CheckboxInput,
+};
+
+export const well_trained__prefers_neuters: Feature<boolean> = {
+  name: 'Subs To It/Its',
+  component: CheckboxInput,
+};
+
+export const well_trained__prefers_other: Feature<boolean> = {
+  name: 'Subs To Any Other Genders',
+  component: CheckboxInput,
+};
+
+export const well_trained__snap: Feature<boolean> = {
+  name: 'Be Commanded With *snap',
+  component: CheckboxInput,
+};
+
+export const well_trained__snap2: Feature<boolean> = {
+  name: 'Be Commanded With *snap2',
+  component: CheckboxInput,
+};
+
+export const well_trained__snap3: Feature<boolean> = {
+  name: 'Be Commanded With *snap3',
+  component: CheckboxInput,
+};
+
+export const well_trained__clicker: Feature<boolean> = {
+  name: 'Be Commanded With Clicker',
+  component: CheckboxInput,
+};
+
+export const well_trained__sub_inspect_dom: Feature<boolean> = {
+  name: 'Be Embarassed Upon Examining Dom',
+  component: CheckboxInput,
+  description:
+    'If unchecked, you will not blush and turn when inspecting a compatible dom. ',
+};
+
+export const well_trained__sub_sense_dom: Feature<boolean> = {
+  name: 'Dom Sense',
+  component: CheckboxInput,
+  description:
+    'If unchecked, you will not be alerted to the presence of compatible doms automatically, and will not recieve a positive moodlet for being near them. ',
+};


### PR DESCRIPTION
## About The Pull Request

Adds a configuration menu to the Dominant Aura and Well-Trained quirks, allowing for players to choose what genders they submit to or dom, as well as what actions they're okay with having mechanical effects. In order for an effect to happen (e.g. *snap3 making a sub fall to the floor), both the sub and dom must like each others' gender, and they must both have that effect enabled in their preferences.

Because this implementation uses preference code, and checks those preferences directly, both gender and action preferences can be changed while in-game simply by ticking or unticking boxes in the quirks menu. (works for cyborgs too, if they have the module for it!)

Also fixes a minor bug where borg doms wouldn't give the positive moodlet to nearby subs.

## Why It's Good For The Game

Allows for characters with Dominant Aura or Well-Trained to more accurately portray their preferences in subs/doms, and gives their players a wider breadth of submissive reactions to opt into or outta. Only blush at men, and not women (or vice versa)! Have an obedient character that can hold eye contact with a dom for more than a few seconds! Or even just have a bashful character that can ignore someone snapping at the end of a sentence. Possibilities abound!

## Proof Of Testing

Flashbang warning!

<details>
<img width="1774" height="1607" alt="image" src="https://github.com/user-attachments/assets/f0e24822-9ce8-493f-b935-f03a1ef8263f" />

</details>

## Changelog

:cl: mintyphresh
add: The Dominant Aura and Well-Trained quirks are now configurable in the quirk menu, filtering by both gender and command.
/:cl: