### PR TITLE
Hopefully fixes antagonist reroll + rerolls always pick from the removed antag type

### DIFF
--- a/code/datums/mind/_mind.dm
+++ b/code/datums/mind/_mind.dm
@@ -474,7 +474,7 @@
 			to_chat(usr, span_warning("Invalid antagonist ref to be removed."))
 			return
 
-		SSgamemode.reroll_antagonist(antag_name = name)
+		SSgamemode.reroll_antagonist(antag_name = name, existing_antag = antag)
 		antag.admin_remove(usr)
 	// BUBBER EDIT ADDITION END - ANTAG RE-ROLLING
 

--- a/modular_zubbers/code/modules/storyteller/gamemode.dm
+++ b/modular_zubbers/code/modules/storyteller/gamemode.dm
@@ -872,7 +872,8 @@ SUBSYSTEM_DEF(gamemode)
 	log_admin("[key_name_admin(usr)] requested a new antagonist to replace [antag_name].")
 	if(isnull(event_control))
 		event_control = pick_weight(SSgamemode.antag_rerolls)
-	SSgamemode.inject_event(event_control = event_control)
+	var/datum/round_event_control/event = locate(event_control) in SSevents.control
+	SSgamemode.inject_event(event_control = event)
 
 ADMIN_VERB(create_antagonist, R_FUN, "Create Antagonist", "Inject a little more action into the round.", ADMIN_CATEGORY_EVENTS)
 	var/list/available_antags = list()

--- a/modular_zubbers/code/modules/storyteller/gamemode.dm
+++ b/modular_zubbers/code/modules/storyteller/gamemode.dm
@@ -134,6 +134,8 @@ SUBSYSTEM_DEF(gamemode)
 	var/sec_antag_cap = 0
 	/// A list of event controls to re-roll antagonists
 	var/list/antag_rerolls
+	/// A assoc list of event controls by pref flag, used for accurately rerolling antags. (flag -> /datum/round_control_event)
+	var/list/antag_rerolls_by_pref
 
 	/// Whether we looked up pop info in this process tick
 	var/pop_data_cached = FALSE
@@ -185,7 +187,10 @@ SUBSYSTEM_DEF(gamemode)
 		var/list/event_tags = event.tags
 		if(LAZYLEN(event_tags))
 			if(LAZYFIND(event_tags, TAG_ANTAG_REROLL))
-				LAZYADDASSOC(antag_rerolls, event.type, event.weight)
+				LAZYADDASSOC(antag_rerolls, event, event.weight)
+				if (istype(event, /datum/round_event_control/antagonist))
+					var/datum/round_event_control/antagonist/antag_event = event
+					LAZYADDASSOC(antag_rerolls_by_pref, antag_event.antag_flag, antag_event)
 				continue
 
 		event_pools[event.track] += event //Add it to the categorized event pools
@@ -200,7 +205,7 @@ SUBSYSTEM_DEF(gamemode)
 	if(EMERGENCY_AT_LEAST_DOCKED)
 		//Don't run any events if the shuttle is docked with the station (or in transit towards central command.
 		return
-	if( (SSshuttle.emergency_no_recall && !SSshuttle.admin_emergency_no_recall) && EMERGENCY_IDLE_OR_RECALLED)
+	if((SSshuttle.emergency_no_recall && !SSshuttle.admin_emergency_no_recall) && EMERGENCY_IDLE_OR_RECALLED)
 		//Don't run any events if the shuttle is in transit in a non-admin no-recall state.
 		return
 
@@ -867,19 +872,19 @@ SUBSYSTEM_DEF(gamemode)
 
 	event.run_event(admin_forced = TRUE)
 
-/datum/controller/subsystem/gamemode/proc/reroll_antagonist(datum/round_event_control/event_control, antag_name)
+/datum/controller/subsystem/gamemode/proc/reroll_antagonist(datum/round_event_control/event_control, antag_name, datum/antagonist/existing_antag)
 	message_admins(span_yellowteamradio("[key_name_admin(usr)] requested a new antagonist to replace [antag_name]."))
 	log_admin("[key_name_admin(usr)] requested a new antagonist to replace [antag_name].")
+	if (!isnull(existing_antag))
+		event_control = SSgamemode.antag_rerolls_by_pref[existing_antag.pref_flag]
 	if(isnull(event_control))
 		event_control = pick_weight(SSgamemode.antag_rerolls)
-	var/datum/round_event_control/event = locate(event_control) in SSevents.control
-	SSgamemode.inject_event(event_control = event)
+	SSgamemode.inject_event(event_control = event_control)
 
 ADMIN_VERB(create_antagonist, R_FUN, "Create Antagonist", "Inject a little more action into the round.", ADMIN_CATEGORY_EVENTS)
 	var/list/available_antags = list()
 	for(var/datum/round_event_control/event_control as anything in SSgamemode.antag_rerolls)
-		var/datum/round_event_control/event = locate(event_control) in SSevents.control
-		LAZYADD(available_antags, event)
+		LAZYADD(available_antags, event_control)
 
 	var/datum/round_event_control/selected_event = tgui_input_list(user, "Choose a crew antagonist type to spawn.", "Create Antagonist", available_antags)
 	if(isnull(selected_event))

--- a/modular_zubbers/code/modules/storyteller/gamemode.dm
+++ b/modular_zubbers/code/modules/storyteller/gamemode.dm
@@ -875,7 +875,7 @@ SUBSYSTEM_DEF(gamemode)
 /datum/controller/subsystem/gamemode/proc/reroll_antagonist(datum/round_event_control/event_control, antag_name, datum/antagonist/existing_antag)
 	message_admins(span_yellowteamradio("[key_name_admin(usr)] requested a new antagonist to replace [antag_name]."))
 	log_admin("[key_name_admin(usr)] requested a new antagonist to replace [antag_name].")
-	if (!isnull(existing_antag))
+	if (isnull(event_control) && !isnull(existing_antag))
 		event_control = SSgamemode.antag_rerolls_by_pref[existing_antag.pref_flag]
 	if(isnull(event_control))
 		event_control = pick_weight(SSgamemode.antag_rerolls)


### PR DESCRIPTION

## About The Pull Request

Title.

So, the proc takes instances, but we were getting typepaths from the global list. This fixes it, by getting the instances.

Also makes rerolled antags always pick from the original reroll.
## Why It's Good For The Game

Bugs bag
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="1736" height="424" alt="image" src="https://github.com/user-attachments/assets/6ad83ee3-f453-4f43-bb32-10b2555b2654" />

</details>

## Changelog
:cl:
fix: Antagonist reroll now works
/:cl:
