### PR TITLE
Protean surgery and also spellcheck I guess

### DIFF
--- a/code/modules/surgery/operations/operation_autopsy.dm
+++ b/code/modules/surgery/operations/operation_autopsy.dm
@@ -5,7 +5,7 @@
 	implements = list(/obj/item/autopsy_scanner = 1)
 	time = 10 SECONDS
 	success_sound = 'sound/machines/printer.ogg'
-	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // BUBBER EDIT CHANGE - SYNTH FLAGS  -Orginal: required_bodytype = ~BODYTYPE_ROBOTIC
+	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // BUBBER EDIT CHANGE - SYNTH FLAGS  -Original: required_bodytype = ~BODYTYPE_ROBOTIC
 	operation_flags = OPERATION_MORBID | OPERATION_IGNORE_CLOTHES
 	all_surgery_states_required = SURGERY_SKIN_OPEN
 

--- a/code/modules/surgery/operations/operation_bioware.dm
+++ b/code/modules/surgery/operations/operation_bioware.dm
@@ -4,7 +4,7 @@
 		IMPLEMENT_HAND = 1,
 	)
 	operation_flags = OPERATION_AFFECTS_MOOD | OPERATION_NOTABLE | OPERATION_MORBID | OPERATION_LOCKED
-	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // NOVA EDIT CHANGE - SYNTH FLAGS  -Orginal: required_bodytype = ~BODYTYPE_ROBOTIC
+	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // NOVA EDIT CHANGE - SYNTH FLAGS  -Original: required_bodytype = ~BODYTYPE_ROBOTIC
 	time = 12.5 SECONDS
 	all_surgery_states_required = SURGERY_SKIN_OPEN|SURGERY_BONE_SAWED|SURGERY_ORGANS_CUT
 	/// What status effect is gained when the surgery is successful?

--- a/code/modules/surgery/operations/operation_filter.dm
+++ b/code/modules/surgery/operations/operation_filter.dm
@@ -5,7 +5,7 @@
 	implements = list(/obj/item/blood_filter = 1)
 	time = 2.5 SECONDS
 	operation_flags = OPERATION_LOOPING
-	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // NOVA EDIT CHANGE - SYNTH FLAGS  -Orginal: required_bodytype = ~BODYTYPE_ROBOTIC
+	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // NOVA EDIT CHANGE - SYNTH FLAGS  -Original: required_bodytype = ~BODYTYPE_ROBOTIC
 	success_sound = 'sound/machines/card_slide.ogg'
 	all_surgery_states_required = SURGERY_SKIN_OPEN
 	any_surgery_states_blocked = SURGERY_VESSELS_UNCLAMPED

--- a/code/modules/surgery/operations/operation_generic.dm
+++ b/code/modules/surgery/operations/operation_generic.dm
@@ -5,7 +5,7 @@
 	// rnd_name = "Laparotomy / Craniotomy / Myotomy (Make Incision)" // Maybe we keep this one simple
 	desc = "Make an incision in the patient's skin to access internal organs. \
 		Causes \"cut skin\" surgical state."
-	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // NOVA EDIT CHANGE - SYNTH FLAGS  -Orginal: required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // NOVA EDIT CHANGE - SYNTH FLAGS  -Orginal: required_bodytype = ~BODYTYPE_ROBOTIC
+	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // NOVA EDIT CHANGE - SYNTH FLAGS  -Original: required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // NOVA EDIT CHANGE - SYNTH FLAGS  -Original: required_bodytype = ~BODYTYPE_ROBOTIC
 	replaced_by = /datum/surgery_operation/limb/incise_skin/abductor
 	implements = list(
 		TOOL_SCALPEL = 1,
@@ -103,7 +103,7 @@
 	desc = "Retract the patient's skin to access their internal organs. \
 		Causes \"skin open\" surgical state."
 	operation_flags = OPERATION_NO_PATIENT_REQUIRED
-	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // NOVA EDIT CHANGE - SYNTH FLAGS  -Orginal: required_bodytype = ~BODYTYPE_ROBOTIC
+	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // NOVA EDIT CHANGE - SYNTH FLAGS  -Original: required_bodytype = ~BODYTYPE_ROBOTIC
 	replaced_by = /datum/surgery_operation/limb/retract_skin/abductor
 	implements = list(
 		TOOL_RETRACTOR = 1,
@@ -147,7 +147,7 @@
 	name = "mend skin incision"
 	desc = "Mend the incision in the patient's skin, closing it up. \
 		Clears most surgical states."
-	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // NOVA EDIT CHANGE - SYNTH FLAGS  -Orginal: required_bodytype = ~BODYTYPE_ROBOTIC
+	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // NOVA EDIT CHANGE - SYNTH FLAGS  -Original: required_bodytype = ~BODYTYPE_ROBOTIC
 	operation_flags = OPERATION_PRIORITY_NEXT_STEP | OPERATION_NO_PATIENT_REQUIRED
 	replaced_by = /datum/surgery_operation/limb/close_skin/abductor
 	implements = list(
@@ -216,7 +216,7 @@
 	name = "clamp bleeders"
 	desc = "Clamp bleeding blood vessels in the patient's body to prevent blood loss. \
 		Causes \"vessels clamped\" surgical state."
-	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // NOVA EDIT CHANGE - SYNTH FLAGS  -Orginal: required_bodytype = ~BODYTYPE_ROBOTIC
+	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // NOVA EDIT CHANGE - SYNTH FLAGS  -Original: required_bodytype = ~BODYTYPE_ROBOTIC
 	operation_flags = OPERATION_PRIORITY_NEXT_STEP | OPERATION_NO_PATIENT_REQUIRED
 	replaced_by = /datum/surgery_operation/limb/clamp_bleeders/abductor
 	implements = list(
@@ -260,7 +260,7 @@
 	name = "unclamp bleeders"
 	desc = "Unclamp blood vessels in the patient's body to allow blood flow again. \
 		Clears \"vessels clamped\" surgical state."
-	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // NOVA EDIT CHANGE - SYNTH FLAGS  -Orginal: required_bodytype = ~BODYTYPE_ROBOTIC
+	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // NOVA EDIT CHANGE - SYNTH FLAGS  -Original: required_bodytype = ~BODYTYPE_ROBOTIC
 	operation_flags = OPERATION_NO_PATIENT_REQUIRED
 	replaced_by = /datum/surgery_operation/limb/unclamp_bleeders/abductor
 	implements = list(
@@ -307,7 +307,7 @@
 	name = "saw limb bone"
 	desc = "Saw through the patient's bones to access their internal organs. \
 		Causes \"bone sawed\" surgical state."
-	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // NOVA EDIT CHANGE - SYNTH FLAGS  -Orginal: required_bodytype = ~BODYTYPE_ROBOTIC
+	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // NOVA EDIT CHANGE - SYNTH FLAGS  -Original: required_bodytype = ~BODYTYPE_ROBOTIC
 	implements = list(
 		TOOL_SAW = 1,
 		/obj/item/shovel/serrated = 1.33,
@@ -370,7 +370,7 @@
 	name = "fix limb bone"
 	desc = "Repair a patient's cut or broken bones. \
 		Clears \"bone sawed\" and \"bone drilled\" surgical states."
-	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // NOVA EDIT CHANGE - SYNTH FLAGS  -Orginal: required_bodytype = ~BODYTYPE_ROBOTIC
+	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // NOVA EDIT CHANGE - SYNTH FLAGS  -Original: required_bodytype = ~BODYTYPE_ROBOTIC
 	operation_flags = OPERATION_NO_PATIENT_REQUIRED
 	implements = list(
 		/obj/item/stack/medical/bone_gel = 1,
@@ -425,7 +425,7 @@
 	name = "drill limb bone"
 	desc = "Drill through a patient's bones. \
 		Causes \"bone drilled\" surgical state."
-	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // NOVA EDIT CHANGE - SYNTH FLAGS  -Orginal: required_bodytype = ~BODYTYPE_ROBOTIC
+	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // NOVA EDIT CHANGE - SYNTH FLAGS  -Original: required_bodytype = ~BODYTYPE_ROBOTIC
 	operation_flags = OPERATION_NO_PATIENT_REQUIRED
 	implements = list(
 		TOOL_DRILL = 1,
@@ -477,7 +477,7 @@
 	name = "incise organs"
 	desc = "Make an incision in the patient's internal organ tissue to allow for manipulation or repair. \
 		Causes \"organs cut\" surgical state."
-	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // NOVA EDIT CHANGE - SYNTH FLAGS  -Orginal: required_bodytype = ~BODYTYPE_ROBOTIC
+	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // NOVA EDIT CHANGE - SYNTH FLAGS  -Original: required_bodytype = ~BODYTYPE_ROBOTIC
 	operation_flags = OPERATION_NO_PATIENT_REQUIRED
 	replaced_by = /datum/surgery_operation/limb/incise_organs/abductor
 	implements = list(

--- a/code/modules/surgery/operations/operation_generic_mechanic.dm
+++ b/code/modules/surgery/operations/operation_generic_mechanic.dm
@@ -11,7 +11,7 @@
 		/obj/item = 10, // i think this amounts to a 180% chance of failure (clamped to 99%)
 	)
 	operation_flags = OPERATION_SELF_OPERABLE | OPERATION_MECHANIC | OPERATION_NO_PATIENT_REQUIRED
-	required_bodytype = BODYTYPE_ROBOTIC
+	required_bodytype = BODYTYPE_ROBOTIC | BODYTYPE_NANO // BUBBER EDIT CHANGE - NANO FLAGS  -Original: required_bodytype = BODYTYPE_ROBOTIC
 	time = 2.4 SECONDS
 	preop_sound = 'sound/items/tools/screwdriver.ogg'
 	success_sound = 'sound/items/tools/screwdriver2.ogg'
@@ -47,7 +47,7 @@
 	name = "open hatch"
 	desc = "Open the hatch of a mechanical patient to access its internals. \
 		Causes \"skin open\" and \"vessels clamped\" surgical states."
-	required_bodytype = BODYTYPE_ROBOTIC
+	required_bodytype = BODYTYPE_ROBOTIC | BODYTYPE_NANO // BUBBER EDIT CHANGE - NANO FLAGS  -Original: required_bodytype = BODYTYPE_ROBOTIC
 	implements = list(
 		IMPLEMENT_HAND = 1,
 		TOOL_CROWBAR = 1,
@@ -83,7 +83,7 @@
 	name = "screw shell"
 	desc = "Screw the shell of a mechanical patient back into place. \
 		Clears most surgical states."
-	required_bodytype = BODYTYPE_ROBOTIC
+	required_bodytype = BODYTYPE_ROBOTIC | BODYTYPE_NANO // BUBBER EDIT CHANGE - NANO FLAGS  -Original: required_bodytype = BODYTYPE_ROBOTIC
 	implements = list(
 		TOOL_SCREWDRIVER = 1,
 		TOOL_SCALPEL = 1.33,
@@ -129,7 +129,7 @@
 	name = "prepare electronics"
 	desc = "Prepare the internal electronics of a mechanical patient for surgery. \
 		Causes \"organs cut\" surgical state."
-	required_bodytype = BODYTYPE_ROBOTIC
+	required_bodytype = BODYTYPE_ROBOTIC | BODYTYPE_NANO // BUBBER EDIT CHANGE - NANO FLAGS  -Original: required_bodytype = BODYTYPE_ROBOTIC
 	implements = list(
 		TOOL_MULTITOOL = 1,
 		TOOL_HEMOSTAT = 1.33,
@@ -164,7 +164,7 @@
 	name = "unwrench endoskeleton"
 	desc = "Unwrench a mechanical patient's endoskeleton to access its internals. \
 		Clears \"bone sawed\" surgical state."
-	required_bodytype = BODYTYPE_ROBOTIC
+	required_bodytype = BODYTYPE_ROBOTIC | BODYTYPE_NANO // BUBBER EDIT CHANGE - NANO FLAGS  -Original: required_bodytype = BODYTYPE_ROBOTIC
 	implements = list(
 		TOOL_WRENCH = 1,
 		TOOL_RETRACTOR = 1.33,
@@ -198,7 +198,7 @@
 	name = "wrench endoskeleton"
 	desc = "Wrench a mechanical patient's endoskeleton back into place. \
 		Clears \"bone sawed\" surgical state."
-	required_bodytype = BODYTYPE_ROBOTIC
+	required_bodytype = BODYTYPE_ROBOTIC | BODYTYPE_NANO // BUBBER EDIT CHANGE - NANO FLAGS  -Original: required_bodytype = BODYTYPE_ROBOTIC
 	implements = list(
 		TOOL_WRENCH = 1,
 		TOOL_RETRACTOR = 1.33,

--- a/code/modules/surgery/operations/operation_lipo.dm
+++ b/code/modules/surgery/operations/operation_lipo.dm
@@ -13,7 +13,7 @@
 		/obj/item = 5,
 	)
 	time = 6.4 SECONDS
-	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // NOVA EDIT CHANGE - SYNTH FLAGS  -Orginal: required_bodytype = ~BODYTYPE_ROBOTIC
+	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // NOVA EDIT CHANGE - SYNTH FLAGS  -Original: required_bodytype = ~BODYTYPE_ROBOTIC
 	preop_sound = list(
 		/obj/item/circular_saw = 'sound/items/handling/surgery/saw.ogg',
 		/obj/item = 'sound/items/handling/surgery/scalpel1.ogg',

--- a/code/modules/surgery/operations/operation_organ_manip.dm
+++ b/code/modules/surgery/operations/operation_organ_manip.dm
@@ -5,7 +5,7 @@
 	name = "organ manipulation"
 	abstract_type = /datum/surgery_operation/limb/organ_manipulation
 	operation_flags = OPERATION_MORBID | OPERATION_NOTABLE | OPERATION_NO_PATIENT_REQUIRED
-	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC & ~BODYTYPE_NANO) // BUBBER EDIT CHANGE - SYNTH/NANO FLAGS  -Original: required_bodytype = ~BODYTYPE_ROBOTIC
+	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // BUBBER EDIT CHANGE - SYNTH FLAGS  -Original: required_bodytype = ~BODYTYPE_ROBOTIC
 	/// Radial slice datums for every organ type we can manipulate
 	VAR_PRIVATE/list/cached_organ_manipulation_options
 

--- a/code/modules/surgery/operations/operation_organ_manip.dm
+++ b/code/modules/surgery/operations/operation_organ_manip.dm
@@ -5,7 +5,7 @@
 	name = "organ manipulation"
 	abstract_type = /datum/surgery_operation/limb/organ_manipulation
 	operation_flags = OPERATION_MORBID | OPERATION_NOTABLE | OPERATION_NO_PATIENT_REQUIRED
-	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC) // BUBBER EDIT CHANGE - SYNTH FLAGS  -Orginal: required_bodytype = ~BODYTYPE_ROBOTIC
+	required_bodytype = (~BODYTYPE_ROBOTIC & ~BODYTYPE_SYNTHETIC & ~BODYTYPE_NANO) // BUBBER EDIT CHANGE - SYNTH/NANO FLAGS  -Original: required_bodytype = ~BODYTYPE_ROBOTIC
 	/// Radial slice datums for every organ type we can manipulate
 	VAR_PRIVATE/list/cached_organ_manipulation_options
 
@@ -240,7 +240,7 @@
 
 /datum/surgery_operation/limb/organ_manipulation/internal/mechanic
 	name = "prosthetic organ manipulation"
-	required_bodytype = (BODYTYPE_ROBOTIC| BODYTYPE_SYNTHETIC) // NOVA EDIT CHANGE - SYNTH FLAGS  -Orginal: required_bodytype = BODYTYPE_ROBOTIC
+	required_bodytype = (BODYTYPE_ROBOTIC | BODYTYPE_SYNTHETIC | BODYTYPE_NANO) // NOVA EDIT CHANGE - SYNTH FLAGS  -Original: required_bodytype = BODYTYPE_ROBOTIC // BUBBER EDIT CHANGE - NANO FLAGS  -Original: required_bodytype = (BODYTYPE_ROBOTIC | BODYTYPE_SYNTHETIC)
 	remove_implements = list(
 		TOOL_CROWBAR = 1,
 		TOOL_HEMOSTAT = 1,
@@ -272,7 +272,7 @@
 
 /datum/surgery_operation/limb/organ_manipulation/external/mechanic
 	name = "prosthetic feature manipulation"
-	required_bodytype = (BODYTYPE_ROBOTIC| BODYTYPE_SYNTHETIC) // NOVA EDIT CHANGE - SYNTH FLAGS  -Orginal: required_bodytype = BODYTYPE_ROBOTIC
+	required_bodytype = (BODYTYPE_ROBOTIC | BODYTYPE_SYNTHETIC | BODYTYPE_NANO) // NOVA EDIT CHANGE - SYNTH FLAGS  -Original: required_bodytype = BODYTYPE_ROBOTIC // BUBBER EDIT CHANGE - NANO FLAGS  -Original: required_bodytype = (BODYTYPE_ROBOTIC | BODYTYPE_SYNTHETIC)
 	remove_implements = list(
 		TOOL_CROWBAR = 1,
 		TOOL_HEMOSTAT = 1,


### PR DESCRIPTION
# About The Pull Request
Restores Protean self-surgery, which was broken by the TG surgery system rework. The rework introduced required_bodytype gating on all mechanical surgery operations and an OPERATION_SELF_OPERABLE flag requirement for self-targeting. Protean limbs use BODYTYPE_NANO, which was never added to any of these checks, leaving Proteans unable to access the synth flavored surgery operations they're intended to have and locked out of self-surgery entirely.

The fix adds BODYTYPE_NANO to the required_bodytype of all six preparatory mechanical operations in operation_generic_mechanic.dm (unscrew shell, open hatch, screw shell, prepare electronics, unwrench/wrench endoskeleton) and to the two prosthetic organ/feature manipulation operations in operation_organ_manip.dm. 

Synths were already handled by a prior Nova edit that added BODYTYPE_SYNTHETIC; this PR extends the same treatment to Proteans and logs it with a Bubber Edit comment.

As a drive-by shooting fix, I also changed a persistent "Orginal" [sic] typo in BUBBER/NOVA EDIT comments across six surgery operation files. These were copied verbatim from the original Nova edit and propagated into every subsequent edit comment in the directory.

# Why It's Good For The Game
Proteans are a Bubberstation-original species with self-surgery as intended functionality. The TG surgery rework silently broke this without any corresponding fix being applied downstream. A surgeon could still operate on a Protean using organic surgical tools but this is sub-optimal and annoying.

# Proof Of Testing
Spawned as Protean, laid down on a table, applied surgical drapes, worked through the full mechanical surgery chain on myself.  Do you really need a screenshot of me laying on a table?


:cl:
fix: Protean self-surgery now works correctly after the TG surgery rework broke it
fix: Surgeons can now use mechanical tools on Proteans as intended, consistent with Synth behaviour
spellcheck: Fixed "Orginal" typo in NOVA/BUBBER EDIT comments across six surgery operation files
/:cl: