### PR TITLE
Makes boosted lycan form resistant to stamina, stun, shoves

### DIFF
--- a/modular_zubbers/code/modules/customization/species/lycans/_lycan_species.dm
+++ b/modular_zubbers/code/modules/customization/species/lycans/_lycan_species.dm
@@ -100,6 +100,8 @@
 
 /datum/species/lycan/proc/handle_gaian_physique(mob/living/carbon/human/gainer)
 	damage_modifier += 30 // bonus percent damgae reduction
+	stunmod = 0.5
+	gainer.physiology.stamina_mod *= 0.25
 
 	var/obj/item/bodypart/arm/l_arm = gainer.get_bodypart(BODY_ZONE_L_ARM)
 	var/obj/item/bodypart/arm/r_arm = gainer.get_bodypart(BODY_ZONE_R_ARM)
@@ -116,6 +118,9 @@
 	ADD_TRAIT(gainer, TRAIT_HARDLY_WOUNDED, SPECIES_TRAIT)
 	ADD_TRAIT(gainer, TRAIT_IGNORESLOWDOWN, SPECIES_TRAIT)
 	ADD_TRAIT(gainer, TRAIT_FEARLESS, SPECIES_TRAIT)
+	ADD_TRAIT(gainer, TRAIT_BRAWLING_KNOCKDOWN_BLOCKED, SPECIES_TRAIT)
+	ADD_TRAIT(gainer, TRAIT_NO_STAGGER, SPECIES_TRAIT)
+	ADD_TRAIT(gainer, TRAIT_NO_THROW_HITPUSH, SPECIES_TRAIT)
 
 	gainer.AddComponent( \
 		/datum/component/regenerator, \
@@ -132,6 +137,12 @@
 	REMOVE_TRAIT(loser, TRAIT_HARDLY_WOUNDED, SPECIES_TRAIT)
 	REMOVE_TRAIT(loser, TRAIT_IGNORESLOWDOWN, SPECIES_TRAIT)
 	REMOVE_TRAIT(loser, TRAIT_FEARLESS, SPECIES_TRAIT)
+	REMOVE_TRAIT(loser, TRAIT_BRAWLING_KNOCKDOWN_BLOCKED, SPECIES_TRAIT)
+	REMOVE_TRAIT(loser, TRAIT_NO_STAGGER, SPECIES_TRAIT)
+	REMOVE_TRAIT(loser, TRAIT_NO_THROW_HITPUSH, SPECIES_TRAIT)
+
 	qdel(loser.GetComponent(/datum/component/regenerator))
+
+	loser.physiology.stamina_mod *= 4
 
 	// already lost the limb shit


### PR DESCRIPTION

## About The Pull Request

Title.

You have to magdump a disabler now to take down a boosted lycan. Lasers are the preferred option.
## Why It's Good For The Game

I shouldve done this in the initial PR haha. A rampaging werewolf should not be easily taken down by a simple disabler or shoves, though its tsill posible.

Also, the regenerator component doesnt regen stamina damage, so... yeah.

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
balance: Boosted lycan form is now resistant to stamina, stuns, and shoves
/:cl:
