### PR TITLE
Makes Well-Trained Characters Stay Laying Down After *snap3

### DIFF
--- a/modular_zubbers/code/datums/quirks/neutral_quirks/dominant_aura.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/dominant_aura.dm
@@ -160,7 +160,8 @@
 
 			if("snap3")
 				if(quirk_holder.client.prefs.read_preference(/datum/preference/toggle/dominant_aura/snap3) && sub.client.prefs.read_preference(/datum/preference/toggle/well_trained/snap3))
-					sub.KnockToFloor(knockdown_amt = 0.1 SECONDS)
+					if(!sub.resting)
+						sub.toggle_resting()
 					step(sub, get_dir(sub, quirk_holder))
 					sub.emote("me",1,"falls to the floor and crawls closer to <b>[quirk_holder]</b>, following their command.",TRUE)
 					sub.do_jitter_animation(0.1 SECONDS)


### PR DESCRIPTION

## About The Pull Request
Switches the Well-Trained response to a dom doing *snap3 from a 0.1 second knockdown to just toggling laying, in addition to its other effects.

## Why It's Good For The Game

One of the minor things that irks me about this effect is that, as it is currently, the sub character will just get back up as soon as the knockdown's finished. I don't want to have to test my reaction speed just to stay laying down when my character is told to.

## Proof Of Testing

<details>
<img width="1380" height="517" alt="image" src="https://github.com/user-attachments/assets/8a9a9381-436c-4d77-bfa2-aaab5a016783" />

</details>
