### PR TITLE
Adds a cursekin only traitor item - the Lycanthropy Booster + makes lycans weak to silver

### DIFF
--- a/modular_skyrat/modules/reagent_forging/code/forge_weapons.dm
+++ b/modular_skyrat/modules/reagent_forging/code/forge_weapons.dm
@@ -12,6 +12,9 @@
 	. = ..()
 	AddComponent(/datum/component/reagent_weapon)
 
+	if (/datum/material/silver in custom_materials)
+		AddElement(/datum/element/bane, /datum/species/lycan, damage_multiplier = 3, requires_combat_mode = FALSE)
+
 /obj/item/forging/reagent_weapon/examine(mob/user)
 	. = ..()
 	. += span_notice("Using a hammer on [src] will repair its damage!")

--- a/modular_zubbers/code/__DEFINES/traits.dm
+++ b/modular_zubbers/code/__DEFINES/traits.dm
@@ -4,3 +4,6 @@
 
 /// The mob's nanites are sending a monitoring signal visible on diag HUD
 #define TRAIT_NANITE_MONITORING "nanite_monitoring"
+
+/// Makes the cursekin's lycan form vastly more powerful.
+#define TRAIT_GAIAN_PHYSIQUE "gaian_physique"

--- a/modular_zubbers/code/modules/customization/species/lycans/_lycan_species.dm
+++ b/modular_zubbers/code/modules/customization/species/lycans/_lycan_species.dm
@@ -77,11 +77,9 @@
 
 /datum/species/lycan/on_species_gain(mob/living/carbon/human/gainer, datum/species/old_species, pref_load, regenerate_icons = TRUE)
 	. = ..()
-	gainer.AddElement(/datum/element/inorganic_rejection)
-	gainer.dna.features["body_size"] = 2
-	gainer.maptext_height = 32 * gainer.dna.features["body_size"] //Adjust runechat height
-	gainer.mob_size = MOB_SIZE_LARGE
-	gainer.dna.update_body_size()
+
+	if (HAS_TRAIT(gainer, TRAIT_GAIAN_PHYSIQUE))
+		handle_gaian_physique(gainer)
 
 /datum/species/lycan/on_species_loss(mob/living/carbon/human/loser, datum/species/new_species, pref_load)
 	. = ..()
@@ -91,3 +89,44 @@
 		loser.maptext_height = 32 * loser.dna.features["body_size"]
 		loser.mob_size = MOB_SIZE_HUMAN
 		loser.dna.update_body_size()
+
+	if (HAS_TRAIT(loser, TRAIT_GAIAN_PHYSIQUE))
+		handle_gaian_physique_loss(loser)
+
+/datum/species/lycan/proc/handle_gaian_physique(mob/living/carbon/human/gainer)
+	damage_modifier += 30 // bonus percent damgae reduction
+
+	var/obj/item/bodypart/arm/l_arm = gainer.get_bodypart(BODY_ZONE_L_ARM)
+	var/obj/item/bodypart/arm/r_arm = gainer.get_bodypart(BODY_ZONE_R_ARM)
+
+	// near esword level, though without blockchance
+	l_arm?.unarmed_damage_low = 27
+	l_arm?.unarmed_damage_high = 27
+	r_arm?.unarmed_damage_low = 27
+	r_arm?.unarmed_damage_high = 27
+	l_arm?.unarmed_effectiveness = 75 // massively increases damage on grabbed targets
+	r_arm?.unarmed_effectiveness = 75
+
+	ADD_TRAIT(gainer, TRAIT_BATON_RESISTANCE, SPECIES_TRAIT)
+	ADD_TRAIT(gainer, TRAIT_HARDLY_WOUNDED, SPECIES_TRAIT)
+	ADD_TRAIT(gainer, TRAIT_IGNORESLOWDOWN, SPECIES_TRAIT)
+	ADD_TRAIT(gainer, TRAIT_FEARLESS, SPECIES_TRAIT)
+
+	gainer.AddComponent( \
+		/datum/component/regenerator, \
+		regeneration_delay = 5 SECONDS, \
+		brute_per_second = 5, \
+		burn_per_second = 1, \
+		tox_per_second = 0.5, \
+		oxy_per_second = 0.5, \
+		ignore_damage_types = list(), \
+	)
+
+/datum/species/lycan/proc/handle_gaian_physique_loss(mob/living/carbon/human/loser)
+	REMOVE_TRAIT(loser, TRAIT_BATON_RESISTANCE, SPECIES_TRAIT)
+	REMOVE_TRAIT(loser, TRAIT_HARDLY_WOUNDED, SPECIES_TRAIT)
+	REMOVE_TRAIT(loser, TRAIT_IGNORESLOWDOWN, SPECIES_TRAIT)
+	REMOVE_TRAIT(loser, TRAIT_FEARLESS, SPECIES_TRAIT)
+	qdel(loser.GetComponent(/datum/component/regenerator))
+
+	// already lost the limb shit

--- a/modular_zubbers/code/modules/customization/species/lycans/_lycan_species.dm
+++ b/modular_zubbers/code/modules/customization/species/lycans/_lycan_species.dm
@@ -77,6 +77,11 @@
 
 /datum/species/lycan/on_species_gain(mob/living/carbon/human/gainer, datum/species/old_species, pref_load, regenerate_icons = TRUE)
 	. = ..()
+	gainer.AddElement(/datum/element/inorganic_rejection)
+	gainer.dna.features["body_size"] = 2
+	gainer.maptext_height = 32 * gainer.dna.features["body_size"] //Adjust runechat height
+	gainer.mob_size = MOB_SIZE_LARGE
+	gainer.dna.update_body_size()
 
 	if (HAS_TRAIT(gainer, TRAIT_GAIAN_PHYSIQUE))
 		handle_gaian_physique(gainer)

--- a/modular_zubbers/code/modules/uplink/uplink_items/species/lycan_booster.dm
+++ b/modular_zubbers/code/modules/uplink/uplink_items/species/lycan_booster.dm
@@ -1,0 +1,46 @@
+/datum/uplink_item/species_restricted/lycan_booster
+	name = "Lycanthropy Booster"
+	desc = "A highly advanced mix of nanomachines and general 'bad vibes' that will significantly boost the combat performance of your \
+	Lycan form, granting significant damage resistance, baton resistance, regeneration, and further sharpening your claws. Additionally grants you expert fitness."
+	cost = 10
+	item = /obj/item/lycan_booster
+	restricted_species = list(SPECIES_CURSEKIN)
+	surplus = 0
+
+/obj/item/lycan_booster
+	name = "lycanthropy booster"
+	desc = "A highly advanced mix of nanomachines and general 'bad vibes' that will significantly boost the combat performance of your \
+	Lycan form, granting significant damage resistance, baton resistance, regeneration, and further sharpening your claws, along other improvements. \
+	Additionally grants you expert fitness."
+	icon = 'icons/obj/medical/syringe.dmi'
+	icon_state = "dnainjector"
+	inhand_icon_state = "dnainjector"
+	worn_icon_state = "pen"
+	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
+	throw_speed = 3
+	throw_range = 5
+	w_class = WEIGHT_CLASS_TINY
+
+/obj/item/lycan_booster/attack_self(mob/user, modifiers)
+	. = ..()
+
+	if (!ishuman(user))
+		return
+
+	var/mob/living/carbon/human/human_user = user
+
+	if (!istype(human_user.dna?.species, /datum/species/human/cursekin))
+		to_chat(human_user, span_warning("You get the feeling your current physiology wouldn't support this booster."))
+		return
+
+	ADD_TRAIT(human_user, TRAIT_GAIAN_PHYSIQUE, SPECIES_TRAIT)
+
+	balloon_alert(human_user, "lycan form boosted")
+	to_chat(human_user, span_bolddanger("As you inject yourself with the serum, you begin to feel more in tune with your lycan curse than ever before. Your claws sharpen, your teeth lengthen..."))
+	to_chat(human_user, span_boldnotice("Your lycan form is now resistant to damage, batons, and immune to damage slowdown. Additionally, your unarmed attacks are far deadlier, and ridiculously strong on grabbed opponents. Consider finding gripper gloves."))
+	human_user.emote("growl")
+
+	human_user.mind?.adjust_experience(/datum/skill/athletics, SKILL_EXP_MASTER, FALSE)
+
+	qdel(src)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10061,6 +10061,7 @@
 #include "modular_zubbers\code\modules\uplink\uplink_items\job.dm"
 #include "modular_zubbers\code\modules\uplink\uplink_items\stealth_items.dm"
 #include "modular_zubbers\code\modules\uplink\uplink_items\uplinkitems.dm"
+#include "modular_zubbers\code\modules\uplink\uplink_items\species\lycan_booster.dm"
 #include "modular_zubbers\code\modules\uplink\uplink_items\syndicat\_syndicat.dm"
 #include "modular_zubbers\code\modules\uplink\uplink_items\syndimaid\_syndimaid.dm"
 #include "modular_zubbers\code\modules\uplink\uplink_items\syndimaid\clothes.dm"


### PR DESCRIPTION

## About The Pull Request

Title.

The Lycanthropy booster makes the cursekin's lycan form claws deal 27 damage (near-esword levels) and also miss far less. Additionally, the lycan gets 30% damage reduction, baton resistance, slowdown immunity, and aggressive healing.

10 TC nominally.

Silver reagent weapons now deal 3x damge to lycans.
## Why It's Good For The Game

Lycan form is really underwhelming, but you cant really buff it without making cursekin overpowered. Thus, my solution: A traitor item.

It is _very_ powerful, it cant be denied, and the TC price and specifics are up for debate. I really, really want to live through my garou power fantasy though, so I think its great if it remains very powerful (regeneration and slowdown resistance are core features).

The regeneration is weak to fire and toxin, so lasers are your go-to counter for boosted lycans.

**I would add** that despite the buffs this gives the form, its still not incredibly good. No equipment, no guns... its a pure juggernaut form, and thats all it can do.

Silver weapon weakness adds a counter to this, as well as adding more flavor to lycan.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

https://github.com/user-attachments/assets/12a209aa-4302-4711-afd1-7f654a2a6b2f

</details>

## Changelog
:cl:
add: The lycanthropy booster, a cursekin-only traitor item that turns your lycan form into a deadly juggernaut.
balance: Silver reagent weapons do 3x damage to lycans.
/:cl:
