### PR TITLE
Fixes genital visibility desynchronization. 

### DIFF
--- a/modular_zubbers/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/modular_zubbers/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -63,3 +63,14 @@
 		overlays_standing[BODY_LAYER] = standing
 
 	apply_overlay(BODY_LAYER)
+
+// Refresh bodypart overlays (genitals etc.) when suit/uniform changes so visibility updates immediately.
+/mob/living/carbon/human/update_worn_oversuit()
+	..()
+	if(!(living_flags & STOP_OVERLAY_UPDATE_BODY_PARTS))
+		update_body_parts()
+
+/mob/living/carbon/human/update_worn_undersuit()
+	..()
+	if(!(living_flags & STOP_OVERLAY_UPDATE_BODY_PARTS))
+		update_body_parts()


### PR DESCRIPTION
# About The Pull Request

Overrides update_worn_oversuit() and update_worn_undersuit() in the modular layer to call update_body_parts() after the parent proc runs.

When clothing is equipped or removed, the game redraws the clothing sprite layer but never re-evaluates bodypart overlays. 

Genital sprites determine their own visibility through can_draw_on_bodypart() at the time update_body_parts() runs, checking whether current clothing covers the relevant body zone. Because update_body_parts() was never called on clothing changes, the visibility state would freeze.

The existing bodypart cache system means this is cheap to call: if nothing actually changed, the before/after key comparison exits early with minimal overhead.

This is likely a problem introduced via upstream sync. The update_worn_oversuit() and update_worn_undersuit() procs have been getting tweaked by tgstation performance work, with refactors tightening them to only touch what they strictly need to render. At some point in that process, an incidental call to update_body_parts() was either removed directly or lost as a side effect of restructuring. Prior to that change, genital visibility was being refreshed as a lucky consequence of the broader body update. Once the upstream procs were slimmed down, the connection was silently severed and the desync emerged.

Tragically I am unable to find a specific person to blame. 

# Why It's Good For The Game

Characters with visible genital configuration would appear as blank barbie dolls after undressing, manual use of the Expose/Hide genitals verb to correct the sprites. (Or they'd just randomly appear when you get surgery, and then be permanently visible until you use expose/hide...)  This is tedious and breaks immersion. The fix makes rendering behave as it should. 
# Proof Of Testing

Tested locally and seemed to work AoK when I spam removed/equipped a jumpsuit class item, still able to manually show genitals too, and so on. 

# Changelog
:cl:
fix: Genital sprites now correctly appear and hide immediately when clothing is equipped or removed, without requiring surgery or manual verb use to refresh them.
/:cl: