### PR TITLE
Adds multiple "new" PSC guns to cargo, nerfs the Wylom significantly. 

### DIFF
--- a/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/ammo/rifle.dm
+++ b/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/ammo/rifle.dm
@@ -45,15 +45,8 @@
 	name =".60 Strela bullet"
 	icon_state = "gaussphase"
 	speed = 2.5
-	damage = 50
-	armour_penetration = 50
-	wound_bonus = 20
-	exposed_wound_bonus = 30
-	demolition_mod = 1.8
-	/// How much damage we add to things that are weak to this bullet
-	var/anti_materiel_damage_addition = 30
-
-/obj/projectile/bullet/p60strela/Initialize(mapload)
-	. = ..()
-	// We do 80 total damage to anything robotic, namely borgs, and robotic simplemobs
-	AddElement(/datum/element/bane, target_type = /mob/living, mob_biotypes = MOB_ROBOTIC, damage_multiplier = 0, added_damage = anti_materiel_damage_addition)
+	damage = 40
+	armour_penetration = 30
+	wound_bonus = 10
+	demolition_mod = 1.3
+//BUBBER change, sorta just fuckin'guts the general insanity with this ammo to make it a mildly viable anti-mech/anti armor weapon

--- a/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/ammo/rifle.dm
+++ b/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/ammo/rifle.dm
@@ -44,9 +44,9 @@
 /obj/projectile/bullet/p60strela // The funny thing is, these are wild but you only get three of them a magazine
 	name =".60 Strela bullet"
 	icon_state = "gaussphase"
-	speed = 2.5
+	speed = 1.5
 	damage = 40
 	armour_penetration = 30
 	wound_bonus = 10
-	demolition_mod = 1.3
+	demolition_mod = 1.2
 //BUBBER change, sorta just fuckin'guts the general insanity with this ammo to make it a mildly viable anti-mech/anti armor weapon

--- a/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/ammo/rifle.dm
+++ b/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/ammo/rifle.dm
@@ -49,4 +49,3 @@
 	armour_penetration = 30
 	wound_bonus = 10
 	demolition_mod = 1.2
-//BUBBER change, sorta just fuckin'guts the general insanity with this ammo to make it a mildly viable anti-mech/anti armor weapon

--- a/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/rifle.dm
+++ b/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/rifle.dm
@@ -33,7 +33,7 @@
 	suppressor_y_offset = 0
 
 	burst_size = 1
-	fire_delay = 1.2 SECONDS
+	fire_delay = 1 SECONDS
 	actions_types = list()
 
 	recoil = 0.5
@@ -42,6 +42,10 @@
 
 /obj/item/gun/ballistic/automatic/lanca/give_manufacturer_examine()
 	AddElement(/datum/element/manufacturer_examine, COMPANY_SZOT)
+
+/obj/item/gun/ballistic/automatic/lanca/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/scope, range_modifier = 1.25)
 
 /obj/item/gun/ballistic/automatic/lanca/examine(mob/user)
 	. = ..()

--- a/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/rifle.dm
+++ b/modular_skyrat/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/rifle.dm
@@ -2,8 +2,7 @@
 
 /obj/item/gun/ballistic/automatic/lanca
 	name = "\improper Lanca Battle Rifle"
-	desc = "A relatively compact, long barreled bullpup battle rifle chambered for .310 Strilka. Has an integrated sight with \
-		a surprisingly functional amount of magnification, given its place of origin."
+	desc = "A relatively compact, long barreled bullpup battle rifle chambered for .310 Strilka."
 
 	icon = 'modular_skyrat/modules/modular_weapons/icons/obj/company_and_or_faction_based/szot_dynamica/guns_48.dmi'
 	icon_state = "lanca"
@@ -40,10 +39,6 @@
 	recoil = 0.5
 	spread = 2.5
 	projectile_wound_bonus = -20
-
-/obj/item/gun/ballistic/automatic/lanca/Initialize(mapload)
-	. = ..()
-	AddComponent(/datum/component/scope, range_modifier = 1.5)
 
 /obj/item/gun/ballistic/automatic/lanca/give_manufacturer_examine()
 	AddElement(/datum/element/manufacturer_examine, COMPANY_SZOT)

--- a/modular_zubbers/code/modules/cargo/packs/contraband.dm
+++ b/modular_zubbers/code/modules/cargo/packs/contraband.dm
@@ -40,7 +40,7 @@
 
 /datum/supply_pack/imports/riflecrate
 	name = "Lanca Battle Rifle Crate"
-	desc = "Need some more reliable firepower than the standard Sakhno? Look no further than these bad boys. Featuring a more modern semi-automatic action and even a low-magnification scope, these bad babies will be sure to make anyone regret messing with you. Don't mind the fees..."
+	desc = "Need some more reliable firepower than the standard Sakhno? Look no further than these bad boys. Featuring a more modern semi-automatic action, these bad babies will be sure to make anyone regret messing with you. Don't mind the fees..."
 	cost = 2500
 	contains = list(
 		/obj/item/gun/ballistic/automatic/lanca,

--- a/modular_zubbers/code/modules/cargo/packs/contraband.dm
+++ b/modular_zubbers/code/modules/cargo/packs/contraband.dm
@@ -25,3 +25,27 @@
 	)
 	crate_name = "lizard goods crate"
 	order_flags = ORDER_CONTRABAND
+
+/datum/supply_pack/imports/antimatcrate
+	name = "Wylom Anti-Material Rifle Crate"
+	desc = "Do you have a hard target that you need dead? That ion gun not stopping the bad guy with a mech? Buy this to aquire a singular Wylom, with two spare magazines."
+	cost = 7500
+	contains = list(
+		/obj/item/gun/ballistic/automatic/wylom,
+		/obj/item/ammo_box/magazine/wylom,
+		/obj/item/ammo_box/magazine/wylom,
+	)
+	crate_name = "AMR Crate"
+	order_flags = ORDER_CONTRABAND
+
+/datum/supply_pack/imports/riflecrate
+	name = "Lanca Battle Rifle Crate"
+	desc = "Need some more reliable firepower than the standard Sakhno? Look no further than these bad boys. Featuring a more modern semi-automatic action and even a low-magnification scope, these bad babies will be sure to make anyone regret messing with you. Don't mind the fees..."
+	cost = 2500
+	contains = list(
+		/obj/item/gun/ballistic/automatic/lanca,
+		/obj/item/ammo_box/magazine/lanca,
+		/obj/item/ammo_box/magazine/lanca,
+	)
+	crate_name = "Battle Rifle Crate"
+	order_flags = ORDER_CONTRABAND

--- a/modular_zubbers/code/modules/cargo/packs/goodies.dm
+++ b/modular_zubbers/code/modules/cargo/packs/goodies.dm
@@ -250,3 +250,10 @@
 	cost = PAYCHECK_COMMAND * 5
 	access_view = ACCESS_WEAPONS
 	contains = list(/obj/item/gun/ballistic/bow/security, /obj/item/storage/bag/quiver/lesser/security)
+
+/datum/supply_pack/goody/russianammo
+	name = ".310 Ammo Box Single-Pack"
+	desc = "Contains a single pack of .310 rounds."
+	cost = PAYCHECK_COMMAND * 2.5
+	access_view = ACCESS_WEAPONS
+	contains = list(/obj/item/ammo_box/c310_cargo_box)

--- a/modular_zubbers/code/modules/cargo/packs/goodies.dm
+++ b/modular_zubbers/code/modules/cargo/packs/goodies.dm
@@ -257,3 +257,10 @@
 	cost = PAYCHECK_COMMAND * 2.5
 	access_view = ACCESS_WEAPONS
 	contains = list(/obj/item/ammo_box/c310_cargo_box)
+
+/datum/supply_pack/goody/lancamag
+	name = "Lanca Magazine Single-Pack"
+	desc = "Contains a single Lanca rifle magazine"
+	cost = PAYCHECK_COMMAND * 1.5
+	contains = list(/obj/item/ammo_box/magazine/lanca)
+	order_flags = ORDER_CONTRABAND


### PR DESCRIPTION

## About The Pull Request

This PR adds more imported PSC gear to cargo, for a price. This also adds the .310 ammo box back into cargo goodies. Funny. 

## Why It's Good For The Game

We have these guns in the code and sprites available, why not use them to have a little fun? The Lanca's at par with the Sahnko in all honesty, the delay making it slightly worse. 

However. The elephant in the room, the Wylom. 

The Wylom has been nerfed pretty seriously, the entire magazine no longer capable of killing an individual unless they're robotic.
This leans in to not just the description that talks more about how the weapon was pushed from service due to overpenetration issues, while also filling the niche of an actually functional anti-mech and anti-material weapon that isn't just a frangible slug.  

The Wylom is also hilariously expensive, while the lanca is about average for a quirky firearm. 


## Proof Of Testing

<img width="430" height="396" alt="image" src="https://github.com/user-attachments/assets/f71d0f9d-e9bd-4833-9d87-2ca69f9da4b0" />

<img width="461" height="414" alt="image" src="https://github.com/user-attachments/assets/ab326bcb-c2d2-4436-bc52-e6695e261808" />


## Changelog
:cl:
add: Adds two new PSC guns to cargo, the Lanca and Wylom. You gotta modify your console first, though. Also you can buy spare lanca mags.
add: Re-adds the .310 ammo box back to goodies
balance: Tweaks how the .60 Strela ammunition type does damage, removing the quirky extra damage to borgs in favor of a general destruction modifier. 
/:cl:
