### PR TITLE
Allows Assistants and Prisoners to be shown on the Job Estimation Panel

### DIFF
--- a/modular_zubbers/code/controllers/subsystem/ticker.dm
+++ b/modular_zubbers/code/controllers/subsystem/ticker.dm
@@ -9,16 +9,13 @@
 		var/mob/dead/new_player/player = players[ckey]
 		var/datum/preferences/prefs = player.client?.prefs
 		var/display = null
-		var/datum/job/J = prefs?.get_highest_priority_job()
-		var/title = J?.title
-		//If a player does not have preferences (for some reason) or they don't want to be shown on the panel, continue
-		if(!J || !(prefs.read_preference(/datum/preference/toggle/ready_job)))
-			continue
-		//If the readied player has selected a miscellaneous job (Assistant, or Prisoner), they shouldn't be displayed
-		if(title == JOB_ASSISTANT || title == JOB_PRISONER)
+		var/datum/job/job_estimation = prefs?.get_highest_priority_job()
+		var/title = job_estimation?.title
+		// If a player does not have preferences (for some reason) or they don't want to be shown on the panel, continue
+		if(!job_estimation || !(prefs.read_preference(/datum/preference/toggle/ready_job)))
 			continue
 
-		//If the job the player is selecting has a special name, that name should be displayed in the menu, otherwise it should use the normal name
+		// If the job the player is selecting has a special name, that name should be displayed in the menu, otherwise it should use the normal name
 		switch(title)
 			if(JOB_AI)
 				display = prefs.read_preference(/datum/preference/name/ai)
@@ -30,16 +27,15 @@
 				display = prefs.read_preference(/datum/preference/name/mime)
 			else
 				display = prefs.read_preference(/datum/preference/name/real_name)
-			//If our player is a member of Command or a Silicon, we want to sort them to the top of the list. Otherwise, just add them to the end of the list.
-		if(J.departments_bitflags & (DEPARTMENT_BITFLAG_COMMAND | DEPARTMENT_BITFLAG_SILICON))
+		// If our player is a member of Command or a Silicon, we want to sort them to the top of the list. Otherwise, just add them to the end of the list.
+		if(job_estimation.departments_bitflags & (DEPARTMENT_BITFLAG_COMMAND | DEPARTMENT_BITFLAG_SILICON))
 			player_ready_data.Insert(1, "* [display] as [title]")
 		else
 			player_ready_data += "* [display] as [title]"
 
-	//The title line for the job estimation panel, obviously needs to be at the top
+	// The title line for the job estimation panel, obviously needs to be at the top
 	if(length(player_ready_data))
 		player_ready_data.Insert(1, "------------------")
 		player_ready_data.Insert(1, "Job Estimation:")
 		player_ready_data.Insert(1, "")
 	return player_ready_data
-//BUBBER EDIT END


### PR DESCRIPTION

## About The Pull Request
Does as the title suggests. I also cleaned up the code in this file a tiny bit by removing an unnecessary modular comment, removing a single letter variable, and making the comments a teeny bit easier to read.
## Why It's Good For The Game
It's nice to know if there is going to be a prisoner so you can decide on if you want to maybe play warden or corrections officer. I also don't see why the panel shouldn't show all potential roles in-game.
## Proof Of Testing
See the screenshot below.
<details>
<summary>Screenshots/Videos</summary>

<img width="216" height="150" alt="image" src="https://github.com/user-attachments/assets/b06ddf2c-2855-4392-a595-5e2902bdc32e" />

</details>

## Changelog
:cl:
qol: The job estimation panel now shows assistants and prisoners.
/:cl:
