### PR TITLE
Fixes a infinite loop, causing MC crash.

### DIFF
--- a/modular_zubbers/code/modules/antagonists/bloodsucker/powers/veil.dm
+++ b/modular_zubbers/code/modules/antagonists/bloodsucker/powers/veil.dm
@@ -104,7 +104,6 @@
 	SIGNAL_HANDLER
 
 	identity[VISIBLE_NAME_FACE] = disguise_name
-	user.get_message_voice(disguise_name)
 
 /datum/action/cooldown/bloodsucker/veil/DeactivatePower(deactivate_flags)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Says it in the title, really.
More specificly of WHY this was causing it:
The removed line causes infinite recursion because get_message_voice() calls COMSIG_HUMAN_GET_VISIBLE, which then calls...this proc again. This wasn't even storing the result, so it was doing nothing *but* causing infinite recursion for no reason.
## Why It's Good For The Game
Mmm, no crashes.
## Proof Of Testing
Yes.
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: fixed infinite recursion bug
/:cl:
