### PR TITLE
Fixes GunHUD and death consequences health analyzer blurb

### DIFF
--- a/code/__DEFINES/hud.dm
+++ b/code/__DEFINES/hud.dm
@@ -69,6 +69,7 @@
 #define HUD_MOB_MOOD "mob_mood"
 #define HUD_MOB_HEALTHDOLL "mob_healthdoll"
 #define HUD_MOB_MEMORIES "mob_memories"
+#define HUD_MOB_AMMO_COUNTER "mob_ammo_counter" // BUBBER EDIT ADDITION
 
 #define HUD_OOZE_NUTRITION_DISPLAY "ooze_nutrition_display"
 

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -52,7 +52,6 @@ GLOBAL_LIST_INIT(available_erp_ui_styles, list(
 	var/inventory_shown = FALSE
 	/// This is to hide the buttons that can be used via hotkeys. (hotkeybuttons list of buttons)
 
-	var/atom/movable/screen/ammo_counter //SKYRAT EDIT ADDITION
 	var/atom/movable/screen/text/activation_text/activation // BUBBER EDIT ADDITION
 	var/hotkey_ui_hidden = FALSE
 

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -33,6 +33,7 @@
 	add_screen_object(/atom/movable/screen/stamina, HUD_MOB_STAMINA, HUD_GROUP_INFO)
 	add_screen_object(/atom/movable/screen/healths, HUD_MOB_HEALTH, HUD_GROUP_INFO)
 	add_screen_object(/atom/movable/screen/hunger, HUD_MOB_HUNGER, HUD_GROUP_INFO)
+	add_screen_object(/atom/movable/screen/ammo_counter, HUD_MOB_AMMO_COUNTER, HUD_GROUP_INFO) // BUBBER EDIT ADDITION
 
 /datum/hud/human/update_locked_slots()
 	if(!mymob)

--- a/modular_skyrat/modules/death_consequences_perk/death_consequences_trauma.dm
+++ b/modular_skyrat/modules/death_consequences_perk/death_consequences_trauma.dm
@@ -142,6 +142,7 @@
 	. = ..()
 
 	RegisterSignal(owner, COMSIG_LIVING_POST_FULLY_HEAL, PROC_REF(victim_ahealed))
+	RegisterSignal(owner, COMSIG_LIVING_HEALTHSCAN, PROC_REF(append_analyzer_info))
 
 	update_variables()
 	START_PROCESSING(SSprocessing, src)
@@ -154,6 +155,7 @@
 		REMOVE_TRAIT(owner, TRAIT_DNR, TRAUMA_TRAIT)
 
 	UnregisterSignal(owner, COMSIG_LIVING_POST_FULLY_HEAL)
+	UnregisterSignal(owner, COMSIG_LIVING_HEALTHSCAN)
 
 	return ..()
 
@@ -406,7 +408,7 @@
 
 /// Returns a short-ish string containing an href to [get_specific_data].
 /datum/brain_trauma/severe/death_consequences/proc/get_health_analyzer_link_text(mob/user)
-	var/message = span_bolddanger("\nSubject suffers from death degradation disorder.")
+	var/message = span_bolddanger("Subject suffers from death degradation disorder.")
 	if (final_death_delivered)
 		message += span_purple("<i>\nNeural patterns are equivalent to the consciousness zero-point. Subject has likely succumbed.</i>")
 		return message
@@ -420,6 +422,8 @@
 		if (isnull(time_til_scan_expires[user]))
 			RegisterSignal(user, COMSIG_QDELETING, PROC_REF(scanning_user_qdeleting))
 		time_til_scan_expires[user] = (world.time + time_to_view_extra_data_after_scan)
+
+	message += "\n"
 
 	return message
 
@@ -437,6 +441,11 @@
 			to_chat(usr, boxed_message(get_specific_data()), trailing_newline = FALSE, type = MESSAGE_TYPE_INFO)
 		else
 			to_chat(usr, span_warning("Your scan has expired! Try scanning again!"))
+
+/datum/brain_trauma/severe/death_consequences/proc/append_analyzer_info(datum/signal_source, list/scan_results, advanced, mob/user, mode)
+	SIGNAL_HANDLER
+
+	scan_results += get_health_analyzer_link_text(user)
 
 /// Returns a large string intended to show specifics of how this degradation work.
 /datum/brain_trauma/severe/death_consequences/proc/get_specific_data()

--- a/modular_skyrat/modules/gunhud/code/gun_hud_component.dm
+++ b/modular_skyrat/modules/gunhud/code/gun_hud_component.dm
@@ -15,10 +15,10 @@
 	SIGNAL_HANDLER
 
 	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(H.is_holding(parent))
-			if(H.hud_used)
-				hud = H.hud_used.ammo_counter
+		var/mob/living/carbon/human/human_user = user
+		if(human_user.is_holding(parent))
+			if(human_user)
+				hud = human_user.hud_used.screen_objects[HUD_MOB_AMMO_COUNTER]
 				turn_on()
 		else
 			turn_off()

--- a/modular_skyrat/modules/gunhud/code/gun_hud_component.dm
+++ b/modular_skyrat/modules/gunhud/code/gun_hud_component.dm
@@ -29,7 +29,7 @@
 	RegisterSignals(parent, list(COMSIG_PREQDELETED, COMSIG_ITEM_DROPPED), PROC_REF(turn_off))
 	RegisterSignals(parent, list(COMSIG_UPDATE_AMMO_HUD, COMSIG_GUN_CHAMBER_PROCESSED), PROC_REF(update_hud))
 
-	hud.turn_on()
+	hud?.turn_on()
 	update_hud()
 
 /datum/component/ammo_hud/proc/turn_off()
@@ -57,6 +57,10 @@
 
 /datum/component/ammo_hud/proc/update_hud()
 	SIGNAL_HANDLER
+
+	if (isnull(hud))
+		return
+
 	if(istype(parent, /obj/item/gun/ballistic))
 		var/obj/item/gun/ballistic/pew = parent
 		hud.maptext = null

--- a/modular_skyrat/modules/gunhud/code/gun_hud_component.dm
+++ b/modular_skyrat/modules/gunhud/code/gun_hud_component.dm
@@ -18,7 +18,7 @@
 		var/mob/living/carbon/human/human_user = user
 		if(human_user.is_holding(parent))
 			if(human_user)
-				hud = human_user.hud_used.screen_objects[HUD_MOB_AMMO_COUNTER]
+				hud = human_user.hud_used?.screen_objects[HUD_MOB_AMMO_COUNTER]
 				turn_on()
 		else
 			turn_off()


### PR DESCRIPTION

## About The Pull Request

Title.

GunHUD works now, as does the death degradation analyzer bit.
## Why It's Good For The Game

bugbgsbhgbafdd
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="655" height="500" alt="image" src="https://github.com/user-attachments/assets/ee568928-a9a9-4978-809c-7d1c22ebfb2b" />

<img width="96" height="96" alt="image" src="https://github.com/user-attachments/assets/c10fce0d-9167-4638-9acb-c6ebcf77c9a2" />

</details>

## Changelog
:cl:
fix: GunHUD now displays
fix: Death consequences now show up in health analyzers again
/:cl:
