### PR TITLE
Reworks Moon Station's Foundry Into an Outpost Because I Played Curator Once

### DIFF
--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -27,7 +27,7 @@
 /area/station/command/bridge)
 "aaj" = (
 /obj/item/radio/intercom/directional/south,
-/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/cargo/miningfoundry/event_protected)
 "aap" = (
@@ -1125,6 +1125,11 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
+"aow" = (
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/pod/large,
+/area/station/cargo/miningfoundry/event_protected)
 "aoy" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/structure/cable,
@@ -1140,6 +1145,12 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/checker,
 /area/station/commons/dorms)
+"aoN" = (
+/obj/machinery/microwave,
+/obj/structure/table,
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron/grimy,
+/area/mine/eva)
 "aoY" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
@@ -1404,8 +1415,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "asp" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
 /obj/structure/closet/crate,
-/turf/open/floor/pod,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/pod/edge{
+	dir = 1
+	},
 /area/station/cargo/miningfoundry/event_protected)
 "asy" = (
 /turf/open/floor/plating,
@@ -1710,6 +1729,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
+"avI" = (
+/obj/structure/table,
+/obj/item/flashlight/lantern,
+/turf/open/floor/iron/grimy,
+/area/mine/eva)
 "avK" = (
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/engie_guard,
@@ -2693,6 +2717,10 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark/corner,
 /area/station/common/wrestling/arena)
+"aGO" = (
+/obj/effect/turf_decal/mining,
+/turf/closed/wall/mineral/titanium/survival/pod,
+/area/mine/eva)
 "aGQ" = (
 /obj/structure/table,
 /obj/item/storage/wallet/random,
@@ -6690,6 +6718,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden/layer5,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/engine/shuttle_construction_bay)
+"bJu" = (
+/obj/machinery/conveyor{
+	id = "mining"
+	},
+/obj/machinery/brm,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/pod/large,
+/area/station/cargo/miningfoundry/event_protected)
 "bJz" = (
 /obj/structure/table,
 /obj/effect/turf_decal/siding/wideplating_new/corner{
@@ -8275,6 +8316,14 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/station/common/pool)
+"cgQ" = (
+/obj/structure/table,
+/obj/machinery/light/directional/west,
+/obj/item/stack/cable_coil,
+/obj/item/stock_parts/power_store/cell/high,
+/obj/item/construction/plumbing/mining,
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock)
 "cgS" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -8382,13 +8431,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "chN" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/structure/lattice/catwalk,
-/turf/open/openspace{
-	can_atmos_pass = 0
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
 	},
+/obj/machinery/wall_healer/directional/north,
+/turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "chS" = (
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -8835,14 +8882,20 @@
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "cmT" = (
-/obj/machinery/conveyor{
-	id = "mining"
+/obj/structure/table,
+/obj/item/storage/medkit/fire{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/structure/railing{
-	dir = 8
+/obj/item/storage/medkit/regular{
+	pixel_x = -3;
+	pixel_y = -3
 	},
-/turf/open/floor/pod,
-/area/station/cargo/miningfoundry/event_protected)
+/obj/effect/turf_decal/bot,
+/obj/machinery/light/small/directional/east,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/pod/large,
+/area/mine/eva)
 "cmV" = (
 /turf/closed/wall/mineral/titanium/survival/pod,
 /area/station/cargo/miningfoundry/event_protected)
@@ -9275,8 +9328,9 @@
 	},
 /area/station/hallway/primary/central/fore)
 "csX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/pod,
 /area/station/cargo/miningfoundry/event_protected)
 "ctq" = (
@@ -11749,6 +11803,11 @@
 /obj/effect/turf_decal/trimline/white/arrow_ccw,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"dbb" = (
+/obj/structure/cable,
+/obj/structure/railing,
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock)
 "dbk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/structure/cable,
@@ -12101,7 +12160,11 @@
 /obj/machinery/door/airlock/survival_pod/glass{
 	name = "Mining Office"
 	},
-/turf/open/floor/catwalk_floor/rust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/pod/dark/half{
+	dir = 1
+	},
 /area/station/cargo/miningfoundry/event_protected)
 "dfH" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
@@ -12447,6 +12510,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
+"djp" = (
+/obj/machinery/conveyor{
+	id = "mining";
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/camera/autoname/mine/directional/south,
+/turf/open/floor/pod/large,
+/area/station/cargo/miningfoundry/event_protected)
 "dju" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 10
@@ -12648,6 +12723,13 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/port)
+"dlE" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock)
 "dlL" = (
 /obj/structure/ladder,
 /obj/effect/turf_decal/stripes/asteroid/box,
@@ -13387,12 +13469,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint)
 "dvE" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/rubble,
-/obj/structure/railing/corner/end/flip{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/machinery/light/small/directional/east,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
 /area/station/cargo/miningfoundry/event_protected)
 "dvH" = (
@@ -13728,6 +13808,18 @@
 /obj/machinery/meter,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"dzN" = (
+/obj/machinery/bouldertech/refinery/smelter,
+/obj/machinery/conveyor{
+	id = "mining";
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/pod/large,
+/area/station/cargo/miningfoundry/event_protected)
 "dzQ" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -13786,13 +13878,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "dAG" = (
-/obj/effect/turf_decal/tile/purple/half/contrasted{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/edge,
+/area/station/cargo/miningfoundry/event_protected)
 "dAK" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/l3closet/scientist,
@@ -13830,7 +13927,6 @@
 /area/station/engineering/supermatter/waste)
 "dBl" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted,
-/obj/machinery/computer/order_console/mining,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
@@ -14724,6 +14820,18 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/night_club)
+"dPf" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/survival_pod/glass{
+	name = "Mining Base"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
+/turf/open/floor/pod/dark/half{
+	dir = 1
+	},
+/area/mine/eva)
 "dPq" = (
 /obj/structure/stone_tile/slab/cracked,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
@@ -15310,11 +15418,9 @@
 /turf/open/floor/plating/rust/moonstation,
 /area/station/cargo/miningelevators)
 "dWY" = (
-/obj/structure/ladder,
 /obj/effect/turf_decal/stripes/box,
-/turf/open/openspace{
-	can_atmos_pass = 0
-	},
+/obj/structure/ladder,
+/turf/open/floor/plating,
 /area/station/cargo/miningdock)
 "dXf" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
@@ -17403,11 +17509,12 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "exa" = (
-/obj/effect/turf_decal/stripes/asteroid/line,
-/obj/machinery/power/floodlight,
+/obj/effect/turf_decal/siding/white{
+	color = "#6d7160"
+	},
 /obj/structure/cable,
-/turf/open/floor/plating/rust/moonstation,
-/area/moonstation/underground)
+/turf/open/floor/iron/grimy,
+/area/mine/eva)
 "exf" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
@@ -17665,11 +17772,8 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/drone_bay)
 "eBs" = (
-/obj/machinery/light/small/directional/west,
-/obj/structure/closet/crate/bin,
-/obj/machinery/mining_weather_monitor/directional/west,
-/turf/open/floor/pod,
-/area/station/cargo/miningfoundry/event_protected)
+/turf/closed/wall/mineral/titanium/survival/pod,
+/area/mine/eva)
 "eBC" = (
 /obj/effect/spawner/random/structure/chair_maintenance{
 	dir = 1
@@ -22374,6 +22478,13 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/glass/reinforced/scrape_below,
 /area/station/hallway/primary/central/fore)
+"fKD" = (
+/obj/structure/cable/multilayer/multiz,
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/cargo/miningfoundry/event_protected)
 "fKI" = (
 /obj/structure/sign/warning/vacuum/external/directional/east,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -24187,6 +24298,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/science/ordnance)
+"giA" = (
+/obj/structure/table,
+/obj/machinery/light/small/directional/south,
+/obj/item/storage/toolbox/emergency,
+/obj/item/wrench,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/pod/large,
+/area/station/cargo/miningfoundry/event_protected)
 "giE" = (
 /obj/structure/railing/corner/end/flip{
 	dir = 1
@@ -24585,7 +24704,7 @@
 	},
 /obj/item/radio/intercom/directional/west,
 /obj/structure/extinguisher_cabinet/directional/north,
-/obj/machinery/computer/security/mining,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "goy" = (
@@ -24657,7 +24776,17 @@
 /area/station/medical/pharmacy)
 "gpd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/pod,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/pod/edge{
+	dir = 4
+	},
 /area/station/cargo/miningfoundry/event_protected)
 "gph" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -24859,10 +24988,17 @@
 /turf/open/floor/iron/freezer,
 /area/mine/laborcamp/security)
 "gsc" = (
-/obj/machinery/light/small/directional/west,
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/structure/table,
-/obj/machinery/cell_charger,
+/obj/item/radio/intercom/directional/west,
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/pod,
 /area/station/cargo/miningfoundry/event_protected)
 "gsk" = (
@@ -25212,6 +25348,12 @@
 /obj/effect/landmark/firealarm_sanity,
 /turf/open/floor/iron/checker,
 /area/station/security/brig)
+"gxR" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/obj/structure/cable,
+/obj/machinery/power/floodlight,
+/turf/open/floor/plating/rust/moonstation,
+/area/moonstation/underground)
 "gxW" = (
 /obj/effect/spawner/random/burgerstation/blocking,
 /turf/open/floor/plating,
@@ -27711,6 +27853,12 @@
 	dir = 1
 	},
 /area/station/hallway/primary/port)
+"hgM" = (
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "hgU" = (
 /obj/structure/chair/office,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -27789,6 +27937,17 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/circuit/green,
 /area/station/cargo/drone_bay)
+"hhP" = (
+/obj/effect/turf_decal/siding/white{
+	color = "#6d7160"
+	},
+/obj/item/kirbyplants/random/fullysynthetic{
+	pixel_x = 8
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/grimy,
+/area/mine/eva)
 "hhR" = (
 /obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/iron/cafeteria,
@@ -28430,9 +28589,15 @@
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics/garden)
 "hqe" = (
-/obj/structure/ore_box,
-/turf/open/misc/moonstation_sand,
-/area/moonstation/surface)
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/pod/edge,
+/area/station/cargo/miningfoundry/event_protected)
 "hqg" = (
 /obj/machinery/deepfryer,
 /obj/effect/turf_decal/siding/dark{
@@ -29933,6 +30098,19 @@
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating/rust/moonstation,
 /area/moonstation/surface)
+"hHV" = (
+/obj/machinery/conveyor{
+	id = "mining"
+	},
+/obj/machinery/bouldertech/refinery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/pod/large,
+/area/station/cargo/miningfoundry/event_protected)
 "hHY" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/bureaucracy/briefcase,
@@ -30240,11 +30418,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
 "hLu" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Mining Foundry"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "hLy" = (
@@ -30388,12 +30565,17 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/shuttle_construction_bay)
+"hOm" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/grimy,
+/area/mine/eva)
 "hOs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/atmospheric_sanity/ignore_area,
+/obj/structure/cable,
 /turf/open/floor/pod,
-/area/station/cargo/miningfoundry/event_protected)
+/area/mine/eva)
 "hOv" = (
 /obj/machinery/light_switch/directional/north,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -30991,20 +31173,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/evac_maintenance)
 "hVQ" = (
-/obj/structure/table,
-/obj/machinery/light/directional/west,
-/obj/item/stack/cable_coil,
-/obj/item/stock_parts/power_store/cell/high,
-/obj/effect/mapping_helpers/requests_console/assistance,
-/obj/effect/mapping_helpers/requests_console/information,
-/obj/effect/mapping_helpers/requests_console/supplies,
-/obj/item/construction/plumbing/mining,
-/obj/effect/mapping_helpers/requests_console/ore_update,
-/obj/machinery/requests_console/auto_name/directional/west,
-/obj/structure/lattice/catwalk,
-/turf/open/openspace{
-	can_atmos_pass = 0
-	},
+/turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "hVW" = (
 /obj/effect/turf_decal/stripes/line,
@@ -31146,6 +31315,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
+"hXU" = (
+/obj/machinery/light/small/directional/north,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/structure/sign/calendar/directional/north,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/cargo/miningfoundry/event_protected)
 "hXV" = (
 /obj/effect/spawner/random/burgerstation/loot,
 /obj/structure/sign/warning/electric_shock/directional/south,
@@ -32004,9 +32179,9 @@
 "ikt" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/obj/machinery/light/small/directional/east,
 /obj/effect/mapping_helpers/apc/full_charge,
 /obj/effect/mapping_helpers/apc/cell_10k,
+/obj/machinery/space_heater,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/cargo/miningfoundry/event_protected)
 "iky" = (
@@ -32533,6 +32708,15 @@
 /obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"isk" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/pod/edge,
+/area/mine/eva)
 "iso" = (
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
@@ -32594,10 +32778,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "itY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/turf/open/floor/pod,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/pod/edge,
 /area/station/cargo/miningfoundry/event_protected)
 "itZ" = (
 /obj/machinery/shower/directional/north,
@@ -33387,17 +33577,9 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "iEV" = (
-/obj/machinery/brm,
-/obj/machinery/conveyor{
-	id = "mining";
-	dir = 4
-	},
-/obj/structure/railing/corner/end{
-	dir = 4
-	},
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/pod,
-/area/station/cargo/miningfoundry/event_protected)
+/obj/effect/spawner/structure/window/survival_pod,
+/turf/open/floor/plating,
+/area/mine/eva)
 "iEW" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/dark,
@@ -33729,14 +33911,10 @@
 "iIU" = (
 /obj/item/radio/intercom/directional/north,
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/structure/rack,
-/obj/item/pickaxe{
-	pixel_x = 5
-	},
-/obj/item/clothing/mask/gas/explorer,
-/obj/item/mining_scanner,
-/turf/open/floor/pod/dark,
-/area/station/cargo/miningfoundry/event_protected)
+/obj/machinery/suit_storage_unit/mining,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/pod/dark/large,
+/area/mine/eva)
 "iIW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -33856,6 +34034,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"iKK" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/pod,
+/area/mine/eva)
 "iKL" = (
 /obj/machinery/light/floor,
 /obj/effect/landmark/atmospheric_sanity/ignore_area,
@@ -34135,11 +34322,11 @@
 /turf/open/floor/iron/white,
 /area/station/science)
 "iPd" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/light/small/directional/east,
 /obj/machinery/suit_storage_unit/mining,
-/turf/open/floor/pod/dark,
-/area/station/cargo/miningfoundry/event_protected)
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/pod/dark/large,
+/area/mine/eva)
 "iPk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/meter/layer4,
@@ -35358,6 +35545,10 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/engine/atmos)
+"jdc" = (
+/obj/structure/chair/sofa/right/brown,
+/turf/open/floor/iron/grimy,
+/area/mine/eva)
 "jdf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/trash/caution_sign,
@@ -37150,6 +37341,11 @@
 	initial_gas_mix = "n2=100;TEMP=293.15"
 	},
 /area/station/maintenance/gag_room)
+"jBh" = (
+/obj/structure/marker_beacon/fuchsia,
+/obj/structure/ore_box,
+/turf/open/floor/catwalk_floor/rust/moonstation,
+/area/moonstation/surface)
 "jBk" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
@@ -37517,9 +37713,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/structure/tank_dispenser/oxygen,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/wall_healer/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "jHU" = (
@@ -38286,12 +38480,17 @@
 /turf/closed/wall/mineral/wood,
 /area/station/service/library/private)
 "jRc" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 1
+/obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/donkpockets{
+	pixel_y = 6
 	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
+/obj/machinery/light/small/directional/west,
+/obj/machinery/requests_console/auto_name/directional/west,
+/obj/effect/mapping_helpers/requests_console/ore_update,
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/turf/open/floor/iron/grimy,
+/area/mine/eva)
 "jRe" = (
 /obj/effect/spawner/random/entertainment/money_small,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39155,10 +39354,24 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/station/hallway/primary/central/fore)
-"kdq" = (
-/obj/structure/ore_box,
-/turf/open/floor/pod/dark,
+"kdn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/obj/machinery/meter,
+/obj/structure/cable,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/cargo/miningfoundry/event_protected)
+"kdq" = (
+/obj/structure/rack,
+/obj/item/pickaxe{
+	pixel_x = 5
+	},
+/obj/item/clothing/mask/gas/explorer,
+/obj/item/mining_scanner,
+/obj/effect/turf_decal/bot,
+/obj/machinery/mining_weather_monitor/directional/west,
+/turf/open/floor/pod/dark/large,
+/area/mine/eva)
 "kdE" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Equipment Room"
@@ -39463,6 +39676,16 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/carpet,
 /area/station/security/processing)
+"khU" = (
+/obj/structure/railing/corner/end/flip,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/north,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/pod,
+/area/station/cargo/miningfoundry/event_protected)
 "kia" = (
 /obj/machinery/camera/autoname/security/directional/south,
 /turf/open/openspace,
@@ -41018,11 +41241,17 @@
 /turf/open/floor/plating,
 /area/station/service/bar)
 "kAy" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/turf/open/floor/pod,
-/area/station/cargo/miningfoundry/event_protected)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/pod/edge{
+	dir = 1
+	},
+/area/mine/eva)
 "kAA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
 	dir = 1
@@ -41039,6 +41268,18 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/garden)
+"kAY" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/brown/opposingcorners{
+	dir = 1
+	},
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/pod,
+/area/station/cargo/miningfoundry/event_protected)
 "kBd" = (
 /obj/effect/turf_decal/trimline/yellow/line,
 /turf/open/floor/iron,
@@ -43750,6 +43991,15 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
+"ljv" = (
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/computer/security/mining{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "ljI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45787,17 +46037,10 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/aft)
 "lIU" = (
-/obj/machinery/conveyor{
-	id = "mining"
-	},
-/obj/machinery/bouldertech/refinery/smelter,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/light/small/directional/east,
-/obj/structure/sign/warning/no_smoking/circle/directional/east,
-/turf/open/floor/pod,
-/area/station/cargo/miningfoundry/event_protected)
+/obj/machinery/computer/order_console/mining,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/pod/large,
+/area/mine/eva)
 "lJe" = (
 /obj/machinery/light/directional/north,
 /obj/structure/cable,
@@ -46062,6 +46305,12 @@
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"lLu" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/suit_storage_unit/mining,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/pod/dark/large,
+/area/mine/eva)
 "lLv" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 4
@@ -46126,10 +46375,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "lMC" = (
-/obj/machinery/atmospherics/components/binary/pump/on/supply/visible/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/cargo/miningfoundry/event_protected)
 "lMF" = (
@@ -46454,7 +46702,7 @@
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
-/obj/structure/ore_box,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "lQL" = (
@@ -46624,6 +46872,15 @@
 	},
 /turf/open/floor/iron/checker,
 /area/station/hallway/primary/central/fore)
+"lTd" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock)
 "lTs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47620,8 +47877,11 @@
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
 "mfF" = (
-/obj/machinery/computer/order_console/mining,
-/obj/machinery/camera/autoname/mine/directional/south,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
 /turf/open/floor/pod,
 /area/station/cargo/miningfoundry/event_protected)
 "mfG" = (
@@ -49791,6 +50051,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"mJK" = (
+/obj/machinery/camera/autoname/mine/directional/east,
+/obj/structure/ore_box,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/pod/dark/large,
+/area/mine/eva)
 "mJL" = (
 /obj/structure/railing/corner/end/flip{
 	dir = 1
@@ -51005,9 +51271,11 @@
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
 "nbe" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible/layer4{
+/obj/machinery/atmospherics/components/binary/pump/on/supply/visible/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/cargo/miningfoundry/event_protected)
 "nbm" = (
@@ -53551,8 +53819,15 @@
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
 "nLt" = (
+/obj/machinery/vending/coffee,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/west,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/pod,
-/area/station/cargo/miningfoundry/event_protected)
+/area/mine/eva)
 "nLB" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -53953,11 +54228,8 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 6
-	},
-/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/structure/closet/wardrobe/miner,
+/obj/item/storage/backpack/satchel/explorer,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "nQm" = (
@@ -54029,11 +54301,8 @@
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
 "nRp" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing/corner,
-/turf/open/openspace{
-	can_atmos_pass = 0
-	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "nRr" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
@@ -58787,6 +59056,10 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/medical/morgue/office)
+"pbN" = (
+/obj/structure/chair/sofa/middle/brown,
+/turf/open/floor/iron/grimy,
+/area/mine/eva)
 "pbU" = (
 /turf/closed/wall/r_wall,
 /area/station/command/eva)
@@ -62360,10 +62633,8 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/bar)
 "pVN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/pod,
+/obj/effect/spawner/structure/window/survival_pod,
+/turf/open/floor/plating,
 /area/station/cargo/miningfoundry/event_protected)
 "pVT" = (
 /obj/structure/reflector/box/anchored{
@@ -63039,10 +63310,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison/visit)
 "qdk" = (
-/obj/structure/lattice/catwalk,
-/turf/open/openspace{
-	can_atmos_pass = 0
+/obj/structure/cable,
+/obj/structure/railing/corner{
+	dir = 8
 	},
+/turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "qdp" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
@@ -65719,14 +65991,21 @@
 	},
 /area/station/hallway/secondary/exit)
 "qLr" = (
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/conveyor_switch/oneway{
+	id = "mining";
+	dir = 4;
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/pod/edge{
 	dir = 8
 	},
-/obj/machinery/door/airlock/survival_pod{
-	name = "The Foundry"
-	},
-/turf/open/floor/pod/dark,
 /area/station/cargo/miningfoundry/event_protected)
 "qLz" = (
 /obj/effect/turf_decal/tile/green/half/contrasted{
@@ -67388,11 +67667,11 @@
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
 /obj/item/clipboard,
-/obj/structure/lattice/catwalk,
-/obj/machinery/newscaster/directional/west,
-/turf/open/openspace{
-	can_atmos_pass = 0
+/obj/structure/railing{
+	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "rin" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners{
@@ -67874,6 +68153,12 @@
 /obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /turf/open/floor/carpet/red,
 /area/station/commons/lounge)
+"row" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/turf/open/floor/plating/lavaland_atmos,
+/area/lavaland/surface/outdoors)
 "roz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68232,13 +68517,15 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/machinery/door/airlock/survival_pod{
-	name = "The Foundry"
-	},
 /obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
-/turf/open/floor/pod/dark,
-/area/station/cargo/miningfoundry/event_protected)
+/obj/machinery/door/airlock/survival_pod/glass{
+	name = "Mining Base"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
+/turf/open/floor/pod/dark/half{
+	dir = 1
+	},
+/area/mine/eva)
 "rtL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /obj/machinery/meter,
@@ -68771,13 +69058,13 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/supermatter/room)
 "rBN" = (
-/obj/machinery/conveyor{
-	id = "mining";
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
-/area/station/cargo/miningfoundry/event_protected)
+/area/mine/eva)
 "rBO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/rack,
@@ -69667,6 +69954,19 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"rNC" = (
+/obj/machinery/conveyor{
+	id = "mining"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/sign/warning/no_smoking/circle/directional/east,
+/turf/open/floor/pod/large,
+/area/station/cargo/miningfoundry/event_protected)
 "rNH" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 5
@@ -69913,11 +70213,11 @@
 /turf/open/floor/iron/dark,
 /area/station/command/eva)
 "rQY" = (
+/obj/machinery/light/small/directional/south,
 /obj/structure/ore_box,
-/obj/machinery/light/small/directional/east,
-/obj/machinery/camera/autoname/mine/directional/east,
-/turf/open/floor/pod/dark,
-/area/station/cargo/miningfoundry/event_protected)
+/obj/effect/turf_decal/bot,
+/turf/open/floor/pod/dark/large,
+/area/mine/eva)
 "rRa" = (
 /turf/closed/wall/r_wall,
 /area/station/science/explab)
@@ -70796,6 +71096,11 @@
 /obj/effect/spawner/random/vendor_meal_sides/moth,
 /turf/open/floor/wood/parquet,
 /area/station/engineering/break_room)
+"sdY" = (
+/obj/structure/chair/sofa/corner/brown,
+/obj/structure/sign/poster/random/directional/east,
+/turf/open/floor/iron/grimy,
+/area/mine/eva)
 "sdZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -71996,14 +72301,7 @@
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/flashlight,
 /obj/item/toy/figure/miner,
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/openspace{
-	can_atmos_pass = 0
-	},
+/turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "suj" = (
 /obj/effect/spawner/random/maintenance,
@@ -72176,9 +72474,17 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "swM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/pod,
-/area/station/cargo/miningfoundry/event_protected)
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/item/kirbyplants/random/fullysynthetic{
+	pixel_x = -8
+	},
+/turf/open/floor/pod/edge{
+	dir = 1
+	},
+/area/mine/eva)
 "swO" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
@@ -72410,6 +72716,17 @@
 "sBa" = (
 /turf/closed/wall,
 /area/station/medical/break_room)
+"sBb" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/edge{
+	dir = 1
+	},
+/area/station/cargo/miningfoundry/event_protected)
 "sBe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -73082,15 +73399,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "sLb" = (
-/obj/machinery/conveyor{
-	id = "mining";
-	dir = 6
-	},
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/pod,
-/area/station/cargo/miningfoundry/event_protected)
+/obj/machinery/computer/order_console/mining,
+/obj/effect/turf_decal/bot,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/pod/large,
+/area/mine/eva)
 "sLp" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
@@ -73386,7 +73699,7 @@
 "sPk" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/radio/intercom/directional/south,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "sPn" = (
@@ -73681,11 +73994,14 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "sSN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
 	},
-/turf/open/floor/pod,
-/area/station/cargo/miningfoundry/event_protected)
+/turf/open/floor/pod/edge{
+	dir = 8
+	},
+/area/mine/eva)
 "sST" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -73809,6 +74125,15 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/commons/dorms/room6)
+"sVa" = (
+/obj/effect/turf_decal/siding/white{
+	color = "#6d7160"
+	},
+/obj/structure/closet/crate/bin,
+/obj/machinery/camera/autoname/mine/directional/west,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/grimy,
+/area/mine/eva)
 "sVc" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/stripes/line{
@@ -73993,7 +74318,6 @@
 /area/station/engineering/atmos)
 "sXT" = (
 /obj/structure/ladder,
-/obj/structure/sign/calendar/directional/north,
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating,
 /area/station/cargo/miningfoundry/event_protected)
@@ -74192,6 +74516,19 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
+"tat" = (
+/obj/machinery/conveyor{
+	id = "mining";
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/pod/large,
+/area/station/cargo/miningfoundry/event_protected)
 "tay" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Cell 3"
@@ -74750,13 +75087,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "thZ" = (
-/obj/machinery/light/small/directional/east,
-/obj/structure/cable/multilayer/multiz,
-/obj/effect/turf_decal/stripes/end{
-	dir = 1
-	},
 /obj/machinery/camera/autoname/mine/directional/east,
-/turf/open/floor/plating,
+/obj/machinery/airalarm/directional/south,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/cargo/miningfoundry/event_protected)
 "tie" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -74790,6 +75124,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/security/processing)
+"tiw" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/pod/edge{
+	dir = 4
+	},
+/area/mine/eva)
 "tiB" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/sign/warning/radiation/directional/south,
@@ -75255,10 +75600,15 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "toR" = (
-/obj/machinery/conveyor{
-	id = "mining"
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/turf/open/floor/pod,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/pod/edge,
 /area/station/cargo/miningfoundry/event_protected)
 "toY" = (
 /obj/effect/turf_decal/vg_decals/numbers/three{
@@ -76063,9 +76413,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "tyO" = (
-/obj/machinery/airalarm/directional/south,
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/pod,
+/obj/structure/railing/corner/end{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/pod/edge{
+	dir = 1
+	},
 /area/station/cargo/miningfoundry/event_protected)
 "tzp" = (
 /obj/effect/turf_decal/siding/dark/corner{
@@ -76197,10 +76554,16 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "tAJ" = (
-/obj/item/radio/intercom/directional/west,
-/obj/structure/table,
-/obj/item/storage/toolbox/emergency,
-/turf/open/floor/pod,
+/obj/machinery/conveyor{
+	id = "mining";
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/pod/large,
 /area/station/cargo/miningfoundry/event_protected)
 "tAQ" = (
 /obj/effect/mapping_helpers/broken_floor,
@@ -77567,6 +77930,11 @@
 	dir = 1
 	},
 /area/station/hallway/primary/aft)
+"tRS" = (
+/obj/structure/table,
+/obj/item/folder/yellow,
+/turf/open/floor/iron/grimy,
+/area/mine/eva)
 "tRU" = (
 /obj/structure/sign/warning/no_smoking/circle/directional/north,
 /obj/effect/turf_decal/trimline/dark/filled/warning{
@@ -78685,6 +79053,12 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"uhJ" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/pod/large,
+/area/station/cargo/miningfoundry/event_protected)
 "uhM" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/spawner/random/trash/bacteria,
@@ -79209,9 +79583,17 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/crew_quarters/dorms)
 "uoy" = (
-/obj/effect/landmark/atmospheric_sanity/ignore_area,
-/obj/effect/spawner/random/engineering/tracking_beacon,
-/turf/open/floor/pod,
+/obj/machinery/door/airlock/survival_pod/glass{
+	name = "The Foundry"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/pod/half,
 /area/station/cargo/miningfoundry/event_protected)
 "uoD" = (
 /obj/effect/spawner/random/trash/hobo_squat,
@@ -80074,6 +80456,12 @@
 /obj/effect/spawner/random/burgerstation/atmos,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/project)
+"uAI" = (
+/obj/effect/turf_decal/siding/white{
+	color = "#6d7160"
+	},
+/turf/open/floor/iron/grimy,
+/area/mine/eva)
 "uAR" = (
 /obj/structure/sign/painting/library_secure{
 	pixel_x = 32
@@ -80961,6 +81349,11 @@
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
+"uNv" = (
+/obj/effect/landmark/atmospheric_sanity/ignore_area,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod,
+/area/station/cargo/miningfoundry/event_protected)
 "uNy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -81244,15 +81637,16 @@
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos/hallway)
 "uSf" = (
-/obj/machinery/conveyor{
-	id = "mining";
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/machinery/bouldertech/refinery,
-/obj/structure/railing,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/pod,
-/area/station/cargo/miningfoundry/event_protected)
+/obj/structure/cable,
+/obj/machinery/holopad,
+/turf/open/floor/pod/edge,
+/area/mine/eva)
 "uSl" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 4
@@ -82067,15 +82461,12 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
 "vdC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/conveyor_switch/oneway{
-	id = "mining";
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
-/area/station/cargo/miningfoundry/event_protected)
+/area/mine/eva)
 "vdK" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -82125,9 +82516,12 @@
 /area/station/command/meeting_room)
 "vej" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted,
-/obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_switch/directional/south,
+/obj/machinery/requests_console/auto_name/directional/south,
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/effect/mapping_helpers/requests_console/supplies,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/effect/mapping_helpers/requests_console/ore_update,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "veo" = (
@@ -82810,12 +83204,12 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics/upper)
 "vnv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/brown/opposingcorners{
+	dir = 1
 	},
-/obj/item/wrench,
 /turf/open/floor/pod,
-/area/station/cargo/miningfoundry/event_protected)
+/area/mine/eva)
 "vnA" = (
 /obj/effect/turf_decal/tile/green,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -83948,7 +84342,7 @@
 "vBQ" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/emcloset/anchored,
+/obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/iron/dark/side{
 	dir = 5
 	},
@@ -84058,8 +84452,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/status_display/evac/directional/west,
-/obj/structure/closet/wardrobe/miner,
-/obj/item/storage/backpack/satchel/explorer,
+/obj/machinery/computer/order_console/mining,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "vCL" = (
@@ -85838,9 +86231,10 @@
 /turf/open/floor/catwalk_floor/rust/moonstation,
 /area/moonstation/surface)
 "waX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
-/obj/machinery/meter,
-/obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/cargo/miningfoundry/event_protected)
 "wbb" = (
@@ -86480,9 +86874,7 @@
 /turf/closed/wall/mineral/wood,
 /area/station/service/bar)
 "wjD" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
+/obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/pod,
 /area/station/cargo/miningfoundry/event_protected)
 "wjP" = (
@@ -86739,6 +87131,13 @@
 /obj/machinery/telecomms/receiver/preset_left,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
+"wnu" = (
+/obj/item/kirbyplants/random/fullysynthetic{
+	pixel_y = 12;
+	pixel_x = -8
+	},
+/turf/open/floor/iron/grimy,
+/area/mine/eva)
 "wnA" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -88477,6 +88876,16 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/locker)
+"wNk" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/edge{
+	dir = 1
+	},
+/area/station/cargo/miningfoundry/event_protected)
 "wNq" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
@@ -89158,12 +89567,11 @@
 /turf/open/floor/plating,
 /area/station/ai/satellite/maintenance)
 "wWu" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/obj/structure/railing,
-/turf/open/openspace{
-	can_atmos_pass = 0
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
 	},
+/turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
 "wWw" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
@@ -89339,8 +89747,8 @@
 	},
 /area/station/hallway/secondary/command)
 "wYA" = (
-/turf/open/floor/pod/dark,
-/area/station/cargo/miningfoundry/event_protected)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/mine/eva)
 "wYI" = (
 /obj/effect/mapping_helpers/mail_sorting/service/library,
 /obj/structure/cable,
@@ -92574,10 +92982,12 @@
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos/hallway)
 "xQc" = (
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/space_heater,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/cargo/miningfoundry/event_protected)
+/obj/structure/chair/sofa/left/brown{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/grimy,
+/area/mine/eva)
 "xQm" = (
 /turf/open/floor/iron/dark/herringbone,
 /area/station/science/ordnance)
@@ -93328,12 +93738,12 @@
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/starboard)
 "xZh" = (
-/obj/structure/ore_box,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/structure/sign/warning/docking/directional/north,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/emcloset/anchored,
 /turf/open/floor/iron/dark/side{
 	dir = 9
 	},
@@ -113423,7 +113833,7 @@ czk
 czk
 czk
 czk
-czk
+row
 gef
 rpG
 rpG
@@ -177679,10 +178089,10 @@ lUL
 lUL
 lUL
 olq
-vYx
-vYx
-vYx
-vYx
+upM
+xAC
+esq
+etF
 vYx
 vYx
 vYx
@@ -177936,11 +178346,11 @@ lUL
 lUL
 lUL
 olq
-upM
-xAC
-esq
-etF
-vYx
+hjF
+bzy
+fwk
+kJH
+kJH
 vYx
 vYx
 vYx
@@ -178193,11 +178603,11 @@ lUL
 lUL
 lUL
 olq
-hjF
-bzy
-fwk
-nQm
-vYx
+uPw
+vTI
+qGf
+kJH
+kJH
 kJH
 vYx
 vYx
@@ -178449,14 +178859,14 @@ efh
 lUL
 lUL
 lUL
-olq
-uPw
-vTI
-qGf
+gxR
+ycu
+bLJ
+xuS
 kJH
 kJH
 kJH
-kJH
+vYx
 vYx
 vYx
 jnN
@@ -178706,14 +179116,14 @@ ogU
 sse
 cWP
 sse
-exa
-ycu
-bLJ
-xuS
+cmV
+pVN
+cmV
+pVN
+cmV
 kJH
 kJH
-kJH
-kJH
+vYx
 vYx
 vYx
 jnN
@@ -178959,18 +179369,18 @@ bjQ
 bjQ
 bjQ
 bjQ
-cmV
-vAI
+eBs
+eBs
 rtK
-vAI
+eBs
 cmV
-cmV
-cmV
-cmV
+hLX
+kdn
+fKD
 cmV
 kJH
-kJH
-kJH
+vYx
+vYx
 vYx
 vYx
 jnN
@@ -179216,17 +179626,17 @@ vYx
 vYx
 vYx
 vYx
-cmV
+eBs
 iIU
 wYA
 kdq
 cmV
-hLX
+hXU
 waX
 aaj
 cmV
-kJH
-kJH
+vYx
+vYx
 vYx
 vYx
 vYx
@@ -179471,23 +179881,23 @@ vYx
 vYx
 vYx
 vYx
-vYx
-vYx
-cmV
+hLd
+kJH
+aGO
 iPd
 wYA
 rQY
-cmV
+vAI
 sXT
 nbe
-xQc
-cmV
-kJH
+qXS
+siX
+qBd
+oAN
 vYx
 vYx
 vYx
 vYx
-jnN
 jnN
 jnN
 jnN
@@ -179727,25 +180137,25 @@ vYx
 vYx
 vYx
 vYx
-vYx
-vYx
+sao
 kJH
-cmV
-vAI
-qLr
-vAI
+kJH
+eBs
+lLu
+wYA
+mJK
 cmV
 ikt
 lMC
 thZ
 cmV
+kJH
+kJH
 vYx
 vYx
 vYx
 vYx
 vYx
-jnN
-jnN
 jnN
 jnN
 jnN
@@ -179981,24 +180391,24 @@ kJH
 kJH
 kJH
 vYx
-kJH
-kJH
-sao
-hLd
 vYx
-kJH
-cmV
+vYx
+vYx
+eBs
+eBs
+eBs
+eBs
 iEV
-hOs
+dPf
 eBs
 cmV
-vAI
-dfG
-vAI
 cmV
-vYx
-vYx
-vYx
+dfG
+cmV
+cmV
+cmV
+kJH
+kJH
 vYx
 vYx
 vYx
@@ -180238,25 +180648,25 @@ vYx
 kJH
 vYx
 vYx
-kJH
-kJH
-kJH
-kJH
-kJH
-kJH
-cmV
-rBN
-hOs
+vYx
+vYx
+vYx
+eBs
+aoN
+jRc
+sVa
+iKK
+tiw
 nLt
-tAJ
+cmV
 gsc
 gpd
 mfF
-vAI
-vYx
-vYx
-vYx
-vYx
+uhJ
+cmV
+kJH
+kJH
+jnN
 vYx
 vYx
 vYx
@@ -180496,23 +180906,23 @@ vYx
 vYx
 vYx
 vYx
-kJH
-kJH
-kJH
-kJH
-kJH
-cmV
-rBN
+vYx
+vYx
+iEV
+wnu
+hOm
+uAI
+isk
 vdC
 swM
-swM
+pVN
+dAG
 csX
-csX
-qXS
-siX
-qBd
-oAN
-vYx
+wNk
+giA
+vAI
+kJH
+kJH
 jnN
 jnN
 jnN
@@ -180753,23 +181163,23 @@ vYx
 vYx
 vYx
 vYx
-kJH
-kJH
-kJH
-kJH
-kJH
-cmV
+vYx
+vYx
+iEV
+jdc
+avI
+exa
 uSf
 hOs
 kAy
 uoy
 itY
-nLt
+uNv
 tyO
-vAI
-vYx
+aow
+cmV
 kJH
-vYx
+kJH
 jnN
 jnN
 jnN
@@ -181010,23 +181420,23 @@ vYx
 vYx
 vYx
 vYx
-kJH
-kJH
-kJH
-kJH
-kJH
-cmV
+vYx
+vYx
+iEV
+pbN
+tRS
+exa
 rBN
 sSN
 vnv
 pVN
-pVN
+hqe
 wjD
-asp
+sBb
+djp
 cmV
 kJH
 kJH
-jnN
 jnN
 jnN
 jnN
@@ -181267,23 +181677,23 @@ vYx
 vYx
 vYx
 vYx
-kJH
-kJH
-kJH
-kJH
-kJH
-cmV
+vYx
+vYx
+eBs
+sdY
+xQc
+hhP
 sLb
 cmT
 lIU
-cmT
+cmV
 toR
 dvE
 asp
+dzN
 cmV
 kJH
 kJH
-jnN
 jnN
 jnN
 jnN
@@ -181524,23 +181934,23 @@ vYx
 vYx
 vYx
 vYx
+vYx
+vYx
+eBs
+eBs
+eBs
+eBs
+eBs
+eBs
+eBs
+cmV
+khU
+qLr
+kAY
+tAJ
+vAI
 kJH
 kJH
-kJH
-kJH
-kJH
-cmV
-cmV
-cmV
-cmV
-cmV
-cmV
-cmV
-cmV
-cmV
-kJH
-jnN
-jnN
 jnN
 jnN
 jnN
@@ -181781,6 +182191,8 @@ vYx
 vYx
 vYx
 vYx
+vYx
+vYx
 kJH
 kJH
 kJH
@@ -181788,15 +182200,13 @@ kJH
 kJH
 kJH
 kJH
+cmV
+bJu
+rNC
+hHV
+tat
+cmV
 kJH
-kJH
-kJH
-kJH
-kJH
-kJH
-kJH
-kJH
-jnN
 jnN
 jnN
 jnN
@@ -182039,6 +182449,7 @@ vYx
 vYx
 vYx
 vYx
+vYx
 kJH
 kJH
 kJH
@@ -182046,14 +182457,13 @@ kJH
 kJH
 kJH
 kJH
+cmV
+cmV
+cmV
+cmV
+cmV
+cmV
 kJH
-kJH
-kJH
-kJH
-kJH
-kJH
-jnN
-jnN
 jnN
 jnN
 jnN
@@ -182297,6 +182707,7 @@ vYx
 vYx
 vYx
 vYx
+vYx
 kJH
 kJH
 kJH
@@ -182306,10 +182717,9 @@ kJH
 kJH
 kJH
 kJH
-jnN
-jnN
-jnN
-jnN
+kJH
+kJH
+kJH
 jnN
 jnN
 jnN
@@ -182562,9 +182972,9 @@ kJH
 kJH
 kJH
 kJH
-jnN
-jnN
-jnN
+kJH
+kJH
+kJH
 jnN
 jnN
 jnN
@@ -244241,12 +244651,12 @@ qMl
 qMl
 hni
 ujL
-pXD
+jBh
 ugD
-hqe
-hqe
-stM
-stM
+ugD
+aIy
+ugD
+ugD
 stM
 stM
 mSM
@@ -244500,9 +244910,9 @@ aIy
 aiI
 aIy
 ugD
-ugD
-aIy
-ugD
+cgQ
+dbb
+mVb
 ugD
 stM
 bMP
@@ -245273,7 +245683,7 @@ wLw
 wLw
 chN
 wWu
-mVb
+lTd
 ugD
 hhT
 mSM
@@ -245527,10 +245937,10 @@ gox
 bzR
 voS
 vCJ
-wLw
-aIy
+ljv
+hgM
 hLu
-aIy
+dlE
 wLw
 qNr
 qIg
@@ -245780,10 +246190,10 @@ klp
 dfl
 nOV
 koz
-jRc
+aiQ
 aEy
 qlh
-dAG
+qlh
 jHQ
 sNi
 lLP

--- a/modular_zubbers/code/modules/general_sprite_overrides/objects/structures/window.dm
+++ b/modular_zubbers/code/modules/general_sprite_overrides/objects/structures/window.dm
@@ -53,7 +53,7 @@
 //SURVIVAL
 /obj/structure/window/reinforced/shuttle/survival_pod
 	icon = 'modular_zubbers/icons/obj/smooth_structures/pod_window.dmi'
-	canSmoothWith =  SMOOTH_GROUP_AIRLOCK + SMOOTH_GROUP_WINDOW_FULLTILE + SMOOTH_GROUP_WALLS
+	canSmoothWith =  SMOOTH_GROUP_AIRLOCK + SMOOTH_GROUP_WINDOW_FULLTILE + SMOOTH_GROUP_SURVIVAL_TITANIUM_POD + SMOOTH_GROUP_WALLS
 
 
 //MISC


### PR DESCRIPTION

## About The Pull Request
Previously, the foundry was just two rooms. This changes it so the mining vendors and the actual boulder machine are in two separate areas with different access.

## Why It's Good For The Game
Curators can now use a mining vendor without having to go to the hop, ask someone in cargo or break in, like every other map we have in rotation. This also adds a nice little corner to chill and relax in.

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="1344" height="960" alt="image" src="https://github.com/user-attachments/assets/dab944a5-448f-414b-a3ef-49cc048e3beb" />
<img width="908" height="705" alt="image" src="https://github.com/user-attachments/assets/5088a603-1e66-4f3a-a102-d7f695160706" />


</details>

## Changelog

:cl: Robwo
map: Reworked the Moon Station foundry into a mining outpost
fix: Pod windows smooth with themselves

/:cl:
