### PR TITLE
Fix two issues with icebox lizard gas

### DIFF
--- a/_maps/RandomRuins/IceRuins/bubberstation/icemoon_surface_gas_bubber.dmm
+++ b/_maps/RandomRuins/IceRuins/bubberstation/icemoon_surface_gas_bubber.dmm
@@ -689,9 +689,7 @@
 	},
 /area/ruin/powered/lizard_gas)
 "tk" = (
-/obj/machinery/rnd/production/circuit_imprinter/offstation{
-	name = "Gas Station Imprinter"
-	},
+/obj/machinery/rnd/production/circuit_imprinter/offstation/lizard_gas,
 /turf/open/floor/wood/parquet,
 /area/ruin/powered/lizard_gas)
 "ts" = (

--- a/code/game/area/areas/ruins/icemoon.dm
+++ b/code/game/area/areas/ruins/icemoon.dm
@@ -2,6 +2,7 @@
 
 /area/ruin/powered/lizard_gas
 	name = "\improper Lizard Gas Station"
+	requires_power = TRUE // BUBBER EDIT ADDITION
 
 /area/ruin/unpowered/buried_library
 	name = "\improper Buried Library"

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -25,12 +25,16 @@
 	var/datum/looping_sound/lathe_print/print_sound
 	///made so we dont call addtimer() 40,000 times in on_techweb_update(). only allows addtimer() to be called on the first update
 	var/techweb_updating = FALSE
+	// BUBBER EDIT ADDITION BEGIN - Lizard gas imprinter
+	/// Whether to force the materials container not to connect to the station ore silo
+	var/force_disconnect = FALSE
+	// BUBBER EDIT ADDITION END
 
 /obj/machinery/rnd/production/Initialize(mapload)
 	print_sound = new(src,  FALSE)
 	materials = new (
 		src, \
-		mapload, \
+		force_disconnect ? FALSE : mapload, // BUBBER EDIT CHANGE - Lizard gas imprinter - ORIGINAL: mapload,
 		mat_container_signals = list( \
 			COMSIG_MATCONTAINER_ITEM_CONSUMED = TYPE_PROC_REF(/obj/machinery/rnd/production, local_material_insert)
 		) \

--- a/modular_zubbers/code/modules/research/machinery/circuit_imprinter.dm
+++ b/modular_zubbers/code/modules/research/machinery/circuit_imprinter.dm
@@ -1,0 +1,3 @@
+/obj/machinery/rnd/production/circuit_imprinter/offstation/lizard_gas
+	name = "gas station imprinter"
+	force_disconnect = TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9927,6 +9927,7 @@
 #include "modular_zubbers\code\modules\research\designs\weapon_designs.dm"
 #include "modular_zubbers\code\modules\research\designs\wiremod_designs.dm"
 #include "modular_zubbers\code\modules\research\designs\autolathe\security_designs.dm"
+#include "modular_zubbers\code\modules\research\machinery\circuit_imprinter.dm"
 #include "modular_zubbers\code\modules\research\techweb\all_nodes.dm"
 #include "modular_zubbers\code\modules\research\techweb\circuit_nodes.dm"
 #include "modular_zubbers\code\modules\research\xenobiology\crossbreeding\prismatic.dm"


### PR DESCRIPTION

## About The Pull Request

- The area type for lizard gas on icebox had `requires_power = FALSE` which means when the APC ran out nothing happened, which is dumb because there's an APC and an SMES and a deployable generator the power is clearly supposed to matter
- Because the ruin spawns on the station Z level the circuit imprinter auto connects to the station ore silo, this doesn't make sense and the lavaland version doesn't do it so it doesn't anymore
## Why It's Good For The Game

Fixes #5370 

## Proof Of Testing

I spawned in and set the APC charge to 0 and verified that the area actually loses power and lights go out/machines turn off, then I went and put some mats into the station ore silo and verified that the circuit imprinter in the gas station didn't have them

## Changelog
:cl:
fix: fixed icebox lizard gas having infinite power
fix: fixed icebox lizard gas circuit imprinter connecting to station ore silo
/:cl:
