### PR TITLE
Makes regen extracts not heal physical damage entirely

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -8,7 +8,7 @@ Regenerative extracts:
 	desc = "It's filled with a milky substance, and pulses like a heartbeat."
 	effect = "regenerative"
 	icon_state = "regenerative"
-	effect_desc = "Completely heals your injuries, with no extra effects."
+	effect_desc = "Completely heals your injuries (excluding physical damage), with no extra effects." // BUBBER EDIT CHANGE - cant be used in combat effectively
 
 /obj/item/slimecross/regenerative/proc/core_effect(mob/living/carbon/human/target, mob/user)
 	return
@@ -30,7 +30,14 @@ Regenerative extracts:
 			span_notice("You squeeze [src], and it bursts in your hand, splashing you with milky goo which quickly regenerates your injuries!"))
 	core_effect_before(H, user)
 	user.do_attack_animation(interacting_with)
-	H.revive(HEAL_ALL & ~HEAL_REFRESH_ORGANS)
+	//H.revive(HEAL_ALL & ~HEAL_REFRESH_ORGANS) // BUBBER EDIT REMOVAL
+	// BUBBER EDIT ADDITION BEGIN - regen extracts arent very good in combat
+	H.heal_damage_type(10, BRUTE)
+	H.heal_damage_type(10, BURN)
+	H.heal_damage_type(10, TOX)
+	// BUBBER EDIT ADDITION END
+
+	H.fully_heal((HEAL_AFFLICTIONS|HEAL_BODY) & ~(HEAL_REFRESH_ORGANS))
 	core_effect(H, user)
 	playsound(H, 'sound/effects/splat.ogg', 40, TRUE)
 	qdel(src)


### PR DESCRIPTION

## About The Pull Request

Title.

Burn/brute/tox are now healed by 10 instead.
## Why It's Good For The Game

Im going to be honest. I hate this thing. It trivializes medbay, entirely. If you get a box of regen cerulean extracts, you basically dont have an excuse to do your job anymore, for any kind of injury. Simultaniously, there are scenarios where a regen extract should be used. So instead of gutting it Im doing this.

A more ideal solution would for there to be a massive downside to using it taht would discourage its use outside of pretty bad scenarios, like a bugged revival. But I cant think of it right now, so the most Im doing it making it not esaily usable in combat.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="648" height="384" alt="image" src="https://github.com/user-attachments/assets/c224fda8-8a40-4e20-8371-01899dee92aa" />

</details>

## Changelog
:cl:
balance: Regen extracts now only heal 10 of the major damage types.
/:cl:
