### PR TITLE
Partially reverts #4614, leaving record defaults but separating exploitables and security

### DIFF
--- a/code/datums/records/manifest.dm
+++ b/code/datums/records/manifest.dm
@@ -143,7 +143,8 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 		locked_dna = record_dna,
 		mind_ref = person.mind,
 		// BUBBER EDIT ADDITION BEGIN - Records
-		exploitable_information = person_client?.prefs.read_preference(/datum/preference/text/security) || "",
+		exploitable_information = person_client?.prefs.read_preference(/datum/preference/text/exploitable) || "",
+		background_information = person_client?.prefs.read_preference(/datum/preference/text/background) || "",
 		// BUBBER EDIT END
 	)
 

--- a/code/datums/records/record.dm
+++ b/code/datums/records/record.dm
@@ -168,6 +168,7 @@
 	datum/mind/mind_ref,
 	// BUBBER EDIT BEGIN - Records
 	exploitable_information = "",
+	background_information = "",
 )
 	. = ..()
 	src.locked_dna = locked_dna
@@ -176,7 +177,8 @@
 
 	GLOB.manifest.locked += src
 
-	// BUBBER EDIT BEGIN - Records
+	// BUBBER EDIT BEGIn - Records
+	src.background_information = background_information
 	src.exploitable_information = exploitable_information
 	// BUBBER EDIT END
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -409,6 +409,8 @@
 				to_chat(usr, "<b>Medical Record:</b> [target_record.past_medical_records]")
 			if(href_list["genrecords"])
 				to_chat(usr, "<b>General Record:</b> [target_record.past_general_records]")
+		if(target_locked_record && href_list["bgrecords"])
+			to_chat(usr, "<b>Background information:</b> [target_locked_record.background_information]")
 	if(isobserver(usr) || usr.mind.can_see_exploitables || usr.mind.has_exploitables_override)
 		if(target_locked_record && href_list["exprecords"])
 			to_chat(usr, "<b>Exploitable information:</b> [target_locked_record.exploitable_information]")

--- a/modular_skyrat/master_files/code/datums/records/record.dm
+++ b/modular_skyrat/master_files/code/datums/records/record.dm
@@ -11,5 +11,7 @@
 	var/past_security_records
 
 /datum/record/locked
+	/// Contains their background information.
+	var/background_information
 	/// Contains their exploitable information.,
 	var/exploitable_information

--- a/modular_skyrat/master_files/code/modules/client/preferences/flavor_text.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/flavor_text.dm
@@ -115,3 +115,24 @@
 
 /datum/preference/text/security/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	return FALSE
+
+/datum/preference/text/exploitable
+	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
+	savefile_identifier = PREFERENCE_CHARACTER
+	savefile_key = "exploitable_info"
+	maximum_value_length = MAX_FLAVOR_LEN
+
+/datum/preference/text/exploitable/create_default_value()
+	return EXPLOITABLE_DEFAULT_TEXT
+
+/datum/preference/text/exploitable/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	return FALSE
+
+/datum/preference/text/background
+	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
+	savefile_identifier = PREFERENCE_CHARACTER
+	savefile_key = "background_info"
+	maximum_value_length = MAX_FLAVOR_LEN
+
+/datum/preference/text/background/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	return FALSE

--- a/modular_skyrat/modules/records_on_examine/code/record_manifest.dm
+++ b/modular_skyrat/modules/records_on_examine/code/record_manifest.dm
@@ -86,6 +86,13 @@
 		if(!isnull(target_record)) // this can be null
 			to_chat(usr, "<b>Exploitable information:</b> [target_record.exploitable_information]")
 
+	else if(action == "show_background")
+		var/background_id = params["background_id"]
+		var/datum/record/locked/target_record = find_record(background_id, TRUE)
+		if(!isnull(target_record))
+			to_chat(usr, "<b>Background information:</b> [target_record.background_information]")
+
+
 /datum/record_manifest/ui_data(mob/user)
 	var/list/positions = list()
 

--- a/modular_zubbers/code/modules/client/verbs/character_directory.dm
+++ b/modular_zubbers/code/modules/client/verbs/character_directory.dm
@@ -194,6 +194,7 @@ GLOBAL_DATUM(character_directory, /datum/character_directory)
 		var/hypno = "Ask"
 		var/noncon = "Ask"
 		var/character_ad = ""
+		var/exploitable = ""
 		var/ref = REF(mob)
 		//Just in case something we get is not a mob
 		if(!mob)
@@ -235,6 +236,13 @@ GLOBAL_DATUM(character_directory, /datum/character_directory)
 		noncon = READ_PREFS(mob, choiced/erp_status_nc)
 		character_ad = READ_PREFS(mob, text/character_ad)
 		ooc_notes = READ_PREFS(mob, text/ooc_notes)
+		//If the user is an antagonist or Observer, we want them to be able to see exploitables in the Directory.
+		if(user.mind?.has_antag_datum(/datum/antagonist) || isobserver(user))
+			if(exploitable == EXPLOITABLE_DEFAULT_TEXT)
+				exploitable = "Unset"
+			else exploitable = READ_PREFS(mob, text/exploitable)
+		else exploitable = "Obscured"
+		//And finally, we want to get the mob's name, taking into account disguised names.
 		name = mob.real_name ? mob.name : mob.real_name
 
 		directory_mobs.Add(list(list(

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/species_features.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/species_features.tsx
@@ -90,7 +90,7 @@ export const general_record: Feature<string> = {
 export const security_record: Feature<string> = {
   name: 'Records - Personnel',
   description:
-    'Privileged information accessible by Security, antags with information, Command and the NTC. \
+    'Privileged information accessible by Security, Command and the NTC. \
     Used to throw these roles a bone, and give more information to work with. \
     For employment and criminal history, loyalties and exploitable tidbits, and more.',
   component: FeatureTextInput,
@@ -101,6 +101,22 @@ export const medical_record: Feature<string> = {
   description:
     'Viewable with medical access. \
   For things like medical history, prescriptions, DNR orders, etc.',
+  component: FeatureTextInput,
+};
+
+export const exploitable_info: Feature<string> = {
+  name: 'Records - Exploitable',
+  description:
+    'Can be IC or OOC. Viewable by certain antagonists/OPFOR users, as well as ghosts. Generally contains \
+  things like weaknesses, strengths, important background, trigger words, etc. It ALSO may contain things like \
+  antagonist preferences, e.g. if you want to be antagonized, by whom, with what, etc.',
+  component: FeatureTextInput,
+};
+
+export const background_info: Feature<string> = {
+  name: 'Records - Background',
+  description:
+    'Only viewable by yourself and ghosts. You can have whatever you want in here - it may be valuable as a way to orient yourself to what your character is.',
   component: FeatureTextInput,
 };
 

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/species_features.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/species_features.tsx
@@ -88,7 +88,7 @@ export const general_record: Feature<string> = {
 };
 
 export const security_record: Feature<string> = {
-  name: 'Records - Personnel',
+  name: 'Records - Security',
   description:
     'Privileged information accessible by Security, Command and the NTC. \
     Used to throw these roles a bone, and give more information to work with. \


### PR DESCRIPTION

## About The Pull Request

Partially reverts #4614.

Exploitables, background, and security are now separate.
## Why It's Good For The Game

This was never a good change. Exploitables and sec records hold completely separate purposes. Sec should not see every single exploitable node you have, basically. Additionally, some people have stuff in their exploitables and background they cant access right now. Exposing them again lets people retrieve them.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="787" height="620" alt="image" src="https://github.com/user-attachments/assets/b8b464a8-ff4a-40f1-a48f-086c99abb6af" />

</details>

## Changelog
:cl:
add: Exploitables, background, and security records are now distinct record fields, instead of being combinced.
/:cl:
