### PR TITLE
digi legs labcoats subtype fix

### DIFF
--- a/modular_zubbers/code/modules/clothing/suits/labcoat.dm
+++ b/modular_zubbers/code/modules/clothing/suits/labcoat.dm
@@ -1,6 +1,3 @@
-/obj/item/clothing/suit/toggle/labcoat
-	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
-
 /obj/item/clothing/suit/toggle/labcoat/cmo
 	worn_icon_teshari = 'modular_zubbers/icons/mob/clothing/suits/labcoat_teshari.dmi'
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
@@ -11,29 +8,38 @@
 
 /obj/item/clothing/suit/toggle/labcoat/genetics
 	greyscale_config_worn_digi = /datum/greyscale_config/labcoat/worn/digi
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
 
 /obj/item/clothing/suit/toggle/labcoat/chemist
 	greyscale_config_worn_digi = /datum/greyscale_config/labcoat/worn/digi
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
 
 /obj/item/clothing/suit/toggle/labcoat/virologist
 	greyscale_config_worn_digi = /datum/greyscale_config/labcoat/worn/digi
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
 
 /obj/item/clothing/suit/toggle/labcoat/coroner
 	greyscale_config_worn_digi = /datum/greyscale_config/labcoat/worn/digi
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
 
 /obj/item/clothing/suit/toggle/labcoat/science
 	greyscale_config_worn_digi = /datum/greyscale_config/labcoat/worn/digi
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
 
 /obj/item/clothing/suit/toggle/labcoat/roboticist
 	greyscale_config_worn_digi = /datum/greyscale_config/labcoat/worn/digi
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
 
 /obj/item/clothing/suit/toggle/labcoat/interdyne
 	greyscale_config_worn_digi = /datum/greyscale_config/labcoat/worn/digi
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
 
 /obj/item/clothing/suit/toggle/labcoat/hospitalgown
 	greyscale_config_worn_digi = /datum/greyscale_config/labcoat/worn/digi
 	greyscale_config_worn_teshari = /datum/greyscale_config/labcoat/worn/teshari
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
 
 /obj/item/clothing/suit/toggle/labcoat/medical
 	greyscale_config_worn_digi = /datum/greyscale_config/labcoat/worn/digi
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION
 


### PR DESCRIPTION

## About The Pull Request

A [recent PR of mine](https://github.com/Bubberstation/Bubberstation/pull/5603) unintentionally resulted in a lot of labcoat related clothing becoming missing textures that looked fine previously. This is because I assigned the base type of labcoats to use the "CLOTHING_DIGITIGRADE_VARIATION" flag, which looks for digi sprites, otherwise becomes a missing texture. 

I did not catch this in my PR because I was unaware that there were more labcoat subtypes than the ones I edited. This PR fixes those labcoats by moving the flag to just the clothing items I edited, leaving the affected clothing to go back to using "CLOTHING_DIGITIGRADE_NO_NEW_ICON", which as the name implies, uses the base non-digi icon and doesn't result in a missing texture.

Note that this PR means that the base labcoat will not look right on digi, but I will fix this again at a later point.

## Why It's Good For The Game

Fixing the bugs I created!
## Proof Of Testing

Works on my machine.

This is an affected clothing item (researcher's lab coat), reverted to a working state.
<img width="639" height="312" alt="image" src="https://github.com/user-attachments/assets/91b9d698-d807-4103-9de9-03f3273a1314" />

The other applied fixes from the last PR (excluding the base labcoat) still work
<img width="105" height="112" alt="image" src="https://github.com/user-attachments/assets/d82edb0b-3204-491d-af4c-5bc4754a9210" />

## Changelog
:cl:
fix: fixed some labcoat subtypes becoming missing textures on digitigrade legs
/:cl:
