### PR TITLE
Blacklists CSL (Common Second Language) from Command and Security

### DIFF
--- a/code/__DEFINES/~skyrat_defines/jobs.dm
+++ b/code/__DEFINES/~skyrat_defines/jobs.dm
@@ -6,9 +6,8 @@
 #define JOB_UNAVAILABLE_AUGMENT (JOB_UNAVAILABLE_FLAVOUR + 1)
 #define JOB_UNAVAILABLE_NOHANDS (JOB_UNAVAILABLE_AUGMENT + 1)
 
-#define SEC_RESTRICTED_QUIRKS "Blind" = TRUE, "Brain Tumor" = TRUE, "Deaf" = TRUE, "Paraplegic" = TRUE, "Hemiplegic" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE, "No Guns" = TRUE, "Illiterate" = TRUE, "Nerve Stapled" = TRUE
-//#define HEAD_RESTRICTED_QUIRKS "Blind" = TRUE, "Deaf" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Brain Tumor" = TRUE, "Illiterate" = TRUE //Bubberstation edit original
-#define HEAD_RESTRICTED_QUIRKS "Deaf" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Brain Tumor" = TRUE, "Illiterate" = TRUE //BUBBERSTATION edit! This is the the new one! the old one is up there
+#define SEC_RESTRICTED_QUIRKS "Blind" = TRUE, "Brain Tumor" = TRUE, "Deaf" = TRUE, "Paraplegic" = TRUE, "Hemiplegic" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE, "No Guns" = TRUE, "Illiterate" = TRUE, "Nerve Stapled" = TRUE, "Common Second Language" = TRUE
+#define HEAD_RESTRICTED_QUIRKS "Deaf" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Brain Tumor" = TRUE, "Illiterate" = TRUE, "Common Second Language" = TRUE
 #define GUARD_RESTRICTED_QUIRKS "Blind" = TRUE, "Deaf" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE, "Nerve Stapled" = TRUE
 
 #define RESTRICTED_QUIRKS_EXCEPTIONS list("Mute" = "Signer")


### PR DESCRIPTION

## About The Pull Request
Does exactly as the title would suggest.

I also cleaned up some unnecessary Bubber comments due to it being in a Skyrat file.
## Why It's Good For The Game
These two departments arguably rely on communication more than any others. If someone takes this quirk, unless they are hyper-focused on managing their mood, chances are they'll be speaking in some language you and potentially the entire rest of security/command does not understand.

Speaking from experience, it really isn't fun and makes it incredibly difficult to play when you can't understand one or more of your team members.
## Proof Of Testing
See below.
<details>
<summary>Screenshots/Videos</summary>

<img width="1005" height="868" alt="image" src="https://github.com/user-attachments/assets/98ac6df4-d059-4f4e-ab25-013f8bda1115" />

</details>

## Changelog
:cl:
balance: The quirk 'Common Second Language' has been blacklisted from Security and Command.
/:cl:
