### PR TITLE
Adds a hardlight bow goodie kit + a few bow tweaks

### DIFF
--- a/modular_zubbers/code/modules/cargo/packs/goodies.dm
+++ b/modular_zubbers/code/modules/cargo/packs/goodies.dm
@@ -241,4 +241,5 @@
 	name = "Hardlight Bow Single-Pack"
 	desc = "Contains a hardlight bow capable of defeating armor, alongside a quiver with nonlethal arrows. Ask your blacksmith for lethal arrows."
 	cost = PAYCHECK_COMMAND * 5
+	access_view = ACCESS_WEAPONS
 	contains = list(/obj/item/gun/ballistic/bow/security, /obj/item/storage/bag/quiver/lesser/security)

--- a/modular_zubbers/code/modules/cargo/packs/goodies.dm
+++ b/modular_zubbers/code/modules/cargo/packs/goodies.dm
@@ -236,3 +236,9 @@
 	desc = "Contains a single magazine for the Miecz Submachinegun."
 	cost = PAYCHECK_COMMAND * 1.5
 	contains = list(/obj/item/ammo_box/magazine/miecz)
+
+/datum/supply_pack/goody/security_bow
+	name = "Hardlight Bow Single-Pack"
+	desc = "Contains a hardlight bow capable of defeating armor, alongside a quiver with nonlethal arrows. Ask your blacksmith for lethal arrows."
+	cost = PAYCHECK_COMMAND * 5
+	contains = list(/obj/item/gun/ballistic/bow/security, /obj/item/storage/bag/quiver/lesser/security)

--- a/modular_zubbers/code/modules/cargo/packs/security.dm
+++ b/modular_zubbers/code/modules/cargo/packs/security.dm
@@ -147,6 +147,7 @@
 	contains = list(/obj/item/ammo_box/magazine/miecz = 4)
 	cost = CARGO_CRATE_VALUE * 4
 	access = ACCESS_SECURITY
+
 /datum/supply_pack/security/armory/archery_kit
 	name = "Archery Crate"
 	desc = "Two hardlight bows capable of defeating armor, alongside a mix of lethal and non/less-than-lethal arrows."

--- a/modular_zubbers/code/modules/security/sec_vouchers_vendor.dm
+++ b/modular_zubbers/code/modules/security/sec_vouchers_vendor.dm
@@ -68,7 +68,7 @@
 
 /datum/voucher_set/security/primary/archery
 	name = "Archery Kit"
-	description = "A powerful bow, a training manual, and a quiver with non/less-than-lethal arrows. You will still need to order the fletching kit from cargo if you want to make lethal arrows."
+	description = "A powerful bow, a training manual, and a quiver with non/less-than-lethal arrows. You will still need to order the fletching book from cargo if you want to make lethal arrows."
 	icon = 'icons/obj/weapons/bows/bows.dmi'
 	icon_state = "hardlightbow"
 	set_items = list(


### PR DESCRIPTION

## About The Pull Request

Title.

It costs 500 credits and only has 1 bow and a quiver with nonlethal arrows.

Fixes a typo in the voucher description.
## Why It's Good For The Game

Makes the bow more accessible. Shouldnt cause a bowtide because like, you could also just kinda get a gun for the price...
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="557" height="44" alt="image" src="https://github.com/user-attachments/assets/0d1f4e6b-ddd1-472f-bdf1-5edf4fc1b038" />

</details>

## Changelog
:cl:
add: A 500 credit hardlight bow goodie case for cargo
/:cl:
