### PR TITLE
Fixes boosted lycans having TOTAL slowdown immunity

### DIFF
--- a/modular_zubbers/code/modules/customization/species/lycans/_lycan_species.dm
+++ b/modular_zubbers/code/modules/customization/species/lycans/_lycan_species.dm
@@ -105,12 +105,12 @@
 
 	ADD_TRAIT(gainer, TRAIT_BATON_RESISTANCE, SPECIES_TRAIT)
 	ADD_TRAIT(gainer, TRAIT_HARDLY_WOUNDED, SPECIES_TRAIT)
-	ADD_TRAIT(gainer, TRAIT_IGNORESLOWDOWN, SPECIES_TRAIT)
 	ADD_TRAIT(gainer, TRAIT_FEARLESS, SPECIES_TRAIT)
 	ADD_TRAIT(gainer, TRAIT_BRAWLING_KNOCKDOWN_BLOCKED, SPECIES_TRAIT)
 	ADD_TRAIT(gainer, TRAIT_NO_STAGGER, SPECIES_TRAIT)
 	ADD_TRAIT(gainer, TRAIT_NO_THROW_HITPUSH, SPECIES_TRAIT)
 
+	gainer.add_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)
 	gainer.AddComponent( \
 		/datum/component/regenerator, \
 		regeneration_delay = 5 SECONDS, \
@@ -124,12 +124,12 @@
 /datum/species/lycan/proc/handle_gaian_physique_loss(mob/living/carbon/human/loser)
 	REMOVE_TRAIT(loser, TRAIT_BATON_RESISTANCE, SPECIES_TRAIT)
 	REMOVE_TRAIT(loser, TRAIT_HARDLY_WOUNDED, SPECIES_TRAIT)
-	REMOVE_TRAIT(loser, TRAIT_IGNORESLOWDOWN, SPECIES_TRAIT)
 	REMOVE_TRAIT(loser, TRAIT_FEARLESS, SPECIES_TRAIT)
 	REMOVE_TRAIT(loser, TRAIT_BRAWLING_KNOCKDOWN_BLOCKED, SPECIES_TRAIT)
 	REMOVE_TRAIT(loser, TRAIT_NO_STAGGER, SPECIES_TRAIT)
 	REMOVE_TRAIT(loser, TRAIT_NO_THROW_HITPUSH, SPECIES_TRAIT)
 
+	loser.remove_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)
 	qdel(loser.GetComponent(/datum/component/regenerator))
 
 	loser.physiology.stamina_mod *= 4


### PR DESCRIPTION

## About The Pull Request

Title.

I didnt know this other proc existed.
## Why It's Good For The Game

Bugs bad.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: Boosted lycans are now only immune to damage slowdown
/:cl:
