### PR TITLE
Holster override update

### DIFF
--- a/modular_zubbers/code/modules/security/sec_clothing_overrides.dm
+++ b/modular_zubbers/code/modules/security/sec_clothing_overrides.dm
@@ -667,12 +667,11 @@
 		/obj/item/gun/ballistic/automatic/pistol,
 		/obj/item/ammo_box/magazine, // Just magazine, because the sec-belt can hold these aswell
 		/obj/item/gun/ballistic/revolver,
-		/obj/item/ammo_box/speedloader/c38, // Revolver speedloaders.
-		/obj/item/ammo_box/speedloader/c357,
-		/obj/item/ammo_box/speedloader/strilka310,
+		/obj/item/ammo_box/speedloader, // Speedloaders, which includes stripper clips on a technicality.
 		/obj/item/gun/energy/e_gun/mini,
 		/obj/item/gun/energy/disabler,
 		/obj/item/gun/ballistic/revolver,
+		/obj/item/gun/energy/laser/pistol,
 		/obj/item/food/grown/banana,
 		/obj/item/gun/energy/dueling,
 		/obj/item/gun/energy/laser/thermal,
@@ -698,12 +697,11 @@
 		/obj/item/gun/ballistic/automatic/pistol,
 		/obj/item/ammo_box/magazine, // Just magazine, because the sec-belt can hold these aswell
 		/obj/item/gun/ballistic/revolver,
-		/obj/item/ammo_box/speedloader/c38, // Revolver speedloaders.
-		/obj/item/ammo_box/speedloader/c357,
-		/obj/item/ammo_box/speedloader/strilka310,
+		/obj/item/ammo_box/speedloader, // Speedloaders, which includes stripper clips on a technicality.
 		/obj/item/gun/energy/e_gun/mini,
 		/obj/item/gun/energy/disabler,
 		/obj/item/gun/ballistic/revolver,
+		/obj/item/gun/energy/laser/pistol,
 		/obj/item/food/grown/banana,
 		/obj/item/gun/energy/dueling,
 		/obj/item/gun/energy/laser/thermal,

--- a/modular_zubbers/code/modules/security/sec_clothing_overrides.dm
+++ b/modular_zubbers/code/modules/security/sec_clothing_overrides.dm
@@ -670,7 +670,6 @@
 		/obj/item/ammo_box/speedloader, // Speedloaders, which includes stripper clips on a technicality.
 		/obj/item/gun/energy/e_gun/mini,
 		/obj/item/gun/energy/disabler,
-		/obj/item/gun/ballistic/revolver,
 		/obj/item/gun/energy/laser/pistol,
 		/obj/item/food/grown/banana,
 		/obj/item/gun/energy/dueling,
@@ -700,7 +699,6 @@
 		/obj/item/ammo_box/speedloader, // Speedloaders, which includes stripper clips on a technicality.
 		/obj/item/gun/energy/e_gun/mini,
 		/obj/item/gun/energy/disabler,
-		/obj/item/gun/ballistic/revolver,
 		/obj/item/gun/energy/laser/pistol,
 		/obj/item/food/grown/banana,
 		/obj/item/gun/energy/dueling,


### PR DESCRIPTION

## About The Pull Request

Updates our override for the holster and the detective holster to make more sense.

This means:
Made it able to hold any speedloader. The normal TG one could already, we just removed that for some reason.
Made it able to hold /obj/item/gun/energy/laser/pistol

This should more or less cover all the pistols and their ammo types, so shoulder holsters make more sense.
## Why It's Good For The Game
I like my holsters making sense!
## Proof Of Testing
works on my machine
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
code: updated what holsters could hold to make more sense
/:cl:
