### PR TITLE
Adds minimum pop restrictions to spy

### DIFF
--- a/modular_zubbers/code/modules/storyteller/event_defines/crewset/spies.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/crewset/spies.dm
@@ -6,12 +6,16 @@
 	antag_datum = /datum/antagonist/spy
 	weight = 8
 	maximum_antags_global = 4
+	
+	min_players = 15
 
 	tags = list(TAG_CREW_ANTAG)
 
 /datum/round_event_control/antagonist/solo/spy/midround
 	name = "Spies (Midround)"
 	roundstart = FALSE
+	
+	min_players = 15
 
 /datum/round_event_control/antagonist/solo/spy/event
 	name = "Event Generated Spy"


### PR DESCRIPTION

## About The Pull Request

Title. Restricts roundstart and midround spy spawns to a minimum population of 15. Tested and works as expected via checking storyteller panel.
## Why It's Good For The Game

Spies are effectively traitors, except that they snowball much harder, given they can theoretically steal an infinite number of items, and thus gain an infinite amount of traitor gear (and in some cases, even more powerful gear)
On low-pop, however, spies become significantly more oppressive. With less people around, breaking into restricted areas and stealing equipment becomes far, far easier, which makes it easier to get equipment to further encourage yet more stealing, etc. It snowballs much harder since there are less chances for them to be caught and therefore targeted. This is especially so if a spy happens to volunteer for acting captaincy with no command crew available - at that point they just have free reign over the entire station, and access to a hell of a lot of powerful equipment as a result - enough that even if that low population WANTED to stop that spy, they may well not even be able to.

Initially I settled on 20 as a minimum requirement, but upon seeing 20 as the restriction for malf AI, I settled on 15 instead - just a touch lower. They're still overall a fairly quiet antag type compared to others, so 15 felt right to me - though this should be discussed.
## Proof Of Testing
Clipped from storyteller panel
<img width="874" height="104" alt="2026-06-04_20-56-45" src="https://github.com/user-attachments/assets/68d03932-fc1a-40da-9d22-73f4fbcb66a1" />

## Changelog
:cl:Fogspot
balance: Added minimum population restrictions to spy spawns.
/:cl:
