### PR TITLE
Headshots in Examine Box

### DIFF
--- a/code/__DEFINES/chat.dm
+++ b/code/__DEFINES/chat.dm
@@ -57,4 +57,4 @@
 /// Helper which creates a chat message which may have a tooltip in some contexts, but not others.
 #define conditional_tooltip(normal_text, tooltip_text, condition) ((condition) ? (span_tooltip(tooltip_text, normal_text)) : (normal_text))
 /// Displays a character headshot in chat examine output.
-#define chat_headshot(str) ("<div class='chat_headshot'><img src='" + str + "' alt='Character headshot' title='Character headshot (hover to expand)'/></div>")
+#define chat_headshot(str) ("<div class='chat_headshot'><img src='" + str + "' alt='Character headshot'/></div>")

--- a/code/__DEFINES/chat.dm
+++ b/code/__DEFINES/chat.dm
@@ -56,3 +56,5 @@
 #define RUNECHAT_BOLD(str) "+[str]+"
 /// Helper which creates a chat message which may have a tooltip in some contexts, but not others.
 #define conditional_tooltip(normal_text, tooltip_text, condition) ((condition) ? (span_tooltip(tooltip_text, normal_text)) : (normal_text))
+/// Displays a character headshot in chat examine output.
+#define chat_headshot(str) ("<div class='chat_headshot'><img src='" + str + "' alt='Character headshot' title='Character headshot (hover to expand)'/></div>")

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -302,6 +302,9 @@
 						break
 
 	var/flavor_text_link = get_flavor_text()
+	var/chat_headshot_line = get_chat_examine_headshot(user)
+	if(chat_headshot_line)
+		. += chat_headshot_line
 	if(flavor_text_link)
 		. += flavor_text_link
 

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -302,9 +302,6 @@
 						break
 
 	var/flavor_text_link = get_flavor_text()
-	var/chat_headshot_line = get_chat_examine_headshot(user)
-	if(chat_headshot_line)
-		. += chat_headshot_line
 	if(flavor_text_link)
 		. += flavor_text_link
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -620,6 +620,7 @@
 	if(!result_combined)
 		var/list/result = examinify.examine(src)
 		var/atom_title = examinify.examine_title(src, thats = TRUE)
+		var/examine_headshot_top = examinify.get_chat_examine_headshot_top(src)
 		examining(examinify, result)
 		var/alist/overrides = alist()
 		SEND_SIGNAL(src, COMSIG_MOB_EXAMINING, examinify, result, overrides)
@@ -627,7 +628,12 @@
 			result = overrides[max(overrides)]
 		if(removes_double_click)
 			result += span_notice("<i>You can <a href=byond://?src=[REF(src)];run_examinate=[REF(examinify)]>examine</a> [examinify] closer...</i>")
-		result_combined = (atom_title ? fieldset_block("[atom_title].", jointext(result, "<br>"), "boxed_message") : boxed_message(jointext(result, "<br>")))
+		if(atom_title)
+			result_combined = fieldset_block("[atom_title].", jointext(result, "<br>"), "boxed_message")
+			if(examine_headshot_top)
+				result_combined = "[examine_headshot_top][result_combined]"
+		else
+			result_combined = boxed_message(jointext(result, "<br>"))
 		result_combined = replacetext(result_combined, "<hr><br>", "<hr>") // BUBBER EDIT ADDITION - bit of a hack here to make sure we don't get linebreaks coming after headers, as well as properly adding the examine_block
 
 	to_chat(src, span_infoplain(result_combined))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -620,7 +620,7 @@
 	if(!result_combined)
 		var/list/result = examinify.examine(src)
 		var/atom_title = examinify.examine_title(src, thats = TRUE)
-		var/examine_headshot_top = examinify.get_chat_examine_headshot_top(src)
+		var/examine_headshot = examinify.get_chat_examine_headshot(src)
 		examining(examinify, result)
 		var/alist/overrides = alist()
 		SEND_SIGNAL(src, COMSIG_MOB_EXAMINING, examinify, result, overrides)
@@ -628,10 +628,10 @@
 			result = overrides[max(overrides)]
 		if(removes_double_click)
 			result += span_notice("<i>You can <a href=byond://?src=[REF(src)];run_examinate=[REF(examinify)]>examine</a> [examinify] closer...</i>")
+		if(examine_headshot)
+			result.Insert(1, examine_headshot)
 		if(atom_title)
 			result_combined = fieldset_block("[atom_title].", jointext(result, "<br>"), "boxed_message")
-			if(examine_headshot_top)
-				result_combined = "[examine_headshot_top][result_combined]"
 		else
 			result_combined = boxed_message(jointext(result, "<br>"))
 		result_combined = replacetext(result_combined, "<hr><br>", "<hr>") // BUBBER EDIT ADDITION - bit of a hack here to make sure we don't get linebreaks coming after headers, as well as properly adding the examine_block

--- a/modular_zubbers/code/modules/mob/living/carbon/examine.dm
+++ b/modular_zubbers/code/modules/mob/living/carbon/examine.dm
@@ -19,10 +19,10 @@
 		flavor_text_link = span_notice("<a href='byond://?src=[REF(src)];lookup_info=open_examine_panel'>\[Examine closely...\]</a>")
 	return flavor_text_link
 
-/mob/living/carbon/proc/get_chat_examine_headshot(mob/user)
+/atom/proc/get_chat_examine_headshot_top(mob/user)
 	return null
 
-/mob/living/carbon/human/get_chat_examine_headshot(mob/user)
+/mob/living/carbon/human/get_chat_examine_headshot_top(mob/user)
 	if(!user?.client)
 		return null
 	if(!user.client.prefs?.read_preference(/datum/preference/toggle/chat_examine_headshot))
@@ -37,7 +37,7 @@
 	if(face_obscured && !isobserver(user))
 		return null
 
-	return "<div class='chat_headshot_wrap'><span class='chat_headshot_label'>Headshot</span>[chat_headshot(html_encode(headshot))]</div>"
+	return "<div class='chat_headshot_top'>[chat_headshot(html_encode(headshot))]</div>"
 
 
 /mob/living/carbon/alien/get_flavor_text()

--- a/modular_zubbers/code/modules/mob/living/carbon/examine.dm
+++ b/modular_zubbers/code/modules/mob/living/carbon/examine.dm
@@ -29,6 +29,10 @@
 	if(!user.client.prefs?.read_preference(/datum/preference/toggle/chat_examine_headshot))
 		return null
 
+	var/is_unidentified = is_face_obscured() && !length(get_id_name(""))
+	if(is_unidentified)
+		return null
+
 	var/headshot = dna?.features?["headshot"]
 	if(!length(headshot))
 		return null
@@ -38,7 +42,7 @@
 	if(face_obscured && !isobserver(user))
 		return null
 
-	return "<div class='chat_headshot_top'>[chat_headshot(html_encode(headshot))]</div>"
+	return "<div class='chat_headshot_top chat_headshot_frame'>[chat_headshot(html_encode(headshot))]</div>"
 
 
 /mob/living/carbon/alien/get_flavor_text()

--- a/modular_zubbers/code/modules/mob/living/carbon/examine.dm
+++ b/modular_zubbers/code/modules/mob/living/carbon/examine.dm
@@ -19,6 +19,26 @@
 		flavor_text_link = span_notice("<a href='byond://?src=[REF(src)];lookup_info=open_examine_panel'>\[Examine closely...\]</a>")
 	return flavor_text_link
 
+/mob/living/carbon/proc/get_chat_examine_headshot(mob/user)
+	return null
+
+/mob/living/carbon/human/get_chat_examine_headshot(mob/user)
+	if(!user?.client)
+		return null
+	if(!user.client.prefs?.read_preference(/datum/preference/toggle/chat_examine_headshot))
+		return null
+
+	var/headshot = dna?.features?["headshot"]
+	if(!length(headshot))
+		return null
+
+	var/obscurity_examine_pref = client?.prefs?.read_preference(/datum/preference/toggle/obscurity_examine)
+	var/face_obscured = (covered_slots & HIDEFACE) && obscurity_examine_pref
+	if(face_obscured && !isobserver(user))
+		return null
+
+	return "<div class='chat_headshot_wrap'><span class='chat_headshot_label'>Headshot</span>[chat_headshot(html_encode(headshot))]</div>"
+
 
 /mob/living/carbon/alien/get_flavor_text()
 	return desc

--- a/modular_zubbers/code/modules/mob/living/carbon/examine.dm
+++ b/modular_zubbers/code/modules/mob/living/carbon/examine.dm
@@ -19,10 +19,11 @@
 		flavor_text_link = span_notice("<a href='byond://?src=[REF(src)];lookup_info=open_examine_panel'>\[Examine closely...\]</a>")
 	return flavor_text_link
 
-/atom/proc/get_chat_examine_headshot_top(mob/user)
+
+/atom/proc/get_chat_examine_headshot(mob/user)
 	return null
 
-/mob/living/carbon/human/get_chat_examine_headshot_top(mob/user)
+/mob/living/carbon/human/get_chat_examine_headshot(mob/user)
 	if(!user?.client)
 		return null
 	if(!user.client.prefs?.read_preference(/datum/preference/toggle/chat_examine_headshot))

--- a/modular_zubbers/master_files/code/modules/client/preferences/chat_examine_headshot.dm
+++ b/modular_zubbers/master_files/code/modules/client/preferences/chat_examine_headshot.dm
@@ -1,0 +1,5 @@
+/datum/preference/toggle/chat_examine_headshot
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "chat_examine_headshot"
+	savefile_identifier = PREFERENCE_PLAYER
+	default_value = TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10189,6 +10189,7 @@
 #include "modular_zubbers\master_files\code\game\objects\effects\spawners\random\decoration.dm"
 #include "modular_zubbers\master_files\code\modules\awaymissions\chamenos.dm"
 #include "modular_zubbers\master_files\code\modules\awaymissions\zlevelmaintsroom.dm"
+#include "modular_zubbers\master_files\code\modules\client\preferences\chat_examine_headshot.dm"
 #include "modular_zubbers\master_files\code\modules\client\preferences\hypnopref.dm"
 #include "modular_zubbers\master_files\code\modules\client\preferences\obscurity_examine.dm"
 #include "modular_zubbers\master_files\code\modules\client\preferences\scaling_method.dm"

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -1097,6 +1097,44 @@ em {
   flex-grow: 1;
 }
 
+.chat_headshot {
+  position: relative;
+  width: min(100px, 100%);
+  height: min(100px, 100%);
+  max-width: 100px;
+  max-height: 100px;
+  display: inline-block;
+  overflow: visible;
+}
+
+.chat_headshot img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  transition: transform 0.35s ease;
+  transform-origin: top left;
+  will-change: transform;
+}
+
+.chat_headshot:hover img {
+  transform: translateX(-12%) scale(2.5);
+  z-index: 100;
+  border-radius: 2px;
+}
+
+.chat_headshot_wrap {
+  display: inline-flex;
+  flex-direction: column;
+  gap: var(--space-xxs);
+  margin: var(--space-xxs) 0;
+}
+
+.chat_headshot_label {
+  color: hsl(220, 20%, 70%);
+  font-size: 0.8em;
+  letter-spacing: 0.02em;
+}
+
 $alert-stripe-colors: (
   'default': hsl(198.6, 100%, 11.4%),
   'green': hsl(120, 100%, 12%),

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -1122,17 +1122,8 @@ em {
   border-radius: 2px;
 }
 
-.chat_headshot_wrap {
-  display: inline-flex;
-  flex-direction: column;
-  gap: var(--space-xxs);
-  margin: var(--space-xxs) 0;
-}
-
-.chat_headshot_label {
-  color: hsl(220, 20%, 70%);
-  font-size: 0.8em;
-  letter-spacing: 0.02em;
+.chat_headshot_top {
+  margin: var(--space-xs) 0;
 }
 
 $alert-stripe-colors: (

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -1126,6 +1126,17 @@ em {
   margin: var(--space-xs) 0;
 }
 
+.chat_headshot_frame {
+  display: inline-flex;
+  padding: var(--space-xs);
+  background: hsl(220, 10%, 10%);
+  border: var(--border-thickness-tiny) solid;
+  border-left: var(--border-thickness-large) solid;
+  border-color: hsla(220, 40%, 75%, 0.25);
+  border-radius: var(--border-radius-medium);
+  overflow: visible;
+}
+
 $alert-stripe-colors: (
   'default': hsl(198.6, 100%, 11.4%),
   'green': hsl(120, 100%, 12%),

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -1103,17 +1103,8 @@ h2.alert {
   border-radius: 2px;
 }
 
-.chat_headshot_wrap {
-  display: inline-flex;
-  flex-direction: column;
-  gap: 2px;
-  margin: 2px 0;
-}
-
-.chat_headshot_label {
-  color: hsl(220, 35%, 35%);
-  font-size: 0.8em;
-  letter-spacing: 0.02em;
+.chat_headshot_top {
+  margin: 4px 0;
 }
 
 $alert-stripe-colors: (

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -1078,6 +1078,44 @@ h2.alert {
   flex-grow: 1;
 }
 
+.chat_headshot {
+  position: relative;
+  width: min(100px, 100%);
+  height: min(100px, 100%);
+  max-width: 100px;
+  max-height: 100px;
+  display: inline-block;
+  overflow: visible;
+}
+
+.chat_headshot img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  transition: transform 0.35s ease;
+  transform-origin: top left;
+  will-change: transform;
+}
+
+.chat_headshot:hover img {
+  transform: translateX(-12%) scale(2.5);
+  z-index: 100;
+  border-radius: 2px;
+}
+
+.chat_headshot_wrap {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 2px;
+  margin: 2px 0;
+}
+
+.chat_headshot_label {
+  color: hsl(220, 35%, 35%);
+  font-size: 0.8em;
+  letter-spacing: 0.02em;
+}
+
 $alert-stripe-colors: (
   'default': hsl(230.5, 100%, 85.1%),
   'green': hsl(120, 100%, 83.9%),

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -1107,6 +1107,17 @@ h2.alert {
   margin: 4px 0;
 }
 
+.chat_headshot_frame {
+  display: inline-flex;
+  padding: 4px;
+  background: hsl(220, 100%, 97.5%);
+  border: 1px solid;
+  border-left: 4px solid;
+  border-color: hsla(220, 75%, 25%, 0.5);
+  border-radius: 4px;
+  overflow: visible;
+}
+
 $alert-stripe-colors: (
   'default': hsl(230.5, 100%, 85.1%),
   'green': hsl(120, 100%, 83.9%),

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/bubber/chat_examine_headshot.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/bubber/chat_examine_headshot.tsx
@@ -1,0 +1,8 @@
+import { CheckboxInput, type FeatureToggle } from '../../base';
+
+export const chat_examine_headshot: FeatureToggle = {
+  name: 'Examine chat headshots',
+  category: 'GAMEPLAY',
+  description: 'Shows character headshots in examine chat when available.',
+  component: CheckboxInput,
+};


### PR DESCRIPTION

## About The Pull Request

I've been a player on Roguetown for a while, and a small thing I noticed I missed a lot was the feature of displaying character headshots in the examine text. As such, i've ported this in a fairly straightforward way from Ratwood Keep. 

The headshot will grow bigger on mouseover and shrink again when the mouse moves away. 

Headshots will be always hidden for someone who has an unknown identity (masked and without standard ID).

There is an option toggle to not view chat headshots, should you prefer to not see them.
## Why It's Good For The Game

Improves immersion, making it much quicker to see someone's headshot in a situation instead of needing to examine them closer.

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="565" height="400" alt="image" src="https://github.com/user-attachments/assets/1b1df66e-63ac-4e8d-be2d-36bcd3461724" />
<img width="593" height="393" alt="image" src="https://github.com/user-attachments/assets/abd355e7-969b-42af-8eff-ded9acc1d52a" />
<img width="660" height="137" alt="image" src="https://github.com/user-attachments/assets/5e890a80-f1a4-453a-8cbf-c96ea6ff0ace" />
<img width="613" height="293" alt="image" src="https://github.com/user-attachments/assets/6024f190-4a1c-4daf-a6b5-d1ba0705c65c" />

</details>

## Changelog
:cl:
add: Headshots now display in examine chat box. A toggle is added to options to disable this if you so desire.
/:cl:
