### PR TITLE
Gives boosted lycans the ability to use their claws on objects + ups to 15 TC

### DIFF
--- a/modular_zubbers/code/modules/customization/species/lycans/_lycan_species.dm
+++ b/modular_zubbers/code/modules/customization/species/lycans/_lycan_species.dm
@@ -1,3 +1,5 @@
+#define DOAFTER_SOURCE_LYCAN_DOOR_PRY "lycan door pry"
+
 /datum/species/lycan
 	id = SPECIES_LYCAN
 	examine_limb_id = SPECIES_LYCAN
@@ -168,6 +170,10 @@
 		oxy_per_second = 0.5, \
 		ignore_damage_types = list(), \
 	)
+	gainer.AddElement(/datum/element/door_pryer, pry_time = 7 SECONDS, interaction_key = DOAFTER_SOURCE_LYCAN_DOOR_PRY)
+
+	var/datum/action/extend_lycan_claws/claws_action = new(src)
+	claws_action.Grant(gainer)
 
 /datum/species/lycan/proc/handle_gaian_physique_loss(mob/living/carbon/human/loser)
 	REMOVE_TRAIT(loser, TRAIT_BATON_RESISTANCE, SPECIES_TRAIT)
@@ -180,6 +186,11 @@
 
 	loser.remove_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)
 	qdel(loser.GetComponent(/datum/component/regenerator))
+	loser.RemoveElement(/datum/element/door_pryer, pry_time = 7 SECONDS, interaction_key = DOAFTER_SOURCE_LYCAN_DOOR_PRY)
+
+	var/datum/action/extend_lycan_claws/claws_action = locate() in loser.actions
+	if (claws_action)
+		qdel(claws_action)
 
 	loser.physiology.stamina_mod *= 4
 
@@ -191,3 +202,5 @@
 	baned.visible_message(span_warning("[baned] seems to react negatively to the silver, [baned.p_their()] flesh scorching and burning on contact!"), ignored_mobs = list(baned))
 	to_chat(baned, span_bolddanger("The sister moon casts its light on you, and you feel your flesh scorch!"))
 	INVOKE_ASYNC(baned, TYPE_PROC_REF(/mob, emote), "scream")
+
+#undef DOAFTER_SOURCE_LYCAN_DOOR_PRY

--- a/modular_zubbers/code/modules/customization/species/lycans/_lycan_species.dm
+++ b/modular_zubbers/code/modules/customization/species/lycans/_lycan_species.dm
@@ -170,7 +170,6 @@
 		oxy_per_second = 0.5, \
 		ignore_damage_types = list(), \
 	)
-	gainer.AddElement(/datum/element/door_pryer, pry_time = 7 SECONDS, interaction_key = DOAFTER_SOURCE_LYCAN_DOOR_PRY)
 
 	var/datum/action/extend_lycan_claws/claws_action = new(src)
 	claws_action.Grant(gainer)
@@ -186,7 +185,6 @@
 
 	loser.remove_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)
 	qdel(loser.GetComponent(/datum/component/regenerator))
-	loser.RemoveElement(/datum/element/door_pryer, pry_time = 7 SECONDS, interaction_key = DOAFTER_SOURCE_LYCAN_DOOR_PRY)
 
 	var/datum/action/extend_lycan_claws/claws_action = locate() in loser.actions
 	if (claws_action)

--- a/modular_zubbers/code/modules/customization/species/lycans/claws.dm
+++ b/modular_zubbers/code/modules/customization/species/lycans/claws.dm
@@ -1,0 +1,55 @@
+/obj/item/mutant_hand/lycan_claw
+	name = "extended claws"
+	desc = "An extended set of claws, slower but more powerful, and capable of striking structures. Worse for actual combat."
+	gender = PLURAL
+	demolition_mod = 1.5
+	armour_penetration = 10
+	attack_speed = CLICK_CD_MELEE * 2
+	hitsound = 'sound/items/weapons/slash.ogg'
+	obj_flags = CONDUCTS_ELECTRICITY
+
+/datum/action/extend_lycan_claws
+	name = "Extend Claws"
+	desc = "Extend your claws to perform powerful, stunning blows on objects and synthetics, at the cost of anti-organic performance."
+	button_icon = 'modular_skyrat/modules/implants/icons/razorclaws.dmi'
+	button_icon_state = "wolverine"
+	var/obj/item/mutant_hand/lycan_claw/claw
+
+/datum/action/extend_lycan_claws/Remove(mob/remove_from)
+	. = ..()
+
+	QDEL_NULL(claw)
+
+/datum/action/extend_lycan_claws/Destroy()
+	. = ..()
+
+	QDEL_NULL(claw)
+
+/datum/action/extend_lycan_claws/Trigger(mob/clicker, trigger_flags)
+	. = ..()
+	if (!.)
+		return FALSE
+	if (!ishuman(owner))
+		return FALSE
+	var/mob/living/carbon/human/human_owner = owner
+	var/obj/item/bodypart/arm/active_arm = human_owner.get_active_hand()
+	if (!istype(active_arm))
+		return FALSE
+
+	if (claw)
+		human_owner.balloon_alert_to_viewers("claws retracted")
+		QDEL_NULL(claw)
+		playsound(get_turf(human_owner), 'sound/items/tools/change_drill.ogg', 50, TRUE)
+		return TRUE
+
+	var/obj/item/existing = human_owner.get_active_held_item()
+	if (!isnull(existing))
+		human_owner.balloon_alert(human_owner, "hand occupied!")
+		return FALSE
+
+	claw = new /obj/item/mutant_hand/lycan_claw()
+	claw.force = active_arm.unarmed_damage_high * 1.25
+	claw.sharpness = active_arm.unarmed_sharpness
+	human_owner.put_in_active_hand(claw, ignore_animation = TRUE)
+	human_owner.balloon_alert_to_viewers("claws extended")
+	playsound(get_turf(human_owner), 'sound/items/tools/change_drill.ogg', 50, TRUE)

--- a/modular_zubbers/code/modules/customization/species/lycans/claws.dm
+++ b/modular_zubbers/code/modules/customization/species/lycans/claws.dm
@@ -31,6 +31,7 @@
 		return FALSE
 	if (HAS_TRAIT(owner, TRAIT_PACIFISM))
 		to_chat(owner, span_warning("You're scared of hurting someone with your elongated claws!"))
+		return FALSE
 	if (!ishuman(owner))
 		return FALSE
 	var/mob/living/carbon/human/human_owner = owner

--- a/modular_zubbers/code/modules/customization/species/lycans/claws.dm
+++ b/modular_zubbers/code/modules/customization/species/lycans/claws.dm
@@ -29,6 +29,8 @@
 	. = ..()
 	if (!.)
 		return FALSE
+	if (HAS_TRAIT(owner, TRAIT_PACIFISM))
+		to_chat(owner, span_warning("You're scared of hurting someone with your elongated claws!"))
 	if (!ishuman(owner))
 		return FALSE
 	var/mob/living/carbon/human/human_owner = owner

--- a/modular_zubbers/code/modules/customization/species/lycans/lycan_status.dm
+++ b/modular_zubbers/code/modules/customization/species/lycans/lycan_status.dm
@@ -122,10 +122,12 @@
 	render_list += span_warning("\n	* Aggressive health regeneration")
 	render_list += span_warning("\n	* Immunity to shoves and resistance to pain/stunning")
 	render_list += span_warning("\n	* The ability to shrug off any amount of pain and keep sprinting")
+	render_list += span_warning("\n	* The ability to smash down airlocks and windows with their claws")
 	render_list += span_boldwarning("\nIf you find yourself facing a Lycan with these traits, take these precautions.")
 	render_list += span_warning("\n	* Avoid physical weaponry and stamina weapons - their regeneration rapidly heals brute and stamina drain")
 	render_list += span_warning("\n	* Use silver weaponry - they deal extra burn damage")
 	render_list += span_warning("\n	* Use aerosolized silver - they cannot use internals and will burn on contact with it")
+	render_list += span_warning("\n	* Pacify the lycan - they cannot smash windows or airlocks while pacified")
 
 	var/output = jointext(render_list, "")
 

--- a/modular_zubbers/code/modules/uplink/uplink_items/species/lycan_booster.dm
+++ b/modular_zubbers/code/modules/uplink/uplink_items/species/lycan_booster.dm
@@ -2,7 +2,7 @@
 	name = "Lycanthropy Booster"
 	desc = "A highly advanced mix of nanomachines and general 'bad vibes' that will significantly boost the combat performance of your \
 	Lycan form, granting significant damage resistance, baton resistance, regeneration, and further sharpening your claws. Additionally grants you expert fitness."
-	cost = 10
+	cost = 15
 	item = /obj/item/lycan_booster
 	restricted_species = list(SPECIES_CURSEKIN)
 	surplus = 0

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9505,6 +9505,7 @@
 #include "modular_zubbers\code\modules\customization\species\lycans\__DEFINES.dm"
 #include "modular_zubbers\code\modules\customization\species\lycans\_cursekin_species.dm"
 #include "modular_zubbers\code\modules\customization\species\lycans\_lycan_species.dm"
+#include "modular_zubbers\code\modules\customization\species\lycans\claws.dm"
 #include "modular_zubbers\code\modules\customization\species\lycans\cursekin_blacklisted_quirks.dm"
 #include "modular_zubbers\code\modules\customization\species\lycans\cursekin_prefs.dm"
 #include "modular_zubbers\code\modules\customization\species\lycans\lycan_status.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

Lycans gain an ability that gives them a claw item that deals slightly increased damage in combat, is slower, and deals extra damage to structures.

Note while this does partially counter chairs, its only partial, because this mode is less effective in overall combat and is mostly for breaking shit.

Pacifism suppresses this mode, to give some counterplay once you catch the lycan. (Pacificiation makes them containable)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

Further leans into the garou powerfantasy. Every time I played lycan I realized it had little utility outside combat (and even then you have NOTHING for silicons). This gives you a massively damaging anti-object ability and should give ways to function and DO things while in lycan form that youd usually need tools for.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Proof Of Testing

<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->
<details>
<summary>Screenshots/Videos</summary>

https://github.com/user-attachments/assets/11cf6f5a-1ec3-46d5-8616-46174f93d59a

Ignore the doorprying, that was removed

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Boosted lycans can now use their claws on objects as long as theyre not pacified
balance: Lycanthropy booster is now 15 TC
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
