### PR TITLE
Fix broken default_deconstruction_screwdriver calls

### DIFF
--- a/modular_skyrat/modules/bluespace_miner/code/bluespace_miner.dm
+++ b/modular_skyrat/modules/bluespace_miner/code/bluespace_miner.dm
@@ -206,7 +206,7 @@
 	. = TRUE
 	if(..())
 		return
-	if(default_deconstruction_screwdriver(user, icon_state, icon_state, tool))
+	if(default_deconstruction_screwdriver(user, tool))
 		update_appearance()
 		return
 	return FALSE

--- a/modular_skyrat/modules/cargo/code/export_gate.dm
+++ b/modular_skyrat/modules/cargo/code/export_gate.dm
@@ -132,7 +132,14 @@
 	return TRUE
 
 /obj/machinery/export_gate/screwdriver_act(mob/living/user, obj/item/tool)
-	return default_deconstruction_screwdriver(user, "[initial(icon_state)]_open", initial(icon_state), tool)
+	return default_deconstruction_screwdriver(user, tool)
+
+/obj/machinery/export_gate/update_icon_state()
+	. = ..()
+	if(panel_open)
+		icon_state = "[initial(icon_state)]_open"
+		return
+	icon_state = initial(icon_state)
 
 /obj/machinery/export_gate/proc/clear_scanline()
 	cut_overlays()

--- a/modular_skyrat/modules/cargo/code/export_gate.dm
+++ b/modular_skyrat/modules/cargo/code/export_gate.dm
@@ -28,6 +28,8 @@
 	COOLDOWN_DECLARE(export_payout)
 	/// Internal timer for scanlines
 	var/scanline_timer
+	/// Current scanline icon state
+	var/scanline_state
 	/// Bool to check if the scanner's controls are locked by an ID.
 	var/locked = FALSE
 	/// The holding bank account used for the export gate
@@ -141,14 +143,20 @@
 		return
 	icon_state = initial(icon_state)
 
+/obj/machinery/export_gate/update_overlays()
+	. = ..()
+	if(scanline_state && !panel_open)
+		. += scanline_state
+
 /obj/machinery/export_gate/proc/clear_scanline()
-	cut_overlays()
+	scanline_state = null
 	deltimer(scanline_timer)
+	update_appearance()
 
 /obj/machinery/export_gate/proc/set_scanline(type, duration)
-	cut_overlays()
+	scanline_state = type
 	deltimer(scanline_timer)
-	add_overlay(type)
+	update_appearance()
 	if(duration)
 		scanline_timer = addtimer(CALLBACK(src, PROC_REF(set_scanline), "passive"), duration, TIMER_STOPPABLE)
 	if(COOLDOWN_FINISHED(src, scanner_beep) && type != "passive")

--- a/modular_skyrat/modules/cargo/code/items/gbp_punchcard.dm
+++ b/modular_skyrat/modules/cargo/code/items/gbp_punchcard.dm
@@ -67,10 +67,18 @@
 	default_unfasten_wrench(user, tool)
 	return ITEM_INTERACT_SUCCESS
 
-/obj/machinery/gbp_redemption/attackby(obj/item/attacking_item, mob/user, params)
-	if(default_deconstruction_screwdriver(user, "gbp_machine_open", "gbp_machine", attacking_item))
+/obj/machinery/gbp_redemption/update_icon_state()
+	. = ..()
+	if(panel_open)
+		icon_state = "[initial(icon_state)]_open"
 		return
+	icon_state = initial(icon_state)
 
+/obj/machinery/gbp_redemption/screwdriver_act(mob/living/user, obj/item/tool)
+	. = ..()
+	return default_deconstruction_screwdriver(user, tool)
+
+/obj/machinery/gbp_redemption/attackby(obj/item/attacking_item, mob/user, params)
 	if(default_pry_open(attacking_item, close_after_pry = TRUE))
 		return
 

--- a/modular_skyrat/modules/multicellcharger/code/multi_cell_charger.dm
+++ b/modular_skyrat/modules/multicellcharger/code/multi_cell_charger.dm
@@ -53,6 +53,13 @@
 		. += span_notice("The status display reads: Charging power: <b>[display_power(charge_rate, convert = FALSE)]</b> per cell.")
 	. += span_notice("Alt click it to remove all the cells at once!")
 
+/obj/machinery/cell_charger_multi/screwdriver_act(mob/living/user, obj/item/tool)
+	. = ..()
+	if(length(charging_batteries))
+		to_chat(user, span_warning("[src] must have no cells inside!"))
+		return ITEM_INTERACT_BLOCKING
+	return default_deconstruction_screwdriver(user, tool)
+
 /obj/machinery/cell_charger_multi/attackby(obj/item/tool, mob/user, params)
 	if(istype(tool, /obj/item/stock_parts/power_store/cell) && !panel_open)
 		if(machine_stat & BROKEN)
@@ -82,8 +89,6 @@
 			user.visible_message(span_notice("[user] inserts a cell into [src]."), span_notice("You insert a cell into [src]."))
 			update_appearance()
 	else
-		if(!charging_batteries.len && default_deconstruction_screwdriver(user, icon_state, icon_state, tool))
-			return
 		if(default_deconstruction_crowbar(tool))
 			return
 		if(!charging_batteries.len && default_unfasten_wrench(user, tool))

--- a/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
+++ b/modular_skyrat/modules/self_actualization_device/code/self_actualization_device.dm
@@ -286,7 +286,7 @@
 		to_chat(user, span_warning("[src] is currently occupied!"))
 		return
 
-	if(default_deconstruction_screwdriver(user, icon_state, icon_state, used_item))
+	if(default_deconstruction_screwdriver(user, used_item))
 		update_appearance()
 		return
 

--- a/modular_zubbers/code/game/machinery/burger_reactor/reactor_acts.dm
+++ b/modular_zubbers/code/game/machinery/burger_reactor/reactor_acts.dm
@@ -35,12 +35,7 @@
 
 //Open the panel.
 /obj/machinery/power/rbmk2/screwdriver_act(mob/living/user, obj/item/attack_item)
-
-	if(default_deconstruction_screwdriver(user, icon_state, icon_state, attack_item))
-		return ITEM_INTERACT_SUCCESS
-
-	return ITEM_INTERACT_FAILURE
-
+	return default_deconstruction_screwdriver(user, attack_item)
 
 //Toggle the reactor on/off.
 /obj/machinery/power/rbmk2/wrench_act(mob/living/user, obj/item/attack_item)

--- a/modular_zubbers/code/game/machinery/burger_reactor_sniffer/reactor_sniffer_acts.dm
+++ b/modular_zubbers/code/game/machinery/burger_reactor_sniffer/reactor_sniffer_acts.dm
@@ -1,9 +1,5 @@
 /obj/machinery/rbmk2_sniffer/screwdriver_act(mob/living/user, obj/item/attack_item)
-
-	if(default_deconstruction_screwdriver(user, icon_state, icon_state, attack_item))
-		return ITEM_INTERACT_SUCCESS
-
-	return ITEM_INTERACT_FAILURE
+	return default_deconstruction_screwdriver(user, attack_item)
 
 /obj/machinery/rbmk2_sniffer/crowbar_act(mob/living/user, obj/item/attack_item)
 

--- a/modular_zubbers/code/game/machinery/syndiepad.dm
+++ b/modular_zubbers/code/game/machinery/syndiepad.dm
@@ -28,11 +28,6 @@
 	circuit = /obj/item/circuitboard/machine/syndiepad
 	var/warmup_reduction = 0
 
-/obj/machinery/piratepad/syndiepad/screwdriver_act(mob/living/user, obj/item/tool)
-	. = ..()
-	if(!.)
-		return default_deconstruction_screwdriver(user, "lpad-idle-open", "lpad-idle-off", tool)
-
 /obj/machinery/piratepad/syndiepad/crowbar_act(mob/living/user, obj/item/tool)
 	. = ..()
 	if(!.)

--- a/modular_zubbers/code/modules/hydroponics/gene_modder.dm
+++ b/modular_zubbers/code/modules/hydroponics/gene_modder.dm
@@ -74,11 +74,12 @@
 	if(panel_open)
 		. += "dnamod-open"
 
+/obj/machinery/plantgenes/screwdriver_act(mob/living/user, obj/item/tool)
+	. = ..()
+	return default_deconstruction_screwdriver(user, tool)
+
 /obj/machinery/plantgenes/attackby(obj/item/I, mob/user, params)
-	if(default_deconstruction_screwdriver(user, "dnamod", "dnamod", I))
-		update_icon()
-		return
-	else if(default_unfasten_wrench(user, I))
+	if(default_unfasten_wrench(user, I))
 		return
 	if(default_deconstruction_crowbar(I))
 		return

--- a/modular_zubbers/code/modules/nanites/machines/nanite_chamber.dm
+++ b/modular_zubbers/code/modules/nanites/machines/nanite_chamber.dm
@@ -189,11 +189,14 @@
 		return
 	open_machine()
 
-/obj/machinery/nanite_chamber/attackby(obj/item/I, mob/user, params)
-	if(!occupant && default_deconstruction_screwdriver(user, icon_state, icon_state, I))//sent icon_state is irrelevant...
-		update_appearance()//..since we're updating the icon here, since the scanner can be unpowered when opened/closed
-		return
+/obj/machinery/nanite_chamber/screwdriver_act(mob/living/user, obj/item/tool)
+	. = ..()
+	if(occupant)
+		balloon_alert(user, "occupied!")
+		return ITEM_INTERACT_BLOCKING
+	return default_deconstruction_screwdriver(user, tool)
 
+/obj/machinery/nanite_chamber/attackby(obj/item/I, mob/user, params)
 	if(default_pry_open(I))
 		return
 

--- a/modular_zubbers/code/modules/nanites/machines/nanite_program_hub.dm
+++ b/modular_zubbers/code/modules/nanites/machines/nanite_program_hub.dm
@@ -50,6 +50,13 @@
 	. += "nanite_program_hub_on"
 	. += emissive_appearance(icon, "nanite_program_hub_on", src, alpha = src.alpha)
 
+/obj/machinery/nanite_program_hub/update_icon_state()
+	. = ..()
+	if(panel_open)
+		icon_state = "[initial(icon_state)]_t"
+		return
+	icon_state = initial(icon_state)
+
 /obj/machinery/nanite_program_hub/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	. = ..()
 	if(!istype(tool, /obj/item/disk/nanite_program))
@@ -71,11 +78,8 @@
 		update_static_data_for_all_viewers()
 	return TRUE
 
-/obj/machinery/nanite_program_hub/screwdriver_act(mob/living/user, obj/item/I)
-	if(..())
-		return TRUE
-
-	return default_deconstruction_screwdriver(user, "nanite_program_hub_t", "nanite_program_hub", I)
+/obj/machinery/nanite_program_hub/screwdriver_act(mob/living/user, obj/item/tool)
+	return default_deconstruction_screwdriver(user, tool)
 
 /obj/machinery/nanite_program_hub/crowbar_act(mob/living/user, obj/item/I)
 	if(..())

--- a/modular_zubbers/code/modules/nanites/machines/nanite_programmer.dm
+++ b/modular_zubbers/code/modules/nanites/machines/nanite_programmer.dm
@@ -21,6 +21,13 @@
 	. += "nanite_programmer_on"
 	. += emissive_appearance(icon, "nanite_programmer_on", src, alpha = src.alpha)
 
+/obj/machinery/nanite_programmer/update_icon_state()
+	. = ..()
+	if(panel_open)
+		icon_state = "[initial(icon_state)]_t"
+		return
+	icon_state = initial(icon_state)
+
 /obj/machinery/nanite_programmer/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	. = ..()
 	if(!istype(tool, /obj/item/disk/nanite_program))
@@ -36,11 +43,8 @@
 	program = new_disk.program
 	return ITEM_INTERACT_SUCCESS
 
-/obj/machinery/nanite_programmer/screwdriver_act(mob/living/user, obj/item/I)
-	if(..())
-		return TRUE
-
-	return default_deconstruction_screwdriver(user, "nanite_programmer_t", "nanite_programmer", I)
+/obj/machinery/nanite_programmer/screwdriver_act(mob/living/user, obj/item/tool)
+	return default_deconstruction_screwdriver(user, tool)
 
 /obj/machinery/nanite_programmer/crowbar_act(mob/living/user, obj/item/I)
 	if(..())

--- a/modular_zubbers/code/modules/nanites/machines/public_chamber.dm
+++ b/modular_zubbers/code/modules/nanites/machines/public_chamber.dm
@@ -183,11 +183,14 @@
 		return
 	open_machine()
 
-/obj/machinery/public_nanite_chamber/attackby(obj/item/I, mob/user, params)
-	if(!occupant && default_deconstruction_screwdriver(user, icon_state, icon_state, I))//sent icon_state is irrelevant...
-		update_appearance()//..since we're updating the icon here, since the scanner can be unpowered when opened/closed
-		return
+/obj/machinery/public_nanite_chamber/screwdriver_act(mob/living/user, obj/item/tool)
+	. = ..()
+	if(occupant)
+		balloon_alert(user, "occupied!")
+		return ITEM_INTERACT_BLOCKING
+	return default_deconstruction_screwdriver(user, tool)
 
+/obj/machinery/public_nanite_chamber/attackby(obj/item/I, mob/user, params)
 	if(default_pry_open(I))
 		return
 

--- a/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
+++ b/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
@@ -460,6 +460,13 @@
 	if(loaded_magazine)
 		. += "ammobench_loaded"
 
+/obj/machinery/ammo_workbench/update_icon_state()
+	. = ..()
+	if(panel_open)
+		icon_state = "[initial(icon_state)]_t"
+		return
+	icon_state = initial(icon_state)
+
 /obj/machinery/ammo_workbench/Destroy()
 	QDEL_NULL(materials)
 	QDEL_NULL(wires)
@@ -483,9 +490,11 @@
 	else
 		return FALSE
 
+/obj/machinery/ammo_workbench/screwdriver_act(mob/living/user, obj/item/tool)
+	. = ..()
+	return default_deconstruction_screwdriver(user, tool)
+
 /obj/machinery/ammo_workbench/attackby(obj/item/O, mob/user, params)
-	if (default_deconstruction_screwdriver(user, "[initial(icon_state)]_t", initial(icon_state), O))
-		return
 	if(default_deconstruction_crowbar(O))
 		return
 	if(panel_open && is_wire_tool(O))


### PR DESCRIPTION

## About The Pull Request

The proc no longer takes icon state arguments so these calls are all broken now

## Why It's Good For The Game

Makes a bunch of stuff not runtime when you try to open the panel on it

## Proof Of Testing

I spawned in every object changed and tested screwdrivering the panel open and closed

## Changelog
:cl:
fix: fixed screwdrivering certain machines not working
/:cl:
