### PR TITLE
Blocks the portable suit tie modsuit theme from being assimilated

### DIFF
--- a/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
@@ -153,7 +153,7 @@
 		var/static/list/obj/item/mod/control/banned_modsuits = list(
 				/obj/item/mod/control/pre_equipped/infiltrator,
 				/obj/item/mod/control/pre_equipped/protean,
-				/datum/design/mod_plating/portable_suit,
+				/obj/item/mod/construction/plating/portable_suit,
 				)
 
 		if(is_type_in_list(tool, banned_modsuits))

--- a/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
@@ -152,7 +152,9 @@
 
 		var/static/list/obj/item/mod/control/banned_modsuits = list(
 				/obj/item/mod/control/pre_equipped/infiltrator,
-				/obj/item/mod/control/pre_equipped/protean,)
+				/obj/item/mod/control/pre_equipped/protean,
+				/datum/design/mod_plating/portable_suit,
+				)
 
 		if(is_type_in_list(tool, banned_modsuits))
 			balloon_alert(user, "incompatable")


### PR DESCRIPTION
## About The Pull Request

Same reason why it blocks the belt modsuit. It bricks your ass and you're screwed unless an admin intervenes.

## Why It's Good For The Game

Stops proteans from breaking themselves.

## Proof Of Testing

It compiles.

## Changelog

:cl:
fix: Added the portable modsuit tie theme to the Protean assimilation blacklist so that proteans don't brick.
/:cl:
