### PR TITLE
Allows security to order Renosters in bulk again because I ran out of shotguns once

### DIFF
--- a/modular_zubbers/code/modules/cargo/packs/security.dm
+++ b/modular_zubbers/code/modules/cargo/packs/security.dm
@@ -208,3 +208,13 @@
 		/obj/item/gun/energy/tacticool,
 		/obj/item/gun/energy/tacticool,
 	)
+
+/datum/supply_pack/security/armory/peacekeepers
+	name = "Renoster Shotgun Crate"
+	desc = "Three Renoster pump-action shotguns to restock your armories with."
+	cost = CARGO_CRATE_VALUE * 10
+	contains = list(
+		/obj/item/gun/ballistic/shotgun/riot/sol,
+		/obj/item/gun/ballistic/shotgun/riot/sol,
+		/obj/item/gun/ballistic/shotgun/riot/sol,
+	)


### PR DESCRIPTION

## About The Pull Request

Allows sec to re-order the main shotgun they use. 

## Why It's Good For The Game

When we messed with guns somehow sec lost the ability to bulk order the main shotgun. This fixes that.

## Proof Of Testing

<img width="431" height="390" alt="image" src="https://github.com/user-attachments/assets/d09226f6-34c4-48ef-861a-0c2d8ac7b047" />

## Changelog
:cl:
add: Renoster crates are in cargo again 
/:cl:
