### PR TITLE
After resetting a Protean with a pen, their sleep is increased to 60 seconds, from 5 seconds.

### DIFF
--- a/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
@@ -176,11 +176,11 @@
 			return
 		protean_in_suit.say("Alert - Random Access Memory Reset. Current memories lost. Any interactions that were ongoing have been forgotten.", forced = TRUE)
 		protean_in_suit.log_message("has had their memory reset.", LOG_ATTACK)
+		message_admins("[protean_in_suit] has had their memories reset with a pen by [user]")
 		to_chat(protean_in_suit, span_boldwarning("Your memories have been reset. You cannot remember who reset you or any of the events leading up to your reset."))
 		playsound(src, 'sound/machines/synth/synth_yes.ogg', 100)
 		playsound(src, 'sound/machines/click.ogg', 100)
-		protean_in_suit.SetSleeping(5 SECONDS)
-
+		protean_in_suit.SetSleeping(1 MINUTES)
 
 /obj/item/mod/control/pre_equipped/protean/ui_status(mob/user, datum/ui_state/state)
 	var/obj/item/mod/core/protean/source = core

--- a/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
@@ -170,7 +170,7 @@
 	if(brain?.dead && istype(tool, /obj/item/pen))
 		to_chat(user, span_notice("You begin to reset the protean's random access memory using a pen!"))
 		user.balloon_alert_to_viewers("resetting memory")
-		user.visible_message(span_boldwarning("[user] is reaching a pen into [protean_in_suit] to find the button!"))
+		user.visible_message(span_boldwarning("[user] is reaching a pen into [protean_in_suit] to find the reset button!"))
 		playsound(src, 'sound/machines/synth/synth_no.ogg', 100)
 		if(!do_after(user, 10 SECONDS))
 			return

--- a/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
@@ -176,7 +176,7 @@
 			return
 		protean_in_suit.say("Alert - Random Access Memory Reset. Current memories lost. Any interactions that were ongoing have been forgotten.", forced = TRUE)
 		protean_in_suit.log_message("has had their memory reset.", LOG_ATTACK)
-		message_admins("[protean_in_suit] has had their memories reset with a pen by [user]")
+		message_admins("[ADMIN_LOOKUPFLW(protean_in_suit)] has had their memories reset with a pen by [ADMIN_LOOKUPFLW(user)]")
 		to_chat(protean_in_suit, span_boldwarning("Your memories have been reset. You cannot remember who reset you or any of the events leading up to your reset."))
 		playsound(src, 'sound/machines/synth/synth_yes.ogg', 100)
 		playsound(src, 'sound/machines/click.ogg', 100)

--- a/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
@@ -168,9 +168,9 @@
 	///Memory Wipe Via Pen
 
 	if(brain?.dead && istype(tool, /obj/item/pen))
-		to_chat(user, span_notice("You begin to reset the protean's random access memory using a pen."))
+		to_chat(user, span_notice("You begin to reset the protean's random access memory using a pen!"))
 		user.balloon_alert_to_viewers("resetting memory")
-		user.visible_message(span_boldwarning("[user] is reaching a pen into [protean_in_suit]!"))
+		user.visible_message(span_boldwarning("[user] is reaching a pen into [protean_in_suit] to find the button!"))
 		playsound(src, 'sound/machines/synth/synth_no.ogg', 100)
 		if(!do_after(user, 10 SECONDS))
 			return


### PR DESCRIPTION

## About The Pull Request

See title

I also gave it an admin message, since it's important information.

## Why It's Good For The Game

We're resetting the memories of an already dead protean, and five seconds isn't nearly enough time for whomever killed them to clear the area. Your memories aren't reset WHEN you wake up. It's like a dead body waking up, with amnesia, and the first thing they see is their murderer. They can still snitch. I think this is a good comprise because dead people don't typically wake up until they're revived.

## Proof Of Testing

It compiles.

<img width="801" height="28" alt="image" src="https://github.com/user-attachments/assets/e6a2934f-2880-484f-af13-d39c0bb8216d" />

## Changelog

:cl:
balance: Increases the sleep duration of Proteans being reset from 5 seconds to 60 seconds.
/:cl:
