### PR TITLE
Fixes a runtime for clientless subs/doms

### DIFF
--- a/modular_zubbers/code/datums/quirks/neutral_quirks/dominant_aura.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/dominant_aura.dm
@@ -127,9 +127,11 @@
 		return
 	if(!TIMER_COOLDOWN_FINISHED(quirk_holder, DOMINANT_COOLDOWN_SNAP))
 		return
+	if(!quirk_holder.client)
+		return
 
 	for(var/mob/living/carbon/human/sub in hearers(world.view / 2, quirk_holder))
-		if(sub == quirk_holder || sub.stat == DEAD || (HAS_TRAIT(sub, TRAIT_QUICKREFLEXES)))
+		if(sub == quirk_holder || sub.stat == DEAD || (HAS_TRAIT(sub, TRAIT_QUICKREFLEXES)) || !sub.client)
 			continue
 		if(!sub.has_quirk(/datum/quirk/well_trained))
 			continue
@@ -170,7 +172,7 @@
 
 //Gotta check for borg module
 	for(var/mob/living/silicon/robot/borg_sub in hearers(world.view / 2, quirk_holder))
-		if(!borg_sub.has_quirk(/datum/quirk/well_trained) || (borg_sub == quirk_holder) || (HAS_TRAIT(borg_sub, TRAIT_QUICKREFLEXES)))
+		if(!borg_sub.has_quirk(/datum/quirk/well_trained) || (borg_sub == quirk_holder) || (HAS_TRAIT(borg_sub, TRAIT_QUICKREFLEXES)) || !borg_sub.client)
 			continue
 		if(borg_sub.stat == DEAD)
 			continue

--- a/modular_zubbers/code/datums/quirks/neutral_quirks/well_trained.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/well_trained.dm
@@ -108,11 +108,11 @@
 		return
 	if(!check_if_sub_dom_mutually_preferred(dom))
 		return
+	if(!quirk_holder.client)
+		return
 	if(!(quirk_holder.client.prefs.read_preference(/datum/preference/toggle/well_trained/sub_inspect_dom) && dom.client.prefs.read_preference(/datum/preference/toggle/dominant_aura/sub_inspect_dom)))
 		return
 	if(dom.stat == DEAD)
-		return
-	if(HAS_TRAIT(quirk_holder, TRAIT_QUICKREFLEXES))
 		return
 	if(HAS_TRAIT(quirk_holder, TRAIT_QUICKREFLEXES))
 		return
@@ -129,7 +129,7 @@
 		return
 	if(!TIMER_COOLDOWN_FINISHED(quirk_holder, NOTICE_COOLDOWN)) // 15 second Early return
 		return
-	if(!quirk_holder)
+	if(!quirk_holder.client)
 		return
 	if(!quirk_holder.client.prefs.read_preference(/datum/preference/toggle/well_trained/sub_sense_dom))
 		return //otherwise subs that disable this effect will be permanently mood debuffed
@@ -140,7 +140,7 @@
 	var/list/mob/living/doms = humandoms + robodoms
 	var/closest_distance
 	for(var/mob/living/dom in doms)
-		if(dom != quirk_holder && dom.has_quirk(/datum/quirk/dominant_aura)) // Does the detected players have dom aura quirk and is not src player
+		if(dom != quirk_holder && dom.has_quirk(/datum/quirk/dominant_aura) && dom.client) // Does the detected players have dom aura quirk and is not src player
 			if(check_if_sub_dom_mutually_preferred(dom) && dom.client.prefs.read_preference(/datum/preference/toggle/dominant_aura/sub_sense_dom)) // Do we like each others' genders, and does the dom want the aura mechanic
 				if(!closest_distance || get_dist(quirk_holder, dom) <= closest_distance) // If original dom is not closest, set a new one
 					. = dom // set parent to new dom.

--- a/modular_zubbers/code/modules/lewd_machinery/clicker.dm
+++ b/modular_zubbers/code/modules/lewd_machinery/clicker.dm
@@ -33,13 +33,15 @@
 // If the user has the dominant aura quirk, nearby bottoms will react to the click.
 	if(istype(user, /mob/living))
 		var/mob/living/living_user = user
-		if(living_user.has_quirk(/datum/quirk/dominant_aura) && TIMER_COOLDOWN_FINISHED(living_user, DOMINANT_COOLDOWN_SNAP))
+		if(!user.client.prefs)
+			return
+		if(living_user.has_quirk(/datum/quirk/dominant_aura) && TIMER_COOLDOWN_FINISHED(living_user, DOMINANT_COOLDOWN_SNAP) && living_user.client.prefs.read_preference(/datum/preference/toggle/dominant_aura/clicker))
 			for(var/mob/living/carbon/human/sub in hearers(world.view / 2, living_user))
 				if(!sub.has_quirk(/datum/quirk/well_trained) || sub == living_user || sub.stat == DEAD || HAS_TRAIT(sub, TRAIT_QUICKREFLEXES))
 					continue
-// Check for matching gender preference on sub and dom, as well as if they both want the clicker interaction
+// Check for matching gender preference on sub and dom, as well as if the sub wants the clicker interaction
 				var/datum/quirk/well_trained/sub_quirk = sub.get_quirk(/datum/quirk/well_trained)
-				if(!sub_quirk.check_if_sub_dom_mutually_preferred(living_user) || !(sub.client.prefs.read_preference(/datum/preference/toggle/well_trained/clicker) && living_user.client.prefs.read_preference(/datum/preference/toggle/dominant_aura/clicker)))
+				if(!sub_quirk.check_if_sub_dom_mutually_preferred(living_user) || !(sub.client.prefs.read_preference(/datum/preference/toggle/well_trained/clicker)))
 					continue
 				if(get_dist(sub, living_user) > world.view / 2)
 					continue
@@ -59,9 +61,9 @@
 			for(var/mob/living/silicon/robot/borg_sub in hearers(world.view / 2, living_user))
 				if(!borg_sub.has_quirk(/datum/quirk/well_trained) || borg_sub == living_user || borg_sub.stat == DEAD || HAS_TRAIT(borg_sub, TRAIT_QUICKREFLEXES))
 					continue
-// Check for matching gender preference on sub and dom, as well as if they both want the clicker interaction
+// Check for matching gender preference on sub and dom, as well as if the sub wants the clicker interaction
 				var/datum/quirk/well_trained/sub_quirk = borg_sub.get_quirk(/datum/quirk/well_trained)
-				if(!sub_quirk.check_if_sub_dom_mutually_preferred(living_user) || !(borg_sub.client.prefs.read_preference(/datum/preference/toggle/well_trained/clicker) && living_user.client.prefs.read_preference(/datum/preference/toggle/dominant_aura/clicker)))
+				if(!sub_quirk.check_if_sub_dom_mutually_preferred(living_user) || !(borg_sub.client.prefs.read_preference(/datum/preference/toggle/well_trained/clicker)))
 					continue
 
 				borg_sub.dir = get_dir(borg_sub, living_user)


### PR DESCRIPTION
## About The Pull Request

Adds a client check for the Well-Trained and Dominant Aura quirks, so that if you ghost out or otherwise don't have a client it doesn't repeatedly runtime.

## Why It's Good For The Game

Less runtimes make the code run better. I think

## Proof Of Testing
<details>
<img width="2622" height="1219" alt="image" src="https://github.com/user-attachments/assets/0ab4ca4c-02b5-4e5d-9be6-53b66b5f3584" />


</details>