### PR TITLE
AmmuNation update PT 1 

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon.dmm
@@ -11708,7 +11708,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/port_tarkon/engineering)
 "Pu" = (
-/obj/machinery/ammo_workbench/unlocked,
+/obj/machinery/ammo_workbench/prefilled/unlocked,
 /obj/effect/turf_decal/tile/red/real_red/half{
 	dir = 1
 	},

--- a/_maps/bubber/automapper/templates/IceBoxStation/iceboxstation_persistence.dmm
+++ b/_maps/bubber/automapper/templates/IceBoxStation/iceboxstation_persistence.dmm
@@ -5135,7 +5135,7 @@
 /area/ruin/space/has_grav/bubbers/persistance/service/lounge)
 "lg" = (
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/machinery/ammo_workbench,
+/obj/machinery/ammo_workbench/prefilled,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/bubbers/persistance/sec/armory)
 "lh" = (

--- a/_maps/bubber/automapper/templates/lavaland/lavaland_persistence.dmm
+++ b/_maps/bubber/automapper/templates/lavaland/lavaland_persistence.dmm
@@ -4181,7 +4181,7 @@
 /area/ruin/space/has_grav/bubbers/persistance/med)
 "iB" = (
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/machinery/ammo_workbench,
+/obj/machinery/ammo_workbench/prefilled,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/bubbers/persistance/sec/armory)
 "iC" = (

--- a/modular_skyrat/modules/modular_weapons/code/modular_projectiles.dm
+++ b/modular_skyrat/modules/modular_weapons/code/modular_projectiles.dm
@@ -5,6 +5,8 @@
 	/// Rubbers aren't advanced. Standard ammo (or FMJ if you're particularly pedantic) isn't advanced.
 	/// Think more specialized or weird, niche ammo, like armor-piercing, incendiary, hollowpoint, or God forbid, phasic.
 	var/advanced_print_req = FALSE
+	/// Optional hex color (e.g. "#d85a30") shown as a tip-dot beside this round in the ammo workbench UI. Null shows a neutral dot.
+	var/workbench_tip_color = null
 
 // whatever goblin decided to spread out bullets over like 3 files and god knows however many overrides i wish you a very stubbed toe
 

--- a/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
+++ b/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
@@ -113,14 +113,6 @@
 	materials.set_local_size(200000)
 	set_wires(new /datum/wires/ammo_workbench(src))
 
-/obj/machinery/ammo_workbench/proc/local_material_insert(obj/machinery/machine, container, obj/item/item_inserted, last_inserted_id, list/mats_consumed, amount_inserted)
-	SIGNAL_HANDLER
-	SStgui.update_uis(src)
-
-/obj/machinery/ammo_workbench/proc/silo_material_insert(obj/machinery/machine, container, obj/item/item_inserted, last_inserted_id, list/mats_consumed, amount_inserted)
-	SIGNAL_HANDLER
-	SStgui.update_uis(src)
-
 /obj/machinery/ammo_workbench/examine(mob/user)
 	. += ..()
 	if(in_range(user, src) || isobserver(user))

--- a/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
+++ b/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
@@ -297,27 +297,22 @@
 			. = TRUE
 
 		if("Release")
-
 			if(!materials?.mat_container)
 				return
 			var/datum/material/mat = locate(params["id"])
-
+			if(!mat)
+				return
 			var/amount = materials.mat_container.materials[mat]
 			if(!amount)
 				return
-
 			var/stored_amount = CEILING(amount / SHEET_MATERIAL_AMOUNT, 0.1)
-
-			if(!stored_amount)
-				return
-
 			var/desired = 0
 			if (params["sheets"])
 				desired = text2num(params["sheets"])
-
-			var/sheets_to_remove = round(min(desired,50,stored_amount))
-
-			materials.mat_container.retrieve_stack(sheets_to_remove, mat, loc)
+			var/sheets_to_remove = round(min(desired, 50, stored_amount))
+			if(sheets_to_remove <= 0)
+				return
+			materials.eject_sheets(mat, sheets_to_remove, drop_location(), sanitize_id_data(ID_DATA(usr)))
 			. = TRUE
 
 		if("remove_mat") // MaterialAccessBar eject: { ref, amount(sheets) }
@@ -332,8 +327,10 @@
 			var/sheets_available = CEILING(units_available / SHEET_MATERIAL_AMOUNT, 0.1)
 			var/desired = text2num(params["amount"]) || 0
 			var/sheets_to_remove = round(min(desired, 50, sheets_available))
-			if(sheets_to_remove > 0)
-				materials.mat_container.retrieve_stack(sheets_to_remove, mat, loc)
+			if(sheets_to_remove <= 0)
+				return
+			// withdrawal goes through eject_sheets so a silo hold is respected and the silo log entry is well-formed.
+			materials.eject_sheets(mat, sheets_to_remove, drop_location(), sanitize_id_data(ID_DATA(usr)))
 			. = TRUE
 
 		if("ReadDisk")
@@ -496,6 +493,10 @@
 	// remove this one round (qdel for instances triggers Exited material bookkeeping; path entries just drop)
 	loaded_magazine.stored_ammo -= target_round
 	if(!ispath(target_round))
+		var/obj/item/ammo_casing/spent = target_round
+		// drop the round's custom materials before qdel so the magazine's own Exited material-subtraction
+		// can't drive a stack to a non-positive value and runtime. we zero the mag wholesale in recycle_finish anyway.
+		spent.set_custom_materials(null)
 		qdel(target_round)
 	loaded_magazine.update_appearance()
 
@@ -587,7 +588,9 @@
 	var/list/efficient_materials = list()
 
 	for(var/material in required_materials)
-		efficient_materials[material] = required_materials[material] * creation_efficiency
+		var/amount = required_materials[material] * creation_efficiency
+		if(amount > 0)
+			efficient_materials[material] = amount
 
 	if(!materials?.mat_container)
 		error_message = "NO MATERIAL STORAGE LINKED"

--- a/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
+++ b/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
@@ -29,8 +29,6 @@
 	// hello future codediver. open to suggestions on how to do the following without it sucking so badly
 	/// what casings we're able to use
 	var/list/valid_casings = list()
-	/// the material requirement strings for these casings (for the tooltip)
-	var/list/casing_mat_strings = list()
 	/// parallel to valid_casings: per-round UI tip-dot hex color (or null).
 	var/list/casing_tip_colors = list()
 	/// can it print ammunition flagged as harmful (e.g. most ammo)?
@@ -150,7 +148,6 @@
 
 /obj/machinery/ammo_workbench/proc/update_ammotypes()
 	LAZYCLEARLIST(valid_casings)
-	LAZYCLEARLIST(casing_mat_strings)
 	LAZYCLEARLIST(casing_tip_colors)
 	if(!loaded_magazine)
 		return
@@ -175,31 +172,33 @@
 				continue // no
 		if(initial(our_casing.projectile_type) == null) // spent casing subtypes >:(
 			continue
-		// i'm very sorry for this, but literally every other thing i tried to get the material composition didn't copy at all
-		var/obj/item/ammo_casing/casing_actual = new our_casing
-		var/list/raw_casing_mats = casing_actual.get_material_composition()
-		var/list/efficient_casing_mats = list()
-		qdel(casing_actual)
-		for(var/material in raw_casing_mats)
-			efficient_casing_mats[material] = raw_casing_mats[material] * creation_efficiency
-		// max_ammo can read 0 on a just-inserted empty container before its contents initialize; fall back to the type's spawn capacity.
-		var/true_capacity = loaded_magazine.max_ammo || initial(loaded_magazine.max_ammo)
-		var/rounds_to_fill = max(true_capacity - length(loaded_magazine.stored_ammo), 0)
-		var/mat_string = ""
-
-		for(var/i in 1 to length(efficient_casing_mats))
-			var/datum/material/our_material = efficient_casing_mats[i]
-			var/per_round = round(efficient_casing_mats[our_material] / SHEET_MATERIAL_AMOUNT, 0.01)
-			var/to_fill = round(per_round * rounds_to_fill, 0.01)
-			mat_string += "[per_round] [our_material.name] ([to_fill] to fill)"
-			if(i != length(efficient_casing_mats))
-				mat_string += ", "
-
 		valid_casings += our_casing // adding the valid typepath
 		valid_casings[our_casing] = initial(our_casing.name)
-		casing_mat_strings += mat_string // adding the casing material cost string
 		casing_tip_colors += initial(our_casing.workbench_tip_color)
 		// we pray to god these indexes stay consistent.
+
+// builds the "0.24 iron (1.68 to fill)" cost string for a casing type. computed live (not cached) since it
+// depends on current efficiency and how full the container is.
+/obj/machinery/ammo_workbench/proc/get_cost_string(casing_type)
+	if(!loaded_magazine)
+		return ""
+	// i'm very sorry for this, but literally every other thing i tried to get the material composition didn't copy at all
+	var/obj/item/ammo_casing/casing_actual = new casing_type
+	var/list/raw_casing_mats = casing_actual.get_material_composition()
+	qdel(casing_actual)
+	if(!length(raw_casing_mats))
+		return ""
+
+	// max_ammo can read 0 on a just-inserted empty container before its contents initialize; fall back to the type's spawn capacity.
+	var/true_capacity = loaded_magazine.max_ammo || initial(loaded_magazine.max_ammo)
+	var/rounds_to_fill = max(true_capacity - length(loaded_magazine.stored_ammo), 0)
+
+	var/list/parts = list()
+	for(var/datum/material/our_material as anything in raw_casing_mats)
+		var/per_round = round(raw_casing_mats[our_material] * creation_efficiency / SHEET_MATERIAL_AMOUNT, 0.01)
+		var/to_fill = round(per_round * rounds_to_fill, 0.01)
+		parts += "[per_round] [our_material.name] ([to_fill] to fill)"
+	return jointext(parts, ", ")
 
 /obj/machinery/ammo_workbench/ui_data(mob/user)
 	// i kinda hate how all of this is done on every tgui process tick
@@ -258,7 +257,7 @@
 			data["available_rounds"] += list(list(
 				"name" = valid_casings[typepath],
 				"typepath" = typepath,
-				"mats_list" = casing_mat_strings[casings_to_relay],
+				"mats_list" = get_cost_string(typepath),
 				"tip_color" = casing_tip_colors[casings_to_relay]
 			))
 
@@ -296,25 +295,6 @@
 			fill_magazine_start(type_to_pass)
 			. = TRUE
 
-		if("Release")
-			if(!materials?.mat_container)
-				return
-			var/datum/material/mat = locate(params["id"])
-			if(!mat)
-				return
-			var/amount = materials.mat_container.materials[mat]
-			if(!amount)
-				return
-			var/stored_amount = CEILING(amount / SHEET_MATERIAL_AMOUNT, 0.1)
-			var/desired = 0
-			if (params["sheets"])
-				desired = text2num(params["sheets"])
-			var/sheets_to_remove = round(min(desired, 50, stored_amount))
-			if(sheets_to_remove <= 0)
-				return
-			materials.eject_sheets(mat, sheets_to_remove, drop_location(), sanitize_id_data(ID_DATA(usr)))
-			. = TRUE
-
 		if("remove_mat") // MaterialAccessBar eject: { ref, amount(sheets) }
 			if(!materials?.mat_container)
 				return
@@ -329,7 +309,6 @@
 			var/sheets_to_remove = round(min(desired, 50, sheets_available))
 			if(sheets_to_remove <= 0)
 				return
-			// withdrawal goes through eject_sheets so a silo hold is respected and the silo log entry is well-formed.
 			materials.eject_sheets(mat, sheets_to_remove, drop_location(), sanitize_id_data(ID_DATA(usr)))
 			. = TRUE
 
@@ -494,9 +473,7 @@
 	loaded_magazine.stored_ammo -= target_round
 	if(!ispath(target_round))
 		var/obj/item/ammo_casing/spent = target_round
-		// drop the round's custom materials before qdel so the magazine's own Exited material-subtraction
-		// can't drive a stack to a non-positive value and runtime. we zero the mag wholesale in recycle_finish anyway.
-		spent.set_custom_materials(null)
+		spent.set_custom_materials(null) // clear before qdel or the mag's Exited subtraction hits zero and runtimes
 		qdel(target_round)
 	loaded_magazine.update_appearance()
 
@@ -506,7 +483,6 @@
 	playsound(loc, 'sound/machines/piston/piston_raise.ogg', 60, TRUE, frequency = -1)
 	SStgui.update_uis(src)
 
-	// recycling is twice as fast as printing at the same part tier, and rides the same turbo/upgrade scaling (turbo makes it faster but wastes material).
 	var/recycle_delay = max(time_per_round * 0.5, 1)
 	timer_id = addtimer(CALLBACK(src, PROC_REF(recycle_round)), recycle_delay, TIMER_STOPPABLE)
 
@@ -608,15 +584,15 @@
 		return
 
 	if(new_casing.type in possible_ammo_types)
-		if(!loaded_magazine.give_round(new_casing))
-			error_message = "AMMUNITION MISMATCH"
+		// respect a remote silo hold before doing anything irreversible
+		if(materials.silo && materials.on_hold())
+			error_message = "MATERIAL ACCESS ON HOLD"
 			error_type = "bad"
 			ammo_fill_finish(FALSE)
 			qdel(new_casing)
 			return
-		// respect a remote silo hold (the vault can pause us), but no nanny-state ID gating; the bench draws and logs, it doesn't police access
-		if(materials.silo && materials.on_hold())
-			error_message = "MATERIAL ACCESS ON HOLD"
+		if(!loaded_magazine.give_round(new_casing))
+			error_message = "AMMUNITION MISMATCH"
 			error_type = "bad"
 			ammo_fill_finish(FALSE)
 			qdel(new_casing)
@@ -663,7 +639,7 @@
 	if(!loaded_datadisk)
 		return FALSE
 	if(loaded_datadisk.type in loaded_datadisks)
-		disk_error = "ERROR: DISK DATA ALREADY IN SYSTEM MEMEORY"
+		disk_error = "ERROR: DISK DATA ALREADY IN SYSTEM MEMORY"
 		return FALSE
 
 	disk_error = "DISK LOADED SUCCESSFULLY"
@@ -801,7 +777,7 @@
 /obj/machinery/ammo_workbench/proc/Insert_Item(obj/item/O, mob/living/user)
 	if(user.combat_mode)
 		return FALSE
-	if(!is_insertion_ready(user))
+	if(!is_insertion_ready(user, O))
 		return FALSE
 	if(istype(O, /obj/item/ammo_box))
 		if(!user.transferItemToLoc(O, src))
@@ -868,8 +844,7 @@
 /obj/machinery/ammo_workbench/proc/adjust_hacked(state)
 	hacked = state
 
-/// Returns a copy of an ID_DATA record with the access list dropped. The raw access list is a flat list that
-/// the silo log serializer can't walk, so we strip it; we only need the name/account for accountability anyway.
+// silo's recursive_jsonify chokes on the flat access list in ID_DATA; strip it and keep the name/account
 /obj/machinery/ammo_workbench/proc/sanitize_id_data(alist/user_data)
 	if(!islist(user_data))
 		return user_data
@@ -877,15 +852,11 @@
 	clean["accesses"] = null
 	return clean
 
-/// Logs a material use to the connected silo for accountability (who printed what), without enforcing the silo's
-/// ID/account policy. No-op when not silo-linked.
+// logs to the silo for accountability without gating on ID. no-op if not silo-linked.
 /obj/machinery/ammo_workbench/proc/log_silo_use(list/mats, action, name)
 	if(!materials?.silo)
 		return
-	var/list/scaled_mats = list()
-	for(var/mat in mats)
-		scaled_mats[mat] = mats[mat]
-	materials.silo.silo_log(src, action, -1, name, scaled_mats, print_log_data)
+	materials.silo.silo_log(src, action, -1, name, mats, print_log_data)
 
 /obj/machinery/ammo_workbench/emag_act(mob/user, obj/item/card/emag/emag_card)
 	if(obj_flags & EMAGGED)
@@ -949,7 +920,7 @@
 	switch(wire)
 		if(WIRE_HACK)
 			A.adjust_hacked(!mend)
-		if(WIRE_HACK)
+		if(WIRE_SHOCK)
 			A.shocked = !mend
 		if(WIRE_DISABLE)
 			A.disabled = !mend

--- a/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
+++ b/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
@@ -114,8 +114,6 @@
 /obj/machinery/ammo_workbench/examine(mob/user)
 	. += ..()
 	if(in_range(user, src) || isobserver(user))
-		if(materials?.mat_container)
-			. += span_notice("The status display reads: Storing up to <b>[materials.mat_container.max_amount]</b> material units.<br>Material consumption at <b>[creation_efficiency*100]%</b>.")
 		. += span_notice("Reclaiming <b>[recycle_percent]%</b> of materials when recycling a loaded container.")
 
 /obj/machinery/ammo_workbench/ui_interact(mob/user, datum/tgui/ui)

--- a/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
+++ b/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
@@ -302,6 +302,7 @@
 
 		if("ReadDisk")
 			loadDisk()
+			return TRUE
 
 		if("EjectDisk")
 			ejectDisk()

--- a/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
+++ b/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
@@ -72,8 +72,9 @@
 
 // mapping variant - comes with decent parts and some materials so you can just plop it down on a ruin/away mission without also placing sheets and a disk
 /obj/machinery/ammo_workbench/prefilled
-	circuit = /obj/item/circuitboard/machine/ammo_workbench/prefilled
+	circuit = /obj/item/circuitboard/machine/ammo_workbench
 	force_local_materials = TRUE
+	allowed_harmful = TRUE // basic lethals available without hacking; maps don't need a wire-cut
 
 /obj/machinery/ammo_workbench/prefilled/Initialize(mapload)
 	. = ..()
@@ -86,6 +87,11 @@
 		materials.mat_container.insert_amount_mat(15 * SHEET_MATERIAL_AMOUNT, /datum/material/silver)
 		materials.mat_container.insert_amount_mat(15 * SHEET_MATERIAL_AMOUNT, /datum/material/gold)
 
+/// Prefilled + full catalogue. For ruins/syndicate/antag maps that need a standalone stocked bench with no restrictions.
+/obj/machinery/ammo_workbench/prefilled/unlocked
+	allowed_harmful = TRUE
+	allowed_advanced = TRUE
+
 /obj/item/circuitboard/machine/ammo_workbench
 	name = "Ammunition Workbench (Machine Board)"
 	icon_state = "circuit_map"
@@ -94,14 +100,6 @@
 		/datum/stock_part/servo = 2,
 		/datum/stock_part/matter_bin = 2,
 		/datum/stock_part/micro_laser = 2
-	)
-
-/obj/item/circuitboard/machine/ammo_workbench/prefilled
-	build_path = /obj/machinery/ammo_workbench/prefilled
-	req_components = list(
-		/datum/stock_part/servo/tier3 = 2,
-		/datum/stock_part/matter_bin/tier3 = 2,
-		/datum/stock_part/micro_laser/tier3 = 2
 	)
 
 /obj/machinery/ammo_workbench/Initialize(mapload)

--- a/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
+++ b/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
@@ -306,6 +306,7 @@
 
 		if("EjectDisk")
 			ejectDisk()
+			return TRUE
 
 		if("turboBoost")
 			toggle_turbo_boost()

--- a/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
+++ b/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
@@ -7,6 +7,8 @@
 	use_power = IDLE_POWER_USE
 	circuit = /obj/item/circuitboard/machine/ammo_workbench
 	var/busy = FALSE
+	/// TRUE while recycling (vs fabricating); routes Cancel.
+	var/is_recycling = FALSE
 	/// if it's hacked it's gonna be able to print lethals. it'll be mad at you for doing so but it'll print basic lethals.
 	var/hacked = FALSE
 	var/disabled = FALSE
@@ -29,6 +31,8 @@
 	var/list/valid_casings = list()
 	/// the material requirement strings for these casings (for the tooltip)
 	var/list/casing_mat_strings = list()
+	/// parallel to valid_casings: per-round UI tip-dot hex color (or null).
+	var/list/casing_tip_colors = list()
 	/// can it print ammunition flagged as harmful (e.g. most ammo)?
 	var/allowed_harmful = FALSE
 	/// can it print advanced ammunition types (e.g. armor-piercing)? see modular_skyrat\modules\modular_weapons\code\modular_projectiles.dm
@@ -47,6 +51,14 @@
 	var/turbo_time_per_round = 0.225 SECONDS
 	/// multiplier for material cost per round (when turbo is enabled)
 	var/turbo_efficiency = 2.8
+	/// percent of a round's base materials returned on recycle. set by servo tier in RefreshParts().
+	var/recycle_percent = 75
+	/// rounded servo tier (1-4), shown as the UI signal bars.
+	var/part_tier = 1
+	/// magazine-bar label while busy (FABRICATING / RECYCLING / joke).
+	var/activity_label = "FABRICATING"
+	/// rounds made this run; distinguishes mid-run depletion from never having enough.
+	var/rounds_made_this_run = 0
 	/// can this print any round of any caliber given a correct ammo_box? (you varedit this at your own risk, especially if used in a player-facing context.)
 	/// does not force ammo to load in. just makes it able to print wacky ammotypes e.g. lionhunter 7.62, techshells
 	var/adminbus = FALSE
@@ -56,6 +68,23 @@
 	allowed_harmful = TRUE
 	allowed_advanced = TRUE
 
+/// Mapping/testing variant: spawns with tier-3 parts (via its own board) and a modest material stock,
+/// so it's usable out of the box without also placing sheets and a datadisk. For away missions, custom maps, admin setups.
+/obj/machinery/ammo_workbench/prefilled
+	circuit = /obj/item/circuitboard/machine/ammo_workbench/prefilled
+
+/obj/machinery/ammo_workbench/prefilled/Initialize(mapload)
+	. = ..()
+	// stock common bullet materials: mostly iron, smaller amounts of metals real rounds use.
+	// deliberately no diamond/bluespace/bananium — no reasonable round needs them.
+	if(materials)
+		materials.insert_amount_mat(50 * SHEET_MATERIAL_AMOUNT, /datum/material/iron)
+		materials.insert_amount_mat(20 * SHEET_MATERIAL_AMOUNT, /datum/material/glass)
+		materials.insert_amount_mat(20 * SHEET_MATERIAL_AMOUNT, /datum/material/titanium)
+		materials.insert_amount_mat(15 * SHEET_MATERIAL_AMOUNT, /datum/material/plasma)
+		materials.insert_amount_mat(15 * SHEET_MATERIAL_AMOUNT, /datum/material/silver)
+		materials.insert_amount_mat(15 * SHEET_MATERIAL_AMOUNT, /datum/material/gold)
+
 /obj/item/circuitboard/machine/ammo_workbench
 	name = "Ammunition Workbench (Machine Board)"
 	icon_state = "circuit_map"
@@ -64,6 +93,15 @@
 		/datum/stock_part/servo = 2,
 		/datum/stock_part/matter_bin = 2,
 		/datum/stock_part/micro_laser = 2
+	)
+
+/// Tier-3 board for the prefilled mapping/testing variant.
+/obj/item/circuitboard/machine/ammo_workbench/prefilled
+	build_path = /obj/machinery/ammo_workbench/prefilled
+	req_components = list(
+		/datum/stock_part/servo/tier3 = 2,
+		/datum/stock_part/matter_bin/tier3 = 2,
+		/datum/stock_part/micro_laser/tier3 = 2
 	)
 
 /obj/machinery/ammo_workbench/Initialize(mapload)
@@ -81,6 +119,7 @@
 	. += ..()
 	if(in_range(user, src) || isobserver(user))
 		. += span_notice("The status display reads: Storing up to <b>[materials.max_amount]</b> material units.<br>Material consumption at <b>[creation_efficiency*100]%</b>.")
+		. += span_notice("Reclaiming <b>[recycle_percent]%</b> of materials when recycling a loaded container.")
 
 /obj/machinery/ammo_workbench/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
@@ -91,9 +130,15 @@
 	if(shocked)
 		workbench_shock(user, 80)
 
+/obj/machinery/ammo_workbench/ui_assets(mob/user)
+	return list(
+		get_asset_datum(/datum/asset/spritesheet_batched/sheetmaterials),
+	)
+
 /obj/machinery/ammo_workbench/proc/update_ammotypes()
 	LAZYCLEARLIST(valid_casings)
 	LAZYCLEARLIST(casing_mat_strings)
+	LAZYCLEARLIST(casing_tip_colors)
 	if(!loaded_magazine)
 		return
 	var/obj/item/ammo_casing/ammo_type = loaded_magazine.ammo_type
@@ -124,19 +169,21 @@
 		qdel(casing_actual)
 		for(var/material in raw_casing_mats)
 			efficient_casing_mats[material] = raw_casing_mats[material] * creation_efficiency
+		var/rounds_to_fill = max(loaded_magazine.max_ammo - length(loaded_magazine.stored_ammo), 0)
 		var/mat_string = ""
 
 		for(var/i in 1 to length(efficient_casing_mats))
 			var/datum/material/our_material = efficient_casing_mats[i]
-			mat_string += "[efficient_casing_mats[our_material]] cm³ [our_material.name]"
-			if(i == length(efficient_casing_mats))
-				mat_string += " per cartridge"
-			else
+			var/per_round = round(efficient_casing_mats[our_material] / SHEET_MATERIAL_AMOUNT, 0.01)
+			var/to_fill = round(per_round * rounds_to_fill, 0.01)
+			mat_string += "[per_round] [our_material.name] ([to_fill] to fill)"
+			if(i != length(efficient_casing_mats))
 				mat_string += ", "
 
 		valid_casings += our_casing // adding the valid typepath
 		valid_casings[our_casing] = initial(our_casing.name)
 		casing_mat_strings += mat_string // adding the casing material cost string
+		casing_tip_colors += initial(our_casing.workbench_tip_color)
 		// we pray to god these indexes stay consistent.
 
 /obj/machinery/ammo_workbench/ui_data(mob/user)
@@ -167,45 +214,37 @@
 
 	data["efficiency"] = creation_efficiency
 	data["time"] = time_per_round / 10
+	data["recyclePercent"] = round(effective_recycle_percent())
+	// turbo drops the signal bar by one (efficiency traded for speed).
+	data["partTier"] = turbo_boost ? max(part_tier - 1, 0) : part_tier
+	data["bar_state"] = activity_label
+	data["recycle_preview"] = get_recycle_preview()
 	data["hacked"] = hacked
 	data["turboBoost"] = turbo_boost
 
-	data["materials"] = list()
-	if (materials)
-		for(var/mat in materials.materials)
-			var/datum/material/M = mat
-			var/amount = materials.materials[M]
-			var/sheet_amount = amount / SHEET_MATERIAL_AMOUNT
-			var/ref = REF(M)
-			data["materials"] += list(list("name" = M.name, "id" = ref, "amount" = sheet_amount))
+	data["materials"] = materials ? materials.ui_data() : list()
+	data["SHEET_MATERIAL_AMOUNT"] = SHEET_MATERIAL_AMOUNT
+	data["materialMaximum"] = materials ? materials.max_amount : 0
 
 	if(error_message)
 		data["error"] = error_message
 		data["error_type"] = error_type
-	else if(busy)
-		data["error"] = "SYSTEM IS BUSY"
-		data["error_type"] = ""
 
-	if(!loaded_magazine)
-		data["error"] = "NO MAGAZINE IS INSERTED"
-		data["error_type"] = ""
-		return data
-	else
-		data["mag_loaded"] = TRUE
+	data["mag_loaded"] = loaded_magazine ? TRUE : FALSE
+	data["mag_name"] = loaded_magazine ? loaded_magazine.name : null
+	data["current_rounds"] = loaded_magazine ? length(loaded_magazine.stored_ammo) : 0
+	data["max_rounds"] = loaded_magazine ? loaded_magazine.max_ammo : 0
 
 	data["available_rounds"] = list()
-
-	for(var/casings_to_relay = 1 to length(valid_casings))
-		var/typepath = valid_casings[casings_to_relay]
-		data["available_rounds"] += list(list(
-			"name" = valid_casings[typepath],
-			"typepath" = typepath,
-			"mats_list" = casing_mat_strings[casings_to_relay]
-		))
-
-	data["mag_name"] = loaded_magazine.name
-	data["current_rounds"] = length(loaded_magazine.stored_ammo)
-	data["max_rounds"] = loaded_magazine.max_ammo
+	if(loaded_magazine)
+		for(var/casings_to_relay = 1 to length(valid_casings))
+			var/typepath = valid_casings[casings_to_relay]
+			data["available_rounds"] += list(list(
+				"name" = valid_casings[typepath],
+				"typepath" = typepath,
+				"mats_list" = casing_mat_strings[casings_to_relay],
+				"tip_color" = casing_tip_colors[casings_to_relay]
+			))
 
 	return data
 
@@ -216,6 +255,22 @@
 	switch(action)
 		if("EjectMag")
 			ejectItem()
+			. = TRUE
+
+		if("RecycleMag")
+			recycle_magazine()
+			. = TRUE
+
+		if("CancelFabrication")
+			if(busy)
+				if(is_recycling)
+					error_message = "RECYCLING CANCELLED"
+					error_type = ""
+					recycle_finish(successfully = FALSE)
+				else
+					error_message = "FABRICATION CANCELLED"
+					error_type = ""
+					ammo_fill_finish(FALSE)
 			. = TRUE
 
 		if("FillMagazine")
@@ -247,6 +302,22 @@
 			materials.retrieve_stack(sheets_to_remove, mat, loc)
 			. = TRUE
 
+		if("remove_mat") // MaterialAccessBar eject: { ref, amount(sheets) }
+			if(!materials)
+				return
+			var/datum/material/mat = locate(params["ref"])
+			if(!mat)
+				return
+			var/units_available = materials.materials[mat]
+			if(!units_available)
+				return
+			var/sheets_available = CEILING(units_available / SHEET_MATERIAL_AMOUNT, 0.1)
+			var/desired = text2num(params["amount"]) || 0
+			var/sheets_to_remove = round(min(desired, 50, sheets_available))
+			if(sheets_to_remove > 0)
+				materials.retrieve_stack(sheets_to_remove, mat, loc)
+			. = TRUE
+
 		if("ReadDisk")
 			loadDisk()
 
@@ -256,20 +327,24 @@
 		if("turboBoost")
 			toggle_turbo_boost()
 
-/// Toggles this ammo bench's turbo setting. If it's on, uses the turbo time-per-round/efficiency; if off, resets to base time-per-round/efficiency. forced_off forces turbo off.
+/// Toggles turbo; forced_off forces it off.
 /obj/machinery/ammo_workbench/proc/toggle_turbo_boost(forced_off = FALSE)
 	if(forced_off)
 		turbo_boost = FALSE
 	else
 		turbo_boost = !turbo_boost
+	apply_speed_state()
+	update_ammotypes()
+	SStgui.update_uis(src)
 
+/// Applies the turbo flag to live time/efficiency from base_* values.
+/obj/machinery/ammo_workbench/proc/apply_speed_state()
 	if(turbo_boost)
 		time_per_round = turbo_time_per_round
 		creation_efficiency = turbo_efficiency
 	else
 		time_per_round = base_time_per_round
 		creation_efficiency = base_efficiency
-	update_ammotypes()
 
 /obj/machinery/ammo_workbench/proc/ejectItem(mob/living/user)
 	if(loaded_magazine)
@@ -287,6 +362,143 @@
 		timer_id = null
 	update_ammotypes()
 	update_appearance()
+
+/// Recycles the loaded mag, reclaiming a servo-tier fraction of each round's base materials (capped 100%).
+
+/// Reclaim percent, reduced under turbo (speed costs efficiency).
+/obj/machinery/ammo_workbench/proc/effective_recycle_percent()
+	return turbo_boost ? recycle_percent * 0.6 : recycle_percent
+
+/// Sheet-yield summary string for recycling the loaded mag, or null.
+/obj/machinery/ammo_workbench/proc/get_recycle_preview()
+	if(!loaded_magazine || !length(loaded_magazine.stored_ammo))
+		return null
+	var/list/reclaimed = list()
+	var/list/comp_cache = list()
+	for(var/atom/entry as anything in loaded_magazine.stored_ammo)
+		var/casing_type = ispath(entry) ? entry : entry.type
+		if(!ispath(casing_type, /obj/item/ammo_casing))
+			continue
+		var/list/base_mats = comp_cache[casing_type]
+		if(isnull(base_mats))
+			var/obj/item/ammo_casing/base_casing = new casing_type
+			base_mats = base_casing.get_material_composition()
+			qdel(base_casing)
+			comp_cache[casing_type] = base_mats || list()
+		for(var/datum/material/mat as anything in base_mats)
+			reclaimed[mat] += base_mats[mat] * (effective_recycle_percent() / 100)
+	if(!length(reclaimed))
+		return null
+	var/list/parts = list()
+	for(var/datum/material/mat as anything in reclaimed)
+		var/sheets = round(reclaimed[mat] / SHEET_MATERIAL_AMOUNT, 0.01)
+		if(sheets > 0)
+			parts += "[sheets] [mat.name]"
+	return length(parts) ? jointext(parts, ", ") : null
+
+/obj/machinery/ammo_workbench/proc/recycle_magazine(mob/living/user)
+	if(machine_stat & (NOPOWER|BROKEN))
+		return
+	if(busy)
+		error_message = "SYSTEM IS BUSY"
+		error_type = ""
+		return
+	if(!loaded_magazine)
+		error_message = "NO CONTAINER INSERTED"
+		error_type = ""
+		return
+	if(!length(loaded_magazine.stored_ammo))
+		error_message = "CONTAINER IS EMPTY"
+		error_type = "bad"
+		return
+
+	// per-round loop: faster than printing, drains visibly.
+	busy = TRUE
+	is_recycling = TRUE
+	activity_label = pick_recycle_status()
+	error_message = "" // ongoing state shows on the magazine bar, not here
+	error_type = ""
+	SStgui.update_uis(src) // disable the controls immediately
+	recycle_round()
+
+/// Recycle status: usually RECYCLING, small chance of a joke.
+/obj/machinery/ammo_workbench/proc/pick_recycle_status()
+	var/static/list/recycle_jokes = list(
+		"UNFABRICATING",
+		"PRINTN'T",
+		"UN-PRINTING",
+	)
+	if(prob(10))
+		return pick(recycle_jokes)
+	return "RECYCLING"
+
+/// Reclaims one round per call, rescheduling until empty.
+/obj/machinery/ammo_workbench/proc/recycle_round()
+	if(machine_stat & (NOPOWER|BROKEN) || !loaded_magazine)
+		recycle_finish()
+		return
+
+	// stored_ammo is a lazy mixed list (typepaths until instantiated)
+	var/atom/target_round
+	for(var/atom/entry as anything in loaded_magazine.stored_ammo)
+		var/entry_type = ispath(entry) ? entry : entry.type
+		if(ispath(entry_type, /obj/item/ammo_casing))
+			target_round = entry
+			break
+
+	if(isnull(target_round)) // nothing left to process
+		recycle_finish(successfully = TRUE)
+		return
+
+	var/casing_type = ispath(target_round) ? target_round : target_round.type
+	// read base composition from a throwaway casing of this type (initial() won't copy material lists)
+	var/obj/item/ammo_casing/base_casing = new casing_type
+	var/list/base_mats = base_casing.get_material_composition()
+	qdel(base_casing)
+
+	// only reclaim if the whole round's worth fits; otherwise stop here with what we've already banked
+	var/round_total = 0
+	for(var/material in base_mats)
+		round_total += base_mats[material] * (effective_recycle_percent() / 100)
+	if(round_total && !materials.has_space(round_total))
+		error_message = "MATERIAL STORAGE FULL"
+		error_type = "bad"
+		recycle_finish(successfully = FALSE)
+		return
+
+	for(var/material in base_mats)
+		materials.insert_amount_mat(base_mats[material] * (effective_recycle_percent() / 100), material)
+
+	// remove this one round (qdel for instances triggers Exited material bookkeeping; path entries just drop)
+	loaded_magazine.stored_ammo -= target_round
+	if(!ispath(target_round))
+		qdel(target_round)
+	loaded_magazine.update_appearance()
+
+	flick("ammobench_process", src)
+	use_energy(3000 JOULES)
+	// the print sound, but backwards: one reverse zerp per round, the inverse of fill_round()'s per-round piston.
+	playsound(loc, 'sound/machines/piston/piston_raise.ogg', 60, TRUE, frequency = -1)
+	SStgui.update_uis(src)
+
+	// recycling is twice as fast as printing at the same part tier, and rides the same turbo/upgrade scaling (turbo makes it faster but wastes material).
+	var/recycle_delay = max(time_per_round * 0.5, 1)
+	timer_id = addtimer(CALLBACK(src, PROC_REF(recycle_round)), recycle_delay, TIMER_STOPPABLE)
+
+/obj/machinery/ammo_workbench/proc/recycle_finish(successfully = TRUE)
+	if(timer_id)
+		deltimer(timer_id) // kill any pending next-round callback, else cancel does nothing
+		timer_id = null
+	busy = FALSE
+	is_recycling = FALSE
+	if(successfully && loaded_magazine)
+		// zero out the mag's own material value so it reads as empty even if a stray entry lingered
+		loaded_magazine.set_custom_materials(list())
+		loaded_magazine.update_appearance()
+		error_message = "MUNITIONS RECYCLED"
+		error_type = "good"
+		playsound(loc, 'sound/machines/ping.ogg', 40, TRUE)
+	SStgui.update_uis(src)
 
 /obj/machinery/ammo_workbench/proc/fill_magazine_start(casing_type)
 	if(machine_stat & (NOPOWER|BROKEN))
@@ -314,12 +526,12 @@
 			return
 
 	if(!loaded_magazine)
-		error_message = "NO MAGAZINE INSERTED"
+		error_message = "NO CONTAINER INSERTED"
 		error_type = ""
 		return
 
 	if(loaded_magazine.stored_ammo.len >= loaded_magazine.max_ammo)
-		error_message = "MAGAZINE IS FULL"
+		error_message = "CONTAINER IS FULL"
 		error_type = "good"
 		return
 
@@ -327,6 +539,10 @@
 		return
 
 	busy = TRUE
+	is_recycling = FALSE
+	activity_label = "FABRICATING"
+	rounds_made_this_run = 0
+	SStgui.update_uis(src) // disable the controls immediately, before the first round fires
 
 	timer_id = addtimer(CALLBACK(src, PROC_REF(fill_round), casing_type), time_per_round, TIMER_STOPPABLE)
 
@@ -350,7 +566,8 @@
 		efficient_materials[material] = required_materials[material] * creation_efficiency
 
 	if(!materials.has_materials(efficient_materials))
-		error_message = "INSUFFICIENT MATERIALS"
+		// ran dry partway through a run = DEPLETED; failed on the very first round = never had enough.
+		error_message = rounds_made_this_run ? "MATERIALS DEPLETED" : "INSUFFICIENT MATERIALS"
 		error_type = "bad"
 		ammo_fill_finish(FALSE)
 		qdel(new_casing)
@@ -365,6 +582,7 @@
 			return
 		materials.use_materials(efficient_materials)
 		new_casing.set_custom_materials(efficient_materials)
+		rounds_made_this_run++
 		loaded_magazine.update_appearance()
 		flick("ammobench_process", src)
 		use_energy(3000 JOULES)
@@ -392,6 +610,7 @@
 		playsound(loc, 'sound/machines/buzz/buzz-sigh.ogg', 40, TRUE)
 	update_appearance()
 	busy = FALSE
+	is_recycling = FALSE
 	if(timer_id)
 		deltimer(timer_id)
 		timer_id = null
@@ -409,6 +628,7 @@
 	disk_error_type = "good"
 	loaded_datadisk.on_bench_install(src)
 	loaded_datadisks += loaded_datadisk.type // upon further reflection this. doesn't cause a hard del. still not a fan since the disks don't do anything by themselves
+	update_ammotypes() // a disk can unlock new printable types; refresh the list now instead of waiting for a mag reinsert
 	return TRUE
 
 /obj/machinery/ammo_workbench/proc/ejectDisk()
@@ -417,6 +637,7 @@
 		loaded_datadisk = null
 		disk_error = ""
 		disk_error_type = ""
+		update_ammotypes() // ejecting can revoke access; keep the printable list in sync
 
 /datum/design/board/ammo_workbench
 	name = "Machine Design (Ammunitions Workbench)"
@@ -431,22 +652,32 @@
 
 /obj/machinery/ammo_workbench/RefreshParts()
 	. = ..()
-	toggle_turbo_boost(forced_off = TRUE) // forces turbo off
 	var/time_efficiency = 1.8 SECONDS
 	for(var/datum/stock_part/micro_laser/new_laser in component_parts)
 		time_efficiency -= new_laser.tier * 2 // there's two lasers
 		// time_eff prog with paired lasers is 1.4 -> 1.0 -> 0.6 -> 0.2 seconds per round
-	time_per_round = clamp(time_efficiency, 1, 20)
-	base_time_per_round = time_per_round
-	turbo_time_per_round = time_efficiency / 8
+	base_time_per_round = clamp(time_efficiency, 1, 20)
+	turbo_time_per_round = max(time_efficiency / 8, 1)
 
 	var/efficiency = 1.4
+	var/total_servo_tier = 0
+	var/servo_count = 0
 	for(var/datum/stock_part/servo/new_servo in component_parts)
 		efficiency -= new_servo.tier * 0.1 // there's two servos
+		total_servo_tier += new_servo.tier
+		servo_count++
+	// material-cost multiplier from servos: 1.2 -> 1 -> 0.8 -> 0.6
+	base_efficiency = max(efficiency, 0.1)
+	turbo_efficiency = base_efficiency * 2
 
-	creation_efficiency = max(0, efficiency) // with paired servos of appropriate tier, progression is 1.2 -> 1 -> 0.8 -> 0.6
-	base_efficiency = creation_efficiency
-	turbo_efficiency = creation_efficiency * 2
+	// reclaim scales with servo tier, mirroring /obj/machinery/recycler. averaged across the bench's pair of servos.
+	// progression with paired servos: t1 62.5% -> t2 75% -> t3 87.5% -> t4 100%
+	var/avg_servo_tier = servo_count ? (total_servo_tier / servo_count) : 1
+	recycle_percent = min(50, 12.5 * avg_servo_tier) + 50
+	part_tier = round(avg_servo_tier) // drives the signal-strength bars in the UI (1-4)
+
+	// re-apply the active turbo state now that base_* are recomputed, so the live numbers reflect upgrades immediately.
+	apply_speed_state()
 
 	var/mat_capacity = 0
 	for(var/datum/stock_part/matter_bin/new_matter_bin in component_parts)
@@ -495,7 +726,7 @@
 	return default_deconstruction_screwdriver(user, tool)
 
 /obj/machinery/ammo_workbench/attackby(obj/item/O, mob/user, params)
-	if(default_deconstruction_crowbar(O))
+	if(default_deconstruction_crowbar(user, O))
 		return
 	if(panel_open && is_wire_tool(O))
 		wires.interact(user)
@@ -594,6 +825,22 @@
 
 /obj/machinery/ammo_workbench/proc/adjust_hacked(state)
 	hacked = state
+
+/obj/machinery/ammo_workbench/emag_act(mob/user, obj/item/card/emag/emag_card)
+	if(obj_flags & EMAGGED)
+		balloon_alert(user, "already overridden!")
+		return FALSE
+	obj_flags |= EMAGGED
+	hacked = TRUE
+	allowed_harmful = TRUE
+	allowed_advanced = TRUE
+	update_ammotypes()
+	balloon_alert(user, "safety protocols overridden")
+	if(user)
+		to_chat(user, span_warning("You short out [src]'s munition safety protocols, unlocking its full catalogue."))
+	playsound(src, 'sound/effects/sparks/sparks4.ogg', 60, TRUE)
+	SStgui.update_uis(src)
+	return TRUE
 
 
 // WIRE DATUM

--- a/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
+++ b/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
@@ -859,7 +859,6 @@
 	if(user)
 		to_chat(user, span_warning("You short out [src]'s munition safety protocols, unlocking its full catalogue."))
 	playsound(src, 'sound/effects/sparks/sparks4.ogg', 60, TRUE)
-	SStgui.update_uis(src)
 	return TRUE
 
 

--- a/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
+++ b/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
@@ -7,7 +7,7 @@
 	use_power = IDLE_POWER_USE
 	circuit = /obj/item/circuitboard/machine/ammo_workbench
 	var/busy = FALSE
-	/// TRUE while recycling (vs fabricating); routes Cancel.
+	/// are we recycling right now (as opposed to printing)
 	var/is_recycling = FALSE
 	/// if it's hacked it's gonna be able to print lethals. it'll be mad at you for doing so but it'll print basic lethals.
 	var/hacked = FALSE
@@ -63,15 +63,16 @@
 	/// does not force ammo to load in. just makes it able to print wacky ammotypes e.g. lionhunter 7.62, techshells
 	var/adminbus = FALSE
 	var/datum/remote_materials/materials
-	/// if TRUE, this bench uses standalone local material storage and never auto-connects to the ore silo (for self-contained map/test variants).
+	/// don't touch the silo, just use local storage (for the prefilled mapping variant)
 	var/force_local_materials = FALSE
+	/// whoever started the current print, for the silo log
+	var/alist/printing_user_data
 
 /obj/machinery/ammo_workbench/unlocked
 	allowed_harmful = TRUE
 	allowed_advanced = TRUE
 
-/// Mapping/testing variant: spawns with tier-3 parts (via its own board) and a modest material stock,
-/// so it's usable out of the box without also placing sheets and a datadisk. For away missions, custom maps, admin setups.
+// mapping variant - comes with decent parts and some materials so you can just plop it down on a ruin/away mission without also placing sheets and a disk
 /obj/machinery/ammo_workbench/prefilled
 	circuit = /obj/item/circuitboard/machine/ammo_workbench/prefilled
 	force_local_materials = TRUE
@@ -98,7 +99,6 @@
 		/datum/stock_part/micro_laser = 2
 	)
 
-/// Tier-3 board for the prefilled mapping/testing variant.
 /obj/item/circuitboard/machine/ammo_workbench/prefilled
 	build_path = /obj/machinery/ammo_workbench/prefilled
 	req_components = list(
@@ -120,12 +120,10 @@
 	RegisterSignal(src, COMSIG_SILO_ITEM_CONSUMED, TYPE_PROC_REF(/obj/machinery/ammo_workbench, silo_material_insert))
 	set_wires(new /datum/wires/ammo_workbench(src))
 
-/// Signal handler: materials inserted into local storage.
 /obj/machinery/ammo_workbench/proc/local_material_insert(obj/machinery/machine, container, obj/item/item_inserted, last_inserted_id, list/mats_consumed, amount_inserted)
 	SIGNAL_HANDLER
 	SStgui.update_uis(src)
 
-/// Signal handler: materials inserted via a connected ore silo.
 /obj/machinery/ammo_workbench/proc/silo_material_insert(obj/machinery/machine, container, obj/item/item_inserted, last_inserted_id, list/mats_consumed, amount_inserted)
 	SIGNAL_HANDLER
 	SStgui.update_uis(src)
@@ -291,6 +289,7 @@
 
 		if("FillMagazine")
 			var/type_to_pass = text2path(params["selected_type"])
+			printing_user_data = ID_DATA(usr)
 			fill_magazine_start(type_to_pass)
 			. = TRUE
 
@@ -343,7 +342,6 @@
 		if("turboBoost")
 			toggle_turbo_boost()
 
-/// Toggles turbo; forced_off forces it off.
 /obj/machinery/ammo_workbench/proc/toggle_turbo_boost(forced_off = FALSE)
 	if(forced_off)
 		turbo_boost = FALSE
@@ -353,7 +351,7 @@
 	update_ammotypes()
 	SStgui.update_uis(src)
 
-/// Applies the turbo flag to live time/efficiency from base_* values.
+// keeps time/efficiency in sync with the turbo toggle so they can't drift apart
 /obj/machinery/ammo_workbench/proc/apply_speed_state()
 	if(turbo_boost)
 		time_per_round = turbo_time_per_round
@@ -379,13 +377,12 @@
 	update_ammotypes()
 	update_appearance()
 
-/// Recycles the loaded mag, reclaiming a servo-tier fraction of each round's base materials (capped 100%).
+// dumps the loaded container back into materials, giving back a chunk of each round's base mats based on servo tier
 
-/// Reclaim percent, reduced under turbo (speed costs efficiency).
+// turbo recycling is faster but you get less back
 /obj/machinery/ammo_workbench/proc/effective_recycle_percent()
 	return turbo_boost ? recycle_percent * 0.6 : recycle_percent
 
-/// Sheet-yield summary string for recycling the loaded mag, or null.
 /obj/machinery/ammo_workbench/proc/get_recycle_preview()
 	if(!loaded_magazine || !length(loaded_magazine.stored_ammo))
 		return null
@@ -437,7 +434,6 @@
 	SStgui.update_uis(src) // disable the controls immediately
 	recycle_round()
 
-/// Recycle status: usually RECYCLING, small chance of a joke.
 /obj/machinery/ammo_workbench/proc/pick_recycle_status()
 	var/static/list/recycle_jokes = list(
 		"UNFABRICATING",
@@ -448,7 +444,7 @@
 		return pick(recycle_jokes)
 	return "RECYCLING"
 
-/// Reclaims one round per call, rescheduling until empty.
+// one round at a time until the thing's empty
 /obj/machinery/ammo_workbench/proc/recycle_round()
 	if(machine_stat & (NOPOWER|BROKEN) || !loaded_magazine)
 		recycle_finish()
@@ -608,7 +604,7 @@
 			ammo_fill_finish(FALSE)
 			qdel(new_casing)
 			return
-		materials.use_materials(efficient_materials)
+		materials.use_materials(efficient_materials, action = "printed", name = "[initial(new_casing.name)]", user_data = printing_user_data)
 		new_casing.set_custom_materials(efficient_materials)
 		rounds_made_this_run++
 		loaded_magazine.update_appearance()

--- a/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
+++ b/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
@@ -65,8 +65,8 @@
 	var/datum/remote_materials/materials
 	/// don't touch the silo, just use local storage (for the prefilled mapping variant)
 	var/force_local_materials = FALSE
-	/// whoever started the current print, for the silo log
-	var/alist/printing_user_data
+	/// sanitized ID record of whoever started the current print, for silo accountability logging (accesses stripped to avoid the logger choking).
+	var/alist/print_log_data
 
 /obj/machinery/ammo_workbench/unlocked
 	allowed_harmful = TRUE
@@ -79,8 +79,7 @@
 
 /obj/machinery/ammo_workbench/prefilled/Initialize(mapload)
 	. = ..()
-	// stock common bullet materials: mostly iron, smaller amounts of metals real rounds use.
-	// deliberately no diamond/bluespace/bananium — no reasonable round needs them.
+	// Give it a reasonable stock of materials used for bullets
 	if(materials?.mat_container)
 		materials.mat_container.insert_amount_mat(50 * SHEET_MATERIAL_AMOUNT, /datum/material/iron)
 		materials.mat_container.insert_amount_mat(20 * SHEET_MATERIAL_AMOUNT, /datum/material/glass)
@@ -183,7 +182,9 @@
 		qdel(casing_actual)
 		for(var/material in raw_casing_mats)
 			efficient_casing_mats[material] = raw_casing_mats[material] * creation_efficiency
-		var/rounds_to_fill = max(loaded_magazine.max_ammo - length(loaded_magazine.stored_ammo), 0)
+		// max_ammo can read 0 on a just-inserted empty container before its contents initialize; fall back to the type's spawn capacity.
+		var/true_capacity = loaded_magazine.max_ammo || initial(loaded_magazine.max_ammo)
+		var/rounds_to_fill = max(true_capacity - length(loaded_magazine.stored_ammo), 0)
 		var/mat_string = ""
 
 		for(var/i in 1 to length(efficient_casing_mats))
@@ -227,6 +228,7 @@
 	data["system_busy"] = busy
 
 	data["efficiency"] = creation_efficiency
+	data["silo_connected"] = materials && materials.silo ? TRUE : FALSE
 	data["time"] = time_per_round / 10
 	data["recyclePercent"] = round(effective_recycle_percent())
 	// turbo drops the signal bar by one (efficiency traded for speed).
@@ -272,6 +274,7 @@
 			. = TRUE
 
 		if("RecycleMag")
+			print_log_data = sanitize_id_data(ID_DATA(usr))
 			recycle_magazine()
 			. = TRUE
 
@@ -289,7 +292,7 @@
 
 		if("FillMagazine")
 			var/type_to_pass = text2path(params["selected_type"])
-			printing_user_data = ID_DATA(usr)
+			print_log_data = sanitize_id_data(ID_DATA(usr))
 			fill_magazine_start(type_to_pass)
 			. = TRUE
 
@@ -483,8 +486,12 @@
 		recycle_finish(successfully = FALSE)
 		return
 
+	var/list/reclaimed_mats = list()
 	for(var/material in base_mats)
-		materials.mat_container.insert_amount_mat(base_mats[material] * (effective_recycle_percent() / 100), material)
+		var/amount = base_mats[material] * (effective_recycle_percent() / 100)
+		materials.mat_container.insert_amount_mat(amount, material)
+		reclaimed_mats[material] = amount
+	log_silo_use(reclaimed_mats, "recycled", "spent rounds")
 
 	// remove this one round (qdel for instances triggers Exited material bookkeeping; path entries just drop)
 	loaded_magazine.stored_ammo -= target_round
@@ -604,7 +611,15 @@
 			ammo_fill_finish(FALSE)
 			qdel(new_casing)
 			return
-		materials.use_materials(efficient_materials, action = "printed", name = "[initial(new_casing.name)]", user_data = printing_user_data)
+		// respect a remote silo hold (the vault can pause us), but no nanny-state ID gating; the bench draws and logs, it doesn't police access
+		if(materials.silo && materials.on_hold())
+			error_message = "MATERIAL ACCESS ON HOLD"
+			error_type = "bad"
+			ammo_fill_finish(FALSE)
+			qdel(new_casing)
+			return
+		materials.mat_container.use_materials(efficient_materials)
+		log_silo_use(efficient_materials, "printed", initial(new_casing.name))
 		new_casing.set_custom_materials(efficient_materials)
 		rounds_made_this_run++
 		loaded_magazine.update_appearance()
@@ -849,6 +864,25 @@
 
 /obj/machinery/ammo_workbench/proc/adjust_hacked(state)
 	hacked = state
+
+/// Returns a copy of an ID_DATA record with the access list dropped. The raw access list is a flat list that
+/// the silo log serializer can't walk, so we strip it; we only need the name/account for accountability anyway.
+/obj/machinery/ammo_workbench/proc/sanitize_id_data(alist/user_data)
+	if(!islist(user_data))
+		return user_data
+	var/alist/clean = user_data.Copy()
+	clean["accesses"] = null
+	return clean
+
+/// Logs a material use to the connected silo for accountability (who printed what), without enforcing the silo's
+/// ID/account policy. No-op when not silo-linked.
+/obj/machinery/ammo_workbench/proc/log_silo_use(list/mats, action, name)
+	if(!materials?.silo)
+		return
+	var/list/scaled_mats = list()
+	for(var/mat in mats)
+		scaled_mats[mat] = mats[mat]
+	materials.silo.silo_log(src, action, -1, name, scaled_mats, print_log_data)
 
 /obj/machinery/ammo_workbench/emag_act(mob/user, obj/item/card/emag/emag_card)
 	if(obj_flags & EMAGGED)

--- a/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
+++ b/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
@@ -317,7 +317,6 @@
 		turbo_boost = !turbo_boost
 	apply_speed_state()
 	update_ammotypes()
-	SStgui.update_uis(src)
 
 // keeps time/efficiency in sync with the turbo toggle so they can't drift apart
 /obj/machinery/ammo_workbench/proc/apply_speed_state()

--- a/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
+++ b/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
@@ -491,7 +491,7 @@
 		var/amount = base_mats[material] * (effective_recycle_percent() / 100)
 		materials.mat_container.insert_amount_mat(amount, material)
 		reclaimed_mats[material] = amount
-	log_silo_use(reclaimed_mats, "recycled", "spent rounds")
+	log_silo_use(reclaimed_mats, "recycled", "munitions")
 
 	// remove this one round (qdel for instances triggers Exited material bookkeeping; path entries just drop)
 	loaded_magazine.stored_ammo -= target_round

--- a/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
+++ b/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
@@ -310,6 +310,7 @@
 
 		if("turboBoost")
 			toggle_turbo_boost()
+			return TRUE
 
 /obj/machinery/ammo_workbench/proc/toggle_turbo_boost(forced_off = FALSE)
 	if(forced_off)

--- a/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
+++ b/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
@@ -62,7 +62,9 @@
 	/// can this print any round of any caliber given a correct ammo_box? (you varedit this at your own risk, especially if used in a player-facing context.)
 	/// does not force ammo to load in. just makes it able to print wacky ammotypes e.g. lionhunter 7.62, techshells
 	var/adminbus = FALSE
-	var/datum/material_container/materials
+	var/datum/remote_materials/materials
+	/// if TRUE, this bench uses standalone local material storage and never auto-connects to the ore silo (for self-contained map/test variants).
+	var/force_local_materials = FALSE
 
 /obj/machinery/ammo_workbench/unlocked
 	allowed_harmful = TRUE
@@ -72,18 +74,19 @@
 /// so it's usable out of the box without also placing sheets and a datadisk. For away missions, custom maps, admin setups.
 /obj/machinery/ammo_workbench/prefilled
 	circuit = /obj/item/circuitboard/machine/ammo_workbench/prefilled
+	force_local_materials = TRUE
 
 /obj/machinery/ammo_workbench/prefilled/Initialize(mapload)
 	. = ..()
 	// stock common bullet materials: mostly iron, smaller amounts of metals real rounds use.
 	// deliberately no diamond/bluespace/bananium — no reasonable round needs them.
-	if(materials)
-		materials.insert_amount_mat(50 * SHEET_MATERIAL_AMOUNT, /datum/material/iron)
-		materials.insert_amount_mat(20 * SHEET_MATERIAL_AMOUNT, /datum/material/glass)
-		materials.insert_amount_mat(20 * SHEET_MATERIAL_AMOUNT, /datum/material/titanium)
-		materials.insert_amount_mat(15 * SHEET_MATERIAL_AMOUNT, /datum/material/plasma)
-		materials.insert_amount_mat(15 * SHEET_MATERIAL_AMOUNT, /datum/material/silver)
-		materials.insert_amount_mat(15 * SHEET_MATERIAL_AMOUNT, /datum/material/gold)
+	if(materials?.mat_container)
+		materials.mat_container.insert_amount_mat(50 * SHEET_MATERIAL_AMOUNT, /datum/material/iron)
+		materials.mat_container.insert_amount_mat(20 * SHEET_MATERIAL_AMOUNT, /datum/material/glass)
+		materials.mat_container.insert_amount_mat(20 * SHEET_MATERIAL_AMOUNT, /datum/material/titanium)
+		materials.mat_container.insert_amount_mat(15 * SHEET_MATERIAL_AMOUNT, /datum/material/plasma)
+		materials.mat_container.insert_amount_mat(15 * SHEET_MATERIAL_AMOUNT, /datum/material/silver)
+		materials.mat_container.insert_amount_mat(15 * SHEET_MATERIAL_AMOUNT, /datum/material/gold)
 
 /obj/item/circuitboard/machine/ammo_workbench
 	name = "Ammunition Workbench (Machine Board)"
@@ -105,20 +108,33 @@
 	)
 
 /obj/machinery/ammo_workbench/Initialize(mapload)
-	materials = new( \
-		src, \
-		SSmaterials.get_materials_by_flag(MATERIAL_SILO_STORED), \
-		200000, \
-		MATCONTAINER_EXAMINE, \
-		allowed_items = /obj/item/stack, \
-	)
 	. = ..()
+	materials = new(
+		src,
+		force_local_materials ? FALSE : mapload,
+		mat_container_signals = list(
+			COMSIG_MATCONTAINER_ITEM_CONSUMED = TYPE_PROC_REF(/obj/machinery/ammo_workbench, local_material_insert)
+		)
+	)
+	materials.set_local_size(200000)
+	RegisterSignal(src, COMSIG_SILO_ITEM_CONSUMED, TYPE_PROC_REF(/obj/machinery/ammo_workbench, silo_material_insert))
 	set_wires(new /datum/wires/ammo_workbench(src))
+
+/// Signal handler: materials inserted into local storage.
+/obj/machinery/ammo_workbench/proc/local_material_insert(obj/machinery/machine, container, obj/item/item_inserted, last_inserted_id, list/mats_consumed, amount_inserted)
+	SIGNAL_HANDLER
+	SStgui.update_uis(src)
+
+/// Signal handler: materials inserted via a connected ore silo.
+/obj/machinery/ammo_workbench/proc/silo_material_insert(obj/machinery/machine, container, obj/item/item_inserted, last_inserted_id, list/mats_consumed, amount_inserted)
+	SIGNAL_HANDLER
+	SStgui.update_uis(src)
 
 /obj/machinery/ammo_workbench/examine(mob/user)
 	. += ..()
 	if(in_range(user, src) || isobserver(user))
-		. += span_notice("The status display reads: Storing up to <b>[materials.max_amount]</b> material units.<br>Material consumption at <b>[creation_efficiency*100]%</b>.")
+		if(materials?.mat_container)
+			. += span_notice("The status display reads: Storing up to <b>[materials.mat_container.max_amount]</b> material units.<br>Material consumption at <b>[creation_efficiency*100]%</b>.")
 		. += span_notice("Reclaiming <b>[recycle_percent]%</b> of materials when recycling a loaded container.")
 
 /obj/machinery/ammo_workbench/ui_interact(mob/user, datum/tgui/ui)
@@ -222,9 +238,9 @@
 	data["hacked"] = hacked
 	data["turboBoost"] = turbo_boost
 
-	data["materials"] = materials ? materials.ui_data() : list()
+	data["materials"] = materials?.mat_container ? materials.mat_container.ui_data() : list()
 	data["SHEET_MATERIAL_AMOUNT"] = SHEET_MATERIAL_AMOUNT
-	data["materialMaximum"] = materials ? materials.max_amount : 0
+	data["materialMaximum"] = materials?.mat_container ? materials.mat_container.max_amount : 0
 
 	if(error_message)
 		data["error"] = error_message
@@ -280,11 +296,11 @@
 
 		if("Release")
 
-			if(!materials)
+			if(!materials?.mat_container)
 				return
 			var/datum/material/mat = locate(params["id"])
 
-			var/amount = materials.materials[mat]
+			var/amount = materials.mat_container.materials[mat]
 			if(!amount)
 				return
 
@@ -299,23 +315,23 @@
 
 			var/sheets_to_remove = round(min(desired,50,stored_amount))
 
-			materials.retrieve_stack(sheets_to_remove, mat, loc)
+			materials.mat_container.retrieve_stack(sheets_to_remove, mat, loc)
 			. = TRUE
 
 		if("remove_mat") // MaterialAccessBar eject: { ref, amount(sheets) }
-			if(!materials)
+			if(!materials?.mat_container)
 				return
 			var/datum/material/mat = locate(params["ref"])
 			if(!mat)
 				return
-			var/units_available = materials.materials[mat]
+			var/units_available = materials.mat_container.materials[mat]
 			if(!units_available)
 				return
 			var/sheets_available = CEILING(units_available / SHEET_MATERIAL_AMOUNT, 0.1)
 			var/desired = text2num(params["amount"]) || 0
 			var/sheets_to_remove = round(min(desired, 50, sheets_available))
 			if(sheets_to_remove > 0)
-				materials.retrieve_stack(sheets_to_remove, mat, loc)
+				materials.mat_container.retrieve_stack(sheets_to_remove, mat, loc)
 			. = TRUE
 
 		if("ReadDisk")
@@ -460,14 +476,19 @@
 	var/round_total = 0
 	for(var/material in base_mats)
 		round_total += base_mats[material] * (effective_recycle_percent() / 100)
-	if(round_total && !materials.has_space(round_total))
+	if(!materials?.mat_container)
+		error_message = "NO MATERIAL STORAGE LINKED"
+		error_type = "bad"
+		recycle_finish(successfully = FALSE)
+		return
+	if(round_total && !materials.mat_container.has_space(round_total))
 		error_message = "MATERIAL STORAGE FULL"
 		error_type = "bad"
 		recycle_finish(successfully = FALSE)
 		return
 
 	for(var/material in base_mats)
-		materials.insert_amount_mat(base_mats[material] * (effective_recycle_percent() / 100), material)
+		materials.mat_container.insert_amount_mat(base_mats[material] * (effective_recycle_percent() / 100), material)
 
 	// remove this one round (qdel for instances triggers Exited material bookkeeping; path entries just drop)
 	loaded_magazine.stored_ammo -= target_round
@@ -565,7 +586,14 @@
 	for(var/material in required_materials)
 		efficient_materials[material] = required_materials[material] * creation_efficiency
 
-	if(!materials.has_materials(efficient_materials))
+	if(!materials?.mat_container)
+		error_message = "NO MATERIAL STORAGE LINKED"
+		error_type = "bad"
+		ammo_fill_finish(FALSE)
+		qdel(new_casing)
+		return
+
+	if(!materials.mat_container.has_materials(efficient_materials))
 		// ran dry partway through a run = DEPLETED; failed on the very first round = never had enough.
 		error_message = rounds_made_this_run ? "MATERIALS DEPLETED" : "INSUFFICIENT MATERIALS"
 		error_type = "bad"
@@ -683,7 +711,7 @@
 	for(var/datum/stock_part/matter_bin/new_matter_bin in component_parts)
 		mat_capacity += new_matter_bin.tier * (40 * SHEET_MATERIAL_AMOUNT)
 
-	materials.max_amount = mat_capacity
+	materials?.set_local_size(mat_capacity)
 	update_ammotypes()
 
 /obj/machinery/ammo_workbench/update_overlays()

--- a/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
+++ b/modular_zubbers/modules/ammo_workbench/code/ammo_workbench.dm
@@ -109,12 +109,8 @@
 	materials = new(
 		src,
 		force_local_materials ? FALSE : mapload,
-		mat_container_signals = list(
-			COMSIG_MATCONTAINER_ITEM_CONSUMED = TYPE_PROC_REF(/obj/machinery/ammo_workbench, local_material_insert)
-		)
 	)
 	materials.set_local_size(200000)
-	RegisterSignal(src, COMSIG_SILO_ITEM_CONSUMED, TYPE_PROC_REF(/obj/machinery/ammo_workbench, silo_material_insert))
 	set_wires(new /datum/wires/ammo_workbench(src))
 
 /obj/machinery/ammo_workbench/proc/local_material_insert(obj/machinery/machine, container, obj/item/item_inserted, last_inserted_id, list/mats_consumed, amount_inserted)

--- a/tgui/packages/tgui/index.tsx
+++ b/tgui/packages/tgui/index.tsx
@@ -7,6 +7,7 @@
 // Themes
 import './styles/main.scss';
 import './styles/themes/clockwork.scss'; // SKYRAT EDIT ADDITION
+import './styles/themes/ammoworkbench.scss'; // BUBBER EDIT: ammo workbench theme
 
 import { setupGlobalEvents } from 'tgui-core/events';
 import { setupHotKeys } from 'tgui-core/hotkeys';

--- a/tgui/packages/tgui/interfaces/AmmoWorkbench.jsx
+++ b/tgui/packages/tgui/interfaces/AmmoWorkbench.jsx
@@ -19,7 +19,8 @@ import { MaterialAccessBar } from './Fabrication/MaterialAccessBar';
 export const AmmoWorkbench = (props) => {
   const [tab, setTab] = useSharedState('tab', 1);
   const { data, act } = useBackend();
-  const { materials = [], SHEET_MATERIAL_AMOUNT, hacked } = data;
+  const { materials = [], SHEET_MATERIAL_AMOUNT, hacked, silo_connected } =
+    data;
 
   return (
     <Window
@@ -39,6 +40,22 @@ export const AmmoWorkbench = (props) => {
               <Box as="span" className="AmmoWorkbench__header-title">
                 ARMADYNE AMMUNITIONS WORKBENCH
               </Box>
+              <Tooltip
+                content={
+                  silo_connected
+                    ? 'Linked to the ore silo.'
+                    : 'Not linked to an ore silo; using local storage. Link with a multitool.'
+                }
+              >
+                <Box
+                  as="span"
+                  className="AmmoWorkbench__header-silo"
+                  color={silo_connected ? 'good' : 'bad'}
+                >
+                  <Icon name="wifi" mr={0.5} />
+                  {silo_connected ? 'LINKED' : 'LOCAL'}
+                </Box>
+              </Tooltip>
               <Box
                 as="span"
                 className="AmmoWorkbench__header-status"
@@ -210,7 +227,7 @@ export const AmmunitionsTab = (props) => {
             <Flex height="100%" align="center" justify="center">
               <Flex.Item color="label" italic>
                 <Icon name="inbox" mr={1} />
-                No container inserted &mdash; insert one to begin.
+                No container inserted. Insert one to begin.
               </Flex.Item>
             </Flex>
           ) : (

--- a/tgui/packages/tgui/interfaces/AmmoWorkbench.jsx
+++ b/tgui/packages/tgui/interfaces/AmmoWorkbench.jsx
@@ -51,7 +51,7 @@ export const AmmoWorkbench = (props) => {
           <Stack.Item>
             <Tabs fluid>
               <Tabs.Tab
-                icon="bolt"
+                icon="gun"
                 selected={tab === 1}
                 onClick={() => setTab(1)}
               >

--- a/tgui/packages/tgui/interfaces/AmmoWorkbench.jsx
+++ b/tgui/packages/tgui/interfaces/AmmoWorkbench.jsx
@@ -33,7 +33,9 @@ export const AmmoWorkbench = (props) => {
           {/* Armadyne identity header (this is an Armadyne bench, not Nanotrasen). */}
           <Stack.Item>
             <Box className="AmmoWorkbench__header">
-              <Icon name="bolt" className="AmmoWorkbench__header-icon" />
+              <Box as="span" className="AmmoWorkbench__header-icon">
+                ⌖
+              </Box>
               <Box as="span" className="AmmoWorkbench__header-title">
                 ARMADYNE AMMUNITIONS WORKBENCH
               </Box>

--- a/tgui/packages/tgui/interfaces/AmmoWorkbench.jsx
+++ b/tgui/packages/tgui/interfaces/AmmoWorkbench.jsx
@@ -88,7 +88,7 @@ export const AmmoWorkbench = (props) => {
             {tab === 3 && <DatadiskTab />}
           </Stack.Item>
           {/* status strip + standard fabricator material dock */}
-          <Stack.Item>
+          <Stack.Item shrink={0}>
             <Section>
               <Flex
                 className="AmmoWorkbench__statusline"

--- a/tgui/packages/tgui/interfaces/AmmoWorkbench.jsx
+++ b/tgui/packages/tgui/interfaces/AmmoWorkbench.jsx
@@ -1,48 +1,99 @@
 // THIS IS A SKYRAT UI FILE
-import { toTitleCase } from 'tgui-core/string';
-import { useState } from 'react';
-
-import { useBackend, useSharedState } from '../backend';
 import {
   Box,
   Button,
   Flex,
+  Icon,
   NoticeBox,
-  NumberInput,
-  ProgressBar,
-  RoundGauge,
   Section,
   Stack,
   Table,
   Tabs,
   Tooltip,
 } from 'tgui-core/components';
+
+import { useBackend, useSharedState } from '../backend';
 import { Window } from '../layouts';
+import { MaterialAccessBar } from './Fabrication/MaterialAccessBar';
 
 export const AmmoWorkbench = (props) => {
   const [tab, setTab] = useSharedState('tab', 1);
+  const { data, act } = useBackend();
+  const { materials = [], SHEET_MATERIAL_AMOUNT, hacked } = data;
+
   return (
     <Window
-      width={600}
-      height={600}
-      theme="hackerman"
+      width={620}
+      height={640}
+      theme="ammoworkbench"
       title="Ammunitions Workbench"
     >
-      <Window.Content scrollable>
-        <Tabs>
-          <Tabs.Tab selected={tab === 1} onClick={() => setTab(1)}>
-            Ammunitions
-          </Tabs.Tab>
-          <Tabs.Tab selected={tab === 2} onClick={() => setTab(2)}>
-            Materials
-          </Tabs.Tab>
-          <Tabs.Tab selected={tab === 3} onClick={() => setTab(3)}>
-            Datadisks
-          </Tabs.Tab>
-        </Tabs>
-        {tab === 1 && <AmmunitionsTab />}
-        {tab === 2 && <MaterialsTab />}
-        {tab === 3 && <DatadiskTab />}
+      <Window.Content>
+        <Stack vertical fill>
+          {/* Armadyne identity header (this is an Armadyne bench, not Nanotrasen). */}
+          <Stack.Item>
+            <Box className="AmmoWorkbench__header">
+              <Icon name="bolt" className="AmmoWorkbench__header-icon" />
+              <Box as="span" className="AmmoWorkbench__header-title">
+                ARMADYNE AMMUNITIONS WORKBENCH
+              </Box>
+              <Box
+                as="span"
+                className="AmmoWorkbench__header-status"
+                color={hacked ? 'bad' : 'good'}
+              >
+                {hacked ? 'SAFETY PROTOCOLS: DISENGAGED' : 'SAFETY PROTOCOLS: ENGAGED'}
+              </Box>
+            </Box>
+          </Stack.Item>
+          <Stack.Item>
+            <Tabs fluid>
+              <Tabs.Tab
+                icon="bolt"
+                selected={tab === 1}
+                onClick={() => setTab(1)}
+              >
+                Ammunitions
+              </Tabs.Tab>
+              <Tabs.Tab
+                icon="compact-disc"
+                selected={tab === 3}
+                onClick={() => setTab(3)}
+              >
+                Datadisks
+              </Tabs.Tab>
+            </Tabs>
+          </Stack.Item>
+          <Stack.Item grow style={{ overflowY: 'auto' }}>
+            {tab === 1 && <AmmunitionsTab />}
+            {tab === 3 && <DatadiskTab />}
+          </Stack.Item>
+          {/* status strip + standard fabricator material dock */}
+          <Stack.Item>
+            <Section>
+              <Flex
+                className="AmmoWorkbench__statusline"
+                align="center"
+                mb={1}
+              >
+                <Flex.Item color="label" style={{ letterSpacing: '1px' }}>
+                  STOCK
+                </Flex.Item>
+                <Flex.Item grow />
+                <Flex.Item color="label">
+                  reclaim {data.recyclePercent}% · {Math.round(data.efficiency * 100)}% cost
+                </Flex.Item>
+              </Flex>
+              <MaterialAccessBar
+                availableMaterials={materials}
+                SHEET_MATERIAL_AMOUNT={SHEET_MATERIAL_AMOUNT}
+                onEjectRequested={(material, amount) =>
+                  act('remove_mat', { ref: material.ref, amount })
+                }
+              />
+            </Section>
+          </Stack.Item>
+        </Stack>
       </Window.Content>
     </Window>
   );
@@ -62,95 +113,188 @@ export const AmmunitionsTab = (props) => {
     max_rounds,
     efficiency,
     time,
-    caliber,
+    recyclePercent,
+    partTier,
+    bar_state,
+    recycle_preview,
     available_rounds = [],
   } = data;
+
+  const isFull = mag_loaded && current_rounds >= max_rounds;
+  let barState = 'IDLE';
+  if (system_busy) {
+    barState = bar_state || 'FABRICATING';
+  } else if (isFull) {
+    barState = 'FULL';
+  }
+
   return (
     <>
-      {!!error && (
-        <NoticeBox textAlign="center" color={error_type}>
-          {error}
-        </NoticeBox>
-      )}
+      {/* fixed-height notice slot so layout doesn't shift */}
+      <Box height="2.5rem" mb={0.5}>
+        {!!error && (
+          <NoticeBox textAlign="center" color={error_type}>
+            {error}
+          </NoticeBox>
+        )}
+      </Box>
+
       <Section title="Machine Settings">
-        <Box inline mr={4}>
-          Current Efficiency:{' '}
-          <RoundGauge
-            value={efficiency}
-            minValue={1.6}
-            maxValue={1}
-            format={() => null}
-          />
-        </Box>
-        <Box>Time Per Round: {time} seconds</Box>
-        <Button.Checkbox
-          textAlign="right"
-          checked={turboBoost}
-          onClick={() => act('turboBoost')}
-        >
-          Turbo Boost
-        </Button.Checkbox>
+        <Flex align="center" justify="space-between">
+          <Flex.Item>
+            <Flex align="center">
+              <Flex.Item mr={2}>
+                <Tooltip content="Component quality. Higher-tier parts mean lower material cost, faster fabrication, and better recycling yield.">
+                  <Box>
+                    <SignalBars level={partTier} />
+                  </Box>
+                </Tooltip>
+              </Flex.Item>
+              <Flex.Item color="label" mr={1}>
+                Cost
+              </Flex.Item>
+              <Flex.Item bold mr={3}>
+                {Math.round(efficiency * 100)}%
+              </Flex.Item>
+              <Flex.Item color="label" mr={1}>
+                Time per round
+              </Flex.Item>
+              <Flex.Item bold>{time}s</Flex.Item>
+            </Flex>
+          </Flex.Item>
+          <Flex.Item>
+            <Button.Checkbox
+              checked={turboBoost}
+              onClick={() => act('turboBoost')}
+            >
+              Turbo Boost
+            </Button.Checkbox>
+          </Flex.Item>
+        </Flex>
       </Section>
+
       <Section
-        title="Loaded Magazine"
+        title="Loaded Container"
         buttons={
           <>
-            {!!mag_loaded && (
-              <Box inline mr={2}>
-                <ProgressBar
-                  value={current_rounds}
-                  minValue={0}
-                  maxValue={max_rounds}
-                />
-              </Box>
-            )}
+            <Button
+              icon="recycle"
+              tooltip={
+                `Empties the container and reclaims ${recyclePercent}% of its rounds' base materials` +
+                (recycle_preview ? ` (${recycle_preview})` : '') +
+                '.'
+              }
+              tooltipPosition="bottom-end"
+              disabled={!mag_loaded || !current_rounds || system_busy}
+              onClick={() => act('RecycleMag')}
+            >
+              Recycle
+            </Button>
             <Button
               icon="eject"
-              content="Eject"
-              disabled={!mag_loaded}
+              tooltip="Ejects the current container."
+              tooltipPosition="bottom-end"
+              disabled={!mag_loaded || system_busy}
               onClick={() => act('EjectMag')}
-            />
+            >
+              Eject
+            </Button>
           </>
         }
       >
-        {!!mag_loaded && <Box>{mag_name}</Box>}
-        {!!mag_loaded && (
-          <Box bold textAlign="right">
-            {current_rounds} / {max_rounds}
+        {/* fixed height so layout holds when no mag loaded */}
+        <Box height="3.5rem">
+          {!mag_loaded ? (
+            <Flex height="100%" align="center" justify="center">
+              <Flex.Item color="label" italic>
+                <Icon name="inbox" mr={1} />
+                No container inserted &mdash; insert one to begin.
+              </Flex.Item>
+            </Flex>
+          ) : (
+            <>
+              <Flex align="center" mb={0.5}>
+                <Flex.Item grow color="label">
+                  {mag_name}
+                </Flex.Item>
+                <Flex.Item bold mr={2} style={{ letterSpacing: '1px' }}>
+                  {'// '}
+                  {barState}
+                </Flex.Item>
+                <Flex.Item bold>
+                  {current_rounds} / {max_rounds}
+                </Flex.Item>
+              </Flex>
+              <SegmentBar
+                current={current_rounds}
+                max={max_rounds}
+                active={system_busy}
+              />
+              {/* inline cancel while busy */}
+              {!!system_busy && (
+                <Button
+                  fluid
+                  mt={0.5}
+                  icon="xmark"
+                  color="bad"
+                  textAlign="center"
+                  onClick={() => act('CancelFabrication')}
+                >
+                  Cancel Operation
+                </Button>
+              )}
+            </>
+          )}
+        </Box>
+      </Section>
+
+      <Section title="Available Ammunition Types">
+        {!mag_loaded && (
+          <Box color="label" italic>
+            Insert a container to list compatible rounds.
           </Box>
         )}
-      </Section>
-      <Section title="Available Ammunition Types">
-        {!!mag_loaded && (
-          <Flex.Item grow={1} basis={0}>
-            {available_rounds.map((available_round) => (
-              <Box
-                key={available_round.name}
-                className="candystripe"
-                p={1}
-                pb={2}
-              >
-                <Stack.Item>
-                  <Tooltip
-                    content={available_round.mats_list}
-                    position={'right'}
-                  >
-                    <Button
-                      content={available_round.name}
-                      disabled={system_busy}
-                      onClick={() =>
-                        act('FillMagazine', {
-                          selected_type: available_round.typepath,
-                        })
-                      }
-                    />
-                  </Tooltip>
-                </Stack.Item>
-              </Box>
-            ))}
-          </Flex.Item>
+        {!!mag_loaded && !available_rounds.length && (
+          <Box color="label" italic>
+            No printable rounds for this container.
+          </Box>
         )}
+        {!!mag_loaded &&
+          available_rounds.map((available_round) => (
+            <Box key={available_round.typepath} mb={0.5}>
+              <Tooltip
+                content={available_round.mats_list}
+                position="bottom-start"
+              >
+                <Button
+                  fluid
+                  textAlign="left"
+                  disabled={system_busy}
+                  onClick={() =>
+                    act('FillMagazine', {
+                      selected_type: available_round.typepath,
+                    })
+                  }
+                >
+                  <Box
+                    inline
+                    mr={1}
+                    style={{
+                      width: '0.6rem',
+                      height: '0.6rem',
+                      borderRadius: '50%',
+                      verticalAlign: 'middle',
+                      backgroundColor: available_round.tip_color || '#888780',
+                      boxShadow: `0 0 3px ${available_round.tip_color || '#888780'}`,
+                    }}
+                  />
+                  {available_round.name}
+                </Button>
+              </Tooltip>
+            </Box>
+          ))}
       </Section>
+
       {!!hacked && (
         <NoticeBox textAlign="center" color="bad">
           !WARNING! - ARMADYNE SAFETY PROTOCOLS ARE NOT ENGAGED! MISUSE IS NOT
@@ -159,29 +303,6 @@ export const AmmunitionsTab = (props) => {
         </NoticeBox>
       )}
     </>
-  );
-};
-
-export const MaterialsTab = (props) => {
-  const { act, data } = useBackend();
-  const { materials = [] } = data;
-  return (
-    <Section title="Materials">
-      <Table>
-        {materials.map((material) => (
-          <MaterialRow
-            key={material.id}
-            material={material}
-            onRelease={(amount) =>
-              act('Release', {
-                id: material.id,
-                sheets: amount,
-              })
-            }
-          />
-        ))}
-      </Table>
-    </Section>
   );
 };
 
@@ -197,46 +318,65 @@ export const DatadiskTab = (props) => {
   } = data;
   return (
     <>
-      {!!disk_error && (
-        <NoticeBox textAlign="center" color={disk_error_type}>
-          {disk_error}
-        </NoticeBox>
-      )}
+      <Box height="2.5rem" mb={0.5}>
+        {!!disk_error && (
+          <NoticeBox textAlign="center" color={disk_error_type}>
+            {disk_error}
+          </NoticeBox>
+        )}
+      </Box>
       <Section
         title="Datadisk"
         buttons={
           <>
             <Button
               icon="save"
-              content="Load Disk"
               disabled={!datadisk_loaded}
               onClick={() => act('ReadDisk')}
-            />
+            >
+              Load Disk
+            </Button>
             <Button
               icon="eject"
-              content="Eject"
               disabled={!datadisk_loaded}
               onClick={() => act('EjectDisk')}
-            />
+            >
+              Eject
+            </Button>
           </>
         }
       >
-        {!!datadisk_loaded && (
-          <Box>
-            Inserted Datadisk: {datadisk_name}
-            <Box>Description: {datadisk_desc}</Box>
+        <Box minHeight="3rem">
+          {datadisk_loaded ? (
+            <Box>
+              <Box bold mb={0.5}>
+                {datadisk_name}
+              </Box>
+              <Box color="label">{datadisk_desc}</Box>
+            </Box>
+          ) : (
+            <Flex height="3rem" align="center" justify="center">
+              <Flex.Item color="label" italic>
+                No datadisk inserted.
+              </Flex.Item>
+            </Flex>
+          )}
+        </Box>
+      </Section>
+      <Section title="Installed Recipe Data" mt={1}>
+        {!loaded_datadisks.length && (
+          <Box color="label" italic>
+            No recipe data installed.
           </Box>
         )}
-      </Section>
-      <Section title="Loaded Datadisks">
         <Table>
           {loaded_datadisks.map((loaded_datadisk) => (
-            <Box key={loaded_datadisk.loaded_disk_name}>
-              {loaded_datadisk.loaded_disk_name}
-              <Box textAlign="right">
-                Description: {loaded_datadisk.loaded_disk_desc}
-              </Box>
-            </Box>
+            <Table.Row key={loaded_datadisk.loaded_disk_name} mb={0.5}>
+              <Table.Cell bold>{loaded_datadisk.loaded_disk_name}</Table.Cell>
+              <Table.Cell color="label">
+                {loaded_datadisk.loaded_disk_desc}
+              </Table.Cell>
+            </Table.Row>
           ))}
         </Table>
       </Section>
@@ -244,36 +384,84 @@ export const DatadiskTab = (props) => {
   );
 };
 
-const MaterialRow = (props) => {
-  const { material, onRelease } = props;
-
-  const [amount, setAmount] = useState(1);
-
-  const amountAvailable = Math.floor(material.amount);
+// Four-bar signal-strength gauge (one bar per part tier), lit to `level`.
+const SignalBars = (props) => {
+  const level = props.level || 0;
+  const heights = [4, 7, 10, 13];
   return (
-    <Table.Row>
-      <Table.Cell>{toTitleCase(material.name)}</Table.Cell>
-      <Table.Cell collapsing textAlign="right">
-        <Box mr={2} color="label" inline>
-          {amountAvailable} sheets
-        </Box>
-      </Table.Cell>
-      <Table.Cell collapsing>
-        <NumberInput
-          width="32px"
-          step={1}
-          stepPixelSize={5}
-          minValue={1}
-          maxValue={50}
-          value={amount}
-          onChange={setAmount}
+    <Box inline style={{ whiteSpace: 'nowrap', lineHeight: 0 }}>
+      {heights.map((h, i) => (
+        <Box
+          key={i}
+          inline
+          style={{
+            width: '4px',
+            height: `${h}px`,
+            marginRight: i < 3 ? '2px' : 0,
+            verticalAlign: 'bottom',
+            borderRadius: '1px',
+            backgroundColor:
+              i < level ? '#7bbd2a' : 'rgba(255, 255, 255, 0.15)',
+          }}
         />
-        <Button
-          disabled={amountAvailable < 1}
-          content="Release"
-          onClick={() => onRelease(amount)}
-        />
-      </Table.Cell>
-    </Table.Row>
+      ))}
+    </Box>
+  );
+};
+
+// Capacity gauge: continuous fill with per-round dividers (up to SEGMENT_CAP).
+const SEGMENT_CAP = 40;
+
+const SegmentBar = (props) => {
+  const { current, max, active } = props;
+  const litColor = '#7bbd2a';
+  const frac = max > 0 ? current / max : 0;
+  const bg = 'rgba(255, 255, 255, 0.06)';
+
+  // single animated fill + gap-colored dividers = synced segmented look
+  const showSegments = max > 1 && max <= SEGMENT_CAP;
+  const dividers = [];
+  if (showSegments) {
+    for (let i = 1; i < max; i++) {
+      dividers.push(
+        <Box
+          key={i}
+          style={{
+            position: 'absolute',
+            top: 0,
+            bottom: 0,
+            left: `calc(${(i / max) * 100}% - 1px)`,
+            width: '2px',
+            backgroundColor: '#0b1109',
+          }}
+        />,
+      );
+    }
+  }
+
+  return (
+    <Box
+      style={{
+        position: 'relative',
+        height: '1.25rem',
+        borderRadius: '2px',
+        border: '1px solid rgba(255,255,255,0.15)',
+        overflow: 'hidden',
+        backgroundColor: bg,
+      }}
+    >
+      <Box
+        className={active ? 'AmmoWorkbench__barberpole' : undefined}
+        style={{
+          position: 'absolute',
+          top: 0,
+          bottom: 0,
+          left: 0,
+          width: `${frac * 100}%`,
+          backgroundColor: active ? undefined : litColor,
+        }}
+      />
+      {dividers}
+    </Box>
   );
 };

--- a/tgui/packages/tgui/styles/themes/ammoworkbench.scss
+++ b/tgui/packages/tgui/styles/themes/ammoworkbench.scss
@@ -43,7 +43,9 @@
 
   .AmmoWorkbench__header-icon {
     color: hsl(40, 75%, 52%);
-    font-size: 1.1em;
+    font-size: 1.7em;
+    line-height: 1;
+    vertical-align: middle;
   }
 
   .AmmoWorkbench__header-title {

--- a/tgui/packages/tgui/styles/themes/ammoworkbench.scss
+++ b/tgui/packages/tgui/styles/themes/ammoworkbench.scss
@@ -1,8 +1,6 @@
 /**
  * Ammunitions Workbench theme.
- * A muted, militarized green, deliberately not the fluorescent hackerman green.
- * Desaturated olive/drab palette with dark panels, plus an animated "barber pole"
- * stripe used by the active fabrication/recycle bar.
+ * Militech ass lookin' thing
  */
 
 .theme-ammoworkbench:root {

--- a/tgui/packages/tgui/styles/themes/ammoworkbench.scss
+++ b/tgui/packages/tgui/styles/themes/ammoworkbench.scss
@@ -20,8 +20,7 @@
   --tooltip-background: hsl(96, 30%, 8%);
 }
 
-// Clean dark panel with no manufacturer watermark. This is an Armadyne bench, not Nanotrasen,
-// so the default tgui "N" backdrop doesn't belong here.
+// Clean dark panel with no manufacturer watermark. We need this because the default applies Nanotrasen branding (inappropriate here)
 .theme-ammoworkbench .Layout__content {
   background-image: none;
   background-color: hsl(96, 20%, 9%);
@@ -77,7 +76,7 @@
   }
 }
 
-// Animated diagonal barber-pole, applied to the active fabrication/recycle bar.
+// Animated diagonal barber-pole, applied to the active fabrication/recycle bar. It's here because it looks COOL AS HELL
 @keyframes ammoworkbench-barberpole {
   from {
     background-position: 0 0;

--- a/tgui/packages/tgui/styles/themes/ammoworkbench.scss
+++ b/tgui/packages/tgui/styles/themes/ammoworkbench.scss
@@ -1,8 +1,6 @@
 /**
  * Ammunitions Workbench theme.
- * A muted, militarized green, deliberately not the fluorescent hackerman green.
- * Desaturated olive/drab palette with dark panels, plus an animated "barber pole"
- * stripe used by the active fabrication/recycle bar.
+ * Militech ass lookin' thing
  */
 
 .theme-ammoworkbench:root {
@@ -22,14 +20,14 @@
   --tooltip-background: hsl(96, 30%, 8%);
 }
 
-// Clean dark panel with no manufacturer watermark. This is an Armadyne bench, not Nanotrasen,
-// so the default tgui "N" backdrop doesn't belong here.
+// Clean dark panel with no manufacturer watermark. We need this because the default
+// applies Nanotrasen branding (inappropriate here)
 .theme-ammoworkbench .Layout__content {
   background-image: none;
   background-color: hsl(96, 20%, 9%);
 }
 
-// Armadyne identity header strip.
+// Armadyne header strip
 .theme-ammoworkbench {
   .AmmoWorkbench__header {
     display: flex;
@@ -54,19 +52,13 @@
     color: hsl(88, 40%, 62%);
   }
 
-  .AmmoWorkbench__header-silo {
+  .AmmoWorkbench__header-status {
     margin-left: auto;
     font-size: 0.8em;
     letter-spacing: 1px;
   }
 
-  .AmmoWorkbench__header-status {
-    margin-left: 12px;
-    font-size: 0.8em;
-    letter-spacing: 1px;
-  }
-
-  // Terminal-style section titles: uppercase, spaced, "//" prefix.
+  // terminal section headers
   .Section__titleText {
     text-transform: uppercase;
     letter-spacing: 1px;
@@ -79,7 +71,7 @@
   }
 }
 
-// Animated diagonal barber-pole, applied to the active fabrication/recycle bar.
+// barber-pole animation for the active fabrication/recycle bar
 @keyframes ammoworkbench-barberpole {
   from {
     background-position: 0 0;

--- a/tgui/packages/tgui/styles/themes/ammoworkbench.scss
+++ b/tgui/packages/tgui/styles/themes/ammoworkbench.scss
@@ -54,8 +54,14 @@
     color: hsl(88, 40%, 62%);
   }
 
-  .AmmoWorkbench__header-status {
+  .AmmoWorkbench__header-silo {
     margin-left: auto;
+    font-size: 0.8em;
+    letter-spacing: 1px;
+  }
+
+  .AmmoWorkbench__header-status {
+    margin-left: 12px;
     font-size: 0.8em;
     letter-spacing: 1px;
   }

--- a/tgui/packages/tgui/styles/themes/ammoworkbench.scss
+++ b/tgui/packages/tgui/styles/themes/ammoworkbench.scss
@@ -1,0 +1,94 @@
+/**
+ * Ammunitions Workbench theme.
+ * A muted, militarized green, deliberately not the fluorescent hackerman green.
+ * Desaturated olive/drab palette with dark panels, plus an animated "barber pole"
+ * stripe used by the active fabrication/recycle bar.
+ */
+
+.theme-ammoworkbench:root {
+  // Base
+  --color-base: hsl(96, 18%, 14%);
+  --color-primary: hsl(88, 38%, 42%);
+  --color-secondary: hsl(96, 22%, 20%);
+  --base-gradient-spread: 6;
+
+  // Components
+  --button-background-selected: hsl(88, 40%, 34%);
+  --button-background-caution: hsl(40, 70%, 45%);
+  --button-background-danger: hsl(2, 55%, 42%);
+  --progress-bar-background: hsla(96, 25%, 8%, 0.6);
+  --input-background: hsl(96, 18%, 18%);
+  --input-color: hsl(88, 30%, 70%);
+  --tooltip-background: hsl(96, 30%, 8%);
+}
+
+// Clean dark panel with no manufacturer watermark. This is an Armadyne bench, not Nanotrasen,
+// so the default tgui "N" backdrop doesn't belong here.
+.theme-ammoworkbench .Layout__content {
+  background-image: none;
+  background-color: hsl(96, 20%, 9%);
+}
+
+// Armadyne identity header strip.
+.theme-ammoworkbench {
+  .AmmoWorkbench__header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    background-color: hsl(96, 28%, 11%);
+    border: 1px solid hsl(88, 30%, 26%);
+    border-radius: 2px;
+  }
+
+  .AmmoWorkbench__header-icon {
+    color: hsl(40, 75%, 52%);
+    font-size: 1.1em;
+  }
+
+  .AmmoWorkbench__header-title {
+    font-size: 0.95em;
+    letter-spacing: 2px;
+    color: hsl(88, 40%, 62%);
+  }
+
+  .AmmoWorkbench__header-status {
+    margin-left: auto;
+    font-size: 0.8em;
+    letter-spacing: 1px;
+  }
+
+  // Terminal-style section titles: uppercase, spaced, "//" prefix.
+  .Section__titleText {
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-size: 0.9em;
+
+    &::before {
+      content: '// ';
+      opacity: 0.7;
+    }
+  }
+}
+
+// Animated diagonal barber-pole, applied to the active fabrication/recycle bar.
+@keyframes ammoworkbench-barberpole {
+  from {
+    background-position: 0 0;
+  }
+  to {
+    background-position: 28px 0;
+  }
+}
+
+.AmmoWorkbench__barberpole {
+  background-image: repeating-linear-gradient(
+    -45deg,
+    hsl(88, 42%, 40%) 0,
+    hsl(88, 42%, 40%) 10px,
+    hsl(88, 36%, 32%) 10px,
+    hsl(88, 36%, 32%) 20px
+  );
+  background-size: 28px 28px;
+  animation: ammoworkbench-barberpole 0.8s linear infinite;
+}


### PR DESCRIPTION
## About The Pull Request
The ammunitions workbench is Security's (And some others'!) tool for refilling ammo boxes, magazines and so on. It's one of the pieces of Skyrat kit I actually enjoyed, but it's got some big problems! In its current state it has a number of long-standing faults nobody was doing anything about, a pretty significant one being that it throws a runtime every single time you interact with it. This PR repairs those faults and brings the machine in line with the rest of the station's lathey things.

Fixes:

- **Runtimes on every interaction.** The machine called `default_deconstruction_crowbar()` with the wrong arguments, so inserting anything (a magazine, an ammo box, a datadisk) threw `Cannot read null.tool_behaviour`. That has been fixed.
- **Material handling now matches other lathes.** It previously used a weird old menu. It now uses the standard UI for lathes and shit: workbenches placed on the map connect to the ore silo at roundstart, newly built ones can be linked with a multitool.

Additions:

- **Recycle function.** A loaded container can be emptied back into materials, mirroring the existing recycler/autolathe, etc. This means no more ugly piles of random bullets on the ground! It also has snazzy previews, jokes and shit built into the tooltips/UI. This is a complete overhaul. 
- **Emag support.** Emagging the workbench unlocks its full catalogue, consistent with other restricted fabricators. Wire-cutting remains as an option too. (Basically just instant hacking with no electrocution risk)
- **Prefilled mapping variant.** `/obj/machinery/ammo_workbench/prefilled` spawns with mid-tier parts and a modest local material stock for away missions, ruins, and custom maps, so it works without also placing loose sheets and a datadisk.  I was debating making it spawn with ammo designs already in it. But decided against it.

## Why It's Good For The Game

We inherited this machine from Skyrat, and it sucked, behaves unlike any comparable machine on the station; eye searing green UI. It runtimed on every interaction, and was just generally a roach hotel of bugginess. The recycle function is also something nice I've wanted for a long time, and the prefilled variant should come in handy.  Also a lot of people gave me the "let it connect to the silo" feedback and nobody told me "no" so here we go.

## Proof Of Testing

<img width="931" height="957" alt="image" src="https://github.com/user-attachments/assets/a0fc7acb-30e7-4d54-9e49-7227b86af730" />
<img width="1650" height="1164" alt="image" src="https://github.com/user-attachments/assets/31e8a28b-64bc-4d73-aa48-4b978e122168" />
<img width="913" height="879" alt="image" src="https://github.com/user-attachments/assets/7a2287fd-ee51-42bf-9491-6bbfa7a497cb" />

</details>

## Changelog
:cl:
fix: The ammunitions workbench no longer runtimes every time you interact with it.
qol: The ammunitions workbench now draws from the ore silo like other lathes, and newly built ones can be linked with a multitool.
add: The ammunitions workbench can now recycle a loaded container back into materials.
add: The ammunitions workbench can be emagged to unlock its full catalogue.
/:cl: