### PR TITLE
Fixes missing APC in Moonstation Robotics

### DIFF
--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -54239,6 +54239,8 @@
 	},
 /obj/item/storage/belt/utility/full,
 /obj/item/book/manual/wiki/robotics_cyborgs,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics)
 "nVl" = (
@@ -57164,7 +57166,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/science/robotics)
@@ -65895,7 +65896,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/science/robotics)
@@ -92748,11 +92748,6 @@
 /obj/machinery/light/small/red/directional/south,
 /turf/open/floor/engine,
 /area/station/maintenance/disposal)
-"xSC" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/herringbone,
-/area/station/science/robotics)
 "xSN" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
@@ -269952,7 +269947,7 @@ isM
 mGd
 mGd
 oXx
-xSC
+oXx
 hdD
 gTr
 jCs


### PR DESCRIPTION
## About The Pull Request

Fixes missing APC in Moonstation Robotics

## Why It's Good For The Game

Fixes missing APC in Moonstation Robotics

## Proof Of Testing

Fixes missing APC in Moonstation Robotics

## Changelog

:cl: BurgerBB
map: Fixes missing APC in Moonstation Robotics
/:cl:

