### PR TITLE
Removes an Infinite Plastic Exploit

### DIFF
--- a/modular_skyrat/modules/colony_fabricator/code/design_datums/construction.dm
+++ b/modular_skyrat/modules/colony_fabricator/code/design_datums/construction.dm
@@ -114,7 +114,7 @@
 		/datum/material/plastic = HALF_SHEET_MATERIAL_AMOUNT,
 		/datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT,
 	)
-	build_path = /obj/item/stack/sheet/plastic_wall_panel/ten
+	build_path = /obj/item/stack/sheet/plastic_wall_panel
 	category = list(
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_CONSTRUCTION + FABRICATOR_SUBCATEGORY_STRUCTURES,


### PR DESCRIPTION

## About The Pull Request
I noticed when looking through fixes Nova made that they had an issue where you could theoretically make infinite plastic due to the one item printed using the /ten subtype.
## Why It's Good For The Game
Bugs and exploits are bad.
## Proof Of Testing
I couldn't actually get my laptop to co-operate and run things so it's untested, but this fix has been on Nova for two years without issue. Please don't kill me for not testing my PR, Draculion.
## Changelog
:cl:
fix: Fixed infinite plastic theoretically being possible via the colony fab.
/:cl:
