### PR TITLE
Fix two more quirks that fail to properly remove themselves

### DIFF
--- a/modular_skyrat/modules/quirks/good.dm
+++ b/modular_skyrat/modules/quirks/good.dm
@@ -54,7 +54,7 @@
 	var/mob/living/carbon/human/human_holder = quirk_holder
 	var/obj/item/bodypart/arm/left/left_arm = human_holder.get_bodypart(BODY_ZONE_L_ARM)
 	if(left_arm)
-		left_arm.unarmed_attack_verbs = initial(left_arm.unarmed_attack_verbs)
+		left_arm.unarmed_attack_verbs = list("punch")
 		left_arm.unarmed_attack_effect = initial(left_arm.unarmed_attack_effect)
 		left_arm.unarmed_attack_sound = initial(left_arm.unarmed_attack_sound)
 		left_arm.unarmed_miss_sound = initial(left_arm.unarmed_miss_sound)
@@ -62,7 +62,7 @@
 
 	var/obj/item/bodypart/arm/right/right_arm = human_holder.get_bodypart(BODY_ZONE_R_ARM)
 	if(right_arm)
-		right_arm.unarmed_attack_verbs = initial(right_arm.unarmed_attack_verbs)
+		right_arm.unarmed_attack_verbs = list("punch")
 		right_arm.unarmed_attack_effect = initial(right_arm.unarmed_attack_effect)
 		right_arm.unarmed_attack_sound = initial(right_arm.unarmed_attack_sound)
 		right_arm.unarmed_miss_sound = initial(right_arm.unarmed_miss_sound)

--- a/modular_zubbers/code/datums/quirks/negative_quirks/dirty.dm
+++ b/modular_zubbers/code/datums/quirks/negative_quirks/dirty.dm
@@ -83,6 +83,11 @@
 
 	return ..()
 
+/datum/quirk/dirty/remove()
+	UnregisterSignal(quirk_holder, list(COMSIG_ATOM_EXAMINE, COMSIG_ATOM_POST_CLEAN, COMSIG_COMPONENT_CLEAN_ACT, COMSIG_MOVABLE_MOVED, COMSIG_LIVING_SEARCHED_TRASH_PILE, COMSIG_LIVING_CHECK_BLOCK))
+
+	return ..()
+
 /datum/quirk/dirty/proc/searched_trash_pile(atom/signal_source, obj/structure/trash_pile/trash)
 	SIGNAL_HANDLER
 


### PR DESCRIPTION

## About The Pull Request

Dirty, and Sharp Claws.

Dirty didnt implement remove at all.

Sharp claws assumed initial() worked on lists. It does not.
## Why It's Good For The Game

bugs bad
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="699" height="424" alt="image" src="https://github.com/user-attachments/assets/cfb5130a-4e7a-4ee5-bfae-ddd0afa7afc0" />

</details>

## Changelog
:cl:
fix: Dirty and Sharp Claws now properly get removed
/:cl:
