### PR TITLE
Removes Armadyne Combat Gloves' innate shockproofness

### DIFF
--- a/_maps/RandomZLevels/maintsroom.dmm
+++ b/_maps/RandomZLevels/maintsroom.dmm
@@ -12940,7 +12940,7 @@
 /obj/item/storage/backpack/industrial/frontier_colonist/military_grade_backpack,
 /obj/item/radio/headset/headset_frontier_colonist,
 /obj/item/storage/belt/utility/frontier_colonist,
-/obj/item/clothing/gloves/combat/peacekeeper,
+/obj/item/clothing/gloves/color/black/peacekeeper,
 /turf/open/floor/wood,
 /area/awaymission/caves/maintsroom)
 "Qo" = (

--- a/modular_skyrat/modules/sec_haul/code/peacekeeper/armadyne_clothing.dm
+++ b/modular_skyrat/modules/sec_haul/code/peacekeeper/armadyne_clothing.dm
@@ -60,7 +60,7 @@
 	worn_icon = 'modular_skyrat/master_files/icons/mob/clothing/eyes.dmi'
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/glasses.dmi'
 
-/obj/item/clothing/gloves/combat/peacekeeper/armadyne
+/obj/item/clothing/gloves/color/black/peacekeeper/armadyne
 	name = "armadyne combat gloves"
 	desc = "Tactical and sleek. Worn by Armadyne representatives."
 	icon = 'modular_skyrat/master_files/icons/obj/clothing/gloves.dmi'

--- a/modular_skyrat/modules/sec_haul/code/peacekeeper/armadyne_clothing.dm
+++ b/modular_skyrat/modules/sec_haul/code/peacekeeper/armadyne_clothing.dm
@@ -68,7 +68,6 @@
 	icon_state = "armadyne_gloves"
 	worn_icon_state = "armadyne_gloves"
 	cut_type = null
-	siemens_coefficient = 0.5
 
 /obj/item/clothing/shoes/jackboots/peacekeeper/armadyne
 	name = "armadyne combat boots"

--- a/modular_skyrat/modules/sec_haul/code/peacekeeper/armadyne_clothing.dm
+++ b/modular_skyrat/modules/sec_haul/code/peacekeeper/armadyne_clothing.dm
@@ -92,7 +92,7 @@
 	suit_store = /obj/item/modular_computer/pda/security
 	ears = /obj/item/radio/headset/headset_cent/commander
 	uniform = /obj/item/clothing/under/rank/security/peacekeeper/armadyne
-	gloves = /obj/item/clothing/gloves/combat/peacekeeper/armadyne
+	gloves = /obj/item/clothing/gloves/color/black/peacekeeper/armadyne
 	head =  /obj/item/clothing/head/beret/sec/peacekeeper/armadyne
 	neck = /obj/item/clothing/neck/tie/black
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses/peacekeeper/armadyne
@@ -116,7 +116,7 @@
 
 	ears = /obj/item/radio/headset/headset_sec/alt
 	uniform = /obj/item/clothing/under/rank/security/peacekeeper/armadyne/tactical
-	gloves = /obj/item/clothing/gloves/combat/peacekeeper/armadyne
+	gloves = /obj/item/clothing/gloves/color/black/peacekeeper/armadyne
 	head = /obj/item/clothing/head/helmet
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses/peacekeeper/armadyne
 	mask = /obj/item/clothing/mask/gas/sechailer
@@ -138,7 +138,7 @@
 
 	ears = /obj/item/radio/headset/headset_sec/alt
 	uniform = /obj/item/clothing/under/rank/security/peacekeeper/armadyne/tactical
-	gloves = /obj/item/clothing/gloves/combat/peacekeeper/armadyne
+	gloves = /obj/item/clothing/gloves/color/black/peacekeeper/armadyne
 	head =  /obj/item/clothing/head/beret/sec/peacekeeper/armadyne
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses/peacekeeper/armadyne
 	mask = /obj/item/clothing/mask/gas/sechailer/swat

--- a/modular_skyrat/modules/sec_haul/code/peacekeeper/armadyne_clothing.dm
+++ b/modular_skyrat/modules/sec_haul/code/peacekeeper/armadyne_clothing.dm
@@ -68,6 +68,7 @@
 	icon_state = "armadyne_gloves"
 	worn_icon_state = "armadyne_gloves"
 	cut_type = null
+	siemens_coefficient = 0.5
 
 /obj/item/clothing/shoes/jackboots/peacekeeper/armadyne
 	name = "armadyne combat boots"

--- a/modular_zubbers/code/modules/loadout/categories/gloves.dm
+++ b/modular_zubbers/code/modules/loadout/categories/gloves.dm
@@ -115,9 +115,9 @@
 	item_path = /obj/item/clothing/gloves/color/black/security
 	restricted_roles = list(ALL_JOBS_SEC)
 
-/datum/loadout_item/gloves/combat/peacekeeper/armadyne
+/datum/loadout_item/gloves/color/black/peacekeeper/armadyne
 	name = "Armadyne Combat Gloves"
-	item_path = /obj/item/clothing/gloves/combat/peacekeeper/armadyne
+	item_path = /obj/item/clothing/gloves/color/black/peacekeeper/armadyne
 	restricted_roles = list(ALL_JOBS_SEC)
 
 /datum/loadout_item/gloves/frontier_colonist

--- a/modular_zubbers/code/modules/vending/multisec.dm
+++ b/modular_zubbers/code/modules/vending/multisec.dm
@@ -44,7 +44,7 @@
 					/obj/item/clothing/neck/pauldron/commander = 6,
 					/obj/item/clothing/neck/pauldron/captain = 6,
 					/obj/item/clothing/gloves/color/black = 6,
-					/obj/item/clothing/gloves/combat/peacekeeper/armadyne = 6,
+					/obj/item/clothing/gloves/color/black/peacekeeper/armadyne = 6,
 					/obj/item/clothing/under/rank/security/officer/skirt = 6,
 					/obj/item/clothing/under/rank/security/skyrat/utility/redsec = 6,
 					/obj/item/clothing/under/rank/security/peacekeeper/skirt_redsec = 6,

--- a/tools/UpdatePaths/Scripts_Bubber/5625_repatharmdynegloves.txt
+++ b/tools/UpdatePaths/Scripts_Bubber/5625_repatharmdynegloves.txt
@@ -1,1 +1,0 @@
-/obj/item/clothing/gloves/combat/peacekeeper/armadyne : /obj/item/clothing/gloves/color/black/peacekeeper/armadyne{@OLD}

--- a/tools/UpdatePaths/Scripts_Bubber/5625_repatharmdynegloves.txt
+++ b/tools/UpdatePaths/Scripts_Bubber/5625_repatharmdynegloves.txt
@@ -1,0 +1,1 @@
+/obj/item/clothing/gloves/combat/peacekeeper/armadyne : /obj/item/clothing/gloves/color/black/peacekeeper/armadyne{@OLD}


### PR DESCRIPTION

## About The Pull Request

So, turns out the Armadyne Combat Gloves in the secvendor (and loadout) available to sec were subtypes of the combat gloves.
<img width="539" height="160" alt="inherit" src="https://github.com/user-attachments/assets/a587f136-3ff4-4c00-a049-d4680e904b23" />
This meant that they were fully insulated to boot. It's a 50 credit glove item that secoffs can get for 10 credits, and there are 6 in each sec vendor. 
<img width="85" height="98" alt="gloves" src="https://github.com/user-attachments/assets/0a8ad937-d05d-4a4a-987e-f5a4c8407428" />
~~This brings the siemens_coeff down to the levels of the standard issue black gloves, which is 0.5~~
This makes the gloves a subtype of color/black
<!--Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

I feel this was an oversight, as I don't think security is meant be able to get round start insulation.
## Proof Of Testing

~~It's a one line change.~~ It's no longer a one line change, it never is.........
<img width="299" height="153" alt="cobm" src="https://github.com/user-attachments/assets/4c9261bc-a2e4-4393-a0b4-59e1d042c2d2" />
Here is the compiled version IN the away mission that gave it the conflict
## Changelog
:cl:
balance: Armadyne Combat Gloves are no longer a combat glove subtype
/:cl:
