### PR TITLE
Adds Fentanyl to Junkie Quirk

### DIFF
--- a/code/_globalvars/lists/quirks.dm
+++ b/code/_globalvars/lists/quirks.dm
@@ -44,6 +44,7 @@ GLOBAL_LIST_INIT(possible_junkie_addictions, setup_junkie_addictions(list(
 	/datum/reagent/medicine/morphine,
 	/datum/reagent/drug/happiness,
 	/datum/reagent/drug/methamphetamine,
+	/datum/reagent/toxin/fentanyl, // Bubber EDIT: Adds Fentanyl
 )))
 
 ///Options for the Smoker quirk to choose from


### PR DESCRIPTION
## About The Pull Request

Allows Fentanyl as an option for Junkie Quirk.
That's it!

## Why It's Good For The Game

Expies (and others) can take Fentanyl as an option. It's neat.

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>
<img width="530" height="120" alt="image" src="https://github.com/user-attachments/assets/35a2afb0-b985-44e6-bab2-e556340229b6" />
<img width="83" height="33" alt="image" src="https://github.com/user-attachments/assets/33dc064b-07df-45c8-9c0c-89405168ffe6" />
</details>

## Changelog

:cl: Lunaf0x
add: Fentanyl can now be taken via the Junkie Quirk
/:cl:
