### PR TITLE
Lock strongarms behind weapon permit

### DIFF
--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -191,6 +191,8 @@
 	name = "Strong-Arm Implant Set"
 	desc = "A crate containing two implants, which can be surgically implanted to empower the strength of human arms. Warranty void if exposed to electromagnetic pulses."
 	cost = CARGO_CRATE_VALUE * 6
+	access = ACCESS_WEAPONS
+	access_view = ACCESS_WEAPONS
 	contains = list(/obj/item/organ/cyberimp/arm/strongarm = 2)
 	crate_name = "Strong-Arm implant crate"
 	discountable = SUPPLY_PACK_RARE_DISCOUNTABLE


### PR DESCRIPTION

## About The Pull Request
As title says. You need weapon permit access to order and unlock em.
## Why It's Good For The Game
Strongarms are combat implants, not sure why they're just free to get with basic med access. Had a paramed player complain to me about it so I decided to fix it for em.
## Proof Of Testing
teehee
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:UvvU
balance: strongarm implants now require weapon permit access to order and open
/:cl:
