### PR TITLE
Gives dep. guards a voucher instead of a taser, allows voucher redeeming via lathes

### DIFF
--- a/modular_skyrat/modules/goofsec/code/department_guards.dm
+++ b/modular_skyrat/modules/goofsec/code/department_guards.dm
@@ -221,7 +221,7 @@
 	l_pocket = /obj/item/restraints/handcuffs
 	backpack_contents = list(
 		/obj/item/melee/baton/security/loaded/departmental/science = 1,
-		/obj/item/gun/energy/e_gun/advtaser = 1,
+		/obj/item/security_voucher/primary = 1,
 		/obj/item/holosign_creator/security = 1
 	)
 
@@ -327,7 +327,7 @@
 	l_pocket = /obj/item/restraints/handcuffs
 	backpack_contents = list(
 		/obj/item/melee/baton/security/loaded/departmental/medical = 1,
-		/obj/item/gun/energy/e_gun/advtaser = 1,
+		/obj/item/security_voucher/primary = 1,
 		/obj/item/holosign_creator/security = 1
 	)
 
@@ -433,7 +433,7 @@
 	l_pocket = /obj/item/restraints/handcuffs
 	backpack_contents = list(
 		/obj/item/melee/baton/security/loaded/departmental/engineering = 1,
-		/obj/item/gun/energy/e_gun/advtaser = 1,
+		/obj/item/security_voucher/primary = 1,
 		/obj/item/holosign_creator/security = 1
 	)
 
@@ -540,7 +540,7 @@
 	l_pocket = /obj/item/restraints/handcuffs
 	backpack_contents = list(
 		/obj/item/melee/baton/security/loaded/departmental/cargo = 1,
-		/obj/item/gun/energy/e_gun/advtaser = 1,
+		/obj/item/security_voucher/primary = 1,
 		/obj/item/holosign_creator/security = 1
 	)
 
@@ -639,7 +639,7 @@
 	r_pocket = /obj/item/reagent_containers/spray/pepper
 	backpack_contents = list(
 		/obj/item/melee/baton/security/loaded/departmental/service = 1,
-		/obj/item/gun/energy/e_gun/advtaser = 1,
+		/obj/item/security_voucher/primary = 1,
 		/obj/item/holosign_creator/security = 1
 	)
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses

--- a/modular_zubbers/code/modules/security/sec_vouchers_vendor.dm
+++ b/modular_zubbers/code/modules/security/sec_vouchers_vendor.dm
@@ -1,10 +1,15 @@
 
 /obj/item/security_voucher
 	name = "security voucher"
-	desc = "A token to redeem a piece of equipment. Use it on a SecTech vendor."
+	desc = "A token to redeem a piece of equipment."
 	icon = 'modular_zubbers/icons/obj/security_voucher.dmi'
 	icon_state = "security_voucher_primary"
 	w_class = WEIGHT_CLASS_TINY
+
+/obj/item/security_voucher/examine(mob/user)
+	. = ..()
+
+	. += span_notice("You can redeem it at a [EXAMINE_HINT("security equipment vendor")] or [EXAMINE_HINT("any lathe")].")
 
 /obj/item/security_voucher/primary
 	name = "security primary voucher"
@@ -19,6 +24,11 @@
 	AddElement(/datum/element/voucher_redeemer, /obj/item/security_voucher/primary, /datum/voucher_set/security/primary)
 	AddElement(/datum/element/voucher_redeemer, /obj/item/security_voucher/utility, /datum/voucher_set/security/utility)
 
+/obj/machinery/rnd/production/techfab/Initialize(mapload)
+	. = ..()
+
+	AddElement(/datum/element/voucher_redeemer, /obj/item/security_voucher/primary, /datum/voucher_set/security/primary)
+	AddElement(/datum/element/voucher_redeemer, /obj/item/security_voucher/utility, /datum/voucher_set/security/utility)
 
 /datum/voucher_set/security
 	blackbox_key = "security_voucher_redeemed"
@@ -26,8 +36,6 @@
 /datum/voucher_set/security/primary
 
 /datum/voucher_set/security/utility
-
-/datum/voucher_set/security/brig_physician
 
 /datum/voucher_set/security/primary/disabler
 	name = "Disabler"


### PR DESCRIPTION

## About The Pull Request

Title.
## Why It's Good For The Game

Allows for dep. guards to expand their loadouts more. It really doesnt make them any better, because honestly, the taser is kind of the optimal choice already.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="712" height="678" alt="image" src="https://github.com/user-attachments/assets/7fb5e40a-e71c-4932-8640-d3d7ad277544" />

</details>

## Changelog
:cl:
add: Dep. guards now have a primary security voucher instead of a taser
/:cl:
