### PR TITLE
Adds an alternative to the navigate verb

### DIFF
--- a/modular_zubbers/modules/plexagon_navsec/code/navsec.dm
+++ b/modular_zubbers/modules/plexagon_navsec/code/navsec.dm
@@ -1,5 +1,4 @@
 /// APC-based area navigator. Displays all station areas with APCs and points an arrow toward the selected one.
-/// No access restriction; intended as a new-player-friendly alternative to the navigate verb.
 /datum/computer_file/program/radar/navsec
 	filename = "plexagonnavsec"
 	filedesc = "Plexagon NavSec"

--- a/modular_zubbers/modules/plexagon_navsec/code/navsec.dm
+++ b/modular_zubbers/modules/plexagon_navsec/code/navsec.dm
@@ -29,7 +29,6 @@
 		)
 		objects += list(apc_info)
 
-/// Pre-load NavSec on assistant PDAs so new players can see it immediately.
 /obj/item/modular_computer/pda/assistant/install_default_programs()
 	. = ..()
 	store_file(new /datum/computer_file/program/radar/navsec)

--- a/modular_zubbers/modules/plexagon_navsec/code/navsec.dm
+++ b/modular_zubbers/modules/plexagon_navsec/code/navsec.dm
@@ -6,7 +6,7 @@
 	extended_desc = "Never get lost again. Plexagon NavSec indexes every area on the station and points you straight to it, no matter how obscure the name or unfamiliar the layout. Perfect for new crew and anyone transferred to a station they've never set foot on."
 	program_flags = PROGRAM_ON_NTNET_STORE | PROGRAM_REQUIRES_NTNET
 	program_icon = "location-arrow"
-	size = 4
+	size = 2
 
 /datum/computer_file/program/radar/navsec/find_atom()
 	return ..() || (locate(selected) in SSmachines.processing_apcs)

--- a/modular_zubbers/modules/plexagon_navsec/code/navsec.dm
+++ b/modular_zubbers/modules/plexagon_navsec/code/navsec.dm
@@ -1,0 +1,36 @@
+/// APC-based area navigator. Displays all station areas with APCs and points an arrow toward the selected one.
+/// No access restriction; intended as a new-player-friendly alternative to the navigate verb.
+/datum/computer_file/program/radar/navsec
+	filename = "plexagonnavsec"
+	filedesc = "Plexagon NavSec"
+	extended_desc = "Never get lost again. Plexagon NavSec indexes every area on the station and points you straight to it, no matter how obscure the name or unfamiliar the layout. Perfect for new crew and anyone transferred to a station they've never set foot on."
+	program_flags = PROGRAM_ON_NTNET_STORE | PROGRAM_REQUIRES_NTNET
+	program_icon = "location-arrow"
+	size = 4
+
+/datum/computer_file/program/radar/navsec/find_atom()
+	return ..() || (locate(selected) in SSmachines.processing_apcs)
+
+/datum/computer_file/program/radar/navsec/scan()
+	objects = list()
+	var/list/name_to_apc = list()
+	for(var/obj/machinery/power/apc/station_apc as anything in SSmachines.processing_apcs)
+		var/area/apc_area = station_apc.area
+		if(!istype(apc_area, /area/station))
+			continue
+		if(!trackable(station_apc))
+			continue
+		name_to_apc[apc_area.name] = station_apc
+	sortTim(name_to_apc, /proc/cmp_text_asc)
+	for(var/area_name in name_to_apc)
+		var/obj/machinery/power/apc/station_apc = name_to_apc[area_name]
+		var/list/apc_info = list(
+			ref = REF(station_apc),
+			name = area_name,
+		)
+		objects += list(apc_info)
+
+/// Pre-load NavSec on assistant PDAs so new players can see it immediately.
+/obj/item/modular_computer/pda/assistant/install_default_programs()
+	. = ..()
+	store_file(new /datum/computer_file/program/radar/navsec)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10246,5 +10246,6 @@
 #include "modular_zubbers\modules\taur_mechanics\taur_body.dm"
 #include "modular_zubbers\modules\taur_mechanics\taur_clothing_offset.dm"
 #include "modular_zubbers\modules\wood_walls\code\new_floors.dm"
+#include "modular_zubbers\modules\plexagon_navsec\code\navsec.dm"
 // END_INCLUDE
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10226,6 +10226,7 @@
 #include "modular_zubbers\modules\awaymissions_zubbers\Maintsroom\spawner_maintsroom.dm"
 #include "modular_zubbers\modules\jobs\job_types\chaplain\chaplain_nullrod.dm"
 #include "modular_zubbers\modules\lewd_clothing\latex_halfcatsuit.dm"
+#include "modular_zubbers\modules\plexagon_navsec\code\navsec.dm"
 #include "modular_zubbers\modules\plexagon_selfserve\code\off_duty_component.dm"
 #include "modular_zubbers\modules\plexagon_selfserve\code\plexagon_selfserve.dm"
 #include "modular_zubbers\modules\plexagon_selfserve\code\shame_box.dm"
@@ -10246,6 +10247,5 @@
 #include "modular_zubbers\modules\taur_mechanics\taur_body.dm"
 #include "modular_zubbers\modules\taur_mechanics\taur_clothing_offset.dm"
 #include "modular_zubbers\modules\wood_walls\code\new_floors.dm"
-#include "modular_zubbers\modules\plexagon_navsec\code\navsec.dm"
 // END_INCLUDE
 


### PR DESCRIPTION
## About The Pull Request

Adds **Plexagon NavSec**, a new PDA app available on the NT store with no access restriction, pre-loaded on the assistant PDA.

NavSec scans `SSmachines.processing_apcs` at runtime to build a complete, alphabetical list of every station area with an APC. Selecting one points the standard NtosRadar arrow (Same one as the nukie pinpointer/ Lifeline app) toward it. Results are filtered to `/area/station` subtypes, so antagonist ships, Centcomm, player created naughty rooms, and away missions are excluded; Yes, I thought about the use case of "use it to find antag hidey holes" and made sure to nip that pre-emptively.

**This is not a replacement for the Navigate verb.** They answer different questions:

- **Navigate** asks *"how do I get there?"* It provides pathing, but requires mapper-placed waypoints, gates routing on your current ID access, and shits the bed when either of those is missing. Also it has a really annoying and unnecessary cooldown.
- **NavSec** asks *"which way?"* It finds the APC for the area and points at it. No pathing, no access check, no waypoint dependency, no mapping maintenance burden. It trusts you to figure out your own flapping.

The tradeoff is intentional. The implementation is light: no new subsystems, no new TGUI, no mapping work. It piggybacks entirely on APC registration, which already happens for free at round start.

## Why It's Good For The Game

There is a category of frustration in this game that has nothing to do with skill, experience, or the actual difficulty of the task at hand. You are an antagonist with an objective, a secoff tasked to patrol for a bounty, or a new player following a job order, and you are stuck patrolling a random corridor in hopes that your destination will magically present itself because the room you need is called something like *"Starboard Aft Secondary Maintenance"* or *"The Clown's Anus"* and you have been wandering around for four minutes. Hell maybe you're a really dim traitor and need help finding the armory to blow it up. 

The Navigate verb is the official answer to this and is frequently insufficient:

- It does not cover many obscure areas
- It requires mappers to actively maintain waypoints
- It will just straight up not be able to get you to your destination half the time

New players probably aren't equipped with the knowledge to troubleshoot Navigate's temperamentality 

NavSec sidesteps all of that. Every station area that has power has an APC. The list is always complete and always current. The app ships pre-loaded on the assistant PDA so new players encounter it without having to know it exists, and is free to download for everyone else if you're not an assistant and need it anyway.

Sure, we should still think about improving the navigate verb, but this is a good alternative in the meantime.

## Proof Of Testing

Spawned as assistant, opened PDA, confirmed NavSec present. Hit Scan, confirmed alphabetical area list populated. Walked directly to aft port maintinence despite not knowing what aft or port means, GREAT SUCCESS! 
<img width="2551" height="1316" alt="image" src="https://github.com/user-attachments/assets/ec415202-7b06-458e-81a0-7223efc06e3c" />

## Changelog

:cl:
add: Added Plexagon NavSec, a PDA app that locates any station area by tracking its APC. No access required. Available on the NT store and pre-loaded on the assistant PDA.
qol: New players and anyone dropped into an unfamiliar station layout can now find obscurely named rooms without relying on the Navigate verb or prior map knowledge.
/:cl: