### PR TITLE
Muridae Traits Update: Phobia

### DIFF
--- a/code/_globalvars/phobias.dm
+++ b/code/_globalvars/phobias.dm
@@ -24,6 +24,7 @@ GLOBAL_LIST_INIT(phobia_types, list(
 	"spiders" = "Arachnophobia",
 	"strangers" = "Xenophobia",
 	"the supernatural" = "Phasmophobia",
+	"mouse traps" = "Cleithrophobia", // BUBBER ADDITION
 ))
 
 GLOBAL_LIST_INIT(phobia_regexes, list(
@@ -50,6 +51,7 @@ GLOBAL_LIST_INIT(phobia_regexes, list(
 	"spiders" = construct_phobia_regex("spiders"),
 	"strangers" = construct_phobia_regex("strangers"),
 	"the supernatural" = construct_phobia_regex("the supernatural"),
+	"mouse traps" = construct_phobia_regex("mouse traps"), // BUBBER ADDITION
 ))
 
 GLOBAL_LIST_INIT(phobia_mobs, list(
@@ -534,6 +536,11 @@ GLOBAL_LIST_INIT(phobia_objs, list(
 		/obj/structure/destructible/eldritch_crucible,
 		/obj/structure/spirit_board,
 	)),
+	// BUBBER ADDITION START
+	"mouse traps" = typecacheof(list(
+		/obj/item/assembly/mousetrap,
+	)),
+	// BUBBER ADDITION END
 ))
 
 GLOBAL_LIST_INIT(phobia_turfs, list(

--- a/code/datums/brain_damage/phobia.dm
+++ b/code/datums/brain_damage/phobia.dm
@@ -137,3 +137,7 @@
 /datum/brain_trauma/mild/phobia/supernatural
 	phobia_type = "the supernatural"
 	random_gain = FALSE
+
+/datum/brain_trauma/mild/phobia/mousetraps // BUBBER ADDITION
+	phobia_type = "mouse traps"
+	random_gain = FALSE

--- a/modular_skyrat/modules/quirks/neutral.dm
+++ b/modular_skyrat/modules/quirks/neutral.dm
@@ -302,6 +302,7 @@ GLOBAL_VAR_INIT(DNR_trait_overlay, generate_DNR_trait_overlay())
 	var/mob/living/carbon/human/human_holder = quirk_holder
 	var/obj/item/organ/tongue/mouse/new_tongue = new(get_turf(human_holder))
 	human_holder.add_faction(FACTION_RAT)
+	human_holder.gain_trauma(new /datum/brain_trauma/mild/phobia/mousetraps, TRAUMA_RESILIENCE_ABSOLUTE)
 
 	new_tongue.copy_traits_from(human_holder.get_organ_slot(ORGAN_SLOT_TONGUE))
 	new_tongue.Insert(human_holder, special = TRUE, movement_flags = DELETE_IF_REPLACED)
@@ -318,6 +319,8 @@ GLOBAL_VAR_INIT(DNR_trait_overlay, generate_DNR_trait_overlay())
 	if(QDELETED(quirk_holder))
 		return
 
+	var/mob/living/carbon/human/human_holder = quirk_holder
+	human_holder.cure_trauma_type(/datum/brain_trauma/mild/phobia/mousetraps, TRAUMA_RESILIENCE_ABSOLUTE)
 	QDEL_NULL(sniff_food)
 
 /datum/action/cooldown/spell/sniff

--- a/strings/phobia.json
+++ b/strings/phobia.json
@@ -549,5 +549,7 @@
 		"wiz",
 		"wizard",
 		"zombie"
-	]
+	],
+
+	"mouse traps": ["mousetrap", "mouse trap"]
 }


### PR DESCRIPTION
## About The Pull Request

This adds a new phobia that makes the holder afraid of mousetraps, using the built-in phobia system. Mobs with the Muridae Traits quirk are given this phobia on add().

## Why It's Good For The Game

It's really funny

## Proof Of Testing
<img width="399" height="153" alt="image" src="https://github.com/user-attachments/assets/9fd4c2ab-43b2-490b-b056-1609a12ebb2b" />
<img width="641" height="42" alt="image" src="https://github.com/user-attachments/assets/74a575f9-373a-43ec-b589-8c938e8782c2" />


## Changelog
:cl:
add: Added phobia: Mousetraps
qol: Mousetraps phobia applied to Muridae Traits
/:cl:

