### PR TITLE
Proteans make the normal amount of money. 

### DIFF
--- a/modular_zubbers/code/modules/customization/species/proteans/_proteans_species.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/_proteans_species.dm
@@ -6,7 +6,7 @@
 	sexes = TRUE
 
 	siemens_coeff = 1.5 // Electricty messes you up.
-	payday_modifier = 0.7 // 30 percent poorer
+	payday_modifier = 1.0 // the normal amount
 
 	exotic_bloodtype = BLOOD_TYPE_NANITE_SLURRY
 	digitigrade_customization = DIGITIGRADE_OPTIONAL


### PR DESCRIPTION
# About The Pull Request

This PR removes the reduced paycheck modifier applied to Protean characters, bringing their income in line with other playable species.

Currently, Proteans receive only 70% of standard station pay despite having no insanely strong gameplay advantages, lore justification, or balancing drawbacks that would warrant a permanent economic penalty _(they do have gameplay differences, but I don't think they justify "make them poor!")._ This change removes that discrepancy and standardizes pay across species. It's also not directly mentioned anywhere in game such as the species description.

This is a web edit but honestly I literally changed one number I will eat my fucking hat if this breaks anything. 

Sharkening says and I quote "It's a balance thing, and I stopped caring about balance a year ago" which I interpret as a go ahead. 

# Why It's Good For The Game

Receiving substantially less pay for identical work is not an "interesting" mechanic in practice; it mostly creates frustration and discourages players from engaging with the species. I'm aware this is kind of a piss take but if I found out I was being paid less than my coworkers (30% less, even) I would be "burn the building down" livid. 

I believe that economic mechanics are generally most compelling when they emerge from player choice, job selection, risk, faction affiliation, or gameplay tradeoffs. A flat species-wide pay reduction instead functions as a passive punishment attached to character selection with little opportunity for it to have a meaningful interaction. Technically, protean players are probably not even aware of this. 

Standardizing pay also improves clarity and consistency for players. Species selection should ideally be driven by roleplay preference, mechanics, or aesthetics rather than hidden or arbitrary financial penalties.

Proof Of Testing

Fuck it we'll do it live.  If someone REALLY wants me to change one number in the code and compile it locally I can, but I truly do not think it is necessary. 

Changelog

:cl:
balance: Removed the reduced paycheck modifier for Protean characters
/:cl: