### PR TITLE
Massively reduces the timer for cursekin to shift forms

### DIFF
--- a/modular_zubbers/code/modules/customization/species/lycans/lycan_verbs.dm
+++ b/modular_zubbers/code/modules/customization/species/lycans/lycan_verbs.dm
@@ -5,7 +5,7 @@
 	button_icon_state = "lycan_form"
 
 #ifndef TESTING
-	cooldown_time = 3 MINUTES
+	cooldown_time = 30 SECONDS
 #else
 	cooldown_time = 1 SECONDS // I don't wanna wait
 #endif


### PR DESCRIPTION

## About The Pull Request

Title.

It is now 30 seconds, down from 3 WHOLE MINUTES
## Why It's Good For The Game

Given how underpowered lycan form is (and on god I dont see why it even needs a timer if it WAS good) I dont see why it needs such an insane timer.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

one line change

</details>

## Changelog
:cl:
balance: Cursekin transformation cooldown is now 30 seconds
/:cl:
