### PR TITLE
Adds blob_act() logic to protean modsuits.

### DIFF
--- a/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
@@ -5,7 +5,7 @@
 
 	applied_core = /obj/item/mod/core/protean
 	applied_cell = null // Goes off stomach
-	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF // funny nanite
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | INDESTRUCTIBLE // funny nanite
 	drag_pickup = FALSE
 	/// Whether or not the wearer can undeploy parts.
 	var/modlocked = FALSE
@@ -323,6 +323,15 @@
 			. += span_deadsay("[t_He] [t_has] entered stasis and [t_has] been completely unresponsive to anything for [round(((world.time - protean_in_suit.lastclienttime) / (1 MINUTES)),1)] minutes. [t_He] may snap out of it soon.")
 		if(!protean_in_suit.key)
 			. += span_deadsay("[t_He] [t_is] totally listless. The stresses of life in deep-space must have been too much for [t_him]. Any recovery is unlikely.")
+
+/obj/item/mod/control/pre_equipped/protean/blob_act(obj/structure/blob/B)
+	var/obj/item/mod/core/protean/p_core = core
+	var/mob/living/carbon/human/protean = p_core?.linked_species.owner
+	var/obj/item/organ/brain/protean/brain = protean.get_organ_slot(ORGAN_SLOT_BRAIN)
+	if(!brain.dead)
+		to_chat(protean, span_boldwarning("The [B] crushes you relentlessly until your refactory pops."))
+		protean.take_overall_damage(300)
+	return ..()
 
 /obj/item/mod/control/pre_equipped/protean/proc/ooc_escape(mob/living/carbon/user)
 	SIGNAL_HANDLER

--- a/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
@@ -327,8 +327,8 @@
 /obj/item/mod/control/pre_equipped/protean/blob_act(obj/structure/blob/B)
 	var/obj/item/mod/core/protean/p_core = core
 	var/mob/living/carbon/human/protean = p_core?.linked_species.owner
-	var/obj/item/organ/brain/protean/brain = protean.get_organ_slot(ORGAN_SLOT_BRAIN)
-	if(!brain.dead)
+	var/obj/item/organ/brain/protean/brain = protean?.get_organ_slot(ORGAN_SLOT_BRAIN)
+	if(!brain.dead && !isnull(brain))
 		to_chat(protean, span_boldwarning("The [B] crushes you relentlessly until your refactory pops."))
 		protean.take_overall_damage(300)
 	return ..()


### PR DESCRIPTION
## About The Pull Request

If you're inside your suit, alive, and a blob spreads over you. You will die.

There's a /tg/ bug that will need to be fixed with the blob destroying indestructible items. I already opened the PR. It doesn't totally stop it yet, but that'll come in eventually.

## Why It's Good For The Game

RRing players is bad.

## Proof Of Testing

<img width="808" height="113" alt="image" src="https://github.com/user-attachments/assets/17818c2b-5418-4061-bd95-31132640353b" />

## Changelog
:cl:
fix: Protean suits are considered indestructible items.
fix: Blobs will properly murder proteans if it spreads over them while inside their suit.
/:cl:
