### PR TITLE
Delays lone op by 3 minutes with an announcement, gives the lone op extra TC

### DIFF
--- a/modular_zubbers/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/modular_zubbers/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -1,15 +1,56 @@
+#define GRACE_PERIOD 45 MINUTES
+#define LONEOP_DELAY 3
+
 /obj/item/disk/nuclear/unsecured_process(last_move)
-
 	//If there is no assigned captain, then don't run the event.
 	if(!SSjob || !SSjob.assigned_captain)
 		return
 
-	. = ..()
+	if(last_move < world.time - GRACE_PERIOD)
+		/// How comfy is our disk?
+		var/disk_comfort_level = 0
 
-/obj/item/disk/nuclear/secured_process(last_move)
+		//Go through and check for items that make disk comfy
+		for(var/obj/comfort_item in loc)
+			if(istype(comfort_item, /obj/item/bedsheet) || istype(comfort_item, /obj/structure/bed))
+				disk_comfort_level++
+		var/comfy = disk_comfort_level >= 2
+		if (comfy)
+			return
+		else
+			begin_nuclear_assault()
 
-	//If there is no assigned captain, then don't run the event.
-	if(!SSjob || !SSjob.assigned_captain)
+/obj/item/disk/nuclear/proc/begin_nuclear_assault()
+	priority_announce(
+		"ALERT:::SYNDICATE TRANSMISSION DETECTED:::NUCLEAR AUTHENTICATION DISK LOCATION PINPOINTED:::EXPECT IMMINENT NUCLEAR STRIKE - \
+		ETA [LONEOP_DELAY] MINUTES.\
+		\n\
+		\n\
+		SUGGESTION:::THROW ROCKS AT YOUR CAPTAIN.",
+		"MILCOM Early Warning System",
+		'sound/machines/engine_alert/engine_alert3.ogg',
+		has_important_message = TRUE,
+		color_override = "red"
+	)
+
+	var/datum/component/keep_me_secure/our_component = GetComponent(/datum/component/keep_me_secure)
+	our_component.last_move = world.time
+
+	addtimer(CALLBACK(src, PROC_REF(spawn_loneop)), LONEOP_DELAY MINUTES)
+
+	message_admins("Lone operative queued up for [LONEOP_DELAY] minutes from now due to the nuke disk being unsecured.")
+
+/obj/item/disk/nuclear/proc/spawn_loneop()
+	var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSgamemode.control
+	if (!istype(loneop))
 		return
+	loneop.run_event(FALSE, event_cause = "the nuke disc being unsecured")
 
+/datum/antagonist/nukeop/lone/on_gain()
 	. = ..()
+
+	var/datum/component/uplink/uplink = owner.find_syndicate_uplink()
+	uplink?.uplink_handler?.telecrystals += 5 // extra for the warning
+
+#undef GRACE_PERIOD
+#undef LONEOP_DELAY

--- a/modular_zubbers/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/modular_zubbers/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -7,18 +7,7 @@
 		return
 
 	if(last_move < world.time - GRACE_PERIOD)
-		/// How comfy is our disk?
-		var/disk_comfort_level = 0
-
-		//Go through and check for items that make disk comfy
-		for(var/obj/comfort_item in loc)
-			if(istype(comfort_item, /obj/item/bedsheet) || istype(comfort_item, /obj/structure/bed))
-				disk_comfort_level++
-		var/comfy = disk_comfort_level >= 2
-		if (comfy)
-			return
-		else
-			begin_nuclear_assault()
+		begin_nuclear_assault()
 
 /obj/item/disk/nuclear/proc/begin_nuclear_assault()
 	priority_announce(


### PR DESCRIPTION

## About The Pull Request

Title.

Additionally, lone op will always spawn at the 45 mark of being unsecured. This is less of a design detail and more of a side effect of how I implemented this.
## Why It's Good For The Game

A lot of the pain of lone op comes from the inability for the crew to really respond. Stealth/blitz ops SUCKS. While 3 minutes isnt much, its still enough time for the crew to mount a response. The lone op has been given extra TC with the knowledge that they might need to brute force their way through the crew.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="1507" height="744" alt="image" src="https://github.com/user-attachments/assets/94067147-9659-4ffe-b1ef-ed2affbdc26d" />

<img width="678" height="195" alt="image" src="https://github.com/user-attachments/assets/e4af766a-e576-4c50-b684-7602e67869bc" />

</details>

## Changelog
:cl:
balance: Lone op now always spawns with a 3 minute delay and an announcement
balance: Lone op gets 5 more TC
/:cl:
