### PR TITLE
Fixes Invisible Stone Griddles [NOVA PORT]

### DIFF
--- a/modular_skyrat/modules/primitive_cooking_additions/code/stone_griddle.dm
+++ b/modular_skyrat/modules/primitive_cooking_additions/code/stone_griddle.dm
@@ -13,11 +13,10 @@
 	variant = 1
 	custom_materials = list(/datum/material/stone = SHEET_MATERIAL_AMOUNT * 5)
 
-/obj/machinery/griddle/Initialize(mapload)
+/obj/machinery/griddle/stone/Initialize(mapload)
 	. = ..()
-	grill_loop = new(src, FALSE)
-	if(isnum(variant))
-		variant = 1
+	variant = 1
+	update_appearance()
 
 /obj/machinery/griddle/stone/examine(mob/user)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
**This is a port of https://github.com/NovaSector/NovaSector/pull/7225 by Diltyrr**
Does as the title suggests, should fix https://github.com/Bubberstation/Bubberstation/issues/5675.
## Why It's Good For The Game
Seeing the things you build is good, yes.
## Proof Of Testing
See below. Making a stone griddle worked no matter what direction Mr. Ghoul was facing.
<details>
<summary>Screenshots/Videos</summary>
<img width="222" height="227" alt="image" src="https://github.com/user-attachments/assets/34d4af5e-2e4e-4159-941f-bdf11e8ca684" />

</details>

## Changelog
:cl: xPokee, Diltyrr
fix: Stone griddles will not spawn invisible based on the direction you're facing anymore.
/:cl:
