### PR TITLE
Adds the Stetchkin APS kit to uplinks

### DIFF
--- a/modular_zubbers/code/modules/uplink/uplink_items/dangerous.dm
+++ b/modular_zubbers/code/modules/uplink/uplink_items/dangerous.dm
@@ -9,3 +9,10 @@
 	item = /obj/effect/mob_spawn/ghost_role/borer_egg/traitor
 	cost = 20
 */
+
+/datum/uplink_item/dangerous/stetchkin
+	name = "Stetchkin APS Machine Pistol kit"
+	desc = "A burst-fire weapon dating all the way back to the first Soviet Union, reproduced and found uncommonly among Syndicate agents."
+	item = /obj/item/storage/toolbox/guncase/skyrat/pistol/aps
+	cost = 8
+	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS


### PR DESCRIPTION

## About The Pull Request

Adds another pistol to the traitor's arsenal, the burst-fire Stetchkin APS. 

## Why It's Good For The Game

More guns are cool and good, and this stands out as being a burst-fire firearm!

## Proof Of Testing

<img width="542" height="69" alt="image" src="https://github.com/user-attachments/assets/32e927f0-54a4-4e68-b3af-d34084de0358" />


## Changelog
:cl:
add: Adds the stetchkin to traitor uplinks
/:cl:
