### PR TITLE
Swaps NOGUN and ILLITERATE on lycans with CHUNKYFINGERS

### DIFF
--- a/modular_zubbers/code/modules/customization/species/lycans/_lycan_species.dm
+++ b/modular_zubbers/code/modules/customization/species/lycans/_lycan_species.dm
@@ -41,11 +41,10 @@
 		// Lycan Specific Things
 		TRAIT_LUPINE,
 		TRAIT_BEAST_FORM,
-		TRAIT_NOGUNS,
 		TRAIT_LYCAN,
 		TRAIT_QUICKER_CARRY, // It'd be on par with nitrile gloves.
 		TRAIT_PIERCEIMMUNE, // Thick skin
-		TRAIT_ILLITERATE, // To avoid using consoles or such.
+		TRAIT_CHUNKYFINGERS,
 		TRAIT_FAST_METABOLISM,
 	)
 


### PR DESCRIPTION

## About The Pull Request

Title.

This makes lycans able to use consoles, PDAs, and triggerguarded guns. Such as bows.
## Why It's Good For The Game

I kinda just dont like that lycans are made randomly unable to read when theyre still the same person? Also, this allows them to use bows, which I think is appropriate for their inspiration (WTA). Not like they can use it well - they have to drag the quiver around.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="853" height="837" alt="image" src="https://github.com/user-attachments/assets/37410f0b-ab4a-48ae-9bf5-92dd46312125" />

</details>

## Changelog
:cl:
balance: Lycans can now use bows, triggerguarded guns, and consoles.
/:cl:
