### PR TITLE
Northstar fixes and improvements

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -1748,6 +1748,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/testlab)
 "auQ" = (
@@ -6827,6 +6830,9 @@
 /obj/structure/railing/corner{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/testlab)
 "bDr" = (
@@ -11712,6 +11718,7 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/wood/tile,
 /area/station/science/xenobiology/hallway)
 "cQr" = (
@@ -19668,9 +19675,6 @@
 /turf/open/floor/wood,
 /area/station/service/theater)
 "eTV" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -21328,6 +21332,11 @@
 /obj/structure/sign/poster/random/directional/west,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/cargo/miningdock)
+"frv" = (
+/obj/structure/stairs/north,
+/obj/effect/landmark/navigate_destination/chapel,
+/turf/open/floor/iron,
+/area/station/hallway/floor3/aft)
 "frw" = (
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 8
@@ -28404,7 +28413,6 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -28986,12 +28994,21 @@
 /mob/living/basic/pet/dog/corgi/ian,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
+"hnE" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/service/kitchen/abandoned)
 "hnG" = (
 /obj/effect/turf_decal/stripes{
 	dir = 5
 	},
 /obj/structure/railing/corner{
 	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/testlab)
@@ -31420,14 +31437,12 @@
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/floor2/fore)
 "hSP" = (
-/obj/structure/railing/corner,
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/tile/purple/opposingcorners,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/service/kitchen/abandoned)
 "hSQ" = (
 /obj/structure/filingcabinet/employment,
 /obj/machinery/status_display/ai/directional/east,
@@ -35557,6 +35572,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
+"iUh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron/chapel{
+	dir = 1
+	},
+/area/station/service/chapel)
 "iUP" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -40401,6 +40425,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "keg" = (
@@ -42863,6 +42890,7 @@
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "kJq" = (
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen/abandoned)
 "kJG" = (
@@ -49481,10 +49509,6 @@
 	},
 /obj/effect/turf_decal/siding/white{
 	dir = 6
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
 	},
 /turf/open/floor/wood/tile,
 /area/station/science/xenobiology/hallway)
@@ -56371,11 +56395,13 @@
 /turf/closed/wall,
 /area/station/commons/fitness)
 "nWk" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/service/kitchen/abandoned)
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "nWo" = (
 /turf/open/floor/carpet/red,
 /area/station/commons/dorms/room1)
@@ -66443,7 +66469,6 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 10
 	},
-/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/wood/tile,
 /area/station/science/xenobiology/hallway)
 "qxN" = (
@@ -77181,11 +77206,16 @@
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor1/starboard/aft)
 "tjF" = (
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/iron/chapel{
-	dir = 8
+/obj/structure/railing/corner,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
-/area/station/service/chapel)
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "tjJ" = (
 /obj/effect/turf_decal/caution/stand_clear/white{
 	dir = 4
@@ -78393,6 +78423,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/service/chapel)
 "tyK" = (
@@ -81021,6 +81054,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/chapel{
 	dir = 4
 	},
@@ -84810,6 +84844,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/wood/tile,
 /area/station/science/xenobiology/hallway)
 "veG" = (
@@ -94679,6 +94714,9 @@
 "xxA" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/testlab)
 "xxC" = (
@@ -95923,7 +95961,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/unres,
-/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
 /turf/open/floor/plating,
 /area/station/maintenance/floor1/port)
 "xMJ" = (
@@ -96430,9 +96468,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "xTG" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes{
 	dir = 1
 	},
@@ -96815,7 +96850,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/chapel,
 /area/station/service/chapel)
 "xYg" = (
@@ -97152,7 +97186,9 @@
 /area/station/service/kitchen/diner)
 "ydi" = (
 /obj/machinery/firealarm/directional/south,
-/obj/effect/landmark/navigate_destination/chapel,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/iron/chapel,
 /area/station/service/chapel)
 "ydm" = (
@@ -186351,8 +186387,8 @@ jJu
 cOh
 kEf
 kJq
-nWk
 lDG
+hnE
 mmY
 jJu
 jJu
@@ -186608,7 +186644,7 @@ jJu
 vVH
 iPX
 kFb
-iZV
+hSP
 xlH
 lNj
 jJu
@@ -258008,7 +258044,7 @@ nAH
 fOH
 oUu
 xHK
-wpt
+tjF
 cuT
 cuT
 vYE
@@ -258264,7 +258300,7 @@ nAH
 nAH
 hUT
 lbJ
-nqi
+nWk
 hfC
 xiM
 eDk
@@ -258521,8 +258557,8 @@ nAH
 nAH
 oJr
 bTy
-nqi
-hSP
+nWk
+wpt
 xiM
 xiM
 qVO
@@ -267788,7 +267824,7 @@ neL
 eKl
 uzP
 iMN
-hJV
+frv
 dxD
 nKq
 nWI
@@ -333322,8 +333358,8 @@ bTu
 wBU
 rKJ
 jks
-veQ
-tjF
+iUh
+kpz
 cVR
 nGl
 rNo

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -5750,6 +5750,12 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
+"bry" = (
+/obj/machinery/exodrone_launcher,
+/obj/item/exodrone,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plating/elevatorshaft,
+/area/station/cargo/drone_bay)
 "brA" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/decal/cleanable/dirt,
@@ -9530,12 +9536,6 @@
 	dir = 1
 	},
 /area/station/hallway/floor1/fore)
-"cmE" = (
-/obj/machinery/exodrone_launcher,
-/obj/item/exodrone,
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plating/elevatorshaft,
-/area/station/cargo/drone_bay)
 "cmG" = (
 /turf/closed/wall,
 /area/station/medical/psychology)
@@ -11108,6 +11108,14 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
+"cIq" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/iron/dark,
+/area/station/hallway/floor2/fore)
 "cIr" = (
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/wood,
@@ -14884,6 +14892,13 @@
 	dir = 5
 	},
 /area/station/hallway/floor3/fore)
+"dGW" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "library2"
+	},
+/turf/open/floor/wood/tile,
+/area/station/service/library/lounge)
 "dHa" = (
 /obj/structure/closet/boxinggloves,
 /obj/machinery/light/small/directional/west,
@@ -18568,13 +18583,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "eCP" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor/heavy,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/airlock{
+	name = "Viewing Room"
 	},
 /turf/open/floor/iron/dark,
-/area/station/hallway/floor1/aft)
+/area/station/maintenance/floor3/starboard/fore)
 "eCQ" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -26499,6 +26512,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor4/aft)
+"gGn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/shieldgen,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "gGp" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -38262,9 +38285,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/multi_tile/public/glass{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor1/aft)
 "jCv" = (
@@ -39219,13 +39239,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/floor2/starboard/aft)
 "jNQ" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/iron/dark,
-/area/station/hallway/floor2/fore)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "library2"
+	},
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	name = "Library"
+	},
+/turf/open/floor/iron,
+/area/station/service/library)
 "jOc" = (
 /obj/item/storage/box/firingpins,
 /obj/item/storage/box/firingpins,
@@ -48892,13 +48914,6 @@
 /obj/structure/drain,
 /turf/open/floor/noslip,
 /area/station/science/lobby)
-"mev" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/public/glass{
-	name = "Lower Library"
-	},
-/turf/open/floor/iron,
-/area/station/service/library)
 "mew" = (
 /obj/machinery/camera/autoname/directional/west,
 /obj/machinery/firealarm/directional/west,
@@ -50960,6 +50975,9 @@
 /area/station/engineering/atmos/project)
 "mEg" = (
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	name = "Lower Library"
+	},
 /turf/open/floor/iron,
 /area/station/service/library)
 "mEh" = (
@@ -55889,6 +55907,17 @@
 /obj/effect/spawner/random/medical/surgery_tool,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/floor1/port)
+"nNI" = (
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "blast_miningdock";
+	name = "Mining Dock Hangar Door"
+	},
+/obj/structure/fans/tiny/forcefield,
+/turf/open/floor/plating,
+/area/station/cargo/miningdock)
 "nNJ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -60030,6 +60059,10 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
+"oPF" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/service/library)
 "oPH" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
@@ -64242,17 +64275,6 @@
 /obj/machinery/griddle,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
-"pTf" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "blast_miningdock";
-	name = "Mining Dock Hangar Door"
-	},
-/obj/structure/fans/tiny/forcefield,
-/turf/open/floor/plating,
-/area/station/cargo/miningdock)
 "pTI" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -69718,13 +69740,8 @@
 	},
 /obj/structure/cable,
 /obj/structure/rack,
-/obj/item/melee/breaching_hammer{
-	pixel_x = 6
-	},
-/obj/item/melee/breaching_hammer,
-/obj/item/melee/breaching_hammer{
-	pixel_x = -6
-	},
+/obj/effect/spawner/random/armory/bulletproof_armor,
+/obj/effect/spawner/random/armory/bulletproof_helmet,
 /turf/open/floor/iron/dark,
 /area/station/security/armory)
 "rhR" = (
@@ -70546,15 +70563,16 @@
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain/private)
 "rtS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/railing{
-	dir = 8
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	dir = 4
 	},
-/obj/machinery/shieldgen,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/turf/open/floor/iron/dark,
+/area/station/hallway/floor1/aft)
 "rtV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -70944,8 +70962,6 @@
 /obj/machinery/light/directional/north,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/rack,
-/obj/effect/spawner/random/armory/bulletproof_armor,
-/obj/effect/spawner/random/armory/bulletproof_helmet,
 /obj/effect/spawner/random/armory/bulletproof_armor,
 /obj/effect/spawner/random/armory/bulletproof_helmet,
 /turf/open/floor/iron/dark,
@@ -81640,11 +81656,6 @@
 /obj/structure/hedge,
 /turf/open/floor/carpet/green,
 /area/station/service/kitchen/diner)
-"ulF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/station/ai/satellite/teleporter)
 "ulN" = (
 /obj/structure/chair/pew{
 	dir = 1
@@ -82634,16 +82645,6 @@
 /obj/item/food/baguette,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/theater)
-"uAd" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "library2"
-	},
-/obj/machinery/door/airlock/multi_tile/public/glass{
-	name = "Library"
-	},
-/turf/open/floor/iron,
-/area/station/service/library)
 "uAe" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
@@ -83150,12 +83151,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor1/fore)
-"uGT" = (
-/obj/machinery/door/airlock{
-	name = "Viewing Room"
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/floor3/starboard/fore)
 "uHa" = (
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/dark/side,
@@ -95991,6 +95986,11 @@
 "xIV" = (
 /turf/open/space/openspace,
 /area/space/nearstation)
+"xJe" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/station/ai/satellite/teleporter)
 "xJk" = (
 /obj/machinery/seed_extractor,
 /obj/effect/turf_decal/tile/green/full,
@@ -96123,13 +96123,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
-"xKD" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "library2"
-	},
-/turf/open/floor/wood/tile,
-/area/station/service/library/lounge)
 "xKZ" = (
 /obj/machinery/light_switch/directional/north,
 /obj/machinery/shower/directional/west,
@@ -122658,7 +122651,7 @@ owI
 owI
 uYl
 pFb
-cmE
+bry
 hDa
 fyg
 xxQ
@@ -126773,8 +126766,8 @@ hKN
 hKN
 hKN
 hKN
-rtS
-rtS
+gGn
+gGn
 xbV
 xbV
 xbV
@@ -129081,7 +129074,7 @@ owI
 owI
 owI
 aux
-pTf
+nNI
 fWE
 uaC
 gHk
@@ -137841,7 +137834,7 @@ iqa
 qSl
 qSl
 rjD
-eCP
+jCi
 qTS
 rjD
 rjD
@@ -137853,7 +137846,7 @@ rjD
 rjD
 rjD
 jIT
-jCi
+rtS
 rjD
 rjD
 xgH
@@ -138881,7 +138874,7 @@ rjD
 rjD
 rjD
 qgE
-jCi
+rtS
 rjD
 rjD
 xgH
@@ -183856,7 +183849,7 @@ fNe
 fNT
 fNT
 fNT
-jNQ
+cIq
 bnV
 fNT
 fNT
@@ -205942,7 +205935,7 @@ dEt
 dEt
 dEt
 amt
-xKD
+dGW
 pBW
 kca
 rCc
@@ -247579,7 +247572,7 @@ acK
 acK
 hEm
 btC
-uGT
+eCP
 sJO
 gec
 vuo
@@ -270449,10 +270442,10 @@ kRR
 fpU
 kmt
 oGM
-uAd
+jNQ
 qPi
 lBK
-mev
+mEg
 fBP
 ddg
 wet
@@ -270709,7 +270702,7 @@ oGM
 cEw
 rdW
 pSd
-mEg
+oPF
 fBP
 ddg
 fAT
@@ -337280,7 +337273,7 @@ oyh
 oyh
 oyh
 hWr
-ulF
+xJe
 tIl
 fEv
 dMt

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -8239,7 +8239,6 @@
 /area/station/maintenance/disposal/incinerator)
 "bYb" = (
 /obj/structure/table/glass,
-/obj/item/stack/medical/gauze,
 /obj/machinery/defibrillator_mount/directional/east,
 /obj/item/storage/medkit/emergency{
 	pixel_y = 4
@@ -16184,6 +16183,7 @@
 	pixel_y = 6
 	},
 /obj/item/stack/medical/mesh,
+/obj/item/stack/medical/wrap/gauze/twelve,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "dXz" = (
@@ -38666,6 +38666,7 @@
 /obj/item/storage/box/rxglasses{
 	pixel_y = 5
 	},
+/obj/item/stack/medical/wrap/gauze/twelve,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/treatment_center)
 "jIy" = (
@@ -44719,7 +44720,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/morgue{
-	name = "Private Study"
+	name = "Private Study";
+	req_access = list("library")
 	},
 /turf/open/floor/iron,
 /area/station/service/library/private)
@@ -62528,7 +62530,8 @@
 "pzu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/morgue{
-	name = "Private Study"
+	name = "Private Study";
+	req_access = list("library")
 	},
 /turf/open/floor/engine/cult,
 /area/station/service/library/private)
@@ -71261,6 +71264,7 @@
 /obj/structure/table/glass,
 /obj/item/storage/box/rxglasses,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/item/stack/medical/wrap/gauze/twelve,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/storage)
 "rJy" = (
@@ -73393,12 +73397,15 @@
 	pixel_x = -5
 	},
 /obj/item/stack/medical/ointment{
-	pixel_y = -5;
-	pixel_x = 5
+	pixel_y = 3;
+	pixel_x = 6
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
+/obj/item/stack/medical/wrap/gauze/twelve{
+	pixel_y = -2
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/lobby)
 "snp" = (
@@ -73727,9 +73734,6 @@
 /area/station/medical/office)
 "ssx" = (
 /obj/item/stack/medical/bandage,
-/obj/item/stack/medical/gauze/improvised{
-	pixel_y = 12
-	},
 /obj/structure/table,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port/aft)
@@ -74067,7 +74071,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/freezer,
 /obj/item/stack/medical/suture,
-/obj/item/stack/medical/gauze/twelve,
 /obj/item/stack/medical/bone_gel,
 /turf/open/floor/iron/white,
 /area/station/maintenance/floor3/starboard/aft)
@@ -74842,7 +74845,6 @@
 /obj/structure/table,
 /obj/machinery/vending/wallmed/directional/north,
 /obj/machinery/duct,
-/obj/item/stack/medical/gauze,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "sHq" = (

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -2232,6 +2232,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor4/fore)
+"aCb" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/hallway/floor1/aft)
 "aCd" = (
 /obj/effect/turf_decal/siding/white,
 /obj/effect/turf_decal/trimline/purple/line{
@@ -7483,6 +7491,13 @@
 /obj/effect/turf_decal/trimline/green/warning,
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor3/aft)
+"bNY" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	name = "Lower Library"
+	},
+/turf/open/floor/iron,
+/area/station/service/library)
 "bOf" = (
 /obj/effect/turf_decal/stripes,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -10809,9 +10824,6 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "library2"
 	},
-/obj/machinery/door/airlock/multi_tile/public/glass{
-	name = "Library"
-	},
 /turf/open/floor/iron,
 /area/station/service/library)
 "cEH" = (
@@ -11715,7 +11727,6 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/west,
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/wood/tile,
 /area/station/science/xenobiology/hallway)
@@ -18562,16 +18573,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "eCP" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/multi_tile/public/glass{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/hallway/floor2/fore)
+/turf/open/floor/plating,
+/area/station/ai/satellite/teleporter)
 "eCQ" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -31848,17 +31853,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plastic,
 /area/station/security/prison/shower)
-"hWI" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "blast_miningdock";
-	name = "Mining Dock Hangar Door"
-	},
-/obj/structure/fans/tiny/forcefield,
-/turf/open/floor/plating,
-/area/station/cargo/miningdock)
 "hWN" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/random/structure/crate,
@@ -37811,11 +37805,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
-"jxd" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/space/basic,
-/area/station/ai/satellite/teleporter)
 "jxf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/baseturf_helper/reinforced_plating/ceiling,
@@ -45668,7 +45657,7 @@
 	dir = 1
 	},
 /obj/machinery/duct,
-/obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/chapel{
 	dir = 8
 	},
@@ -45811,6 +45800,16 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor4/starboard/aft)
+"lsL" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "library2"
+	},
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	name = "Library"
+	},
+/turf/open/floor/iron,
+/area/station/service/library)
 "lsM" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/disposal/bin,
@@ -54208,6 +54207,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
+"nsm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/shieldgen,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "nsn" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59363,12 +59372,6 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
-"oHf" = (
-/obj/machinery/exodrone_launcher,
-/obj/item/exodrone,
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plating/elevatorshaft,
-/area/station/cargo/drone_bay)
 "oHp" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
@@ -61283,6 +61286,12 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/engine/o2,
 /area/station/engineering/atmos)
+"phu" = (
+/obj/machinery/exodrone_launcher,
+/obj/item/exodrone,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plating/elevatorshaft,
+/area/station/cargo/drone_bay)
 "phI" = (
 /obj/effect/turf_decal/stripes{
 	dir = 10
@@ -69755,6 +69764,17 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor3/starboard/fore)
+"rir" = (
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "blast_miningdock";
+	name = "Mining Dock Hangar Door"
+	},
+/obj/structure/fans/tiny/forcefield,
+/turf/open/floor/plating,
+/area/station/cargo/miningdock)
 "ris" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
@@ -70536,12 +70556,16 @@
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain/private)
 "rtS" = (
-/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/multi_tile/public/glass{
-	name = "Lower Library"
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/service/library)
+/turf/open/floor/iron/dark,
+/area/station/hallway/floor2/fore)
 "rtV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -77183,6 +77207,14 @@
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"tfl" = (
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/landmark/firealarm_sanity,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "tfo" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 8
@@ -77551,14 +77583,6 @@
 	},
 /turf/open/floor/eighties,
 /area/station/commons/fitness/recreation/entertainment)
-"tkU" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor/heavy,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/hallway/floor1/aft)
 "tkZ" = (
 /obj/structure/cable,
 /obj/machinery/conveyor/inverted{
@@ -78404,6 +78428,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/floor2/fore)
+"tuU" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "library2"
+	},
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	name = "Library";
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/station/service/library/lounge)
 "tuX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -79932,6 +79967,7 @@
 "tOE" = (
 /obj/machinery/duct,
 /obj/machinery/light/directional/south,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/chapel,
 /area/station/service/chapel)
 "tOF" = (
@@ -89107,6 +89143,7 @@
 	dir = 8
 	},
 /obj/machinery/light/warm/directional/west,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/wood/tile,
 /area/station/science/xenobiology/hallway)
 "wcA" = (
@@ -89318,13 +89355,6 @@
 /obj/effect/turf_decal/arrows,
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/wood/tile,
-/area/station/service/library)
-"wen" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "library2"
-	},
-/turf/open/floor/iron,
 /area/station/service/library)
 "wet" = (
 /obj/structure/disposalpipe/segment{
@@ -94160,17 +94190,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/misc/grass,
 /area/station/maintenance/floor1/starboard)
-"xmf" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "library2"
-	},
-/obj/machinery/door/airlock/multi_tile/public/glass{
-	name = "Library";
-	dir = 4
-	},
-/turf/open/floor/wood/tile,
-/area/station/service/library/lounge)
 "xmh" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/green/opposingcorners,
@@ -97144,6 +97163,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/landmark/firealarm_sanity,
 /turf/open/floor/iron/chapel,
 /area/station/service/chapel)
 "xYg" = (
@@ -97480,7 +97500,6 @@
 /turf/open/floor/wood,
 /area/station/service/kitchen/diner)
 "ydi" = (
-/obj/machinery/firealarm/directional/south,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -97915,16 +97934,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard/fore)
-"yjP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/shieldgen,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "yjR" = (
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 8
@@ -122651,7 +122660,7 @@ owI
 owI
 uYl
 pFb
-oHf
+phu
 hDa
 fyg
 xxQ
@@ -126766,8 +126775,8 @@ hKN
 hKN
 hKN
 hKN
-yjP
-yjP
+nsm
+nsm
 xbV
 xbV
 xbV
@@ -129074,7 +129083,7 @@ owI
 owI
 owI
 aux
-hWI
+rir
 fWE
 uaC
 gHk
@@ -137834,7 +137843,7 @@ iqa
 qSl
 qSl
 rjD
-tkU
+aCb
 qTS
 rjD
 rjD
@@ -182811,7 +182820,7 @@ wwu
 wwu
 fNT
 fqo
-eCP
+rtS
 fNT
 fNT
 fNT
@@ -183839,7 +183848,7 @@ wwu
 wwu
 fNT
 fqo
-eCP
+rtS
 fNT
 fNT
 fNT
@@ -183850,7 +183859,7 @@ fNT
 fNT
 fNT
 bnV
-eCP
+rtS
 fNT
 fNT
 hLz
@@ -205936,7 +205945,7 @@ dEt
 dEt
 amt
 pBW
-xmf
+tuU
 kca
 rCc
 oZz
@@ -259636,7 +259645,7 @@ nAH
 nAH
 maf
 hrL
-nqi
+tfl
 eKB
 nAH
 hUT
@@ -270442,10 +270451,10 @@ kRR
 fpU
 kmt
 oGM
-cEw
+lsL
 qPi
 lBK
-rtS
+bNY
 fBP
 ddg
 wet
@@ -270699,7 +270708,7 @@ fpU
 fpU
 kmt
 oGM
-wen
+cEw
 rdW
 pSd
 mEg
@@ -337273,7 +337282,7 @@ oyh
 oyh
 oyh
 hWr
-jxd
+eCP
 tIl
 fEv
 dMt

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -38403,6 +38403,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
 /turf/open/floor/iron/white/textured_large,
 /area/station/cargo/miningoffice)
 "jEk" = (
@@ -40265,6 +40266,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
 /turf/open/floor/iron/white/textured_large,
 /area/station/cargo/miningoffice)
 "kbN" = (
@@ -87066,6 +87068,7 @@
 	name = "Xenoflora"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
 /turf/open/floor/iron/textured_large,
 /area/station/cargo/miningdock)
 "vAU" = (

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -5475,6 +5475,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor2/fore)
 "boa" = (
@@ -9527,6 +9530,12 @@
 	dir = 1
 	},
 /area/station/hallway/floor1/fore)
+"cmE" = (
+/obj/machinery/exodrone_launcher,
+/obj/item/exodrone,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plating/elevatorshaft,
+/area/station/cargo/drone_bay)
 "cmG" = (
 /turf/closed/wall,
 /area/station/medical/psychology)
@@ -10808,9 +10817,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "library2"
-	},
-/obj/machinery/door/airlock/multi_tile/public/glass{
-	name = "Library"
 	},
 /turf/open/floor/iron,
 /area/station/service/library)
@@ -18562,11 +18568,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "eCP" = (
-/obj/machinery/door/airlock{
-	name = "Viewing Room"
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/maintenance/floor3/starboard/fore)
+/area/station/hallway/floor1/aft)
 "eCQ" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -22208,11 +22216,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/prison/work)
-"fDk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/station/ai/satellite/teleporter)
 "fDq" = (
 /obj/structure/sign/poster/contraband/atmosia_independence/directional/west,
 /turf/open/floor/pod/light,
@@ -30293,10 +30296,6 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor2/starboard/fore)
-"hCu" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/service/library)
 "hCv" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -33366,17 +33365,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
-"iqT" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/multi_tile/public/glass{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/hallway/floor2/fore)
 "ira" = (
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/effect/turf_decal/bot,
@@ -36594,7 +36582,7 @@
 "jgK" = (
 /obj/machinery/atmospherics/components/trinary/filter,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/light/blacklight/directional/east,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "jgO" = (
@@ -39231,16 +39219,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/floor2/starboard/aft)
 "jNQ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "library2"
-	},
-/obj/machinery/door/airlock/multi_tile/public/glass{
-	name = "Library";
-	dir = 4
-	},
-/turf/open/floor/wood/tile,
-/area/station/service/library/lounge)
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/iron/dark,
+/area/station/hallway/floor2/fore)
 "jOc" = (
 /obj/item/storage/box/firingpins,
 /obj/item/storage/box/firingpins,
@@ -44407,12 +44392,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/engineering/atmos)
-"lau" = (
-/obj/machinery/exodrone_launcher,
-/obj/item/exodrone,
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plating/elevatorshaft,
-/area/station/cargo/drone_bay)
 "lax" = (
 /obj/structure/table,
 /obj/item/storage/dice,
@@ -48913,6 +48892,13 @@
 /obj/structure/drain,
 /turf/open/floor/noslip,
 /area/station/science/lobby)
+"mev" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	name = "Lower Library"
+	},
+/turf/open/floor/iron,
+/area/station/service/library)
 "mew" = (
 /obj/machinery/camera/autoname/directional/west,
 /obj/machinery/firealarm/directional/west,
@@ -50974,9 +50960,6 @@
 /area/station/engineering/atmos/project)
 "mEg" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/public/glass{
-	name = "Lower Library"
-	},
 /turf/open/floor/iron,
 /area/station/service/library)
 "mEh" = (
@@ -62923,6 +62906,10 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "library2"
 	},
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	name = "Library";
+	dir = 4
+	},
 /turf/open/floor/wood/tile,
 /area/station/service/library/lounge)
 "pBZ" = (
@@ -64255,6 +64242,17 @@
 /obj/machinery/griddle,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
+"pTf" = (
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "blast_miningdock";
+	name = "Mining Dock Hangar Door"
+	},
+/obj/structure/fans/tiny/forcefield,
+/turf/open/floor/plating,
+/area/station/cargo/miningdock)
 "pTI" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -64337,14 +64335,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
-"pUt" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor/heavy,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/hallway/floor1/aft)
 "pUB" = (
 /obj/machinery/power/smes/super/full,
 /obj/structure/cable,
@@ -70556,12 +70546,15 @@
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain/private)
 "rtS" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "library2"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/shieldgen,
 /turf/open/floor/iron,
-/area/station/service/library)
+/area/station/cargo/storage)
 "rtV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -72716,16 +72709,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/circuit,
 /area/station/ai/satellite/interior)
-"rZG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/shieldgen,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "rZS" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -79511,17 +79494,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
-"tJc" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "blast_miningdock";
-	name = "Mining Dock Hangar Door"
-	},
-/obj/structure/fans/tiny/forcefield,
-/turf/open/floor/plating,
-/area/station/cargo/miningdock)
 "tJi" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 1
@@ -81668,6 +81640,11 @@
 /obj/structure/hedge,
 /turf/open/floor/carpet/green,
 /area/station/service/kitchen/diner)
+"ulF" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/station/ai/satellite/teleporter)
 "ulN" = (
 /obj/structure/chair/pew{
 	dir = 1
@@ -82657,6 +82634,16 @@
 /obj/item/food/baguette,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/theater)
+"uAd" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "library2"
+	},
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	name = "Library"
+	},
+/turf/open/floor/iron,
+/area/station/service/library)
 "uAe" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
@@ -83163,6 +83150,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor1/fore)
+"uGT" = (
+/obj/machinery/door/airlock{
+	name = "Viewing Room"
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/floor3/starboard/fore)
 "uHa" = (
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/dark/side,
@@ -96130,6 +96123,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
+"xKD" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "library2"
+	},
+/turf/open/floor/wood/tile,
+/area/station/service/library/lounge)
 "xKZ" = (
 /obj/machinery/light_switch/directional/north,
 /obj/machinery/shower/directional/west,
@@ -122658,7 +122658,7 @@ owI
 owI
 uYl
 pFb
-lau
+cmE
 hDa
 fyg
 xxQ
@@ -126773,8 +126773,8 @@ hKN
 hKN
 hKN
 hKN
-rZG
-rZG
+rtS
+rtS
 xbV
 xbV
 xbV
@@ -129081,7 +129081,7 @@ owI
 owI
 owI
 aux
-tJc
+pTf
 fWE
 uaC
 gHk
@@ -137841,7 +137841,7 @@ iqa
 qSl
 qSl
 rjD
-pUt
+eCP
 qTS
 rjD
 rjD
@@ -182818,7 +182818,7 @@ wwu
 wwu
 fNT
 fqo
-iqT
+bnV
 fNT
 fNT
 fNT
@@ -183846,7 +183846,7 @@ wwu
 wwu
 fNT
 fqo
-iqT
+bnV
 fNT
 fNT
 fNT
@@ -183856,8 +183856,8 @@ fNe
 fNT
 fNT
 fNT
+jNQ
 bnV
-iqT
 fNT
 fNT
 hLz
@@ -205942,8 +205942,8 @@ dEt
 dEt
 dEt
 amt
+xKD
 pBW
-jNQ
 kca
 rCc
 oZz
@@ -247579,7 +247579,7 @@ acK
 acK
 hEm
 btC
-eCP
+uGT
 sJO
 gec
 vuo
@@ -270449,10 +270449,10 @@ kRR
 fpU
 kmt
 oGM
-cEw
+uAd
 qPi
 lBK
-mEg
+mev
 fBP
 ddg
 wet
@@ -270706,10 +270706,10 @@ fpU
 fpU
 kmt
 oGM
-rtS
+cEw
 rdW
 pSd
-hCu
+mEg
 fBP
 ddg
 fAT
@@ -337280,7 +337280,7 @@ oyh
 oyh
 oyh
 hWr
-fDk
+ulF
 tIl
 fEv
 dMt

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -1748,8 +1748,9 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/room4)
 "auO" = (
-/turf/open/floor/iron/dark,
-/area/station/engineering/circuit_workshop)
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/ordnance/testlab)
 "auQ" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
@@ -2773,6 +2774,7 @@
 /area/station/hallway/floor2/aft)
 "aIU" = (
 /obj/machinery/firealarm/directional/north,
+/obj/structure/trash_pile,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/port)
 "aIV" = (
@@ -4862,14 +4864,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/construction)
-"bik" = (
-/obj/effect/turf_decal/stripes{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/science/ordnance/testlab)
 "bin" = (
 /obj/effect/turf_decal/trimline/green/warning{
 	dir = 1
@@ -6671,6 +6665,7 @@
 /obj/effect/turf_decal/trimline/green/warning{
 	dir = 8
 	},
+/obj/structure/trash_pile,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor3/starboard)
 "bBS" = (
@@ -6975,8 +6970,12 @@
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor3/port/aft)
 "bGl" = (
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology/hallway)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/floor4/starboard)
 "bGn" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -7375,10 +7374,6 @@
 /obj/machinery/light/floor,
 /turf/open/floor/wood/tile,
 /area/station/service/library)
-"bMw" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology/hallway)
 "bMz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/girder,
@@ -7489,6 +7484,12 @@
 /obj/effect/turf_decal/trimline/green/warning,
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor3/aft)
+"bOf" = (
+/obj/effect/turf_decal/stripes,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/science/ordnance/testlab)
 "bOg" = (
 /obj/effect/turf_decal/trimline/brown/warning,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -9026,6 +9027,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/pharmacy)
+"chw" = (
+/obj/effect/turf_decal/tile/neutral/full,
+/obj/effect/turf_decal/tile/neutral/full,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron,
+/area/station/science/ordnance/testlab)
 "chF" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/tile/red/opposingcorners{
@@ -12269,7 +12280,19 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor3/starboard/aft)
 "cWZ" = (
-/turf/closed/wall/r_wall,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/north,
+/obj/machinery/light_switch/directional/north{
+	pixel_x = 9
+	},
+/obj/effect/mapping_helpers/turn_off_lights_with_lightswitch,
+/turf/open/floor/iron/dark,
 /area/station/engineering/circuit_workshop)
 "cXi" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12998,6 +13021,16 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor3/port/aft)
+"dgK" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron/dark,
+/area/station/security/armory)
 "dgU" = (
 /obj/structure/cable,
 /obj/machinery/light/red/dim/directional/north,
@@ -13948,6 +13981,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard)
+"dvz" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/power_store/cell/high{
+	pixel_y = -2;
+	pixel_x = 5
+	},
+/obj/item/mmi{
+	pixel_x = -4;
+	pixel_y = 11
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/engineering/circuit_workshop)
 "dvA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -14482,6 +14532,18 @@
 	},
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
+"dCB" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/ammo_workbench,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
+/area/station/security/armory)
 "dCD" = (
 /obj/effect/spawner/random/entertainment/arcade,
 /obj/machinery/light/blacklight/directional/north,
@@ -14943,8 +15005,9 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard/fore)
 "dIJ" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/neutral/full,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
 "dIO" = (
 /obj/structure/cable,
@@ -15868,6 +15931,24 @@
 	dir = 5
 	},
 /area/station/hallway/floor1/aft)
+"dUz" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/rack,
+/obj/item/melee/breaching_hammer{
+	pixel_x = 6
+	},
+/obj/item/melee/breaching_hammer,
+/obj/item/melee/breaching_hammer{
+	pixel_x = -6
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/armory)
 "dUF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -17067,6 +17148,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/floor3/starboard/aft)
+"ejH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/trash_pile,
+/turf/open/floor/pod,
+/area/station/maintenance/floor4/starboard/aft)
 "ejI" = (
 /obj/effect/turf_decal/trimline/green/warning{
 	dir = 8
@@ -18478,18 +18564,7 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/disposal/incinerator)
 "eCr" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/structure/rack,
-/obj/item/controller,
-/obj/item/controller,
-/obj/item/compact_remote,
-/obj/item/compact_remote,
-/obj/effect/turf_decal/bot,
-/obj/machinery/camera/autoname/directional/west,
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/dark,
+/turf/closed/wall/r_wall,
 /area/station/engineering/circuit_workshop)
 "eCz" = (
 /obj/machinery/door/window/left/directional/south{
@@ -19324,6 +19399,7 @@
 /obj/effect/turf_decal/trimline/green/corner{
 	dir = 1
 	},
+/obj/structure/trash_pile,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor3/port/aft)
 "eOf" = (
@@ -19695,11 +19771,9 @@
 /turf/open/floor/wood,
 /area/station/service/theater)
 "eTV" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/iron,
-/area/station/science/ordnance/testlab)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology/hallway)
 "eUn" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -20494,17 +20568,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/cargo/office)
-"fgO" = (
-/obj/effect/turf_decal/stripes{
-	dir = 6
-	},
-/obj/machinery/firealarm/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/white,
-/area/station/science/ordnance/testlab)
 "fhl" = (
 /obj/structure/bed{
 	dir = 1
@@ -22771,11 +22834,19 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor2/aft)
 "fKr" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
-	dir = 6
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
 	},
-/turf/open/floor/engine/vacuum,
-/area/station/science/ordnance/freezerchamber)
+/obj/structure/rack,
+/obj/item/controller,
+/obj/item/controller,
+/obj/item/compact_remote,
+/obj/item/compact_remote,
+/obj/effect/turf_decal/bot,
+/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/engineering/circuit_workshop)
 "fKs" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -24067,6 +24138,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/structure/trash_pile,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
 "gaJ" = (
@@ -25422,12 +25494,15 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor4/starboard/fore)
 "gsy" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/spawner/random/trash/graffiti{
-	pixel_y = -32
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/stripes{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/floor1/port/aft)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/ordnance/testlab)
 "gsD" = (
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 1
@@ -25871,11 +25946,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/carpet/royalblue,
 /area/station/medical/break_room)
-"gyi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/space_heater,
-/turf/open/floor/pod/light,
-/area/station/maintenance/floor4/starboard)
 "gyp" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -26412,6 +26482,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/floor2/port)
+"gFJ" = (
+/turf/open/floor/iron/dark,
+/area/station/engineering/circuit_workshop)
 "gFO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -26599,6 +26672,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"gHR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/frame/machine,
+/obj/item/circuitboard/machine/telecomms/receiver,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor3/starboard/fore)
 "gHU" = (
 /obj/structure/rack,
 /obj/item/storage/box/syringes,
@@ -27423,11 +27502,9 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/central)
 "gSD" = (
-/obj/structure/rack,
 /obj/structure/sign/poster/official/random/directional/east,
 /obj/effect/turf_decal/tile/red/fourcorners,
-/obj/effect/spawner/random/armory/bulletproof_armor,
-/obj/effect/spawner/random/armory/bulletproof_helmet,
+/obj/structure/closet/secure_closet/armory_kiboko,
 /turf/open/floor/iron/dark,
 /area/station/security/armory)
 "gSS" = (
@@ -27548,9 +27625,9 @@
 /area/station/maintenance/floor2/starboard)
 "gUH" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/rack,
 /obj/effect/turf_decal/tile/red/fourcorners,
-/obj/effect/spawner/random/armory/laser_gun,
+/obj/effect/spawner/random/armory/e_gun,
+/obj/structure/rack/gunrack,
 /turf/open/floor/iron/dark,
 /area/station/security/armory)
 "gUO" = (
@@ -28479,20 +28556,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/floor2/starboard/aft)
 "hfE" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/machinery/light/small/directional/north,
-/obj/machinery/light_switch/directional/north{
-	pixel_x = 9
-	},
-/obj/effect/mapping_helpers/turn_off_lights_with_lightswitch,
-/turf/open/floor/iron/dark,
-/area/station/engineering/circuit_workshop)
+/turf/closed/wall,
+/area/station/science/ordnance/testlab)
 "hfO" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
 /obj/structure/filingcabinet/chestdrawer,
@@ -30143,6 +30208,13 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/treatment_center)
+"hBj" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/spawner/random/trash/graffiti{
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/floor1/port/aft)
 "hBm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -33296,10 +33368,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "ira" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/rack,
 /obj/effect/turf_decal/tile/red/fourcorners,
-/obj/effect/spawner/random/armory/shotgun,
+/obj/effect/turf_decal/bot,
+/obj/structure/rack/gunrack,
+/obj/effect/spawner/random/armory/dragnet,
 /turf/open/floor/iron/dark,
 /area/station/security/armory)
 "irb" = (
@@ -33867,10 +33939,9 @@
 	},
 /area/station/hallway/floor4/aft)
 "izj" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/rack,
 /obj/effect/turf_decal/tile/red/fourcorners,
-/obj/effect/spawner/random/armory/e_gun,
+/obj/machinery/dish_drive/bullet,
+/obj/effect/turf_decal/delivery/red,
 /turf/open/floor/iron/dark,
 /area/station/security/armory)
 "izl" = (
@@ -36507,15 +36578,11 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/service)
 "jgK" = (
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/trinary/filter,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/blacklight/directional/east,
 /turf/open/floor/iron/dark,
-/area/station/engineering/circuit_workshop)
+/area/station/science/ordnance/testlab)
 "jgO" = (
 /obj/effect/spawner/random/trash/soap,
 /obj/machinery/light/small/directional/south,
@@ -36656,6 +36723,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"jiP" = (
+/obj/effect/turf_decal/tile/red/fourcorners,
+/obj/machinery/dish_drive/bullet,
+/obj/effect/turf_decal/delivery/red,
+/turf/open/floor/iron/dark,
+/area/station/security/lockers)
 "jja" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
@@ -36890,7 +36963,6 @@
 /turf/open/floor/carpet/red,
 /area/station/service/library)
 "jlW" = (
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
@@ -36898,7 +36970,14 @@
 	dir = 4
 	},
 /obj/machinery/light_switch/directional/west,
-/obj/structure/cable,
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/item/storage/belt/sheath/sabre/cargo{
+	pixel_x = 2
+	},
+/obj/item/storage/belt/sheath/sabre/cargo{
+	pixel_x = -7
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/armory)
 "jmc" = (
@@ -37396,6 +37475,11 @@
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/mechbay)
+"jsN" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/pod/dark,
+/area/station/maintenance/floor2/starboard)
 "jsP" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
@@ -40782,12 +40866,16 @@
 /area/station/hallway/floor2/aft)
 "khn" = (
 /obj/item/storage/box/chemimp{
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 5
 	},
 /obj/item/storage/box/trackimp{
-	pixel_x = -3
+	pixel_x = -7;
+	pixel_y = 6
 	},
-/obj/item/storage/lockbox/loyalty,
+/obj/item/storage/lockbox/loyalty{
+	pixel_y = -4
+	},
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/item/radio/intercom/directional/south,
@@ -45046,6 +45134,30 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
+"lix" = (
+/obj/machinery/light_switch/directional/west,
+/obj/effect/turf_decal/stripes{
+	dir = 9
+	},
+/obj/item/assembly/timer,
+/obj/structure/closet/crate/science{
+	name = "Parts crate"
+	},
+/obj/item/assembly/timer,
+/obj/item/assembly/timer,
+/obj/item/assembly/timer,
+/obj/item/assembly/signaler,
+/obj/item/assembly/signaler,
+/obj/item/assembly/signaler,
+/obj/item/assembly/prox_sensor,
+/obj/item/assembly/signaler,
+/obj/item/assembly/signaler,
+/obj/item/assembly/signaler,
+/obj/item/assembly/prox_sensor,
+/obj/item/assembly/prox_sensor,
+/obj/item/assembly/prox_sensor,
+/turf/open/floor/iron/white,
+/area/station/science/ordnance/testlab)
 "liL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -46826,12 +46938,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"lHS" = (
-/obj/effect/turf_decal/stripes,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/science/ordnance/testlab)
 "lIe" = (
 /obj/structure/railing{
 	dir = 8
@@ -47745,6 +47851,7 @@
 "lRY" = (
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/machinery/ammo_workbench,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "lSd" = (
@@ -49376,6 +49483,14 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/openspace,
 /area/station/solars/starboard/aft)
+"mlV" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Circuit Workshop"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/station/engineering/circuit_workshop)
 "mlX" = (
 /obj/structure/chair/comfy/brown,
 /obj/effect/landmark/start/assistant,
@@ -49867,6 +49982,12 @@
 "mrG" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/break_room)
+"mrJ" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron,
+/area/station/science/ordnance/testlab)
 "mrL" = (
 /obj/structure/transit_tube/diagonal,
 /turf/open/floor/engine/hull/reinforced,
@@ -52875,6 +52996,11 @@
 	name = "boxing ring"
 	},
 /area/station/commons/fitness)
+"neI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/space_heater,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor4/starboard)
 "neJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -53147,12 +53273,12 @@
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/floor3/aft)
 "nhm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/effect/turf_decal/bot,
+/obj/structure/rack/gunrack,
+/obj/effect/spawner/armory_spawn/shotguns,
 /turf/open/floor/iron/dark,
 /area/station/security/armory)
 "nho" = (
@@ -54722,11 +54848,11 @@
 /turf/open/floor/iron/white/textured,
 /area/station/medical/storage)
 "nzV" = (
-/obj/structure/rack,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/structure/cable,
 /obj/effect/spawner/random/armory/disablers,
+/obj/structure/rack/gunrack,
 /turf/open/floor/iron/dark,
 /area/station/security/armory)
 "nAb" = (
@@ -57562,8 +57688,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/spawner/random/structure/closet_maintenance,
-/obj/effect/spawner/random/maintenance,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor2/starboard)
 "okK" = (
@@ -58295,12 +58419,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/floor3/aft)
-"otP" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral/full,
-/turf/open/floor/iron,
-/area/station/science/ordnance/testlab)
 "otQ" = (
 /obj/machinery/power/smes,
 /obj/structure/cable,
@@ -58825,6 +58943,16 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"oAS" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/armory)
 "oAZ" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/engine/plasma,
@@ -59859,9 +59987,18 @@
 /turf/open/floor/iron/white,
 /area/station/science/lower)
 "oOW" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/armory/dragnet,
-/turf/open/floor/iron/dark,
+/obj/structure/rack/gunrack,
+/obj/item/gun/energy/laser/carbine{
+	pixel_y = 6;
+	pixel_x = 6
+	},
+/obj/item/gun/energy/laser/carbine,
+/obj/item/gun/energy/laser/carbine{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/recharge_floor,
 /area/station/security/armory)
 "oOY" = (
 /obj/structure/table/wood/fancy/red,
@@ -61762,13 +61899,6 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor2/aft)
-"ppE" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor4/starboard)
 "ppN" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Tech Storage"
@@ -62208,10 +62338,11 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor3/port/fore)
 "puQ" = (
-/obj/machinery/recharger,
-/obj/structure/table/reinforced,
 /obj/structure/sign/poster/official/random/directional/south,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/bot,
+/obj/structure/rack/gunrack,
+/obj/effect/spawner/random/armory/laser_gun,
+/turf/open/floor/iron/recharge_floor,
 /area/station/security/armory)
 "puY" = (
 /obj/structure/rack,
@@ -63322,6 +63453,14 @@
 	},
 /turf/open/floor/wood,
 /area/station/hallway/secondary/entry)
+"pIL" = (
+/obj/effect/turf_decal/stripes{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/science/ordnance/testlab)
 "pIS" = (
 /obj/machinery/requests_console/directional/east{
 	department = "Captain's Desk";
@@ -64246,10 +64385,15 @@
 /turf/open/floor/wood/parquet,
 /area/station/commons/dorms/room2)
 "pUK" = (
-/obj/structure/railing,
-/obj/machinery/door/firedoor/border_only,
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
-/area/station/science/ordnance/testlab)
+/area/station/engineering/circuit_workshop)
 "pUV" = (
 /turf/open/floor/plating/airless,
 /area/station/solars/port/aft)
@@ -68110,11 +68254,11 @@
 /area/station/solars/starboard/aft)
 "qQG" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/armory)
@@ -70779,6 +70923,12 @@
 	},
 /obj/structure/cable,
 /obj/machinery/light/directional/north,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/rack,
+/obj/effect/spawner/random/armory/bulletproof_armor,
+/obj/effect/spawner/random/armory/bulletproof_helmet,
+/obj/effect/spawner/random/armory/bulletproof_helmet,
+/obj/effect/spawner/random/armory/bulletproof_armor,
 /turf/open/floor/iron/dark,
 /area/station/security/armory)
 "rAV" = (
@@ -70862,14 +71012,15 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/virology/isolation)
 "rBU" = (
-/obj/structure/rack,
 /obj/machinery/button/door/directional/south{
 	id = "armory";
 	name = "Armory Shutters";
 	req_access = list("armory")
 	},
-/obj/item/gun/energy/temperature/security,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/bot,
+/obj/structure/rack/gunrack,
+/obj/effect/spawner/armory_spawn/smg,
+/turf/open/floor/iron/recharge_floor,
 /area/station/security/armory)
 "rBW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -71003,6 +71154,11 @@
 /obj/effect/turf_decal/tile/green/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/hallway/floor2/aft)
+"rDg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/trash_pile,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port/fore)
 "rDh" = (
 /obj/machinery/camera/autoname/directional/west,
 /obj/item/radio/intercom/directional/west,
@@ -71685,6 +71841,7 @@
 "rNL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/red/dim/directional/north,
+/obj/structure/trash_pile,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard/fore)
 "rNN" = (
@@ -72124,13 +72281,13 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor3/port/aft)
 "rTw" = (
-/obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/station/security/armory)
 "rTz" = (
@@ -72931,30 +73088,6 @@
 	dir = 8
 	},
 /area/station/hallway/floor3/fore)
-"seR" = (
-/obj/machinery/light_switch/directional/west,
-/obj/effect/turf_decal/stripes{
-	dir = 9
-	},
-/obj/item/assembly/timer,
-/obj/structure/closet/crate/science{
-	name = "Parts crate"
-	},
-/obj/item/assembly/timer,
-/obj/item/assembly/timer,
-/obj/item/assembly/timer,
-/obj/item/assembly/signaler,
-/obj/item/assembly/signaler,
-/obj/item/assembly/signaler,
-/obj/item/assembly/prox_sensor,
-/obj/item/assembly/signaler,
-/obj/item/assembly/signaler,
-/obj/item/assembly/signaler,
-/obj/item/assembly/prox_sensor,
-/obj/item/assembly/prox_sensor,
-/obj/item/assembly/prox_sensor,
-/turf/open/floor/iron/white,
-/area/station/science/ordnance/testlab)
 "sfe" = (
 /obj/structure/chair/comfy/carp,
 /obj/effect/decal/cleanable/glitter,
@@ -74886,8 +75019,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/floor2/aft)
 "sFR" = (
-/turf/closed/wall,
-/area/station/science/ordnance/testlab)
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
+	dir = 6
+	},
+/turf/open/floor/engine/vacuum,
+/area/station/science/ordnance/freezerchamber)
 "sGb" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall/r_wall,
@@ -82046,14 +82182,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/misc/dirt/jungle,
 /area/station/service/hydroponics/garden/abandoned)
-"uue" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Circuit Workshop"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/station/engineering/circuit_workshop)
 "uuh" = (
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/dark,
@@ -82173,11 +82301,8 @@
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "uwf" = (
-/obj/machinery/atmospherics/components/trinary/filter,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/light/blacklight/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance/testlab)
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology/hallway)
 "uwl" = (
 /obj/machinery/computer/slot_machine,
 /obj/machinery/firealarm/directional/west,
@@ -83674,11 +83799,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/floor2/starboard/aft)
 "uOc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/frame/machine,
-/obj/item/circuitboard/machine/telecomms/receiver,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/pod/light,
-/area/station/maintenance/floor3/starboard/fore)
+/area/station/maintenance/floor4/starboard)
 "uOd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -85162,16 +85288,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
-"vhB" = (
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/turf_decal/box,
-/turf/open/floor/iron,
-/area/station/science/ordnance/testlab)
 "vhL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -92246,6 +92362,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"wPo" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/armory)
 "wPs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -92267,11 +92395,17 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor3/starboard/fore)
 "wPG" = (
-/obj/structure/rack,
 /obj/structure/secure_safe/directional/east,
 /obj/effect/turf_decal/tile/red/fourcorners,
-/obj/effect/spawner/random/armory/bulletproof_armor,
-/obj/effect/spawner/random/armory/bulletproof_helmet,
+/obj/structure/rack/gunrack,
+/obj/item/gun/energy/modular_laser_rifle/carbine{
+	pixel_y = 5;
+	pixel_x = -1
+	},
+/obj/item/gun/energy/temperature/security{
+	pixel_y = -5;
+	pixel_x = 2
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/armory)
 "wPK" = (
@@ -92704,7 +92838,7 @@
 /area/station/maintenance/floor1/port)
 "wVr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/mess,
+/obj/structure/trash_pile,
 /turf/open/floor/pod,
 /area/station/maintenance/floor4/port/fore)
 "wVu" = (
@@ -94844,12 +94978,11 @@
 /turf/open/floor/iron,
 /area/station/service/barber)
 "xxA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/pod/light,
-/area/station/maintenance/floor4/starboard)
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/full,
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/iron,
+/area/station/science/ordnance/testlab)
 "xxC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -95788,7 +95921,9 @@
 /area/station/engineering/atmos/pumproom)
 "xIP" = (
 /obj/structure/table/reinforced,
-/obj/machinery/recharger,
+/obj/machinery/recharger{
+	pixel_x = -6
+	},
 /obj/machinery/door/window/brigdoor/left/directional/south{
 	name = "Armory Desk";
 	req_access = list("armory")
@@ -95797,6 +95932,9 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "armblast";
 	name = "Armory Blast Door"
+	},
+/obj/machinery/recharger{
+	pixel_x = 6
 	},
 /turf/open/floor/plating,
 /area/station/security/brig)
@@ -96598,22 +96736,16 @@
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "xTG" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
+/obj/effect/turf_decal/stripes{
+	dir = 6
 	},
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/power_store/cell/high{
-	pixel_y = -2;
-	pixel_x = 5
+/obj/machinery/firealarm/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/mmi{
-	pixel_x = -4;
-	pixel_y = 11
-	},
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/engineering/circuit_workshop)
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/white,
+/area/station/science/ordnance/testlab)
 "xTH" = (
 /obj/structure/table/wood,
 /obj/item/instrument/violin,
@@ -96645,16 +96777,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
-"xUj" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/ordnance/testlab)
 "xUk" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -96781,9 +96903,9 @@
 	},
 /area/station/maintenance/floor1/starboard/aft)
 "xVV" = (
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
+/obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "xVX" = (
 /obj/effect/turf_decal/trimline/white/arrow_ccw,
@@ -96887,6 +97009,11 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/secondary/exit/escape_pod)
+"xXc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/pod,
+/area/station/maintenance/floor4/port/fore)
 "xXd" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -97699,6 +97826,7 @@
 "yit" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/east,
+/obj/structure/trash_pile,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard/aft)
 "yiw" = (
@@ -119716,7 +119844,7 @@ usj
 dac
 fQm
 fQm
-qez
+rDg
 hJy
 hJy
 owI
@@ -141802,11 +141930,11 @@ xMu
 wWw
 eEA
 nDf
-cWZ
-cWZ
-cWZ
-cWZ
-cWZ
+eCr
+eCr
+eCr
+eCr
+eCr
 dEc
 ulU
 ggX
@@ -142059,10 +142187,10 @@ tNA
 rcd
 cQB
 yhO
-cWZ
-fGt
 eCr
-xTG
+fGt
+fKr
+dvz
 hca
 dEc
 koJ
@@ -142316,9 +142444,9 @@ loN
 bXe
 saA
 vvK
+eCr
 cWZ
-hfE
-auO
+gFJ
 uhx
 msL
 dEc
@@ -142573,9 +142701,9 @@ uMl
 oOd
 otD
 gnY
-uue
+mlV
 gqO
-jgK
+pUK
 pzY
 ssx
 dEc
@@ -142830,11 +142958,11 @@ sZb
 xYU
 fYg
 kHS
-cWZ
+eCr
 bhb
-cWZ
-cWZ
-cWZ
+eCr
+eCr
+eCr
 dEc
 kUe
 wRM
@@ -143092,7 +143220,7 @@ sTQ
 pRN
 ccK
 mWg
-gsy
+hBj
 khQ
 dEc
 dEc
@@ -200878,7 +201006,7 @@ ucA
 ucA
 vnK
 vnK
-pog
+jsN
 dMV
 vnK
 vnK
@@ -253830,7 +253958,7 @@ ycg
 uHe
 vVo
 ccH
-uOc
+gHR
 wRJ
 igy
 rip
@@ -254340,7 +254468,7 @@ xeE
 pbj
 gMv
 vjT
-bGl
+uwf
 gTk
 ccH
 xDK
@@ -254597,7 +254725,7 @@ fok
 bpY
 xAo
 rLB
-bMw
+eTV
 gTk
 ccH
 oMv
@@ -313226,7 +313354,7 @@ lvm
 vSG
 mpK
 key
-qNk
+xXc
 qNk
 iQE
 rej
@@ -318339,10 +318467,10 @@ nPE
 bvM
 fUk
 rXJ
-ppE
+bGl
 xXm
 eRZ
-gyi
+neI
 nPE
 tKs
 hug
@@ -318849,11 +318977,11 @@ wFa
 tYV
 oUW
 xwL
-seR
-xUj
+lix
+gsy
 gOF
-otP
-eTV
+mrJ
+xxA
 nPE
 pDq
 aex
@@ -319108,7 +319236,7 @@ bJA
 mKu
 hHi
 fMc
-lHS
+bOf
 ddH
 jjT
 nPE
@@ -319355,7 +319483,7 @@ ucA
 ucA
 ucA
 vyc
-fKr
+sFR
 crp
 dWz
 lYx
@@ -319364,9 +319492,9 @@ wMU
 aaN
 pGz
 jjj
-dIJ
+auO
 oTq
-xVV
+dIJ
 hmM
 nPE
 pDq
@@ -319623,7 +319751,7 @@ tHk
 bDn
 gwe
 eoI
-bik
+pIL
 sJm
 nPE
 pDq
@@ -319876,9 +320004,9 @@ lYx
 ngD
 wMU
 aqm
-pUK
+xVV
 ptg
-dIJ
+auO
 xdE
 tcI
 uZr
@@ -320133,9 +320261,9 @@ tyR
 tyR
 xqB
 voX
-pUK
+xVV
 kFy
-dIJ
+auO
 fNt
 hsT
 lEs
@@ -320394,7 +320522,7 @@ bep
 hnG
 pNa
 sJM
-fgO
+xTG
 sJm
 vyb
 nPE
@@ -320651,7 +320779,7 @@ hoa
 oWs
 ilx
 oPU
-vhB
+chw
 sJm
 pDq
 nPE
@@ -320909,7 +321037,7 @@ sJm
 sJm
 sJm
 sJm
-sFR
+hfE
 pDq
 nPE
 nCP
@@ -321158,7 +321286,7 @@ rDL
 mcr
 rhw
 mZT
-uwf
+jgK
 xLo
 use
 sJm
@@ -321710,7 +321838,7 @@ dGf
 nJC
 saB
 iqR
-apg
+jiP
 sWm
 kHO
 iAq
@@ -323988,7 +324116,7 @@ sbU
 tAW
 gDy
 lIS
-xxA
+uOc
 vsO
 rAy
 hGB
@@ -325534,7 +325662,7 @@ dlW
 kDq
 dlW
 xrY
-xdm
+ejH
 jZp
 vJf
 rVI
@@ -325821,9 +325949,9 @@ gwE
 sHY
 dPH
 jlW
-mqB
-mqB
-lOp
+dgK
+wPo
+oAS
 rBU
 qjr
 sWo
@@ -326334,7 +326462,7 @@ jIV
 fBT
 sHY
 rDZ
-cbw
+dUz
 lOp
 ira
 dtX
@@ -327105,7 +327233,7 @@ fCE
 cLF
 sHY
 cAt
-cbw
+dCB
 xOY
 nzV
 xDG

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -45389,7 +45389,6 @@
 /turf/open/floor/wood/parquet,
 /area/station/commons/dorms/room2)
 "lok" = (
-/obj/structure/table/reinforced,
 /obj/machinery/door/window/right/directional/west{
 	name = "Order Window";
 	req_access = list("service")
@@ -66070,6 +66069,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/genetics)
+"qts" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = 3
+	},
+/turf/open/floor/iron/checker,
+/area/station/service/bar/atrium)
 "qtw" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -252924,7 +252934,7 @@ mdN
 uDb
 vGv
 yeR
-qHE
+qts
 bmO
 rVY
 tQd

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -5475,9 +5475,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/multi_tile/public/glass{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor2/fore)
 "boa" = (
@@ -12280,11 +12277,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/machinery/light/small/directional/north,
 /obj/machinery/light_switch/directional/north{
 	pixel_x = 9
 	},
 /obj/effect/mapping_helpers/turn_off_lights_with_lightswitch,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/circuit_workshop)
 "cXi" = (
@@ -14480,13 +14477,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/floor3/aft)
-"dBB" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "library2"
-	},
-/turf/open/floor/wood/tile,
-/area/station/service/library/lounge)
 "dBO" = (
 /obj/effect/turf_decal/siding/wideplating,
 /obj/structure/table/reinforced,
@@ -18572,12 +18562,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "eCP" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/public/glass{
-	name = "Lower Library"
+/obj/machinery/door/airlock{
+	name = "Viewing Room"
 	},
-/turf/open/floor/iron,
-/area/station/service/library)
+/turf/open/floor/iron/dark,
+/area/station/maintenance/floor3/starboard/fore)
 "eCQ" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -22219,6 +22208,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/prison/work)
+"fDk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/station/ai/satellite/teleporter)
 "fDq" = (
 /obj/structure/sign/poster/contraband/atmosia_independence/directional/west,
 /turf/open/floor/pod/light,
@@ -22947,11 +22941,6 @@
 /obj/item/shard,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/kitchen/abandoned)
-"fMn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/station/ai/satellite/teleporter)
 "fMs" = (
 /turf/open/floor/plating/airless,
 /area/station/maintenance/floor3/port/aft)
@@ -24408,14 +24397,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/wood/tile,
 /area/station/service/library)
-"geu" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor/heavy,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/hallway/floor1/aft)
 "geA" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/item/kirbyplants/random,
@@ -30312,6 +30293,10 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor2/starboard/fore)
+"hCu" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/service/library)
 "hCv" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -33381,6 +33366,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
+"iqT" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/hallway/floor2/fore)
 "ira" = (
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/effect/turf_decal/bot,
@@ -38361,17 +38357,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/kitchen/diner)
-"jDi" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "blast_miningdock";
-	name = "Mining Dock Hangar Door"
-	},
-/obj/structure/fans/tiny/forcefield,
-/turf/open/floor/plating,
-/area/station/cargo/miningdock)
 "jDq" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39250,8 +39235,12 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "library2"
 	},
-/turf/open/floor/iron,
-/area/station/service/library)
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	name = "Library";
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/station/service/library/lounge)
 "jOc" = (
 /obj/item/storage/box/firingpins,
 /obj/item/storage/box/firingpins,
@@ -44418,6 +44407,12 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/engineering/atmos)
+"lau" = (
+/obj/machinery/exodrone_launcher,
+/obj/item/exodrone,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plating/elevatorshaft,
+/area/station/cargo/drone_bay)
 "lax" = (
 /obj/structure/table,
 /obj/item/storage/dice,
@@ -50979,6 +50974,9 @@
 /area/station/engineering/atmos/project)
 "mEg" = (
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	name = "Lower Library"
+	},
 /turf/open/floor/iron,
 /area/station/service/library)
 "mEh" = (
@@ -54551,12 +54549,6 @@
 	dir = 4
 	},
 /area/station/hallway/floor1/fore)
-"nwq" = (
-/obj/machinery/exodrone_launcher,
-/obj/item/exodrone,
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plating/elevatorshaft,
-/area/station/cargo/drone_bay)
 "nwx" = (
 /obj/item/wallframe/button,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -60628,16 +60620,6 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/service/lawoffice)
-"oWH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/shieldgen,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "oWM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/tile,
@@ -62941,10 +62923,6 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "library2"
 	},
-/obj/machinery/door/airlock/multi_tile/public/glass{
-	name = "Library";
-	dir = 4
-	},
 /turf/open/floor/wood/tile,
 /area/station/service/library/lounge)
 "pBZ" = (
@@ -64359,6 +64337,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
+"pUt" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/hallway/floor1/aft)
 "pUB" = (
 /obj/machinery/power/smes/super/full,
 /obj/structure/cable,
@@ -64419,14 +64405,6 @@
 	dir = 4
 	},
 /area/station/cargo/bitrunning/den)
-"pVc" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/iron/dark,
-/area/station/hallway/floor2/fore)
 "pVd" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
@@ -70578,11 +70556,12 @@
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain/private)
 "rtS" = (
-/obj/machinery/door/airlock{
-	name = "Viewing Room"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "library2"
 	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/floor3/starboard/fore)
+/turf/open/floor/iron,
+/area/station/service/library)
 "rtV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -72737,6 +72716,16 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/circuit,
 /area/station/ai/satellite/interior)
+"rZG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/shieldgen,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "rZS" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -79522,6 +79511,17 @@
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
+"tJc" = (
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "blast_miningdock";
+	name = "Mining Dock Hangar Door"
+	},
+/obj/structure/fans/tiny/forcefield,
+/turf/open/floor/plating,
+/area/station/cargo/miningdock)
 "tJi" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 1
@@ -122658,7 +122658,7 @@ owI
 owI
 uYl
 pFb
-nwq
+lau
 hDa
 fyg
 xxQ
@@ -126773,8 +126773,8 @@ hKN
 hKN
 hKN
 hKN
-oWH
-oWH
+rZG
+rZG
 xbV
 xbV
 xbV
@@ -129081,7 +129081,7 @@ owI
 owI
 owI
 aux
-jDi
+tJc
 fWE
 uaC
 gHk
@@ -137841,7 +137841,7 @@ iqa
 qSl
 qSl
 rjD
-geu
+pUt
 qTS
 rjD
 rjD
@@ -182818,7 +182818,7 @@ wwu
 wwu
 fNT
 fqo
-bnV
+iqT
 fNT
 fNT
 fNT
@@ -183846,7 +183846,7 @@ wwu
 wwu
 fNT
 fqo
-bnV
+iqT
 fNT
 fNT
 fNT
@@ -183856,8 +183856,8 @@ fNe
 fNT
 fNT
 fNT
-pVc
 bnV
+iqT
 fNT
 fNT
 hLz
@@ -205942,8 +205942,8 @@ dEt
 dEt
 dEt
 amt
-dBB
 pBW
+jNQ
 kca
 rCc
 oZz
@@ -247579,7 +247579,7 @@ acK
 acK
 hEm
 btC
-rtS
+eCP
 sJO
 gec
 vuo
@@ -270452,7 +270452,7 @@ oGM
 cEw
 qPi
 lBK
-eCP
+mEg
 fBP
 ddg
 wet
@@ -270706,10 +270706,10 @@ fpU
 fpU
 kmt
 oGM
-jNQ
+rtS
 rdW
 pSd
-mEg
+hCu
 fBP
 ddg
 fAT
@@ -337280,7 +337280,7 @@ oyh
 oyh
 oyh
 hWr
-fMn
+fDk
 tIl
 fEv
 dMt

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -1748,11 +1748,8 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/room4)
 "auO" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral/full,
-/turf/open/floor/iron,
-/area/station/science/ordnance/testlab)
+/turf/open/floor/iron/dark,
+/area/station/engineering/circuit_workshop)
 "auQ" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
@@ -4865,6 +4862,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/construction)
+"bik" = (
+/obj/effect/turf_decal/stripes{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/science/ordnance/testlab)
 "bin" = (
 /obj/effect/turf_decal/trimline/green/warning{
 	dir = 1
@@ -6970,15 +6975,8 @@
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor3/port/aft)
 "bGl" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
-/area/station/science/ordnance/testlab)
+/area/station/science/xenobiology/hallway)
 "bGn" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -7377,6 +7375,10 @@
 /obj/machinery/light/floor,
 /turf/open/floor/wood/tile,
 /area/station/service/library)
+"bMw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology/hallway)
 "bMz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/girder,
@@ -14941,10 +14943,9 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard/fore)
 "dIJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/space_heater,
-/turf/open/floor/pod/light,
-/area/station/maintenance/floor4/starboard)
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/ordnance/testlab)
 "dIO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -18477,12 +18478,19 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/disposal/incinerator)
 "eCr" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor4/starboard)
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/item/controller,
+/obj/item/controller,
+/obj/item/compact_remote,
+/obj/item/compact_remote,
+/obj/effect/turf_decal/bot,
+/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/engineering/circuit_workshop)
 "eCz" = (
 /obj/machinery/door/window/left/directional/south{
 	name = "Pen 4";
@@ -19687,11 +19695,10 @@
 /turf/open/floor/wood,
 /area/station/service/theater)
 "eTV" = (
-/obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/stripes,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/full,
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
 "eUn" = (
 /obj/effect/turf_decal/siding/white{
@@ -20017,14 +20024,6 @@
 	name = "lab floor"
 	},
 /area/station/science/robotics/lab)
-"eYM" = (
-/obj/effect/turf_decal/stripes{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/science/ordnance/testlab)
 "eYN" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20495,6 +20494,17 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/cargo/office)
+"fgO" = (
+/obj/effect/turf_decal/stripes{
+	dir = 6
+	},
+/obj/machinery/firealarm/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/white,
+/area/station/science/ordnance/testlab)
 "fhl" = (
 /obj/structure/bed{
 	dir = 1
@@ -22761,11 +22771,11 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor2/aft)
 "fKr" = (
-/obj/machinery/atmospherics/components/trinary/filter,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/light/blacklight/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance/testlab)
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
+	dir = 6
+	},
+/turf/open/floor/engine/vacuum,
+/area/station/science/ordnance/freezerchamber)
 "fKs" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -22913,10 +22923,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard/aft)
-"fMO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology/hallway)
 "fMY" = (
 /obj/effect/turf_decal/tile/green/full,
 /obj/structure/railing/corner{
@@ -25416,11 +25422,12 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor4/starboard/fore)
 "gsy" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/iron,
-/area/station/science/ordnance/testlab)
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/spawner/random/trash/graffiti{
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/floor1/port/aft)
 "gsD" = (
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 1
@@ -25864,6 +25871,11 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/carpet/royalblue,
 /area/station/medical/break_room)
+"gyi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/space_heater,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor4/starboard)
 "gyp" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -28467,10 +28479,20 @@
 /turf/open/floor/plating,
 /area/station/maintenance/floor2/starboard/aft)
 "hfE" = (
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/station/science/ordnance/testlab)
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/north,
+/obj/machinery/light_switch/directional/north{
+	pixel_x = 9
+	},
+/obj/effect/mapping_helpers/turn_off_lights_with_lightswitch,
+/turf/open/floor/iron/dark,
+/area/station/engineering/circuit_workshop)
 "hfO" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
 /obj/structure/filingcabinet/chestdrawer,
@@ -36485,11 +36507,15 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/service)
 "jgK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/frame/machine,
-/obj/item/circuitboard/machine/telecomms/receiver,
-/turf/open/floor/pod/light,
-/area/station/maintenance/floor3/starboard/fore)
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/circuit_workshop)
 "jgO" = (
 /obj/effect/spawner/random/trash/soap,
 /obj/machinery/light/small/directional/south,
@@ -36571,9 +36597,6 @@
 /obj/structure/cable,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard/fore)
-"jhH" = (
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology/hallway)
 "jhU" = (
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
@@ -46803,6 +46826,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"lHS" = (
+/obj/effect/turf_decal/stripes,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/science/ordnance/testlab)
 "lIe" = (
 /obj/structure/railing{
 	dir = 8
@@ -50119,12 +50148,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"mvl" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
-	dir = 6
-	},
-/turf/open/floor/engine/vacuum,
-/area/station/science/ordnance/freezerchamber)
 "mvs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -50359,16 +50382,6 @@
 "myr" = (
 /turf/open/floor/iron/textured_large,
 /area/station/hallway/secondary/entry)
-"myv" = (
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/turf_decal/box,
-/turf/open/floor/iron,
-/area/station/science/ordnance/testlab)
 "myO" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/exit/escape_pod)
@@ -58282,6 +58295,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/floor3/aft)
+"otP" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron,
+/area/station/science/ordnance/testlab)
 "otQ" = (
 /obj/machinery/power/smes,
 /obj/structure/cable,
@@ -59891,30 +59910,6 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
-"oPF" = (
-/obj/machinery/light_switch/directional/west,
-/obj/effect/turf_decal/stripes{
-	dir = 9
-	},
-/obj/item/assembly/timer,
-/obj/structure/closet/crate/science{
-	name = "Parts crate"
-	},
-/obj/item/assembly/timer,
-/obj/item/assembly/timer,
-/obj/item/assembly/timer,
-/obj/item/assembly/signaler,
-/obj/item/assembly/signaler,
-/obj/item/assembly/signaler,
-/obj/item/assembly/prox_sensor,
-/obj/item/assembly/signaler,
-/obj/item/assembly/signaler,
-/obj/item/assembly/signaler,
-/obj/item/assembly/prox_sensor,
-/obj/item/assembly/prox_sensor,
-/obj/item/assembly/prox_sensor,
-/turf/open/floor/iron/white,
-/area/station/science/ordnance/testlab)
 "oPH" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
@@ -61230,16 +61225,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/theater)
-"piu" = (
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/circuit_workshop)
 "piw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -61777,6 +61762,13 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor2/aft)
+"ppE" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/floor4/starboard)
 "ppN" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Tech Storage"
@@ -64254,7 +64246,9 @@
 /turf/open/floor/wood/parquet,
 /area/station/commons/dorms/room2)
 "pUK" = (
-/turf/closed/wall,
+/obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "pUV" = (
 /turf/open/floor/plating/airless,
@@ -65487,7 +65481,9 @@
 "qkU" = (
 /obj/machinery/button/door/directional/north{
 	name = "Bolt Control";
-	id = "council_toilet_bolt"
+	id = "council_toilet_bolt";
+	specialfunctions = 4;
+	normaldoorcontrol = 1
 	},
 /obj/structure/toilet{
 	dir = 8
@@ -72935,6 +72931,30 @@
 	dir = 8
 	},
 /area/station/hallway/floor3/fore)
+"seR" = (
+/obj/machinery/light_switch/directional/west,
+/obj/effect/turf_decal/stripes{
+	dir = 9
+	},
+/obj/item/assembly/timer,
+/obj/structure/closet/crate/science{
+	name = "Parts crate"
+	},
+/obj/item/assembly/timer,
+/obj/item/assembly/timer,
+/obj/item/assembly/timer,
+/obj/item/assembly/signaler,
+/obj/item/assembly/signaler,
+/obj/item/assembly/signaler,
+/obj/item/assembly/prox_sensor,
+/obj/item/assembly/signaler,
+/obj/item/assembly/signaler,
+/obj/item/assembly/signaler,
+/obj/item/assembly/prox_sensor,
+/obj/item/assembly/prox_sensor,
+/obj/item/assembly/prox_sensor,
+/turf/open/floor/iron/white,
+/area/station/science/ordnance/testlab)
 "sfe" = (
 /obj/structure/chair/comfy/carp,
 /obj/effect/decal/cleanable/glitter,
@@ -73815,9 +73835,6 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/floor1/fore)
-"sso" = (
-/turf/open/floor/iron/dark,
-/area/station/engineering/circuit_workshop)
 "ssr" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 1
@@ -74869,9 +74886,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/floor2/aft)
 "sFR" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/engine/airless,
-/area/station/science/ordnance/freezerchamber)
+/turf/closed/wall,
+/area/station/science/ordnance/testlab)
 "sGb" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall/r_wall,
@@ -76290,13 +76306,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor1/aft)
-"sXa" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/spawner/random/trash/graffiti{
-	pixel_y = -32
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/floor1/port/aft)
 "sXf" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/button/door/directional/north{
@@ -76823,14 +76832,10 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/tools)
 "tcI" = (
-/obj/effect/turf_decal/stripes{
-	dir = 6
-	},
-/obj/machinery/firealarm/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light/directional/south,
+/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/stripes,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/testlab)
 "tcM" = (
@@ -81365,13 +81370,6 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor2/fore)
-"uka" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/pod/light,
-/area/station/maintenance/floor4/starboard)
 "ukd" = (
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 1
@@ -82048,6 +82046,14 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/misc/dirt/jungle,
 /area/station/service/hydroponics/garden/abandoned)
+"uue" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Circuit Workshop"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/station/engineering/circuit_workshop)
 "uuh" = (
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/dark,
@@ -82167,19 +82173,11 @@
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "uwf" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/structure/rack,
-/obj/item/controller,
-/obj/item/controller,
-/obj/item/compact_remote,
-/obj/item/compact_remote,
-/obj/effect/turf_decal/bot,
-/obj/machinery/camera/autoname/directional/west,
-/obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/components/trinary/filter,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/blacklight/directional/east,
 /turf/open/floor/iron/dark,
-/area/station/engineering/circuit_workshop)
+/area/station/science/ordnance/testlab)
 "uwl" = (
 /obj/machinery/computer/slot_machine,
 /obj/machinery/firealarm/directional/west,
@@ -83676,20 +83674,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/floor2/starboard/aft)
 "uOc" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/machinery/light/small/directional/north,
-/obj/machinery/light_switch/directional/north{
-	pixel_x = 9
-	},
-/obj/effect/mapping_helpers/turn_off_lights_with_lightswitch,
-/turf/open/floor/iron/dark,
-/area/station/engineering/circuit_workshop)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/frame/machine,
+/obj/item/circuitboard/machine/telecomms/receiver,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor3/starboard/fore)
 "uOd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -85173,6 +85162,16 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
+"vhB" = (
+/obj/effect/turf_decal/tile/neutral/full,
+/obj/effect/turf_decal/tile/neutral/full,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron,
+/area/station/science/ordnance/testlab)
 "vhL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -86630,22 +86629,9 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor4/starboard)
 "vyc" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/power_store/cell/high{
-	pixel_y = -2;
-	pixel_x = 5
-	},
-/obj/item/mmi{
-	pixel_x = -4;
-	pixel_y = 11
-	},
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/engineering/circuit_workshop)
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/engine/airless,
+/area/station/science/ordnance/freezerchamber)
 "vym" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -88315,12 +88301,6 @@
 	},
 /turf/open/floor/carpet/green,
 /area/station/service/bar/atrium)
-"vUZ" = (
-/obj/effect/turf_decal/stripes,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/science/ordnance/testlab)
 "vVf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -94864,9 +94844,12 @@
 /turf/open/floor/iron,
 /area/station/service/barber)
 "xxA" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/science/ordnance/testlab)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor4/starboard)
 "xxC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -96615,11 +96598,20 @@
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "xTG" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Circuit Workshop"
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/machinery/door/firedoor,
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/power_store/cell/high{
+	pixel_y = -2;
+	pixel_x = 5
+	},
+/obj/item/mmi{
+	pixel_x = -4;
+	pixel_y = 11
+	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/engineering/circuit_workshop)
 "xTH" = (
@@ -96653,6 +96645,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"xUj" = (
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/ordnance/testlab)
 "xUk" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -96779,9 +96781,9 @@
 	},
 /area/station/maintenance/floor1/starboard/aft)
 "xVV" = (
-/obj/structure/railing,
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/neutral/full,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
 "xVX" = (
 /obj/effect/turf_decal/trimline/white/arrow_ccw,
@@ -142059,8 +142061,8 @@ cQB
 yhO
 cWZ
 fGt
-uwf
-vyc
+eCr
+xTG
 hca
 dEc
 koJ
@@ -142315,8 +142317,8 @@ bXe
 saA
 vvK
 cWZ
-uOc
-sso
+hfE
+auO
 uhx
 msL
 dEc
@@ -142571,9 +142573,9 @@ uMl
 oOd
 otD
 gnY
-xTG
+uue
 gqO
-piu
+jgK
 pzY
 ssx
 dEc
@@ -143090,7 +143092,7 @@ sTQ
 pRN
 ccK
 mWg
-sXa
+gsy
 khQ
 dEc
 dEc
@@ -253828,7 +253830,7 @@ ycg
 uHe
 vVo
 ccH
-jgK
+uOc
 wRJ
 igy
 rip
@@ -254338,7 +254340,7 @@ xeE
 pbj
 gMv
 vjT
-jhH
+bGl
 gTk
 ccH
 xDK
@@ -254595,7 +254597,7 @@ fok
 bpY
 xAo
 rLB
-fMO
+bMw
 gTk
 ccH
 oMv
@@ -318337,10 +318339,10 @@ nPE
 bvM
 fUk
 rXJ
-eCr
+ppE
 xXm
 eRZ
-dIJ
+gyi
 nPE
 tKs
 hug
@@ -318847,11 +318849,11 @@ wFa
 tYV
 oUW
 xwL
-oPF
-bGl
+seR
+xUj
 gOF
-auO
-gsy
+otP
+eTV
 nPE
 pDq
 aex
@@ -319106,7 +319108,7 @@ bJA
 mKu
 hHi
 fMc
-vUZ
+lHS
 ddH
 jjT
 nPE
@@ -319352,8 +319354,8 @@ ucA
 ucA
 ucA
 ucA
-sFR
-mvl
+vyc
+fKr
 crp
 dWz
 lYx
@@ -319362,9 +319364,9 @@ wMU
 aaN
 pGz
 jjj
-xxA
+dIJ
 oTq
-hfE
+xVV
 hmM
 nPE
 pDq
@@ -319609,7 +319611,7 @@ ucA
 ucA
 ucA
 ucA
-sFR
+vyc
 vPP
 rrs
 mCU
@@ -319621,7 +319623,7 @@ tHk
 bDn
 gwe
 eoI
-eYM
+bik
 sJm
 nPE
 pDq
@@ -319874,11 +319876,11 @@ lYx
 ngD
 wMU
 aqm
-xVV
+pUK
 ptg
-xxA
+dIJ
 xdE
-eTV
+tcI
 uZr
 jNM
 xZu
@@ -320131,9 +320133,9 @@ tyR
 tyR
 xqB
 voX
-xVV
+pUK
 kFy
-xxA
+dIJ
 fNt
 hsT
 lEs
@@ -320392,7 +320394,7 @@ bep
 hnG
 pNa
 sJM
-tcI
+fgO
 sJm
 vyb
 nPE
@@ -320649,7 +320651,7 @@ hoa
 oWs
 ilx
 oPU
-myv
+vhB
 sJm
 pDq
 nPE
@@ -320907,7 +320909,7 @@ sJm
 sJm
 sJm
 sJm
-pUK
+sFR
 pDq
 nPE
 nCP
@@ -321156,7 +321158,7 @@ rDL
 mcr
 rhw
 mZT
-fKr
+uwf
 xLo
 use
 sJm
@@ -323986,7 +323988,7 @@ sbU
 tAW
 gDy
 lIS
-uka
+xxA
 vsO
 rAy
 hGB

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -5475,8 +5475,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Airlock"
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor2/fore)
@@ -7356,8 +7356,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Airlock"
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor1/fore)
@@ -10036,9 +10036,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Airlock"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -10252,9 +10249,6 @@
 /turf/open/floor/grass,
 /area/station/science/cytology)
 "cvM" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Garden"
-	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
@@ -10818,7 +10812,7 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "library2"
 	},
-/obj/machinery/door/airlock/public/glass{
+/obj/machinery/door/airlock/multi_tile/public/glass{
 	name = "Library"
 	},
 /turf/open/floor/iron,
@@ -11411,9 +11405,6 @@
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "cLQ" = (
-/obj/machinery/door/airlock{
-	name = "Locker Room"
-	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/commons/locker)
@@ -14006,9 +13997,6 @@
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "dvC" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Garden"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14017,6 +14005,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/landmark/navigate_destination/autoname,
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "dvF" = (
@@ -15076,9 +15067,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Airlock"
-	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor2/fore)
 "dJC" = (
@@ -15257,9 +15245,6 @@
 "dMj" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/wood{
-	name = "Dining Room"
-	},
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen/diner)
 "dMk" = (
@@ -15513,6 +15498,14 @@
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/floor/grass,
 /area/station/medical/virology)
+"dPm" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/hallway/floor1/aft)
 "dPv" = (
 /obj/machinery/chem_master/condimaster{
 	desc = "Used to separate out liquids - useful for purifying botanical extracts. Also dispenses condiments.";
@@ -15648,9 +15641,6 @@
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "dRR" = (
-/obj/machinery/door/airlock{
-	name = "Locker Room"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15658,6 +15648,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "dRX" = (
@@ -17240,8 +17233,8 @@
 "elI" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/public/glass{
-	name = "Departures"
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -18572,10 +18565,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "eCP" = (
-/obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
+/obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor3/starboard/fore)
 "eCQ" = (
@@ -18723,7 +18716,11 @@
 /obj/effect/turf_decal/stripes{
 	dir = 1
 	},
-/obj/structure/emergency_shield/regenerating,
+/obj/structure/fans/tiny/forcefield,
+/obj/machinery/door/poddoor/preopen{
+	id = "blast_miningdock";
+	name = "Mining Dock Hangar Door"
+	},
 /turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "eFe" = (
@@ -21853,8 +21850,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "fyg" = (
-/obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/button/door/directional/east{
+	name = "Drone Bay Hangar Doors";
+	id = "blast_dronebay";
+	req_access = list("cargo")
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/drone_bay)
 "fyQ" = (
@@ -23732,7 +23733,7 @@
 /area/station/security/checkpoint/science)
 "fWE" = (
 /obj/effect/turf_decal/stripes,
-/obj/structure/emergency_shield/regenerating,
+/obj/structure/fans/tiny/forcefield,
 /turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "fWY" = (
@@ -25668,9 +25669,6 @@
 "gvp" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/door/airlock/public/glass{
-	name = "Medbay"
-	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/medbay/lobby)
@@ -26310,7 +26308,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/sign/poster/random/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -28457,8 +28454,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Airlock"
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor3/fore)
@@ -28795,6 +28792,12 @@
 /obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/station/service/library)
+"hjj" = (
+/obj/machinery/door/airlock{
+	name = "Viewing Room"
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/floor3/starboard/fore)
 "hjr" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -34566,8 +34569,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Airlock"
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor2/aft)
@@ -36331,8 +36334,8 @@
 	cycle_id = "bridge"
 	},
 /obj/machinery/door/poddoor/preopen{
-	id = "bridge_blast";
-	name = "Bridge Blast Door"
+	id = "blast_miningdock";
+	name = "Mining Dock Hangar Door"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -36730,8 +36733,8 @@
 "jjc" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Airlock"
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor2/fore)
@@ -36785,7 +36788,7 @@
 "jjC" = (
 /obj/effect/mapping_helpers/airlock/access/any/medical/psychology,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical{
+/obj/machinery/door/airlock/multi_tile/public/glass{
 	name = "Mental Health Ward"
 	},
 /turf/open/floor/iron/white,
@@ -37484,8 +37487,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Airlock"
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor3/aft)
@@ -38260,8 +38263,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Airlock"
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor1/aft)
@@ -38843,9 +38846,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Airlock"
-	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor1/aft)
 "jIV" = (
@@ -39220,12 +39220,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/floor2/starboard/aft)
 "jNQ" = (
-/obj/effect/spawner/random/structure/closet_maintenance,
-/obj/effect/turf_decal/trimline/green/warning{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/pod/light,
-/area/station/maintenance/floor3/starboard/fore)
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/shieldgen,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "jOc" = (
 /obj/item/storage/box/firingpins,
 /obj/item/storage/box/firingpins,
@@ -43805,9 +43808,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Library Garden"
-	},
 /turf/open/floor/iron/dark,
 /area/station/service/library/lounge)
 "kTh" = (
@@ -45422,9 +45422,6 @@
 /area/station/maintenance/floor4/starboard)
 "lme" = (
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/public/glass{
-	name = "Departures"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -47183,9 +47180,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Airlock"
-	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor1/fore)
 "lKz" = (
@@ -49026,11 +49020,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/button/door/directional/east{
-	id = "qmblast";
-	name = "Office Blast Doors";
-	req_access = list("qm")
-	},
 /turf/open/floor/iron/textured,
 /area/station/command/heads_quarters/qm)
 "mfU" = (
@@ -50213,8 +50202,8 @@
 "muB" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Airlock"
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor2/aft)
@@ -50974,9 +50963,6 @@
 /area/station/engineering/atmos/project)
 "mEg" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Library"
-	},
 /turf/open/floor/iron,
 /area/station/service/library)
 "mEh" = (
@@ -51066,9 +51052,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/door/airlock/public/glass{
-	name = "Medbay"
-	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/medbay/lobby)
@@ -52135,9 +52118,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Airlock"
-	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor2/aft)
 "mTK" = (
@@ -53033,11 +53013,7 @@
 	},
 /area/station/security/brig)
 "neW" = (
-/obj/machinery/door/airlock/medical{
-	name = "Mental Health Ward"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/any/medical/psychology,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
@@ -53461,6 +53437,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/spawner/random/structure/tank_holder,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor3/starboard/fore)
 "niG" = (
@@ -57636,7 +57613,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
+/obj/machinery/door/airlock/multi_tile/public/glass{
 	name = "Library Garden"
 	},
 /turf/open/floor/iron/dark,
@@ -58041,16 +58018,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
-/obj/machinery/door/airlock/public/glass{
+/obj/machinery/door/airlock/multi_tile/public/glass{
 	name = "Bar"
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar/atrium)
 "ooF" = (
-/obj/effect/spawner/random/structure/tank_holder,
 /obj/effect/turf_decal/trimline/green/warning{
 	dir = 1
 	},
+/obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor3/starboard/fore)
 "ooN" = (
@@ -59688,6 +59665,11 @@
 	},
 /obj/structure/chair/plastic,
 /obj/effect/landmark/start/cargo_technician,
+/obj/machinery/button/door/directional/north{
+	name = "Cargo Bay Hangar Doors";
+	id = "blast_cargobay";
+	req_access = list("cargo")
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "oKY" = (
@@ -60222,9 +60204,6 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Airlock"
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor3/aft)
@@ -61203,8 +61182,8 @@
 "pfC" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Airlock"
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor3/aft)
@@ -62147,11 +62126,12 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Theater"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	dir = 4;
+	name = "Theatre"
 	},
 /turf/open/floor/carpet/red,
 /area/station/service/theater)
@@ -62891,9 +62871,6 @@
 /obj/machinery/door/airlock/hatch{
 	name = "Maintenance Hatch"
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -62934,8 +62911,9 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "library2"
 	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Lower Library"
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	name = "Library";
+	dir = 4
 	},
 /turf/open/floor/wood/tile,
 /area/station/service/library/lounge)
@@ -63207,7 +63185,7 @@
 /area/station/engineering/atmos/office)
 "pFb" = (
 /obj/effect/turf_decal/stripes,
-/obj/structure/emergency_shield/regenerating,
+/obj/structure/fans/tiny/forcefield,
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
 "pFy" = (
@@ -65383,9 +65361,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Airlock"
-	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor1/aft)
 "qgQ" = (
@@ -67422,6 +67397,13 @@
 /obj/effect/baseturf_helper/reinforced_plating/ceiling,
 /turf/open/floor/iron/dark/textured,
 /area/station/command/heads_quarters/ce)
+"qFh" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	name = "Lower Library"
+	},
+/turf/open/floor/iron,
+/area/station/service/library)
 "qFi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68058,8 +68040,8 @@
 /area/station/commons/dorms/room1)
 "qOF" = (
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/public/glass{
-	name = "Departures"
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -68305,8 +68287,8 @@
 "qRi" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Airlock"
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor1/fore)
@@ -68495,8 +68477,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Airlock"
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor1/aft)
@@ -69161,7 +69143,11 @@
 /obj/effect/turf_decal/stripes{
 	dir = 1
 	},
-/obj/structure/emergency_shield/regenerating,
+/obj/structure/fans/tiny/forcefield,
+/obj/machinery/door/poddoor/preopen{
+	id = "blast_cargobay";
+	name = "Cargo Hangar Door"
+	},
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "rbR" = (
@@ -70561,13 +70547,11 @@
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain/private)
 "rtS" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Airlock"
-	},
-/turf/open/floor/iron/dark,
-/area/station/hallway/floor3/fore)
+/obj/machinery/exodrone_launcher,
+/obj/item/exodrone,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plating/elevatorshaft,
+/area/station/cargo/drone_bay)
 "rtV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -72247,7 +72231,7 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/wood{
+/obj/machinery/door/airlock/multi_tile/public/glass{
 	name = "Dining Room"
 	},
 /turf/open/floor/iron/dark,
@@ -74145,8 +74129,8 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Airlock"
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor3/aft)
@@ -76162,10 +76146,10 @@
 /area/station/science/cytology)
 "sTU" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Lower Library"
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	name = "Library"
+	},
 /turf/open/floor/iron,
 /area/station/service/library/lounge)
 "sUj" = (
@@ -77058,9 +77042,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Theater"
-	},
 /obj/effect/landmark/navigate_destination/autoname,
 /turf/open/floor/carpet/red,
 /area/station/service/theater)
@@ -78359,6 +78340,11 @@
 	dir = 8
 	},
 /obj/machinery/keycard_auth/wall_mounted/directional/north,
+/obj/machinery/button/door/directional/east{
+	id = "qmblast";
+	name = "Office Blast Doors";
+	req_access = list("qm")
+	},
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/qm)
 "tun" = (
@@ -82289,7 +82275,7 @@
 /area/station/maintenance/floor3/starboard)
 "uvv" = (
 /obj/effect/turf_decal/stripes,
-/obj/structure/emergency_shield/regenerating,
+/obj/structure/fans/tiny/forcefield,
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "uvD" = (
@@ -82334,9 +82320,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Airlock"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer5,
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor3/fore)
@@ -83248,6 +83231,17 @@
 /obj/machinery/light/floor,
 /turf/open/floor/iron/dark,
 /area/station/science/cytology)
+"uIb" = (
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "blast_miningdock";
+	name = "Mining Dock Hangar Door"
+	},
+/obj/structure/fans/tiny/forcefield,
+/turf/open/floor/plating,
+/area/station/cargo/miningdock)
 "uIh" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -84112,9 +84106,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Airlock"
-	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor3/aft)
 "uRg" = (
@@ -84674,7 +84665,11 @@
 /obj/effect/turf_decal/stripes{
 	dir = 1
 	},
-/obj/structure/emergency_shield/regenerating,
+/obj/structure/fans/tiny/forcefield,
+/obj/machinery/door/poddoor/preopen{
+	id = "blast_dronebay";
+	name = "Drone Bay Hangar Door"
+	},
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
 "uYB" = (
@@ -86241,6 +86236,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
+/obj/effect/spawner/random/structure/tank_holder,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor3/starboard/fore)
 "vse" = (
@@ -86763,7 +86759,11 @@
 /area/station/hallway/floor3/aft)
 "vxU" = (
 /obj/effect/turf_decal/stripes/corner,
-/obj/item/radio/intercom/directional/north,
+/obj/machinery/button/door/directional/north{
+	name = "Mining Dock Hangar Doors";
+	id = "blast_miningdock";
+	req_access = list("mining")
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "vxY" = (
@@ -87179,6 +87179,14 @@
 	dir = 1
 	},
 /area/station/security/brig)
+"vCQ" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/iron/dark,
+/area/station/hallway/floor2/fore)
 "vDf" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -87707,9 +87715,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Lower Library"
-	},
 /turf/open/floor/iron,
 /area/station/service/library/lounge)
 "vLa" = (
@@ -91882,9 +91887,6 @@
 "wJl" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Airlock"
-	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor1/aft)
 "wJp" = (
@@ -92393,6 +92395,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor3/port/fore)
+"wOH" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "library2"
+	},
+/turf/open/floor/iron,
+/area/station/service/library)
 "wOJ" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -92682,9 +92691,6 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor/heavy,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/public/glass{
-	name = "Bar"
-	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar/atrium)
 "wTg" = (
@@ -93389,9 +93395,6 @@
 /area/station/service/library)
 "xcg" = (
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/public/glass{
-	name = "Departures"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -96505,10 +96508,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Airlock"
-	},
 /obj/machinery/duct,
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor3/fore)
 "xPL" = (
@@ -97613,6 +97616,13 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor2/port)
+"yeE" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "library2"
+	},
+/turf/open/floor/wood/tile,
+/area/station/service/library/lounge)
 "yeR" = (
 /obj/structure/chair/sofa/bench/left,
 /obj/effect/landmark/start/janitor,
@@ -117270,7 +117280,7 @@ jxa
 oic
 kyR
 kyR
-qRi
+vOK
 bMo
 kyR
 kyR
@@ -118298,7 +118308,7 @@ aWe
 oic
 kyR
 kyR
-qRi
+vOK
 bMo
 kyR
 kyR
@@ -121630,7 +121640,7 @@ eEB
 yiZ
 bUC
 rYA
-rYA
+yiZ
 jUP
 pwE
 jQf
@@ -122647,7 +122657,7 @@ owI
 owI
 uYl
 pFb
-gHw
+rtS
 hDa
 fyg
 xxQ
@@ -125999,7 +126009,7 @@ oCK
 mjQ
 rbT
 ijL
-rbT
+nAm
 hLP
 ydt
 mVL
@@ -126762,8 +126772,8 @@ hKN
 hKN
 hKN
 hKN
-xbV
-xbV
+jNQ
+jNQ
 xbV
 xbV
 xbV
@@ -129070,7 +129080,7 @@ owI
 owI
 owI
 aux
-eFc
+uIb
 fWE
 uaC
 gHk
@@ -137830,7 +137840,7 @@ iqa
 qSl
 qSl
 rjD
-jCi
+dPm
 qTS
 rjD
 rjD
@@ -182806,7 +182816,7 @@ vWj
 wwu
 wwu
 fNT
-jjc
+fqo
 bnV
 fNT
 fNT
@@ -183834,7 +183844,7 @@ sbK
 wwu
 wwu
 fNT
-jjc
+fqo
 bnV
 fNT
 fNT
@@ -183845,7 +183855,7 @@ fNe
 fNT
 fNT
 fNT
-bnV
+vCQ
 bnV
 fNT
 fNT
@@ -203366,7 +203376,7 @@ yaR
 amt
 ttb
 ttb
-muB
+elB
 iGq
 ttb
 ttb
@@ -204394,7 +204404,7 @@ jOS
 amt
 ttb
 ttb
-muB
+elB
 iGq
 ttb
 ttb
@@ -205931,7 +205941,7 @@ dEt
 dEt
 dEt
 amt
-pBW
+yeE
 pBW
 kca
 rCc
@@ -247567,9 +247577,9 @@ gDL
 acK
 acK
 hEm
-jNQ
-wRJ
-oVY
+btC
+hjj
+sJO
 gec
 vuo
 oon
@@ -247826,7 +247836,7 @@ wRJ
 wRJ
 wRJ
 wRJ
-sJO
+oVY
 fjo
 ePM
 xxF
@@ -248342,7 +248352,7 @@ uIN
 ltq
 ltq
 eDe
-rtS
+ybQ
 xPI
 eDe
 eDe
@@ -249370,7 +249380,7 @@ lzd
 uIN
 ltq
 eDe
-rtS
+ybQ
 xPI
 eDe
 eDe
@@ -270441,7 +270451,7 @@ oGM
 cEw
 qPi
 lBK
-mEg
+qFh
 fBP
 ddg
 wet
@@ -270695,7 +270705,7 @@ fpU
 fpU
 kmt
 oGM
-cEw
+wOH
 rdW
 pSd
 mEg

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -27067,13 +27067,13 @@
 /area/station/command/heads_quarters/captain)
 "gMo" = (
 /obj/structure/rack,
-/obj/item/gun/energy/ionrifle{
-	pixel_y = 4
-	},
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/item/gun/energy/temperature/security{
 	pixel_y = -5;
 	pixel_x = 2
+	},
+/obj/item/gun/energy/ionrifle{
+	pixel_y = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/armory)
@@ -30715,7 +30715,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/lobby)
 "hHi" = (
-/obj/machinery/camera/autoname/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -45149,6 +45148,7 @@
 /obj/item/assembly/prox_sensor,
 /obj/item/assembly/prox_sensor,
 /obj/item/assembly/prox_sensor,
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/testlab)
 "liL" = (
@@ -82194,18 +82194,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
-"utG" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/ammo_workbench,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark,
-/area/station/security/armory)
 "utJ" = (
 /obj/effect/mapping_helpers/airlock/access/any/security/court,
 /obj/machinery/door/firedoor,
@@ -84757,9 +84745,15 @@
 /turf/open/floor/wood,
 /area/station/service/kitchen/diner)
 "uZr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /obj/machinery/light/red/dim/directional/north,
-/turf/closed/wall/r_wall,
-/area/station/science/ordnance/testlab)
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/floor4/starboard)
 "uZF" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/floor2/starboard/aft)
@@ -92449,13 +92443,8 @@
 "wPG" = (
 /obj/structure/secure_safe/directional/east,
 /obj/effect/turf_decal/tile/red/fourcorners,
-/obj/structure/rack/gunrack,
-/obj/item/gun/energy/modular_laser_rifle/carbine{
-	pixel_x = -3
-	},
-/obj/item/gun/energy/modular_laser_rifle/carbine{
-	pixel_x = 3
-	},
+/obj/machinery/ammo_workbench,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/security/armory)
 "wPK" = (
@@ -320050,8 +320039,8 @@ ptg
 auO
 xdE
 tcI
+sJm
 uZr
-jNM
 xZu
 nPE
 fkN
@@ -327274,7 +327263,7 @@ fCE
 cLF
 sHY
 cAt
-utG
+cbw
 xOY
 nzV
 xDG

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -14480,6 +14480,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/floor3/aft)
+"dBB" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "library2"
+	},
+/turf/open/floor/wood/tile,
+/area/station/service/library/lounge)
 "dBO" = (
 /obj/effect/turf_decal/siding/wideplating,
 /obj/structure/table/reinforced,
@@ -15277,6 +15284,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/south,
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/teleporter)
 "dMA" = (
@@ -15498,14 +15507,6 @@
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/floor/grass,
 /area/station/medical/virology)
-"dPm" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor/heavy,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/hallway/floor1/aft)
 "dPv" = (
 /obj/machinery/chem_master/condimaster{
 	desc = "Used to separate out liquids - useful for purifying botanical extracts. Also dispenses condiments.";
@@ -17453,11 +17454,17 @@
 /turf/open/floor/iron,
 /area/station/hallway/floor3/fore)
 "enJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/holopad,
 /obj/structure/cable/layer3,
+/obj/machinery/atmospherics/components/binary/pump/on/layer2{
+	dir = 8;
+	target_pressure = 4500;
+	name = "AI scrubber pump"
+	},
+/obj/machinery/atmospherics/components/binary/pump/on/layer4{
+	dir = 4;
+	name = "AI air supply pump"
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/teleporter)
 "enX" = (
@@ -18565,12 +18572,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "eCP" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	name = "Lower Library"
 	},
-/obj/structure/sign/poster/random/directional/north,
-/turf/open/floor/pod/light,
-/area/station/maintenance/floor3/starboard/fore)
+/turf/open/floor/iron,
+/area/station/service/library)
 "eCQ" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -22940,6 +22947,11 @@
 /obj/item/shard,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/kitchen/abandoned)
+"fMn" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/station/ai/satellite/teleporter)
 "fMs" = (
 /turf/open/floor/plating/airless,
 /area/station/maintenance/floor3/port/aft)
@@ -24396,6 +24408,14 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/wood/tile,
 /area/station/service/library)
+"geu" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/hallway/floor1/aft)
 "geA" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/item/kirbyplants/random,
@@ -26308,6 +26328,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/sign/poster/random/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -28792,12 +28813,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/station/service/library)
-"hjj" = (
-/obj/machinery/door/airlock{
-	name = "Viewing Room"
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/floor3/starboard/fore)
 "hjr" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -38346,6 +38361,17 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/kitchen/diner)
+"jDi" = (
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "blast_miningdock";
+	name = "Mining Dock Hangar Door"
+	},
+/obj/structure/fans/tiny/forcefield,
+/turf/open/floor/plating,
+/area/station/cargo/miningdock)
 "jDq" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39220,15 +39246,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/floor2/starboard/aft)
 "jNQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "library2"
 	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/shieldgen,
 /turf/open/floor/iron,
-/area/station/cargo/storage)
+/area/station/service/library)
 "jOc" = (
 /obj/item/storage/box/firingpins,
 /obj/item/storage/box/firingpins,
@@ -42142,15 +42165,8 @@
 "kyo" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/layer3,
-/obj/machinery/atmospherics/components/binary/pump/on/layer2{
-	dir = 8;
-	target_pressure = 4500;
-	name = "AI scrubber pump"
-	},
-/obj/machinery/atmospherics/components/binary/pump/on/layer4{
-	dir = 4;
-	name = "AI air supply pump"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
 "kyr" = (
@@ -52464,7 +52480,7 @@
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor1/port/aft)
 "mXD" = (
-/obj/structure/tank_holder/emergency_oxygen,
+/obj/structure/tank_holder/oxygen,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "mXH" = (
@@ -52501,9 +52517,9 @@
 "mYg" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/binary/pressure_valve/on/layer2{
-	dir = 1;
-	name = "Waste release"
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/teleporter)
@@ -54535,6 +54551,12 @@
 	dir = 4
 	},
 /area/station/hallway/floor1/fore)
+"nwq" = (
+/obj/machinery/exodrone_launcher,
+/obj/item/exodrone,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plating/elevatorshaft,
+/area/station/cargo/drone_bay)
 "nwx" = (
 /obj/item/wallframe/button,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -57586,10 +57608,8 @@
 /turf/open/floor/wood/tile,
 /area/station/service/library)
 "ojl" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/station/ai/satellite/teleporter)
 "ojp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -60608,6 +60628,16 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/service/lawoffice)
+"oWH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/shieldgen,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "oWM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/tile,
@@ -64389,6 +64419,14 @@
 	dir = 4
 	},
 /area/station/cargo/bitrunning/den)
+"pVc" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/iron/dark,
+/area/station/hallway/floor2/fore)
 "pVd" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
@@ -67397,13 +67435,6 @@
 /obj/effect/baseturf_helper/reinforced_plating/ceiling,
 /turf/open/floor/iron/dark/textured,
 /area/station/command/heads_quarters/ce)
-"qFh" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/public/glass{
-	name = "Lower Library"
-	},
-/turf/open/floor/iron,
-/area/station/service/library)
 "qFi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68793,10 +68824,10 @@
 /area/station/security/prison/garden)
 "qXy" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/ai/satellite/teleporter)
 "qXE" = (
@@ -70547,11 +70578,11 @@
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain/private)
 "rtS" = (
-/obj/machinery/exodrone_launcher,
-/obj/item/exodrone,
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plating/elevatorshaft,
-/area/station/cargo/drone_bay)
+/obj/machinery/door/airlock{
+	name = "Viewing Room"
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/floor3/starboard/fore)
 "rtV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -79400,9 +79431,12 @@
 /area/station/maintenance/floor1/port)
 "tIl" = (
 /obj/machinery/light/small/directional/east,
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/item/radio/intercom/directional/east,
+/obj/machinery/atmospherics/components/binary/pressure_valve/on/layer2{
+	dir = 1;
+	name = "Waste release"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/teleporter)
 "tIm" = (
@@ -83231,17 +83265,6 @@
 /obj/machinery/light/floor,
 /turf/open/floor/iron/dark,
 /area/station/science/cytology)
-"uIb" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "blast_miningdock";
-	name = "Mining Dock Hangar Door"
-	},
-/obj/structure/fans/tiny/forcefield,
-/turf/open/floor/plating,
-/area/station/cargo/miningdock)
 "uIh" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -87179,14 +87202,6 @@
 	dir = 1
 	},
 /area/station/security/brig)
-"vCQ" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/iron/dark,
-/area/station/hallway/floor2/fore)
 "vDf" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -92395,13 +92410,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor3/port/fore)
-"wOH" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "library2"
-	},
-/turf/open/floor/iron,
-/area/station/service/library)
 "wOJ" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -93022,10 +93030,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/floor2/port/fore)
 "wXk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/teleporter)
 "wXq" = (
@@ -97616,13 +97624,6 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor2/port)
-"yeE" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "library2"
-	},
-/turf/open/floor/wood/tile,
-/area/station/service/library/lounge)
 "yeR" = (
 /obj/structure/chair/sofa/bench/left,
 /obj/effect/landmark/start/janitor,
@@ -122657,7 +122658,7 @@ owI
 owI
 uYl
 pFb
-rtS
+nwq
 hDa
 fyg
 xxQ
@@ -126772,8 +126773,8 @@ hKN
 hKN
 hKN
 hKN
-jNQ
-jNQ
+oWH
+oWH
 xbV
 xbV
 xbV
@@ -129080,7 +129081,7 @@ owI
 owI
 owI
 aux
-uIb
+jDi
 fWE
 uaC
 gHk
@@ -137840,7 +137841,7 @@ iqa
 qSl
 qSl
 rjD
-dPm
+geu
 qTS
 rjD
 rjD
@@ -183855,7 +183856,7 @@ fNe
 fNT
 fNT
 fNT
-vCQ
+pVc
 bnV
 fNT
 fNT
@@ -205941,7 +205942,7 @@ dEt
 dEt
 dEt
 amt
-yeE
+dBB
 pBW
 kca
 rCc
@@ -247316,7 +247317,7 @@ ucA
 kVp
 wRJ
 wRJ
-eCP
+wPF
 wrh
 wPF
 cil
@@ -247578,7 +247579,7 @@ acK
 acK
 hEm
 btC
-hjj
+rtS
 sJO
 gec
 vuo
@@ -270451,7 +270452,7 @@ oGM
 cEw
 qPi
 lBK
-qFh
+eCP
 fBP
 ddg
 wet
@@ -270705,7 +270706,7 @@ fpU
 fpU
 kmt
 oGM
-wOH
+jNQ
 rdW
 pSd
 mEg
@@ -337021,7 +337022,7 @@ oyh
 oyh
 oyh
 oyh
-hWr
+oyh
 ojl
 mYg
 enJ
@@ -337278,8 +337279,8 @@ oyh
 oyh
 oyh
 oyh
-oyh
-nbP
+hWr
+fMn
 tIl
 fEv
 dMt

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -438,11 +438,16 @@
 /area/station/construction)
 "afg" = (
 /obj/structure/table/reinforced,
-/obj/machinery/recharger,
+/obj/machinery/recharger{
+	pixel_x = -6
+	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /obj/structure/reagent_dispensers/wall/peppertank/directional/south,
+/obj/item/radio/off{
+	pixel_x = 6
+	},
 /turf/open/floor/iron/corner{
 	dir = 4
 	},
@@ -1328,8 +1333,6 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard)
 "aqm" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/railing,
 /obj/effect/turf_decal/box/red,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
 	dir = 8
@@ -1745,13 +1748,10 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/room4)
 "auO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
 "auQ" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -4489,17 +4489,14 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard)
 "bep" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
@@ -4758,15 +4755,14 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "bhb" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/railing/corner,
-/obj/structure/disposalpipe/segment{
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
 	},
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor1/port/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/engineering/circuit_workshop)
 "bhh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6187,9 +6183,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 10
 	},
-/turf/open/floor/pod/dark,
+/obj/machinery/light/red/dim/directional/north,
+/turf/open/floor/plating,
 /area/station/maintenance/floor4/starboard)
 "bvO" = (
 /obj/effect/turf_decal/stripes/line{
@@ -6517,14 +6514,10 @@
 /area/station/science/xenobiology)
 "bzF" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/table/reinforced,
-/obj/effect/spawner/random/bureaucracy/folder,
-/obj/effect/spawner/random/bureaucracy/pen,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id = "lockers";
-	name = "Locker Room Shutters"
+/obj/effect/landmark/navigate_destination/autoname,
+/obj/machinery/door/airlock/glass{
+	name = "Locker Room"
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/locker)
@@ -6625,7 +6618,6 @@
 /area/station/medical/virology/isolation)
 "bAx" = (
 /obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "bAG" = (
@@ -6825,12 +6817,10 @@
 /obj/effect/turf_decal/stripes{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/railing/corner{
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
+/obj/structure/railing{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -6854,16 +6844,14 @@
 "bDU" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 2
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 1;
 	id = "lockers";
 	name = "Locker Room Shutters"
 	},
+/obj/effect/spawner/random/bureaucracy/folder,
+/obj/effect/spawner/random/bureaucracy/pen,
 /turf/open/floor/iron/dark,
 /area/station/commons/locker)
 "bDV" = (
@@ -6982,10 +6970,15 @@
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor3/port/aft)
 "bGl" = (
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/machinery/light/small/red/directional/north,
-/turf/open/floor/pod/light,
-/area/station/maintenance/floor3/starboard/fore)
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/ordnance/testlab)
 "bGn" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -7545,6 +7538,9 @@
 /area/station/command/eva)
 "bOJ" = (
 /obj/effect/spawner/random/maintenance/two,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard)
 "bPh" = (
@@ -7736,9 +7732,9 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard/aft)
 "bRx" = (
-/obj/structure/frame/machine,
-/obj/item/circuitboard/machine/telecomms/receiver,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/garbage,
+/obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor3/starboard/fore)
 "bRI" = (
@@ -10952,7 +10948,7 @@
 	pixel_y = 9
 	},
 /obj/item/raw_anomaly_core/random{
-	pixel_y = 5
+	pixel_y = 12
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
@@ -11881,6 +11877,9 @@
 "cSk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/maintenance/two,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard)
 "cSu" = (
@@ -12268,11 +12267,8 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor3/starboard/aft)
 "cWZ" = (
-/obj/effect/spawner/random/trash/graffiti{
-	pixel_y = -32
-	},
-/turf/open/floor/pod/light,
-/area/station/maintenance/floor1/port/aft)
+/turf/closed/wall/r_wall,
+/area/station/engineering/circuit_workshop)
 "cXi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -12744,8 +12740,8 @@
 /area/station/security/checkpoint/second)
 "ddH" = (
 /obj/effect/turf_decal/tile/neutral/full,
-/obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
 "ddM" = (
@@ -13976,6 +13972,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/landmark/navigate_destination/autoname,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "dvF" = (
@@ -14912,9 +14909,14 @@
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "dIl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/light,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/mail_sorting/science/ordnance,
+/turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor4/starboard)
 "dIv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -14939,10 +14941,10 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard/fore)
 "dIJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/science/ordnance/testlab)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/space_heater,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor4/starboard)
 "dIO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17486,7 +17488,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/armory)
 "eoI" = (
-/obj/effect/turf_decal/stripes,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/testlab)
 "eoL" = (
@@ -18471,11 +18477,12 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/disposal/incinerator)
 "eCr" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 8
-	},
-/turf/open/floor/pod/light,
-/area/station/maintenance/floor1/port/aft)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/floor4/starboard)
 "eCz" = (
 /obj/machinery/door/window/left/directional/south{
 	name = "Pen 4";
@@ -19531,8 +19538,14 @@
 /area/station/hallway/floor2/fore)
 "eRZ" = (
 /obj/effect/spawner/random/maintenance/two,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/light,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor4/starboard)
 "eSa" = (
 /obj/machinery/airalarm/directional/south,
@@ -19552,7 +19565,6 @@
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "eSq" = (
-/obj/structure/railing/corner,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer4{
 	dir = 8
 	},
@@ -19675,11 +19687,10 @@
 /turf/open/floor/wood,
 /area/station/service/theater)
 "eTV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
+/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/stripes,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/testlab)
 "eUn" = (
@@ -19912,11 +19923,12 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "ai_sat"
 	},
-/obj/machinery/door/airlock/hatch{
-	name = "External Airlock"
-	},
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
 /obj/effect/mapping_helpers/airlock/access/any/command/minisat,
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock";
+	shuttledocked = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/teleporter)
 "eXR" = (
@@ -20005,6 +20017,14 @@
 	name = "lab floor"
 	},
 /area/station/science/robotics/lab)
+"eYM" = (
+/obj/effect/turf_decal/stripes{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/science/ordnance/testlab)
 "eYN" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20751,7 +20771,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer5,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/floor1/port/aft)
 "fkb" = (
@@ -22260,15 +22280,12 @@
 /turf/open/floor/mineral/silver,
 /area/station/service/chapel)
 "fEr" = (
-/obj/machinery/atmospherics/components/binary/pump{
+/obj/machinery/light/directional/north,
+/obj/machinery/barsign/directional/north,
+/turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
+/area/station/hallway/floor3/fore)
 "fEv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22396,13 +22413,22 @@
 /area/station/hallway/floor1/aft)
 "fGt" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
 	},
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor1/port/aft)
+/obj/structure/rack,
+/obj/item/integrated_circuit/loaded/speech_relay{
+	pixel_y = 5;
+	pixel_x = -6
+	},
+/obj/item/integrated_circuit/loaded/hello_world{
+	pixel_y = -2;
+	pixel_x = 5
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
+/area/station/engineering/circuit_workshop)
 "fGx" = (
 /obj/effect/turf_decal/trimline/dark_blue/corner{
 	dir = 1
@@ -22735,11 +22761,11 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor2/aft)
 "fKr" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners{
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
-/area/station/command/heads_quarters/rd)
+/obj/machinery/atmospherics/components/trinary/filter,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/blacklight/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance/testlab)
 "fKs" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -22843,10 +22869,8 @@
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor3/starboard)
 "fMc" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/testlab)
 "fMf" = (
@@ -22889,6 +22913,10 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard/aft)
+"fMO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology/hallway)
 "fMY" = (
 /obj/effect/turf_decal/tile/green/full,
 /obj/structure/railing/corner{
@@ -22928,13 +22956,10 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor3/starboard)
 "fNt" = (
-/obj/effect/turf_decal/stripes,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/testlab)
 "fNy" = (
@@ -23089,9 +23114,16 @@
 /turf/open/floor/iron/textured_edge,
 /area/station/medical/chemistry)
 "fPj" = (
-/obj/machinery/barsign,
-/turf/closed/wall,
-/area/station/maintenance/floor3/starboard/fore)
+/obj/structure/table,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = 3
+	},
+/turf/open/floor/iron/checker,
+/area/station/service/bar/atrium)
 "fPl" = (
 /obj/machinery/requests_console/directional/south{
 	department = "Medbay";
@@ -23474,7 +23506,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/pod/dark,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
 /area/station/maintenance/floor4/starboard)
 "fUm" = (
 /obj/structure/cable,
@@ -25026,7 +25059,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/station_engineer,
-/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "goe" = (
@@ -25235,15 +25267,14 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/maintenance/floor2/starboard/aft)
 "gqO" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/warning{
+	dir = 5
 	},
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor1/port/aft)
+/turf/open/floor/iron/dark,
+/area/station/engineering/circuit_workshop)
 "gqP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -25385,12 +25416,11 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor4/starboard/fore)
 "gsy" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/pod/dark,
-/area/station/maintenance/floor4/starboard)
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/full,
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/iron,
+/area/station/science/ordnance/testlab)
 "gsD" = (
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 1
@@ -25649,10 +25679,13 @@
 /turf/open/floor/wood,
 /area/station/service/barber)
 "gwe" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/testlab)
 "gwl" = (
@@ -28115,12 +28148,22 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/disposal)
 "hca" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor1/port/aft)
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
+/obj/structure/table,
+/obj/item/multitool/circuit{
+	pixel_x = -6
+	},
+/obj/item/multitool/circuit{
+	pixel_x = 7
+	},
+/obj/item/multitool/circuit{
+	pixel_x = 1;
+	pixel_y = 3
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/circuit_workshop)
 "hch" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28424,16 +28467,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/floor2/starboard/aft)
 "hfE" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/neutral/full,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
 "hfO" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
@@ -28906,9 +28942,9 @@
 /area/station/hallway/floor1/aft)
 "hmM" = (
 /obj/effect/turf_decal/tile/neutral/full,
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/bot,
 /obj/machinery/light/small/directional/south,
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/pipe_scrubber,
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
 "hmN" = (
@@ -29004,8 +29040,8 @@
 /obj/effect/turf_decal/stripes{
 	dir = 5
 	},
-/obj/structure/railing/corner{
-	dir = 1
+/obj/structure/railing{
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -29045,13 +29081,20 @@
 "hoa" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/ordnance{
-	pixel_x = 4;
-	pixel_y = 1
+	pixel_x = 7;
+	pixel_y = -12
 	},
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/full,
 /obj/structure/cable,
+/obj/item/pipe_dispenser{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/item/pipe_dispenser{
+	pixel_y = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "hoj" = (
@@ -29375,14 +29418,15 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/port/aft)
 "hsT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/spawner/structure/window/hollow/plasma/middle,
-/obj/structure/girder/reinforced,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/engine,
-/area/station/maintenance/floor4/starboard)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/science/ordnance/testlab)
 "hsU" = (
 /obj/structure/chair/stool/bar/directional/south,
 /obj/item/stack/arcadeticket,
@@ -30578,28 +30622,10 @@
 /area/station/medical/medbay/lobby)
 "hHi" = (
 /obj/machinery/camera/autoname/directional/west,
-/obj/structure/closet/crate/science{
-	name = "Parts crate"
-	},
-/obj/item/assembly/prox_sensor,
-/obj/item/assembly/prox_sensor,
-/obj/item/assembly/prox_sensor,
-/obj/item/assembly/prox_sensor,
-/obj/item/assembly/signaler,
-/obj/item/assembly/signaler,
-/obj/item/assembly/signaler,
-/obj/item/assembly/signaler,
-/obj/item/assembly/signaler,
-/obj/item/assembly/signaler,
-/obj/item/assembly/timer,
-/obj/item/assembly/timer,
-/obj/item/assembly/timer,
-/obj/item/assembly/timer,
-/obj/machinery/light_switch/directional/west,
-/obj/effect/turf_decal/stripes{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/testlab)
 "hHn" = (
@@ -31138,7 +31164,6 @@
 /area/station/command/gateway)
 "hOP" = (
 /obj/machinery/incident_display/delam/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "hOR" = (
@@ -32807,16 +32832,16 @@
 /turf/open/floor/circuit/green/telecomms,
 /area/station/tcommsat/server)
 "ilx" = (
-/obj/machinery/modular_computer/preset/civilian{
-	dir = 8
-	},
 /obj/machinery/newscaster/directional/east,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot/right,
 /obj/effect/turf_decal/tile/neutral/full,
 /obj/structure/cable,
+/obj/effect/turf_decal/bot/right,
+/obj/machinery/modular_computer/preset/civilian{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
 "ilA" = (
@@ -36460,8 +36485,9 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/service)
 "jgK" = (
-/obj/machinery/newscaster/directional/north,
-/obj/structure/table/reinforced/plastitaniumglass,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/frame/machine,
+/obj/item/circuitboard/machine/telecomms/receiver,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor3/starboard/fore)
 "jgO" = (
@@ -36545,6 +36571,9 @@
 /obj/structure/cable,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard/fore)
+"jhH" = (
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology/hallway)
 "jhU" = (
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
@@ -36594,9 +36623,13 @@
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor3/aft)
 "jiM" = (
-/obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/tile/red/opposingcorners{
 	dir = 1
+	},
+/obj/machinery/status_display/door_timer{
+	pixel_x = -32;
+	name = "Isolation";
+	id = "isolationcell"
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
@@ -36625,7 +36658,6 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/tools)
 "jjj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes{
 	dir = 1
 	},
@@ -38977,6 +39009,7 @@
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/structure/flora/bush/lavendergrass/style_random,
 /mob/living/basic/butterfly,
+/obj/machinery/barsign/directional/north,
 /turf/open/floor/grass,
 /area/station/service/bar/atrium)
 "jME" = (
@@ -40313,11 +40346,15 @@
 	id = "lockers";
 	name = "Locker Room Shutters"
 	},
+/obj/machinery/door/firedoor,
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 2
+	},
 /obj/item/storage/crayons{
 	pixel_x = 6;
 	pixel_y = -3
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/commons/locker)
 "kdh" = (
@@ -40903,10 +40940,9 @@
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/lobby)
 "kjQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer5,
+/turf/closed/wall/r_wall,
+/area/station/maintenance/floor1/port/aft)
 "kjW" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
@@ -44859,6 +44895,7 @@
 /area/station/cargo/miningdock)
 "lhh" = (
 /obj/structure/closet/radiation,
+/obj/machinery/atmospherics/pipe/layer_manifold/cyan/hidden,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "lhi" = (
@@ -46537,14 +46574,13 @@
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "lEs" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/structure/window/hollow/plasma/middle,
+/obj/structure/girder/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor4/starboard)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/science/ordnance/testlab)
 "lEu" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/pod/light,
@@ -47151,9 +47187,8 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor2/fore)
 "lMf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
 "lMj" = (
 /obj/effect/turf_decal/trimline/white/arrow_ccw,
@@ -49910,9 +49945,12 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor3/starboard)
 "msL" = (
-/obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/pod/light,
-/area/station/maintenance/floor1/port/aft)
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/machinery/bci_implanter,
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/sign/poster/random/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/engineering/circuit_workshop)
 "mta" = (
 /obj/structure/railing,
 /obj/machinery/door/firedoor/border_only,
@@ -50081,6 +50119,12 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"mvl" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
+	dir = 6
+	},
+/turf/open/floor/engine/vacuum,
+/area/station/science/ordnance/freezerchamber)
 "mvs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -50315,6 +50359,16 @@
 "myr" = (
 /turf/open/floor/iron/textured_large,
 /area/station/hallway/secondary/entry)
+"myv" = (
+/obj/effect/turf_decal/tile/neutral/full,
+/obj/effect/turf_decal/tile/neutral/full,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron,
+/area/station/science/ordnance/testlab)
 "myO" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/exit/escape_pod)
@@ -51333,10 +51387,10 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/port/fore)
 "mLI" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/structure/disposalpipe/junction/yjunction{
 	dir = 8
 	},
-/obj/structure/disposalpipe/junction/yjunction{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -51579,7 +51633,6 @@
 /obj/structure/railing{
 	dir = 5
 	},
-/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/wood,
 /area/station/service/bar/atrium)
 "mOt" = (
@@ -53228,13 +53281,14 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "ai_sat"
 	},
-/obj/machinery/door/airlock/hatch{
-	name = "External Airlock"
-	},
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
 /obj/effect/mapping_helpers/airlock/access/any/command/minisat,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock";
+	shuttledocked = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/teleporter)
 "niA" = (
@@ -54851,6 +54905,7 @@
 	},
 /obj/effect/landmark/start/station_engineer,
 /obj/machinery/light/directional/south,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "nDg" = (
@@ -59587,7 +59642,8 @@
 /area/station/maintenance/floor1/port/aft)
 "oMv" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/garbage,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/light/small/red/directional/north,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor3/starboard/fore)
 "oMz" = (
@@ -59835,6 +59891,30 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
+"oPF" = (
+/obj/machinery/light_switch/directional/west,
+/obj/effect/turf_decal/stripes{
+	dir = 9
+	},
+/obj/item/assembly/timer,
+/obj/structure/closet/crate/science{
+	name = "Parts crate"
+	},
+/obj/item/assembly/timer,
+/obj/item/assembly/timer,
+/obj/item/assembly/timer,
+/obj/item/assembly/signaler,
+/obj/item/assembly/signaler,
+/obj/item/assembly/signaler,
+/obj/item/assembly/prox_sensor,
+/obj/item/assembly/signaler,
+/obj/item/assembly/signaler,
+/obj/item/assembly/signaler,
+/obj/item/assembly/prox_sensor,
+/obj/item/assembly/prox_sensor,
+/obj/item/assembly/prox_sensor,
+/turf/open/floor/iron/white,
+/area/station/science/ordnance/testlab)
 "oPH" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
@@ -59860,17 +59940,16 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "oPU" = (
-/obj/structure/rack,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
-/obj/effect/turf_decal/bot,
-/obj/machinery/firealarm/directional/south,
 /obj/machinery/status_display/ai/directional/east,
+/obj/effect/turf_decal/tile/neutral/full,
+/obj/effect/turf_decal/bot,
+/obj/item/storage/toolbox/mechanical,
+/obj/structure/rack,
 /obj/item/storage/toolbox/mechanical{
 	pixel_x = 2;
 	pixel_y = 4
 	},
-/obj/item/storage/toolbox/mechanical,
-/obj/effect/turf_decal/tile/neutral/full,
 /obj/item/stack/sheet/iron/fifty,
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
@@ -60184,11 +60263,10 @@
 	},
 /area/station/hallway/secondary/entry)
 "oTq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral/full,
 /obj/effect/turf_decal/stripes,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/testlab)
 "oTu" = (
@@ -60368,17 +60446,11 @@
 /area/station/commons/fitness/recreation)
 "oWs" = (
 /obj/item/analyzer{
-	pixel_y = 4
+	pixel_y = 15;
+	pixel_x = -2
 	},
 /obj/item/analyzer{
-	pixel_y = 4
-	},
-/obj/item/pipe_dispenser{
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/obj/item/pipe_dispenser{
-	pixel_y = -2
+	pixel_y = 17
 	},
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
 /obj/effect/turf_decal/bot,
@@ -60386,6 +60458,14 @@
 /obj/effect/turf_decal/tile/neutral/full,
 /obj/effect/turf_decal/bot,
 /obj/structure/cable,
+/obj/item/disk/computer{
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/obj/item/disk/computer/ordnance{
+	pixel_x = 7;
+	pixel_y = -2
+	},
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
 "oWt" = (
@@ -61150,6 +61230,16 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/theater)
+"piu" = (
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/circuit_workshop)
 "piw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -62576,13 +62666,14 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/room3)
 "pzY" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 8
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
 	},
-/obj/structure/table_frame,
-/obj/item/stack/sheet/iron,
-/turf/open/floor/pod/light,
-/area/station/maintenance/floor1/port/aft)
+/obj/machinery/component_printer,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
+/area/station/engineering/circuit_workshop)
 "pAb" = (
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/east,
@@ -63081,6 +63172,9 @@
 /area/station/security/office)
 "pGz" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "pGG" = (
@@ -63466,7 +63560,6 @@
 /area/station/engineering/lobby)
 "pLK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "pLO" = (
@@ -63596,6 +63689,12 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes{
 	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/railing/corner{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/testlab)
@@ -64155,19 +64254,8 @@
 /turf/open/floor/wood/parquet,
 /area/station/commons/dorms/room2)
 "pUK" = (
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Bulkhead"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/turf/open/floor/pod/dark,
-/area/station/maintenance/floor4/starboard)
+/turf/closed/wall,
+/area/station/science/ordnance/testlab)
 "pUV" = (
 /turf/open/floor/plating/airless,
 /area/station/solars/port/aft)
@@ -65640,6 +65728,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "qnT" = (
@@ -66069,17 +66158,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/genetics)
-"qts" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_x = 3
-	},
-/turf/open/floor/iron/checker,
-/area/station/service/bar/atrium)
 "qtw" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68809,7 +68887,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "raz" = (
@@ -69982,9 +70059,16 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "rpD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer5,
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "rpF" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/siding/thinplating_new/dark,
@@ -72341,8 +72425,9 @@
 "rXJ" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor4/starboard)
 "rXL" = (
@@ -73730,6 +73815,9 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/floor1/fore)
+"sso" = (
+/turf/open/floor/iron/dark,
+/area/station/engineering/circuit_workshop)
 "ssr" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 1
@@ -73743,10 +73831,13 @@
 /turf/open/floor/iron/white/textured,
 /area/station/medical/office)
 "ssx" = (
-/obj/item/stack/medical/bandage,
-/obj/structure/table,
-/turf/open/floor/pod/light,
-/area/station/maintenance/floor1/port/aft)
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
+	},
+/obj/machinery/module_duplicator,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
+/area/station/engineering/circuit_workshop)
 "ssy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/watertank,
@@ -73890,6 +73981,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/broken_floor,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/floor1/port/aft)
 "sus" = (
@@ -74777,10 +74869,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/floor2/aft)
 "sFR" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
-	dir = 6
-	},
-/obj/structure/window/reinforced/plasma/spawner/directional/north,
+/obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/engine/airless,
 /area/station/science/ordnance/freezerchamber)
 "sGb" = (
@@ -75071,7 +75160,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer5,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor1/port/aft)
 "sJt" = (
@@ -75128,12 +75216,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes{
-	dir = 6
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/testlab)
 "sJO" = (
@@ -76206,6 +76290,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor1/aft)
+"sXa" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/spawner/random/trash/graffiti{
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/floor1/port/aft)
 "sXf" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/button/door/directional/north{
@@ -76731,6 +76822,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/tools)
+"tcI" = (
+/obj/effect/turf_decal/stripes{
+	dir = 6
+	},
+/obj/machinery/firealarm/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/white,
+/area/station/science/ordnance/testlab)
 "tcM" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/engineering/toolbox,
@@ -78359,9 +78461,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/floor3/port/fore)
 "txF" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance/two,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/office/light{
+	dir = 8
+	},
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor3/starboard/fore)
 "txP" = (
@@ -79057,15 +79160,10 @@
 /turf/open/floor/pod,
 /area/station/maintenance/floor4/starboard/aft)
 "tHk" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
+/obj/structure/railing/corner,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "tHn" = (
@@ -80484,6 +80582,7 @@
 /obj/effect/decal/cleanable/blood/gibs/core,
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor4/starboard)
 "tZO" = (
@@ -81041,8 +81140,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "uhx" = (
-/turf/open/floor/pod/light,
-/area/station/maintenance/floor1/port/aft)
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/circuit_workshop)
 "uhB" = (
 /obj/effect/turf_decal/tile/green/opposingcorners{
 	dir = 8
@@ -81263,6 +81365,13 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor2/fore)
+"uka" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor4/starboard)
 "ukd" = (
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 1
@@ -81573,7 +81682,6 @@
 /area/station/medical/pharmacy)
 "unW" = (
 /obj/machinery/firealarm/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "uov" = (
@@ -82059,12 +82167,19 @@
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "uwf" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/pod/dark,
-/area/station/maintenance/floor4/starboard)
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/item/controller,
+/obj/item/controller,
+/obj/item/compact_remote,
+/obj/item/compact_remote,
+/obj/effect/turf_decal/bot,
+/obj/machinery/camera/autoname/directional/west,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/engineering/circuit_workshop)
 "uwl" = (
 /obj/machinery/computer/slot_machine,
 /obj/machinery/firealarm/directional/west,
@@ -83561,11 +83676,20 @@
 /turf/open/floor/plating,
 /area/station/maintenance/floor2/starboard/aft)
 "uOc" = (
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/machinery/portable_atmospherics/pipe_scrubber,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/station/science/ordnance/testlab)
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/north,
+/obj/machinery/light_switch/directional/north{
+	pixel_x = 9
+	},
+/obj/effect/mapping_helpers/turn_off_lights_with_lightswitch,
+/turf/open/floor/iron/dark,
+/area/station/engineering/circuit_workshop)
 "uOd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -84459,15 +84583,9 @@
 /turf/open/floor/wood,
 /area/station/service/kitchen/diner)
 "uZr" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/red/dim/directional/north,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor4/starboard)
+/turf/closed/wall/r_wall,
+/area/station/science/ordnance/testlab)
 "uZF" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/floor2/starboard/aft)
@@ -85662,8 +85780,6 @@
 /turf/closed/wall,
 /area/station/maintenance/floor4/port/fore)
 "voX" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/railing,
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
 	},
@@ -86505,13 +86621,31 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor1/fore)
-"vyc" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
-	dir = 10
+"vyb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/window/reinforced/plasma/spawner/directional/north,
-/turf/open/floor/engine/airless,
-/area/station/science/ordnance/freezerchamber)
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/floor4/starboard)
+"vyc" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/power_store/cell/high{
+	pixel_y = -2;
+	pixel_x = 5
+	},
+/obj/item/mmi{
+	pixel_x = -4;
+	pixel_y = 11
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/engineering/circuit_workshop)
 "vym" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -87803,9 +87937,12 @@
 /area/station/command/heads_quarters/cmo)
 "vPP" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/ordnance_freezer_chamber_input{
-	dir = 4
+	dir = 4;
+	on = 1
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
+	dir = 10
+	},
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/freezerchamber)
 "vQb" = (
@@ -88178,6 +88315,12 @@
 	},
 /turf/open/floor/carpet/green,
 /area/station/service/bar/atrium)
+"vUZ" = (
+/obj/effect/turf_decal/stripes,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/science/ordnance/testlab)
 "vVf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -88814,7 +88957,7 @@
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/machinery/restaurant_portal/bar,
-/obj/machinery/digital_clock/directional/south,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/checker,
 /area/station/service/bar/atrium)
 "wcm" = (
@@ -89732,7 +89875,8 @@
 /area/station/maintenance/floor1/port)
 "wmI" = (
 /obj/machinery/door/airlock/security{
-	name = "Isolation"
+	name = "Isolation";
+	id = "isolationcell"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /obj/machinery/door/firedoor,
@@ -90224,7 +90368,7 @@
 "wth" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/layer_manifold/cyan/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "wtl" = (
@@ -93224,14 +93368,10 @@
 	},
 /area/station/security/checkpoint)
 "xdE" = (
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/stripes/end{
+/obj/machinery/holopad,
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/testlab)
 "xdJ" = (
@@ -94724,11 +94864,7 @@
 /turf/open/floor/iron,
 /area/station/service/barber)
 "xxA" = (
-/obj/machinery/holopad,
 /obj/structure/cable,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/testlab)
 "xxC" = (
@@ -95206,10 +95342,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/armory)
 "xDK" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor3/starboard/fore)
 "xDM" = (
@@ -96480,13 +96615,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "xTG" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Circuit Workshop"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/science/ordnance/testlab)
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/station/engineering/circuit_workshop)
 "xTH" = (
 /obj/structure/table/wood,
 /obj/item/instrument/violin,
@@ -96644,15 +96779,10 @@
 	},
 /area/station/maintenance/floor1/starboard/aft)
 "xVV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/light/red/dim/directional/north,
-/turf/open/floor/pod/dark,
-/area/station/maintenance/floor4/starboard)
+/obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance/testlab)
 "xVX" = (
 /obj/effect/turf_decal/trimline/white/arrow_ccw,
 /obj/effect/turf_decal/trimline/red/warning,
@@ -96790,9 +96920,11 @@
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "xXm" = (
-/obj/machinery/space_heater,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/light,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor4/starboard)
 "xXo" = (
 /obj/docking_port/stationary{
@@ -97526,7 +97658,9 @@
 "yhO" = (
 /obj/machinery/suit_storage_unit/engine,
 /obj/structure/window/spawner/directional/east,
-/obj/machinery/incident_display/delam/directional/south,
+/obj/machinery/incident_display/delam/directional/south{
+	pixel_y = -28
+	},
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 1
 	},
@@ -141666,11 +141800,11 @@ xMu
 wWw
 eEA
 nDf
-dEc
-dEc
-dEc
-dEc
-dEc
+cWZ
+cWZ
+cWZ
+cWZ
+cWZ
 dEc
 ulU
 ggX
@@ -141923,12 +142057,12 @@ tNA
 rcd
 cQB
 yhO
-dEc
+cWZ
 fGt
+uwf
+vyc
 hca
-hca
-hca
-hca
+dEc
 koJ
 dEc
 dEc
@@ -142180,12 +142314,12 @@ loN
 bXe
 saA
 vvK
-dEc
-ulU
-vcr
+cWZ
+uOc
+sso
 uhx
 msL
-vcr
+dEc
 xep
 dEc
 ags
@@ -142437,12 +142571,12 @@ uMl
 oOd
 otD
 gnY
-dEc
+xTG
 gqO
-vcr
+piu
 pzY
 ssx
-vcr
+dEc
 xep
 ldD
 qFX
@@ -142694,12 +142828,12 @@ sZb
 xYU
 fYg
 kHS
-dEc
-bhb
-vcr
-eCr
 cWZ
-vcr
+bhb
+cWZ
+cWZ
+cWZ
+dEc
 kUe
 wRM
 nJt
@@ -142956,7 +143090,7 @@ sTQ
 pRN
 ccK
 mWg
-vFE
+sXa
 khQ
 dEc
 dEc
@@ -143719,8 +143853,8 @@ sHL
 ddT
 mVF
 wOm
-lMf
-fEr
+wOm
+hZm
 fWc
 dEc
 tKc
@@ -144489,7 +144623,7 @@ iNW
 xyb
 aVM
 pEq
-lMf
+wOm
 hOP
 dEc
 wus
@@ -144746,7 +144880,7 @@ vap
 kBK
 juf
 wOm
-kjQ
+kfo
 wfl
 dEc
 lhl
@@ -145003,7 +145137,7 @@ uyD
 uyD
 uyD
 upc
-kjQ
+kfo
 mvg
 dEc
 lEI
@@ -145260,7 +145394,7 @@ qbo
 lYg
 jER
 wOm
-rpD
+xgW
 tyQ
 dEc
 dEc
@@ -145775,9 +145909,9 @@ tyQ
 tyQ
 fJl
 tyQ
-tyQ
+lMf
 lhh
-dEc
+kjQ
 skq
 vcr
 kdQ
@@ -192527,8 +192661,8 @@ rkM
 rkM
 rkM
 rkM
-fKr
-fKr
+rWT
+rWT
 rWT
 ujc
 rWT
@@ -250869,7 +251003,7 @@ cee
 wRJ
 wRJ
 wRJ
-fPj
+wRJ
 jMv
 iGI
 vUS
@@ -251910,7 +252044,7 @@ upT
 sjX
 rGd
 tQd
-spd
+fEr
 qcd
 nsn
 rSS
@@ -252934,7 +253068,7 @@ mdN
 uDb
 vGv
 yeR
-qts
+fPj
 bmO
 rVY
 tQd
@@ -253694,7 +253828,7 @@ ycg
 uHe
 vVo
 ccH
-rip
+jgK
 wRJ
 igy
 rip
@@ -254204,9 +254338,9 @@ xeE
 pbj
 gMv
 vjT
+jhH
 gTk
-rtl
-jgK
+ccH
 xDK
 rip
 oYT
@@ -254461,9 +254595,9 @@ fok
 bpY
 xAo
 rLB
+fMO
 gTk
-rtl
-bGl
+ccH
 oMv
 txF
 wRJ
@@ -318203,10 +318337,10 @@ nPE
 bvM
 fUk
 rXJ
-gDy
+eCr
 xXm
 eRZ
-uIr
+dIJ
 nPE
 tKs
 hug
@@ -318457,12 +318591,12 @@ rDL
 heI
 jha
 nPE
-xVV
-gsy
-uwf
-pUK
-moL
-hMp
+nPE
+nPE
+nPE
+nPE
+nPE
+pDq
 gDy
 nPE
 nPE
@@ -318713,11 +318847,11 @@ wFa
 tYV
 oUW
 xwL
-nPE
-nPE
-nPE
-nPE
-nPE
+oPF
+bGl
+gOF
+auO
+gsy
 nPE
 pDq
 aex
@@ -318972,9 +319106,9 @@ bJA
 mKu
 hHi
 fMc
-gOF
+vUZ
 ddH
-uOc
+jjT
 nPE
 pDq
 vfi
@@ -319219,7 +319353,7 @@ ucA
 ucA
 ucA
 sFR
-crp
+mvl
 crp
 dWz
 lYx
@@ -319228,9 +319362,9 @@ wMU
 aaN
 pGz
 jjj
-dIJ
+xxA
 oTq
-jjT
+hfE
 hmM
 nPE
 pDq
@@ -319475,7 +319609,7 @@ ucA
 ucA
 ucA
 ucA
-vyc
+sFR
 vPP
 rrs
 mCU
@@ -319487,8 +319621,8 @@ tHk
 bDn
 gwe
 eoI
-nPE
-nPE
+eYM
+sJm
 nPE
 pDq
 nPE
@@ -319740,13 +319874,13 @@ lYx
 ngD
 wMU
 aqm
+xVV
 ptg
-xTG
 xxA
 xdE
-nPE
+eTV
 uZr
-moL
+jNM
 xZu
 nPE
 fkN
@@ -319997,9 +320131,9 @@ tyR
 tyR
 xqB
 voX
+xVV
 kFy
-eTV
-auO
+xxA
 fNt
 hsT
 lEs
@@ -320253,14 +320387,14 @@ sab
 vuB
 vuB
 vuB
-hfE
+vuB
 bep
 hnG
 pNa
 sJM
-nPE
-pDq
-cSk
+tcI
+sJm
+vyb
 nPE
 wIz
 jLt
@@ -320515,9 +320649,9 @@ hoa
 oWs
 ilx
 oPU
-nPE
-whI
-hMp
+myv
+sJm
+pDq
 nPE
 xBt
 qlf
@@ -320761,7 +320895,7 @@ ucA
 ucA
 ucA
 sJm
-sJm
+rDL
 mcr
 rhw
 kKO
@@ -320772,8 +320906,8 @@ sJm
 sJm
 sJm
 sJm
-nPE
-gDy
+sJm
+pUK
 pDq
 nPE
 nCP
@@ -321018,11 +321152,11 @@ ucA
 ucA
 ucA
 sJm
-sJm
+rDL
 mcr
 rhw
 mZT
-xLo
+fKr
 xLo
 use
 sJm
@@ -323852,7 +323986,7 @@ sbU
 tAW
 gDy
 lIS
-uIr
+uka
 vsO
 rAy
 hGB
@@ -329542,7 +329676,7 @@ xkw
 qXW
 skD
 skD
-skD
+rpD
 qBm
 qXp
 qXp

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -3078,6 +3078,8 @@
 	},
 /obj/structure/cable,
 /obj/structure/cable/layer3,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/teleporter)
 "aNV" = (
@@ -13021,16 +13023,6 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor3/port/aft)
-"dgK" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron/dark,
-/area/station/security/armory)
 "dgU" = (
 /obj/structure/cable,
 /obj/machinery/light/red/dim/directional/north,
@@ -14199,6 +14191,8 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor4/aft)
 "dyo" = (
@@ -14222,6 +14216,8 @@
 "dyt" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
 "dyG" = (
@@ -14532,18 +14528,6 @@
 	},
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
-"dCB" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/ammo_workbench,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark,
-/area/station/security/armory)
 "dCD" = (
 /obj/effect/spawner/random/entertainment/arcade,
 /obj/machinery/light/blacklight/directional/north,
@@ -15931,24 +15915,6 @@
 	dir = 5
 	},
 /area/station/hallway/floor1/aft)
-"dUz" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/rack,
-/obj/item/melee/breaching_hammer{
-	pixel_x = 6
-	},
-/obj/item/melee/breaching_hammer,
-/obj/item/melee/breaching_hammer{
-	pixel_x = -6
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/armory)
 "dUF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -17148,11 +17114,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/floor3/starboard/aft)
-"ejH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/trash_pile,
-/turf/open/floor/pod,
-/area/station/maintenance/floor4/starboard/aft)
 "ejI" = (
 /obj/effect/turf_decal/trimline/green/warning{
 	dir = 8
@@ -21281,6 +21242,13 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood,
 /area/station/commons/dorms/apartment1)
+"foV" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable/layer3,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/engine/hull/reinforced,
+/area/space/nearstation)
 "fpb" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/green,
@@ -24631,6 +24599,12 @@
 	},
 /turf/open/floor/pod/dark,
 /area/station/cargo/miningdock)
+"ghm" = (
+/obj/effect/turf_decal/tile/red/fourcorners,
+/obj/machinery/dish_drive/bullet,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark,
+/area/station/security/lockers)
 "gho" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/structure/tank_holder,
@@ -27089,9 +27063,14 @@
 /area/station/command/heads_quarters/captain)
 "gMo" = (
 /obj/structure/rack,
-/obj/item/gun/energy/ionrifle,
-/obj/item/clothing/suit/hooded/ablative,
+/obj/item/gun/energy/ionrifle{
+	pixel_y = 4
+	},
 /obj/effect/turf_decal/tile/red/fourcorners,
+/obj/item/gun/energy/temperature/security{
+	pixel_y = -5;
+	pixel_x = 2
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/armory)
 "gMs" = (
@@ -28157,6 +28136,18 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
 /area/station/hallway/floor4/fore)
+"hbh" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/armory)
 "hbi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28947,6 +28938,11 @@
 /obj/effect/turf_decal/tile/green/full,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
+"hlB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/trash_pile,
+/turf/open/floor/pod,
+/area/station/maintenance/floor4/starboard/aft)
 "hlG" = (
 /obj/structure/closet/mini_fridge{
 	pixel_x = 6;
@@ -33371,7 +33367,7 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/effect/turf_decal/bot,
 /obj/structure/rack/gunrack,
-/obj/effect/spawner/random/armory/dragnet,
+/obj/effect/spawner/armory_spawn/shotguns,
 /turf/open/floor/iron/dark,
 /area/station/security/armory)
 "irb" = (
@@ -33939,7 +33935,6 @@
 	},
 /area/station/hallway/floor4/aft)
 "izj" = (
-/obj/effect/turf_decal/tile/red/fourcorners,
 /obj/machinery/dish_drive/bullet,
 /obj/effect/turf_decal/delivery/red,
 /turf/open/floor/iron/dark,
@@ -36523,6 +36518,11 @@
 	},
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard)
+"jfz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/pod,
+/area/station/maintenance/floor4/port/fore)
 "jfH" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/structure/flora/bush/lavendergrass/style_random,
@@ -36723,12 +36723,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
-"jiP" = (
-/obj/effect/turf_decal/tile/red/fourcorners,
-/obj/machinery/dish_drive/bullet,
-/obj/effect/turf_decal/delivery/red,
-/turf/open/floor/iron/dark,
-/area/station/security/lockers)
 "jja" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
@@ -37475,11 +37469,6 @@
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/mechbay)
-"jsN" = (
-/obj/effect/spawner/random/structure/closet_maintenance,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/pod/dark,
-/area/station/maintenance/floor2/starboard)
 "jsP" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
@@ -37657,12 +37646,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/floor2/port/aft)
 "jvu" = (
-/obj/effect/turf_decal/trimline/red/line{
+/obj/structure/reagent_dispensers/plumbed{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/plumbed{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 5
 	},
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard/aft)
@@ -38773,6 +38762,8 @@
 "jIc" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/multilayer/connected,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
 "jIe" = (
@@ -39241,6 +39232,9 @@
 /obj/item/key/security,
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/red/fourcorners,
+/obj/item/clothing/suit/hooded/ablative{
+	pixel_x = -13
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/armory)
 "jOj" = (
@@ -42145,6 +42139,15 @@
 "kyo" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/layer3,
+/obj/machinery/atmospherics/components/binary/pump/on/layer2{
+	dir = 8;
+	target_pressure = 4500;
+	name = "AI scrubber pump"
+	},
+/obj/machinery/atmospherics/components/binary/pump/on/layer4{
+	dir = 4;
+	name = "AI air supply pump"
+	},
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
 "kyr" = (
@@ -49542,6 +49545,11 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/wood/large,
 /area/station/service/library/lounge)
+"mmG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/trash_pile,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port/fore)
 "mmI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark/side{
@@ -50259,10 +50267,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "mvg" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister,
 /obj/machinery/camera{
 	c_tag = "Supermatter Foyer Cam #4";
 	network = list("ss13","engine")
@@ -52515,9 +52519,12 @@
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "mYg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/pressure_valve/on/layer2{
+	dir = 1;
+	name = "Waste release"
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai/satellite/teleporter)
 "mYh" = (
@@ -53273,12 +53280,10 @@
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/floor3/aft)
 "nhm" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot,
-/obj/structure/rack/gunrack,
-/obj/effect/spawner/armory_spawn/shotguns,
+/obj/structure/rack,
+/obj/effect/spawner/random/armory/dragnet,
+/obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/armory)
 "nho" = (
@@ -53961,6 +53966,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
+"npH" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron/dark,
+/area/station/security/armory)
 "npK" = (
 /obj/structure/closet/firecloset/full,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -58943,16 +58958,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"oAS" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/armory)
 "oAZ" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/engine/plasma,
@@ -59998,6 +60003,7 @@
 	pixel_y = -6
 	},
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron/recharge_floor,
 /area/station/security/armory)
 "oOY" = (
@@ -62340,8 +62346,9 @@
 "puQ" = (
 /obj/structure/sign/poster/official/random/directional/south,
 /obj/effect/turf_decal/bot,
-/obj/structure/rack/gunrack,
 /obj/effect/spawner/random/armory/laser_gun,
+/obj/structure/rack,
+/obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron/recharge_floor,
 /area/station/security/armory)
 "puY" = (
@@ -65142,6 +65149,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/floor1/aft)
+"qdO" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/pod/dark,
+/area/station/maintenance/floor2/starboard)
 "qdS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -68801,6 +68813,8 @@
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/layer3,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/ai/satellite/teleporter)
 "qXE" = (
@@ -69710,6 +69724,24 @@
 /obj/machinery/computer/security/telescreen/interrogation/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
+"rhP" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/rack,
+/obj/item/melee/breaching_hammer{
+	pixel_x = 6
+	},
+/obj/item/melee/breaching_hammer,
+/obj/item/melee/breaching_hammer{
+	pixel_x = -6
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/armory)
 "rhR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -70927,8 +70959,8 @@
 /obj/structure/rack,
 /obj/effect/spawner/random/armory/bulletproof_armor,
 /obj/effect/spawner/random/armory/bulletproof_helmet,
-/obj/effect/spawner/random/armory/bulletproof_helmet,
 /obj/effect/spawner/random/armory/bulletproof_armor,
+/obj/effect/spawner/random/armory/bulletproof_helmet,
 /turf/open/floor/iron/dark,
 /area/station/security/armory)
 "rAV" = (
@@ -71018,8 +71050,9 @@
 	req_access = list("armory")
 	},
 /obj/effect/turf_decal/bot,
-/obj/structure/rack/gunrack,
 /obj/effect/spawner/armory_spawn/smg,
+/obj/structure/rack,
+/obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron/recharge_floor,
 /area/station/security/armory)
 "rBW" = (
@@ -71154,11 +71187,6 @@
 /obj/effect/turf_decal/tile/green/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/hallway/floor2/aft)
-"rDg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/trash_pile,
-/turf/open/floor/pod/light,
-/area/station/maintenance/floor1/port/fore)
 "rDh" = (
 /obj/machinery/camera/autoname/directional/west,
 /obj/item/radio/intercom/directional/west,
@@ -71639,15 +71667,11 @@
 /turf/open/floor/plating,
 /area/station/security/execution/transfer)
 "rLb" = (
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/pod/light,
+/turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor4/starboard/aft)
 "rLd" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -77942,6 +77966,16 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/storage)
+"tpt" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/armory)
 "tpw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -81832,10 +81866,8 @@
 /turf/open/floor/wood/tile,
 /area/station/service/library/printer)
 "upc" = (
-/obj/machinery/atmospherics/components/trinary/filter/critical{
-	dir = 4
-	},
 /obj/machinery/status_display/evac/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "uph" = (
@@ -82141,6 +82173,18 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
+"utG" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/ammo_workbench,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
+/area/station/security/armory)
 "utJ" = (
 /obj/effect/mapping_helpers/airlock/access/any/security/court,
 /obj/machinery/door/firedoor,
@@ -83304,14 +83348,10 @@
 /turf/open/floor/carpet/green,
 /area/station/command/heads_quarters/nt_rep)
 "uIM" = (
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/pod/light,
+/turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor4/starboard/aft)
 "uIN" = (
 /turf/closed/wall/r_wall,
@@ -84192,10 +84232,10 @@
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor2/starboard/aft)
 "uTk" = (
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 9
+	},
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard/aft)
 "uTx" = (
@@ -89369,12 +89409,10 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "wfl" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/hallway/floor4/aft)
 "wfx" = (
 /obj/machinery/door/window/brigdoor/left/directional/west,
 /obj/structure/cable,
@@ -89863,6 +89901,13 @@
 	dir = 10
 	},
 /area/station/command/bridge)
+"wlM" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/hallway/floor4/aft)
 "wlP" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Atmos to Engine Filters"
@@ -92362,18 +92407,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
-"wPo" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/armory)
 "wPs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -92399,12 +92432,10 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/structure/rack/gunrack,
 /obj/item/gun/energy/modular_laser_rifle/carbine{
-	pixel_y = 5;
-	pixel_x = -1
+	pixel_x = -3
 	},
-/obj/item/gun/energy/temperature/security{
-	pixel_y = -5;
-	pixel_x = 2
+/obj/item/gun/energy/modular_laser_rifle/carbine{
+	pixel_x = 3
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/armory)
@@ -93305,6 +93336,7 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "xbE" = (
+/obj/effect/spawner/random/engineering/tank,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/port/aft)
 "xbF" = (
@@ -97009,11 +97041,6 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/secondary/exit/escape_pod)
-"xXc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/spawner/random/trash/mess,
-/turf/open/floor/pod,
-/area/station/maintenance/floor4/port/fore)
 "xXd" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -97434,13 +97461,14 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/theater)
 "ycx" = (
-/obj/structure/table,
 /obj/item/gun/energy/laser/practice{
-	pixel_x = 3;
-	pixel_y = -3
+	pixel_x = -5
 	},
-/obj/item/gun/energy/laser/carbine/practice,
+/obj/item/gun/energy/laser/carbine/practice{
+	pixel_x = 5
+	},
 /obj/machinery/light/directional/north,
+/obj/structure/rack/gunrack,
 /turf/open/floor/iron/dark,
 /area/station/security/range)
 "ycy" = (
@@ -119844,7 +119872,7 @@ usj
 dac
 fQm
 fQm
-rDg
+mmG
 hJy
 hJy
 owI
@@ -145010,8 +145038,8 @@ vap
 kBK
 juf
 wOm
-kfo
-wfl
+xgW
+xgW
 dEc
 lhl
 uov
@@ -145267,7 +145295,7 @@ uyD
 uyD
 uyD
 upc
-kfo
+xgW
 mvg
 dEc
 lEI
@@ -201006,7 +201034,7 @@ ucA
 ucA
 vnK
 vnK
-jsN
+qdO
 dMV
 vnK
 vnK
@@ -313354,7 +313382,7 @@ lvm
 vSG
 mpK
 key
-xXc
+jfz
 qNk
 iQE
 rej
@@ -321838,7 +321866,7 @@ dGf
 nJC
 saB
 iqR
-jiP
+ghm
 sWm
 kHO
 iAq
@@ -325662,7 +325690,7 @@ dlW
 kDq
 dlW
 xrY
-ejH
+hlB
 jZp
 vJf
 rVI
@@ -325949,9 +325977,9 @@ gwE
 sHY
 dPH
 jlW
-dgK
-wPo
-oAS
+npH
+hbh
+tpt
 rBU
 qjr
 sWo
@@ -326462,7 +326490,7 @@ jIV
 fBT
 sHY
 rDZ
-dUz
+rhP
 lOp
 ira
 dtX
@@ -327233,7 +327261,7 @@ fCE
 cLF
 sHY
 cAt
-dCB
+utG
 xOY
 nzV
 xDG
@@ -333388,7 +333416,7 @@ oyh
 oyh
 xot
 wTj
-wTj
+wfl
 whM
 eOP
 oyh
@@ -333902,7 +333930,7 @@ oyh
 mrL
 nWW
 xot
-xot
+wlM
 xot
 nWW
 ric
@@ -335444,7 +335472,7 @@ kgW
 oyh
 oyh
 oyh
-kyo
+foV
 oyh
 oyh
 oyh
@@ -335701,7 +335729,7 @@ rCR
 vfU
 oyh
 iSU
-kyo
+foV
 iSU
 oyh
 vOv
@@ -335958,7 +335986,7 @@ kgW
 oyh
 oyh
 oyh
-kyo
+foV
 oyh
 oyh
 oyh

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -5475,9 +5475,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/multi_tile/public/glass{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor2/fore)
 "boa" = (
@@ -5750,12 +5747,6 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
-"bry" = (
-/obj/machinery/exodrone_launcher,
-/obj/item/exodrone,
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plating/elevatorshaft,
-/area/station/cargo/drone_bay)
 "brA" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/decal/cleanable/dirt,
@@ -10818,6 +10809,9 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "library2"
 	},
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	name = "Library"
+	},
 /turf/open/floor/iron,
 /area/station/service/library)
 "cEH" = (
@@ -11108,14 +11102,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
-"cIq" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/iron/dark,
-/area/station/hallway/floor2/fore)
 "cIr" = (
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/wood,
@@ -14892,13 +14878,6 @@
 	dir = 5
 	},
 /area/station/hallway/floor3/fore)
-"dGW" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "library2"
-	},
-/turf/open/floor/wood/tile,
-/area/station/service/library/lounge)
 "dHa" = (
 /obj/structure/closet/boxinggloves,
 /obj/machinery/light/small/directional/west,
@@ -18583,11 +18562,16 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "eCP" = (
-/obj/machinery/door/airlock{
-	name = "Viewing Room"
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/maintenance/floor3/starboard/fore)
+/area/station/hallway/floor2/fore)
 "eCQ" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -26512,16 +26496,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor4/aft)
-"gGn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/shieldgen,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "gGp" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -31874,6 +31848,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plastic,
 /area/station/security/prison/shower)
+"hWI" = (
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "blast_miningdock";
+	name = "Mining Dock Hangar Door"
+	},
+/obj/structure/fans/tiny/forcefield,
+/turf/open/floor/plating,
+/area/station/cargo/miningdock)
 "hWN" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/random/structure/crate,
@@ -37826,6 +37811,11 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
+"jxd" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/space/basic,
+/area/station/ai/satellite/teleporter)
 "jxf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/baseturf_helper/reinforced_plating/ceiling,
@@ -38283,6 +38273,9 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor/heavy,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/multi_tile/public/glass{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -39239,15 +39232,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/floor2/starboard/aft)
 "jNQ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "library2"
+/obj/machinery/door/airlock{
+	name = "Viewing Room"
 	},
-/obj/machinery/door/airlock/multi_tile/public/glass{
-	name = "Library"
-	},
-/turf/open/floor/iron,
-/area/station/service/library)
+/turf/open/floor/iron/dark,
+/area/station/maintenance/floor3/starboard/fore)
 "jOc" = (
 /obj/item/storage/box/firingpins,
 /obj/item/storage/box/firingpins,
@@ -50975,9 +50964,6 @@
 /area/station/engineering/atmos/project)
 "mEg" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/public/glass{
-	name = "Lower Library"
-	},
 /turf/open/floor/iron,
 /area/station/service/library)
 "mEh" = (
@@ -55907,17 +55893,6 @@
 /obj/effect/spawner/random/medical/surgery_tool,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/floor1/port)
-"nNI" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "blast_miningdock";
-	name = "Mining Dock Hangar Door"
-	},
-/obj/structure/fans/tiny/forcefield,
-/turf/open/floor/plating,
-/area/station/cargo/miningdock)
 "nNJ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -59388,6 +59363,12 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
+"oHf" = (
+/obj/machinery/exodrone_launcher,
+/obj/item/exodrone,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plating/elevatorshaft,
+/area/station/cargo/drone_bay)
 "oHp" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
@@ -60059,10 +60040,6 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
-"oPF" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/service/library)
 "oPH" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
@@ -62938,10 +62915,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "library2"
-	},
-/obj/machinery/door/airlock/multi_tile/public/glass{
-	name = "Library";
-	dir = 4
 	},
 /turf/open/floor/wood/tile,
 /area/station/service/library/lounge)
@@ -70563,16 +70536,12 @@
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain/private)
 "rtS" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor/heavy,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/multi_tile/public/glass{
-	dir = 4
+	name = "Lower Library"
 	},
-/turf/open/floor/iron/dark,
-/area/station/hallway/floor1/aft)
+/turf/open/floor/iron,
+/area/station/service/library)
 "rtV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -77582,6 +77551,14 @@
 	},
 /turf/open/floor/eighties,
 /area/station/commons/fitness/recreation/entertainment)
+"tkU" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/hallway/floor1/aft)
 "tkZ" = (
 /obj/structure/cable,
 /obj/machinery/conveyor/inverted{
@@ -89342,6 +89319,13 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/wood/tile,
 /area/station/service/library)
+"wen" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "library2"
+	},
+/turf/open/floor/iron,
+/area/station/service/library)
 "wet" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -94176,6 +94160,17 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/misc/grass,
 /area/station/maintenance/floor1/starboard)
+"xmf" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "library2"
+	},
+/obj/machinery/door/airlock/multi_tile/public/glass{
+	name = "Library";
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/station/service/library/lounge)
 "xmh" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/green/opposingcorners,
@@ -95986,11 +95981,6 @@
 "xIV" = (
 /turf/open/space/openspace,
 /area/space/nearstation)
-"xJe" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/station/ai/satellite/teleporter)
 "xJk" = (
 /obj/machinery/seed_extractor,
 /obj/effect/turf_decal/tile/green/full,
@@ -97925,6 +97915,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard/fore)
+"yjP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/shieldgen,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "yjR" = (
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 8
@@ -122651,7 +122651,7 @@ owI
 owI
 uYl
 pFb
-bry
+oHf
 hDa
 fyg
 xxQ
@@ -126766,8 +126766,8 @@ hKN
 hKN
 hKN
 hKN
-gGn
-gGn
+yjP
+yjP
 xbV
 xbV
 xbV
@@ -129074,7 +129074,7 @@ owI
 owI
 owI
 aux
-nNI
+hWI
 fWE
 uaC
 gHk
@@ -137834,7 +137834,7 @@ iqa
 qSl
 qSl
 rjD
-jCi
+tkU
 qTS
 rjD
 rjD
@@ -137846,7 +137846,7 @@ rjD
 rjD
 rjD
 jIT
-rtS
+jCi
 rjD
 rjD
 xgH
@@ -138874,7 +138874,7 @@ rjD
 rjD
 rjD
 qgE
-rtS
+jCi
 rjD
 rjD
 xgH
@@ -182811,7 +182811,7 @@ wwu
 wwu
 fNT
 fqo
-bnV
+eCP
 fNT
 fNT
 fNT
@@ -183839,7 +183839,7 @@ wwu
 wwu
 fNT
 fqo
-bnV
+eCP
 fNT
 fNT
 fNT
@@ -183849,8 +183849,8 @@ fNe
 fNT
 fNT
 fNT
-cIq
 bnV
+eCP
 fNT
 fNT
 hLz
@@ -205935,8 +205935,8 @@ dEt
 dEt
 dEt
 amt
-dGW
 pBW
+xmf
 kca
 rCc
 oZz
@@ -247572,7 +247572,7 @@ acK
 acK
 hEm
 btC
-eCP
+jNQ
 sJO
 gec
 vuo
@@ -270442,10 +270442,10 @@ kRR
 fpU
 kmt
 oGM
-jNQ
+cEw
 qPi
 lBK
-mEg
+rtS
 fBP
 ddg
 wet
@@ -270699,10 +270699,10 @@ fpU
 fpU
 kmt
 oGM
-cEw
+wen
 rdW
 pSd
-oPF
+mEg
 fBP
 ddg
 fAT
@@ -337273,7 +337273,7 @@ oyh
 oyh
 oyh
 hWr
-xJe
+jxd
 tIl
 fEv
 dMt


### PR DESCRIPTION

## About The Pull Request

Several changes to Northstar based on prior feedback. Full list:

- Fixed chemistry storage access
- Moved firelocks at top of stairs to save people from being Barclay'd (IYKYK)
- Adds curator access restriction to the weird library door thing
- Replaced medbay gauze with 12-stacks (StrongDMM thought this was important)
- Modified bar to make access to seating from behind the bar easier
- Extra door leading to locker room to make it easier to enter (no longer having to go through the garden)
- Expanded ordnance lab and added some data disks
- Added circuit lab to engineering
- Fixed non-working bolt button on the council chamber bathroom
- Brings armory up to par with armories on other stations, adding more weapons to account for higher population
- Removed waste filter cans in supermatter chamber (the cooling room already has its own filter cans, so they were superfluous). This unintentionally optimizes the supermatter setup, though.
- Connected AI satellite to the distro and waste loops, via a pair of pumps. These can be remotely disabled by any AI that so wishes to do so.
- Replaced most instances of double-doors with two-tile doors instead.
- Replaced cargo bay energy shields with holographic fans, adding blast doors operable by buttons in case the extra security is needed.
- Add 'bit_den' access to mining dock doors
## Why It's Good For The Game

People like Northstar apparently! So this will make it better. The only change that isn't an objective upgrade is the cargo shield change. Though, the blast doors are more robust than the original energy shields, they do start open (because it looks nicer). May have to be changed later if it proves too easily abused (though what with almost all the exterior doors having restricted access, maybe that's a good change for space-based antags?)
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="1216" height="989" alt="image" src="https://github.com/user-attachments/assets/100c634c-02de-446c-935a-3de565131789" />
<img width="1216" height="989" alt="image" src="https://github.com/user-attachments/assets/155638db-4070-4c83-bcf0-5fc6e1c0c7f3" />
<img width="1216" height="989" alt="image" src="https://github.com/user-attachments/assets/cd118499-d93e-48a5-97ec-b3cba7f18d92" />
(Note: Ordnance isn't actually this purple in current iteration)
</details>

## Changelog
:cl:Fogspot
map: Various fixes and improvements to Northstar, including but not limited to access fixes, moving firelocks at the top of stairs, easier access to bar, expanded ordnance, circuit lab in engineering, improved armory on par with other stations, and replacing the cargo energy shields with walk-through shields and blast doors.
/:cl:
