### PR TITLE
Make gravgen sounds respect announcement preference

### DIFF
--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -423,8 +423,9 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 			shake_camera(mobs, 15, 1)
 			mobs.playsound_local(T, null, 100, 1, 0.5, sound_to_use = alert_sound)
 	*/
-		if(mobs.client)
-			shake_camera(M = mobs, duration = 3.2 SECONDS, strength = 0.5)
+	if(mobs.client)
+		shake_camera(M = mobs, duration = 3.2 SECONDS, strength = 0.5)
+		if(mobs.client.prefs?.read_preference(/datum/preference/toggle/sound_announcements))
 			mobs.playsound_local(
 				turf_source = mob_turf,
 				soundin = alert_sound,

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -423,15 +423,15 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 			shake_camera(mobs, 15, 1)
 			mobs.playsound_local(T, null, 100, 1, 0.5, sound_to_use = alert_sound)
 	*/
-	if(mobs.client)
-		shake_camera(M = mobs, duration = 3.2 SECONDS, strength = 0.5)
-		if(mobs.client.prefs?.read_preference(/datum/preference/toggle/sound_announcements))
-			mobs.playsound_local(
-				turf_source = mob_turf,
-				soundin = alert_sound,
-				vol = 90,
-				vary = FALSE,
-			)
+		if(mobs.client)
+			shake_camera(M = mobs, duration = 3.2 SECONDS, strength = 0.5)
+			if(mobs.client.prefs?.read_preference(/datum/preference/toggle/sound_announcements))
+				mobs.playsound_local(
+					turf_source = mob_turf,
+					soundin = alert_sound,
+					vol = 90,
+					vary = FALSE,
+				)
 	/* Shut up Skyrat priority announcer
 	//SKYRAT EDIT ADDITON BEGIN
 	if(!SSmapping.level_has_any_trait(z, ZTRAIT_STATION)) // SHUT THE FUCK UP ABANDONED STATIONS, I DON'T CARE


### PR DESCRIPTION
## About The Pull Request

Gates the EXTREMELY LOUD gravity generator startup/shutdown sound behind the existing announcement sound preference with the other highly irritating Skyrat announcement sounds. Why do we even have these? Why don't we just use Tg's? Fuck it nobody is paying me to care. 

Previously, the gravity generator’s up/down sounds were played directly through `playsound_local()`, which meant they could still play even when a player had disabled announcement sounds. This PR checks `/datum/preference/toggle/sound_announcements` before playing the gravgen sound.

This only affects the sound playback. Camera shake and gravity behavior are unchanged; it actually still makes a soft sound of some kind, so it's not like you can't hear the gravgen, you can also you know, hear the radio announcement, or notice that there's no gravity.

## Why It's Good For The Game

The gravity generator restart sound is loud, lengthy, and announcement-like, so it should respect the same player preference as other announcement sounds. I can distinctly tell that these two sounds are part of the "Skyrat announcer pack" which is mostly dispelled by the announcement sounds pref. The station still shakes and it makes a softer noise somehow anyways, so I think it works great! 

This improves preference consistency and gives players who disable announcement sounds a way to avoid what is definitely an announcement sound.


## Changelog

:cl:
sound: Gravity generator startup/shutdown sounds now respect the announcement sounds preference.
/:cl: