### PR TITLE
Removes the 30% damage resist from boosted lycans

### DIFF
--- a/modular_zubbers/code/modules/customization/species/lycans/_lycan_species.dm
+++ b/modular_zubbers/code/modules/customization/species/lycans/_lycan_species.dm
@@ -88,7 +88,6 @@
 		handle_gaian_physique_loss(loser)
 
 /datum/species/lycan/proc/handle_gaian_physique(mob/living/carbon/human/gainer)
-	damage_modifier += 30 // bonus percent damgae reduction
 	stunmod = 0.5
 	gainer.physiology.stamina_mod *= 0.25
 


### PR DESCRIPTION

## About The Pull Request

This was added on faulty information. I was under the impressions had no damage resistance, when they have 50% brute and 20% burn natively.
## Why It's Good For The Game

This is no longer needed.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

oneline change

</details>

## Changelog
:cl:
del: Boosted lycans no longer get a bonus 30% damage resistance
/:cl:
