### PR TITLE
Updating LoneOp pop spawn requirement to 20

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -23,7 +23,7 @@
 
 	if(!fake)
 		AddComponent(/datum/component/stationloving, !fake)
-		AddComponent(/datum/component/keep_me_secure, CALLBACK(src, PROC_REF(secured_process)), CALLBACK(src, PROC_REF(unsecured_process)), 10)
+		AddComponent(/datum/component/keep_me_secure, CALLBACK(src, PROC_REF(secured_process)), CALLBACK(src, PROC_REF(unsecured_process)), 20)
 		SSpoints_of_interest.make_point_of_interest(src)
 	else
 		// Ensure fake disks still have examine text, but dont actually do anything

--- a/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -23,7 +23,7 @@
 
 	if(!fake)
 		AddComponent(/datum/component/stationloving, !fake)
-		AddComponent(/datum/component/keep_me_secure, CALLBACK(src, PROC_REF(secured_process)), CALLBACK(src, PROC_REF(unsecured_process)), 20)
+		AddComponent(/datum/component/keep_me_secure, CALLBACK(src, PROC_REF(secured_process)), CALLBACK(src, PROC_REF(unsecured_process)), 20) //BUBBER EDIT: Changed value from 10 to 20 for population
 		SSpoints_of_interest.make_point_of_interest(src)
 	else
 		// Ensure fake disks still have examine text, but dont actually do anything


### PR DESCRIPTION
## About The Pull Request

Updates the LoneOp Pop spawn requirement to 20

## Why It's Good For The Game

LoneOp should not spawn on a station with only 10 crew.

## Proof Of Testing
<details>

Updated the value, it is now 20 instead of 10! 

</details>

## Changelog

:cl:
balance: Increased LoneOp population spawn requirement to 20 from 10
/:cl:


