### PR TITLE
Makes hungry quirk -2, and customizable

### DIFF
--- a/modular_zubbers/code/datums/quirks/neutral_quirks/hungry.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/hungry.dm
@@ -2,23 +2,43 @@
 
 /datum/quirk/hungry
 	name = "Hungry"
-	desc = "For some reason, you get hungrier faster than others"
-	value = 0
+	desc = "For some reason, you get hungrier faster than others!"
+	value = -2
 	icon = FA_ICON_BOWL_FOOD
-	gain_text = span_notice("You feel like your stomach is bottomless")
-	lose_text = span_notice("You no longer feel like your stomach is bottomless")
-	medical_record_text = "Patient exhibits a significantly faster metabolism"
+	gain_text = span_notice("You feel like your stomach is bottomless.")
+	lose_text = span_notice("You no longer feel like your stomach is bottomless.")
+	medical_record_text = "Patient exhibits a significantly faster metabolism."
 	quirk_flags = QUIRK_HUMAN_ONLY
 	mail_goodies = list(/obj/item/food/chips)
 
+/datum/quirk_constant_data/hungry
+	associated_typepath = /datum/quirk/hungry
+	customization_options = list(/datum/preference/numeric/hungry_level)
+
+/datum/preference/numeric/hungry_level
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_key = "hungry_quirk_level"
+	savefile_identifier = PREFERENCE_CHARACTER
+	step = 0.1
+	minimum = 1.5
+	maximum = 3
+
+/datum/preference/numeric/hungry_level/create_default_value()
+	return 1.5
+
+
+/datum/preference/numeric/hungry_level/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	return
+
 /datum/quirk/hungry/add(client/client_source)
-	var/mob/living/carbon/human/H = quirk_holder
-	if(istype(H))
-		H.physiology.hunger_mod *= QUIRK_HUNGRY_MOD
+	var/mob/living/carbon/human/human_holder = quirk_holder
+	if(istype(human_holder))
+		human_holder.physiology.hunger_mod *= client_source.prefs.read_preference(/datum/preference/numeric/hungry_level)
 
 /datum/quirk/hungry/remove()
-	var/mob/living/carbon/human/H = quirk_holder
-	if(istype(H))
-		H.physiology.hunger_mod /= QUIRK_HUNGRY_MOD
+	var/mob/living/carbon/human/human_holder = quirk_holder
+	var/client/target_client = human_holder?.client
+	if (istype(human_holder) && target_client)
+		human_holder.physiology.hunger_mod /= target_client.prefs.read_preference(/datum/preference/numeric/hungry_level)
 
 #undef QUIRK_HUNGRY_MOD

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/bubbers/hungry.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/bubbers/hungry.tsx
@@ -1,0 +1,6 @@
+import { type Feature, FeatureNumberInput } from '../../base';
+
+export const hungry_quirk_level: Feature<number> = {
+  name: 'Hunger rate increase',
+  component: FeatureNumberInput,
+};


### PR DESCRIPTION

## About The Pull Request

Title.

The default value is also 1.5x now.
## Why It's Good For The Game

This is a negative quirk without a negative cost? Plus, customization is good.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="521" height="237" alt="image" src="https://github.com/user-attachments/assets/1794e60d-2c18-4bec-9ec9-47c531690148" />

</details>

## Changelog
:cl:
add: Hungry quirk is now -2 and customizable
/:cl:
