### PR TITLE
Revert the revert of #5639 (Updating LoneOp pop spawn requirement to 20)

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -23,7 +23,7 @@
 
 	if(!fake)
 		AddComponent(/datum/component/stationloving, !fake)
-		AddComponent(/datum/component/keep_me_secure, CALLBACK(src, PROC_REF(secured_process)), CALLBACK(src, PROC_REF(unsecured_process)), 10)
+		AddComponent(/datum/component/keep_me_secure, CALLBACK(src, PROC_REF(secured_process)), CALLBACK(src, PROC_REF(unsecured_process)), 20) //BUBBER EDIT: Changed value from 10 to 20 for population
 		SSpoints_of_interest.make_point_of_interest(src)
 	else
 		// Ensure fake disks still have examine text, but dont actually do anything

--- a/modular_zubbers/code/modules/storyteller/event_defines/moderate/moderate_overrides.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/moderate/moderate_overrides.dm
@@ -57,6 +57,7 @@
 
 /datum/round_event_control/operative
 	track = EVENT_TRACK_MODERATE
+	min_players = 20
 
 /datum/round_event_control/radiation_storm
 	track = EVENT_TRACK_MODERATE


### PR DESCRIPTION

## About The Pull Request

Un-reverts https://github.com/Bubberstation/Bubberstation/pull/5639 and adds a min_pop restriction to Lone Ops round event control.

## Changelog
:cl: BingusTheClown
Balance: Increased LoneOp population spawn requirement to 20 from 10
/:cl: