### PR TITLE
Lets you wrench plumbing machines on ducts/machinery again

### DIFF
--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -51,7 +51,7 @@
 		enable()
 
 /datum/component/plumbing/RegisterWithParent()
-	RegisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_WRENCH), PROC_REF(check_wrench))
+	// RegisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_WRENCH), PROC_REF(check_wrench)) // BUBBER EDIT REMOVAL - Let people still place machines on ducts and manifolds.
 	RegisterSignal(parent, COMSIG_MOVABLE_SET_ANCHORED, PROC_REF(toggle_active))
 	RegisterSignal(parent, COMSIG_OBJ_HIDE, PROC_REF(hide))
 	RegisterSignal(parent, COMSIG_ATOM_UPDATE_OVERLAYS, PROC_REF(create_overlays))
@@ -136,6 +136,8 @@
 		if(net.remove_plumber(src))
 			qdel(net)
 
+//BUBBER EDIT REMOVAL - Let people still place machines on ducts and manifolds.
+/*
 /datum/component/plumbing/proc/check_wrench(obj/parent_obj, mob/user, tool, processing_recipes)
 	SIGNAL_HANDLER
 
@@ -144,6 +146,7 @@
 		if(!isnull(overlap))
 			parent_obj.balloon_alert(user, "overlapping [istype(overlap, /obj/machinery/duct) ? "duct" : "machine"] detected!")
 			return ITEM_INTERACT_FAILURE
+*/
 
 /datum/component/plumbing/proc/toggle_active(obj/parent_obj, new_state)
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request
TG changed the behavior of the plumbing machinery to not allow it anymore, much to the chagrin of chem players.
## Why It's Good For The Game
Lets chem players use the setups they have been using, nice and compact. I have been requested by Several Chem Players to restore it to the old behavior.
## Proof Of Testing
<img width="216" height="224" alt="afbeelding" src="https://github.com/user-attachments/assets/6abc548a-a84e-444b-8742-9222afa18161" />
<img width="344" height="76" alt="afbeelding" src="https://github.com/user-attachments/assets/35875eb2-ab37-4a7a-8161-0246146d65cb" />
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
balance: You can once more place chemistry machines on ducts/manifolds/etc
/:cl:
