### PR TITLE
Disables lone op from being spawned via the disk being unsecured

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -23,7 +23,8 @@
 
 	if(!fake)
 		AddComponent(/datum/component/stationloving, !fake)
-		AddComponent(/datum/component/keep_me_secure, CALLBACK(src, PROC_REF(secured_process)), CALLBACK(src, PROC_REF(unsecured_process)), 10)
+		//AddComponent(/datum/component/keep_me_secure, CALLBACK(src, PROC_REF(secured_process)), CALLBACK(src, PROC_REF(unsecured_process)), 10) // BUBBER EDIT REMOVAL
+		AddComponent(/datum/component/keep_me_secure) // BUBBER EDIT ADDITION
 		SSpoints_of_interest.make_point_of_interest(src)
 	else
 		// Ensure fake disks still have examine text, but dont actually do anything


### PR DESCRIPTION

## About The Pull Request

Title.

No, this is not a salt PR, I just realized this might actually get accepted and am willing to try my luck.
## Why It's Good For The Game

I have never really thought lone op via disk encourages anything interesting. For _us_, the only effect it has is to occasionally bite us in the ass in the case of incompetent command, ending the round with no real input from Anyone Else. It just causes bitterness.

Yes, its soulful, yes its "cool", but I just dont think soul and cool factor really justify it in this case.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
del: The nuke disc can now be unsecured and wont spawn a lone operative.
/:cl:
