### PR TITLE
Revenants can change their name [OCULIS PORT]

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/revenant/_revenant.dm
+++ b/code/modules/mob/living/basic/space_fauna/revenant/_revenant.dm
@@ -113,6 +113,7 @@
 		SIGNAL_REMOVETRAIT(TRAIT_NO_TRANSFORM),
 	), PROC_REF(update_revenant_appearance))
 	name = generate_random_mob_name()
+	real_name = name // BUBBER EDIT - ADDITION
 
 	GLOB.revenant_relay_mobs |= src
 

--- a/modular_zubbers/code/modules/mob/living/basic/space_fauna/revenant/revenant_antag.dm
+++ b/modular_zubbers/code/modules/mob/living/basic/space_fauna/revenant/revenant_antag.dm
@@ -1,0 +1,27 @@
+// revenant antag datum is given on login, so this should be fine
+/datum/antagonist/revenant/on_gain()
+	. = ..()
+	INVOKE_ASYNC(src, PROC_REF(pick_name), owner.current)
+
+/datum/antagonist/revenant/proc/pick_name(mob/living/basic/revenant/revenant)
+	if(!istype(revenant))
+		CRASH("Somehow a non-revenant got a revenant antag datum?")
+	while(revenant?.client)
+		var/new_name = reject_bad_text(tgui_input_text(revenant, "Would you like to change your ghostly name to something else?", "Spooky Identity", revenant.name, MAX_NAME_LEN, encode = FALSE))
+		if(!new_name || new_name == revenant.name)
+			if(tgui_alert(revenant, "Are you sure you would like to keep your default name of \"[revenant.name]\"?", "Spooky Identity", list("Yes", "No")) == "Yes")
+				return
+			else
+				continue
+		new_name = sanitize_name(new_name, allow_numbers = TRUE)
+		if(!new_name)
+			if(tgui_alert(revenant, "Invalid name, please pick another!", "Spooky Identity", list("Try Again", "Keep Default Name")) == "Try Again")
+				continue
+			else
+				return
+
+		revenant.log_message("set their revenant name to [new_name]", LOG_OWNERSHIP)
+		message_admins("[ADMIN_LOOKUPFLW(revenant)] has changed their revenant name to \"[span_name(new_name)]\"")
+		revenant.fully_replace_character_name(null, new_name)
+		to_chat(revenant, span_revennotice("Your name is now \"[span_name(new_name)]\"."), type = MESSAGE_TYPE_INFO)
+		return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9747,6 +9747,7 @@
 #include "modular_zubbers\code\modules\mob\living\basic\space_fauna\carp.dm"
 #include "modular_zubbers\code\modules\mob\living\basic\space_fauna\dolphin.dm"
 #include "modular_zubbers\code\modules\mob\living\basic\space_fauna\dolphin_ai.dm"
+#include "modular_zubbers\code\modules\mob\living\basic\space_fauna\revenant\revenant_antag.dm"
 #include "modular_zubbers\code\modules\mob\living\basic\space_fauna\space_dragon\space_dragon.dm"
 #include "modular_zubbers\code\modules\mob\living\basic\trooper\nanotrasen.dm"
 #include "modular_zubbers\code\modules\mob\living\basic\trooper\syndicate.dm"


### PR DESCRIPTION

## About The Pull Request
**PORT OF https://github.com/Monkestation/OculisStation/pull/129.**

Allows revenants to choose their own name or use the default name.
## Why It's Good For The Game
This allows for more roleplay opportunities as you can now run with a potential gimmick without needing admin intervention. There is also precedent with antagonists being able to rename themselves due to Space Dragon.
## Proof Of Testing
See below.
<details>
<summary>Screenshots/Videos</summary>

https://github.com/user-attachments/assets/0b0c73c0-d9a8-4ffd-bc43-f34df5eccde7

<img width="650" height="116" alt="Ghouling Spirit" src="https://github.com/user-attachments/assets/a4459720-0c8d-43c0-9ddf-95342e32be40" />

<img width="648" height="63" alt="That&#39;s Ghouling Spirit" src="https://github.com/user-attachments/assets/0c2e2d51-8ff1-4002-9407-75aa44fe4c73" />

</details>

## Changelog
:cl: Absolucy
add: Revenants can now rename themselves.
/:cl:
