### PR TITLE
Makes lycans take damage from the silver reagent

### DIFF
--- a/modular_zubbers/code/modules/customization/species/lycans/reagents.dm
+++ b/modular_zubbers/code/modules/customization/species/lycans/reagents.dm
@@ -43,10 +43,11 @@
 
 	var/intensity = 0
 	if (islycan(affected_mob))
+		return 3
 		intensity = 3
 	else if (iscursekin(affected_mob))
-		intensity = 1
+		return 1
 
-	return intensity
+	return 0
 
 #undef BASE_BURN_PER_SECOND

--- a/modular_zubbers/code/modules/customization/species/lycans/reagents.dm
+++ b/modular_zubbers/code/modules/customization/species/lycans/reagents.dm
@@ -43,7 +43,6 @@
 
 	if (islycan(affected_mob))
 		return 3
-		intensity = 3
 	else if (iscursekin(affected_mob))
 		return 1
 

--- a/modular_zubbers/code/modules/customization/species/lycans/reagents.dm
+++ b/modular_zubbers/code/modules/customization/species/lycans/reagents.dm
@@ -1,0 +1,52 @@
+#define BASE_BURN_PER_SECOND 0.5
+
+/datum/reagent/silver/on_mob_metabolize(mob/living/affected_mob)
+	. = ..()
+
+	if (get_lycanthropy_intensity(affected_mob) == 0)
+		return
+
+	to_chat(affected_mob, span_userdanger("THE SILVER STEEL OF LUNA IS WITHIN YOUR VERY VEINS! YOUR FLESH BURNS AND BOILS!"))
+	affected_mob.emote("scream")
+
+/datum/reagent/silver/on_mob_end_metabolize(mob/living/affected_mob, metabolization_ratio)
+	. = ..()
+
+	if (get_lycanthropy_intensity(affected_mob) == 0)
+		return
+
+	to_chat(affected_mob, span_bolddanger("You feel comfort return to you as the last of the blessed lunar steel is filtered from your blood."))
+
+/datum/reagent/silver/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
+	. = ..()
+
+	var/intensity = get_lycanthropy_intensity(affected_mob)
+	if (intensity == 0)
+		return
+
+	// we are a lycan and we have silver in our blood ohhhh noooo broooooooo
+
+	var/damage_amt = BASE_BURN_PER_SECOND * intensity * seconds_per_tick
+	affected_mob.apply_damage(
+		damage_amt,
+		BURN,
+		wound_bonus = CANT_WOUND // TODO - maybe have a small chance to cause a burn wound?
+	)
+
+	if (SPT_PROB(5, seconds_per_tick))
+		to_chat(affected_mob, span_warning("The silver in your veins burns your lycanthropic flesh...!"))
+		affected_mob.emote("scream")
+
+/datum/reagent/silver/proc/get_lycanthropy_intensity(mob/living/carbon/affected_mob)
+	if (!ishuman(affected_mob))
+		return 0
+
+	var/intensity = 0
+	if (islycan(affected_mob))
+		intensity = 3
+	else if (iscursekin(affected_mob))
+		intensity = 1
+
+	return intensity
+
+#undef BASE_BURN_PER_SECOND

--- a/modular_zubbers/code/modules/customization/species/lycans/reagents.dm
+++ b/modular_zubbers/code/modules/customization/species/lycans/reagents.dm
@@ -41,7 +41,6 @@
 	if (!ishuman(affected_mob))
 		return 0
 
-	var/intensity = 0
 	if (islycan(affected_mob))
 		return 3
 		intensity = 3

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9506,7 +9506,6 @@
 #include "modular_zubbers\code\modules\customization\species\lycans\lycan_status.dm"
 #include "modular_zubbers\code\modules\customization\species\lycans\lycan_verbs.dm"
 #include "modular_zubbers\code\modules\customization\species\lycans\martial_arts.dm"
-#include "modular_zubbers\code\modules\customization\species\lycans\reagents.dm"
 #include "modular_zubbers\code\modules\customization\species\lycans\materials.dm"
 #include "modular_zubbers\code\modules\customization\species\lycans\reagents.dm"
 #include "modular_zubbers\code\modules\customization\species\lycans\bodyparts\lycan_bodyparts.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9506,6 +9506,7 @@
 #include "modular_zubbers\code\modules\customization\species\lycans\lycan_status.dm"
 #include "modular_zubbers\code\modules\customization\species\lycans\lycan_verbs.dm"
 #include "modular_zubbers\code\modules\customization\species\lycans\martial_arts.dm"
+#include "modular_zubbers\code\modules\customization\species\lycans\reagents.dm"
 #include "modular_zubbers\code\modules\customization\species\lycans\bodyparts\lycan_bodyparts.dm"
 #include "modular_zubbers\code\modules\customization\species\lycans\organs\lycan_brain.dm"
 #include "modular_zubbers\code\modules\customization\species\lycans\organs\lycan_ears.dm"


### PR DESCRIPTION

## About The Pull Request

I missed this in my atomization of my bigass cursekin PR.

Damage scales depending on if youre in your cursekin form or lycan form.

Damage is relatively low in cursekin form, but it IS burn damage.
## Why It's Good For The Game

Flavor, mostly, and also consistency with silver weapons.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="670" height="176" alt="image" src="https://github.com/user-attachments/assets/aa70d6b5-4f75-4370-8779-58297bebacd4" />

</details>

## Changelog
:cl:
balance: The silver reagent now hurts lycans
/:cl:
