### PR TITLE
Fixes voice modulator gas mask not clearing properly when stripped

### DIFF
--- a/modular_zubbers/code/modules/clothing/mask/gasmask.dm
+++ b/modular_zubbers/code/modules/clothing/mask/gasmask.dm
@@ -54,6 +54,11 @@
 	UnregisterSignal(user, list(COMSIG_MOB_SAY, SIGNAL_ADDTRAIT(TRAIT_SIGN_LANG), SIGNAL_REMOVETRAIT(TRAIT_SIGN_LANG)))
 	update_voice(user)
 
+/obj/item/clothing/mask/gas/modulator/doStrip(mob/stripper, mob/user)
+	. = ..()
+	UnregisterSignal(user, list(COMSIG_MOB_SAY, SIGNAL_ADDTRAIT(TRAIT_SIGN_LANG), SIGNAL_REMOVETRAIT(TRAIT_SIGN_LANG)))
+	update_voice(user)
+
 /obj/item/clothing/mask/gas/modulator/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
 	context[SCREENTIP_CONTEXT_ALT_LMB] = "[modulate_voice ? "Disable":"Enable"] voice modulator"


### PR DESCRIPTION

## About The Pull Request

Noticed a bug while using the voice mod/Unknown bot speech gas mask, where I had it forcefully removed, but retained the "Unknown" speech and say mods.
Adds a proc to the gas mask to also remove signals on a doStrip()
## Why It's Good For The Game

Bugs bad. As funny as it is to force identity death on someone, it's not good to trap someone with "Unknown" voice until they manage to equip and unequip a voice modulating gas mask again.
## Proof Of Testing
<img width="642" height="389" alt="Screenshot_20260602_234046" src="https://github.com/user-attachments/assets/d4a7b35c-44bb-4ee9-adec-2ed7d3f8f55f" />

## Changelog
:cl:Impish_Delights
fix: Stripping voice mod gas mask properly clears speech changes
/:cl:
