### PR TITLE
Takes the Skyrat Ferry Out Back With A Chain Saw

### DIFF
--- a/_maps/shuttles/skyrat/ferry_skyrat.dmm
+++ b/_maps/shuttles/skyrat/ferry_skyrat.dmm
@@ -1,328 +1,153 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aF" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "1,4"
-	},
-/area/shuttle/transport)
-"bd" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "5,1"
-	},
+/obj/item/paper_bin/carbon,
+/obj/item/pen,
+/obj/structure/table/reinforced,
+/obj/machinery/light/no_nightlight/directional/west,
+/turf/open/floor/iron/shuttle/evac,
 /area/shuttle/transport)
 "cz" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "1,6"
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4;
+	color = "#ffff81"
 	},
-/area/shuttle/transport)
-"cK" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "2,3"
-	},
-/area/shuttle/transport)
-"el" = (
 /obj/structure/chair/comfy/shuttle{
-	dir = 1
+	dir = 8
+	},
+/obj/machinery/computer/crew{
+	dir = 4;
+	density = 0;
+	pixel_x = -24
+	},
+/turf/open/floor/iron/shuttle/evac,
+/area/shuttle/transport)
+"fT" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/light/no_nightlight/directional/south,
+/obj/structure/closet/emcloset/wall/empty{
+	pixel_x = 26
+	},
+/obj/item/storage/toolbox/emergency,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/gas/alt,
+/obj/item/clothing/mask/gas/alt,
+/turf/open/floor/iron/shuttle/evac,
+/area/shuttle/transport)
+"go" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8;
+	color = "#ffff81"
+	},
+/obj/effect/turf_decal/caution{
+	dir = 4
+	},
+/turf/open/floor/iron/shuttle/ferry{
+	dir = 4;
+	icon_state = "floor"
+	},
+/area/shuttle/transport)
+"gS" = (
+/obj/structure/marker_beacon/burgundy,
+/obj/structure/fluff/metalpole/end{
+	pixel_y = -32
+	},
+/turf/closed/wall/mineral/titanium/spaceship/nodiagonal,
+/area/shuttle/transport)
+"ht" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/computer/crew{
+	dir = 8;
+	density = 0;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8;
+	color = "#ffff81"
+	},
+/turf/open/floor/iron/shuttle/evac,
+/area/shuttle/transport)
+"hw" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/indestructible/plating,
+/area/shuttle/transport)
+"jG" = (
+/obj/machinery/light/no_nightlight/directional/west,
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/iron/shuttle/evac,
+/area/shuttle/transport)
+"jP" = (
+/turf/open/floor/iron/shuttle/ferry{
+	dir = 4;
+	icon_state = "floor"
+	},
+/area/shuttle/transport)
+"nC" = (
+/obj/structure/marker_beacon/burgundy,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/transport)
+"oR" = (
+/obj/machinery/light/no_nightlight/directional/north,
+/obj/structure/closet/emcloset/wall{
+	pixel_x = 26
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/iron/shuttle/evac,
+/area/shuttle/transport)
+"rq" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8;
+	color = "#ffff81"
+	},
+/obj/effect/turf_decal/caution{
+	dir = 4
 	},
 /turf/open/floor/iron/shuttle/ferry{
 	dir = 8;
 	icon_state = "floor"
 	},
 /area/shuttle/transport)
-"fT" = (
-/turf/open/floor/iron/shuttle/ferry{
-	dir = 8;
-	icon_state = "sign_2"
-	},
-/area/shuttle/transport)
-"gd" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "3,2"
-	},
-/area/shuttle/transport)
-"go" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "16,7"
-	},
-/area/shuttle/transport)
-"gS" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "19,3"
-	},
-/area/shuttle/transport)
-"hn" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "17,9"
-	},
-/area/shuttle/transport)
-"ht" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "7,2"
-	},
-/area/shuttle/transport)
-"hw" = (
-/turf/open/floor/iron/shuttle/ferry{
-	dir = 8
-	},
-/area/shuttle/transport)
-"hY" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "15,6"
-	},
-/area/shuttle/transport)
-"io" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "17,5"
-	},
-/area/shuttle/transport)
-"iF" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "2,6"
-	},
-/area/shuttle/transport)
-"iL" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "18,9"
-	},
-/area/shuttle/transport)
-"jg" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "6,8"
-	},
-/area/shuttle/transport)
-"jE" = (
-/obj/machinery/computer/security/shuttle,
-/turf/open/floor/iron/shuttle/ferry{
-	dir = 8
-	},
-/area/shuttle/transport)
-"jG" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "9,7"
-	},
-/area/shuttle/transport)
-"jP" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "12,3"
-	},
-/area/shuttle/transport)
-"lN" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "2,2"
-	},
-/area/shuttle/transport)
-"nf" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "19,1"
-	},
-/area/shuttle/transport)
-"ny" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "18,0"
-	},
-/area/shuttle/transport)
-"nC" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "8,4"
-	},
-/area/shuttle/transport)
-"oR" = (
-/turf/open/floor/iron/shuttle/ferry{
-	dir = 8;
-	icon_state = "sign_1"
-	},
-/area/shuttle/transport)
-"pk" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "2,5"
-	},
-/area/shuttle/transport)
-"qm" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "16,6"
-	},
-/area/shuttle/transport)
-"qr" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "0,4"
-	},
-/area/shuttle/transport)
-"qN" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "3,8"
-	},
-/area/shuttle/transport)
-"rb" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "19,7"
-	},
-/area/shuttle/transport)
-"rg" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "18,8"
-	},
-/area/shuttle/transport)
-"rq" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "18,6"
-	},
-/area/shuttle/transport)
-"rT" = (
-/obj/machinery/computer/crew/shuttle,
-/turf/open/floor/iron/shuttle/ferry{
-	dir = 8
-	},
-/area/shuttle/transport)
 "sk" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "3,9"
-	},
-/area/shuttle/transport)
-"tq" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "17,8"
-	},
-/area/shuttle/transport)
-"tu" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "13,7"
-	},
+/obj/structure/table/reinforced,
+/obj/item/folder,
+/obj/item/crowbar,
+/obj/machinery/light/no_nightlight/directional/east,
+/turf/open/floor/iron/shuttle/evac,
 /area/shuttle/transport)
 "tB" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "14,4"
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4;
+	color = "#ffff81"
 	},
-/area/shuttle/transport)
-"tI" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "19,9"
-	},
-/area/shuttle/transport)
-"uf" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "1,7"
-	},
-/area/shuttle/transport)
-"ur" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "1,3"
-	},
-/area/shuttle/transport)
-"uD" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/turf/open/floor/iron/shuttle/ferry{
+/obj/effect/turf_decal/caution{
 	dir = 8
 	},
-/area/shuttle/transport)
-"uI" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
+/turf/open/floor/iron/shuttle/ferry{
 	dir = 8;
-	icon_state = "17,4"
-	},
-/area/shuttle/transport)
-"ve" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "1,5"
-	},
-/area/shuttle/transport)
-"vl" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "5,9"
-	},
-/area/shuttle/transport)
-"xR" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "6,2"
-	},
-/area/shuttle/transport)
-"xS" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "19,2"
-	},
-/area/shuttle/transport)
-"yB" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "4,1"
+	icon_state = "floor"
 	},
 /area/shuttle/transport)
 "yF" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "15,4"
+/obj/machinery/light/no_nightlight/directional/east,
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
 	},
+/turf/open/floor/iron/shuttle/evac,
 /area/shuttle/transport)
 "zs" = (
-/obj/effect/turf_decal/caution{
-	dir = 4
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 2;
+	color = "#ffff81"
 	},
-/obj/machinery/light/no_nightlight{
-	dir = 8
-	},
-/turf/open/floor/iron/shuttle/ferry{
-	dir = 8
-	},
-/area/shuttle/transport)
-"zN" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "17,7"
-	},
-/area/shuttle/transport)
-"AB" = (
-/obj/machinery/computer/security/shuttle{
-	dir = 4
-	},
-/turf/open/floor/iron/shuttle/ferry{
-	dir = 8
-	},
-/area/shuttle/transport)
-"AW" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/open/floor/iron/shuttle/ferry{
-	dir = 8
-	},
+/obj/machinery/power/shuttle_engine/propulsion,
+/turf/open/indestructible/plating,
 /area/shuttle/transport)
 "By" = (
 /obj/structure/fans/tiny/forcefield{
@@ -334,42 +159,8 @@
 	icon_state = "floor"
 	},
 /area/shuttle/transport)
-"Co" = (
-/obj/machinery/light/no_nightlight{
-	dir = 4
-	},
-/obj/structure/closet/shuttle/medical{
-	dir = 8
-	},
-/turf/open/floor/iron/shuttle/ferry{
-	dir = 8
-	},
-/area/shuttle/transport)
-"Cz" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "13,3"
-	},
-/area/shuttle/transport)
 "CC" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "15,5"
-	},
-/area/shuttle/transport)
-"CE" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "17,6"
-	},
-/area/shuttle/transport)
-"CL" = (
-/obj/machinery/computer/security/shuttle{
-	dir = 8
-	},
-/turf/open/floor/iron/shuttle/ferry{
-	dir = 8
-	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/transport)
 "CM" = (
 /turf/open/floor/iron/shuttle/ferry{
@@ -377,201 +168,68 @@
 	icon_state = "floor"
 	},
 /area/shuttle/transport)
-"Dt" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "12,7"
-	},
-/area/shuttle/transport)
-"Dy" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "17,2"
-	},
-/area/shuttle/transport)
 "Ed" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "19,0"
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4;
+	color = "#ffff81"
 	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/computer/security{
+	dir = 4;
+	density = 0;
+	pixel_x = -24
+	},
+/turf/open/floor/iron/shuttle/evac,
 /area/shuttle/transport)
 "Ei" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "16,3"
-	},
+/obj/structure/closet/crate,
+/turf/open/floor/iron/shuttle/evac,
 /area/shuttle/transport)
 "El" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "16,4"
-	},
-/area/shuttle/transport)
-"Ev" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin/carbon,
-/obj/machinery/light/no_nightlight{
-	dir = 8
-	},
-/turf/open/floor/iron/shuttle/ferry{
-	dir = 8
-	},
-/area/shuttle/transport)
-"Ew" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/obj/machinery/light/no_nightlight{
-	dir = 8
-	},
-/turf/open/floor/iron/shuttle/ferry{
-	dir = 8
-	},
-/area/shuttle/transport)
-"Fk" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "14,5"
-	},
+/turf/closed/wall/mineral/titanium/spaceship,
 /area/shuttle/transport)
 "Fz" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "16,5"
-	},
+/obj/machinery/power/shuttle_engine/heater,
+/turf/closed/wall/mineral/titanium/spaceship/nodiagonal,
 /area/shuttle/transport)
 "GQ" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "13,4"
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4;
+	color = "#ffff81"
 	},
-/area/shuttle/transport)
-"GX" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "7,8"
-	},
-/area/shuttle/transport)
-"GY" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Cockpit";
-	req_access = list("cent_general")
-	},
-/turf/open/floor/iron/stairs,
-/area/shuttle/transport)
-"Hn" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "18,3"
-	},
-/area/shuttle/transport)
-"HU" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "19,10"
-	},
-/area/shuttle/transport)
-"Ig" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "17,3"
-	},
-/area/shuttle/transport)
-"Im" = (
-/obj/structure/chair/comfy/shuttle{
+/obj/effect/turf_decal/caution{
 	dir = 8
 	},
 /turf/open/floor/iron/shuttle/ferry{
-	dir = 8
-	},
-/area/shuttle/transport)
-"Io" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "8,2"
-	},
-/area/shuttle/transport)
-"Ip" = (
-/obj/machinery/computer/shuttle/ferry/shuttle,
-/turf/open/floor/iron/shuttle/ferry{
-	dir = 8;
+	dir = 4;
 	icon_state = "floor"
 	},
 /area/shuttle/transport)
-"IG" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "6,9"
-	},
+"Hn" = (
+/turf/closed/wall/mineral/titanium/spaceship/nodiagonal,
 /area/shuttle/transport)
-"IM" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "18,7"
+"Io" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
 	},
-/area/shuttle/transport)
-"Ks" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8
+/obj/machinery/computer/shuttle/ferry/request{
+	dir = 2;
+	pixel_y = 24;
+	density = 0
 	},
-/area/shuttle/transport)
-"Kx" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "4,9"
-	},
-/area/shuttle/transport)
-"KY" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "17,1"
-	},
-/area/shuttle/transport)
-"Lq" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "2,8"
-	},
-/area/shuttle/transport)
-"LW" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "8,8"
+/turf/open/floor/iron/shuttle/ferry{
+	dir = 4;
+	icon_state = "floor"
 	},
 /area/shuttle/transport)
 "Mr" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "6,1"
-	},
-/area/shuttle/transport)
-"NL" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin/carbon,
-/obj/machinery/light/no_nightlight{
-	dir = 4
-	},
-/turf/open/floor/iron/shuttle/ferry{
-	dir = 8
-	},
+/turf/closed/wall/mineral/titanium,
 /area/shuttle/transport)
 "ON" = (
 /turf/template_noop,
 /area/template_noop)
-"Py" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "13,6"
-	},
-/area/shuttle/transport)
-"Pz" = (
-/obj/structure/closet/shuttle/emergency{
-	dir = 8
-	},
-/turf/open/floor/iron/shuttle/ferry{
-	dir = 8
-	},
-/area/shuttle/transport)
 "Qg" = (
 /obj/structure/fans/tiny/forcefield{
 	dir = 8
@@ -589,366 +247,143 @@
 	},
 /area/shuttle/transport)
 "Ql" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "2,7"
+/obj/effect/turf_decal/bot,
+/obj/machinery/light/no_nightlight/directional/south,
+/obj/structure/closet/generic/wall/empty{
+	pixel_x = -25;
+	name = "first-aid closet";
+	desc = "It's a storage unit for emergency medical supplies."
 	},
-/area/shuttle/transport)
-"Qo" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "0,5"
-	},
-/area/shuttle/transport)
-"QN" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "18,10"
-	},
-/area/shuttle/transport)
-"Rc" = (
-/obj/effect/turf_decal/caution{
-	dir = 8
-	},
-/obj/machinery/light/no_nightlight{
-	dir = 4
-	},
-/turf/open/floor/iron/shuttle/ferry{
-	dir = 8
-	},
-/area/shuttle/transport)
-"RL" = (
-/obj/machinery/computer/crew/shuttle{
-	dir = 8
-	},
-/turf/open/floor/iron/shuttle/ferry{
-	dir = 8
-	},
-/area/shuttle/transport)
-"Ss" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "8,7"
-	},
+/obj/item/storage/medkit/emergency,
+/obj/item/healthanalyzer,
+/obj/item/reagent_containers/hypospray,
+/turf/open/floor/iron/shuttle/evac,
 /area/shuttle/transport)
 "SN" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "18,1"
-	},
-/area/shuttle/transport)
-"SQ" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "18,4"
-	},
-/area/shuttle/transport)
-"Tk" = (
-/obj/structure/closet/shuttle/emergency{
-	dir = 1
-	},
-/obj/machinery/light/no_nightlight,
-/turf/open/floor/iron/shuttle/ferry{
-	dir = 8
-	},
-/area/shuttle/transport)
-"Tm" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "14,6"
-	},
-/area/shuttle/transport)
-"TM" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "3,1"
-	},
-/area/shuttle/transport)
-"Ud" = (
-/obj/machinery/computer/crew/shuttle{
+/obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/turf/open/floor/iron/shuttle/ferry{
+/obj/machinery/computer/security{
+	dir = 8;
+	density = 0;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8;
+	color = "#ffff81"
+	},
+/turf/open/floor/iron/shuttle/evac,
+/area/shuttle/transport)
+"SQ" = (
+/obj/machinery/light/no_nightlight/directional/north,
+/obj/structure/closet/emcloset/wall{
+	pixel_x = -25
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/iron/shuttle/evac,
+/area/shuttle/transport)
+"Tk" = (
+/obj/structure/fans/tiny/forcefield{
 	dir = 8
+	},
+/obj/machinery/door/airlock/grunge,
+/turf/open/floor/iron/shuttle/ferry{
+	dir = 4;
+	icon_state = "floor"
 	},
 /area/shuttle/transport)
 "UD" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "19,8"
+/obj/machinery/door/airlock/shuttle/glass{
+	req_access = list("cent_general")
 	},
-/area/shuttle/transport)
-"Vc" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "8,3"
-	},
-/area/shuttle/transport)
-"Xl" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "8,6"
-	},
-/area/shuttle/transport)
-"XG" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "2,4"
-	},
-/area/shuttle/transport)
-"XP" = (
-/obj/machinery/light/small/red/directional/north,
-/turf/closed/wall/mineral/titanium/shuttle_wall/window/ferry{
-	dir = 8;
-	icon_state = "18,5"
+/turf/open/floor/iron/stairs{
+	color = "#777d88"
 	},
 /area/shuttle/transport)
 "YJ" = (
-/turf/closed/wall/mineral/titanium/shuttle_wall/ferry{
-	dir = 8;
-	icon_state = "9,3"
+/obj/machinery/power/shuttle_engine/propulsion,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 2;
+	color = "#ffff81"
 	},
+/turf/open/indestructible/plating,
 /area/shuttle/transport)
 
 (1,1,1) = {"
+Mr
+nC
+CC
+CC
+CC
+CC
+CC
+Tk
+By
+CC
+Fz
+YJ
 ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ny
-Ed
 "}
 (2,1,1) = {"
-ON
-ON
-ON
-TM
-yB
-bd
-Mr
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-KY
-SN
-nf
+hw
+aF
+cz
+Ed
+Ql
+CC
+SQ
+go
+rq
+jG
+El
+Fz
+zs
 "}
 (3,1,1) = {"
-ON
-ON
-lN
-gd
-Ud
-AB
-xR
-ht
+CC
 Io
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-Dy
-Ks
-xS
-"}
-(4,1,1) = {"
-ON
-ur
-cK
-Ev
-Im
-hw
-AW
-Ew
-Vc
-YJ
-By
-By
+CM
 jP
-Cz
-ON
-ON
+CM
+UD
+jP
+CM
+jP
+CM
 Ei
-Ig
 Hn
 gS
 "}
-(5,1,1) = {"
-qr
-aF
-XG
-rT
+(4,1,1) = {"
 hw
-hw
-AW
-AW
-nC
-zs
+sk
+ht
+SN
 fT
-fT
-zs
+CC
+oR
 GQ
 tB
 yF
 El
-uI
-SQ
-ON
+Fz
+zs
 "}
-(6,1,1) = {"
-Qo
-ve
-pk
-Ip
-el
-CM
-CM
-CM
-GY
-CM
-CM
-CM
-CM
+(5,1,1) = {"
+Mr
+nC
+CC
+CC
+CC
+CC
+CC
 Tk
-Fk
+Qg
 CC
 Fz
-io
-XP
+YJ
 ON
-"}
-(7,1,1) = {"
-ON
-cz
-iF
-jE
-hw
-hw
-oR
-oR
-Xl
-Rc
-fT
-fT
-Rc
-Py
-Tm
-hY
-qm
-CE
-rq
-ON
-"}
-(8,1,1) = {"
-ON
-uf
-Ql
-NL
-uD
-uD
-Pz
-Co
-Ss
-jG
-By
-Qg
-Dt
-tu
-ON
-ON
-go
-zN
-IM
-rb
-"}
-(9,1,1) = {"
-ON
-ON
-Lq
-qN
-RL
-CL
-jg
-GX
-LW
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-tq
-rg
-UD
-"}
-(10,1,1) = {"
-ON
-ON
-ON
-sk
-Kx
-vl
-IG
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-hn
-iL
-tI
-"}
-(11,1,1) = {"
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-ON
-QN
-HU
 "}


### PR DESCRIPTION
## About The Pull Request

So there I was, porting pubby, and I thought "wow I really don't want to make such large concessions for the ert ferry" then remembered I had a redesign in my files laying around unused so here I bring you my redesign that doesn't use the unique turf icons!

## Why It's Good For The Game

The old shuttle was massive and almost every ported map had to make a large dock to fit it's wide birth. This is why we have the massive room at arrivals on meta station... its for housing _The Beast_. Needless to say, reducing the footprint so it's docking airlocks are not inset makes a huge difference for how much space mappers need to account for.

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="448" height="960" alt="image" src="https://github.com/user-attachments/assets/48012bad-1fc6-437d-813e-222400555bd7" />

</details>

:cl: Robwo
map: centcom has reevaluated its ferry design to make docking easier
/:cl:
