### PR TITLE
Allows CSL to work with every species

### DIFF
--- a/code/modules/unit_tests/language_transfer.dm
+++ b/code/modules/unit_tests/language_transfer.dm
@@ -11,10 +11,11 @@
 	var/list/initial_spoken = holder.spoken_languages.Copy()
 	var/list/initial_understood = holder.understood_languages.Copy()
 
-	TEST_ASSERT(length(initial_spoken) == 2, \ // BUBBER EDIT - CHANGE - PREVIOUS: 1
-		"Dummy should only speak two languages! Instead, it knew the following: [print_language_list(initial_spoken)]") // BUBBER EDIT - CHANGE - ONE -> TWO LANGUAGEs
-	TEST_ASSERT(length(initial_understood) == 2, \ // BUBBER EDIT - CHANGE - PREVIOUS: 1
-		"Dummy should only understand two languages! Instead, it knew the following: [print_language_list(initial_understood)]") // BUBBER EDIT - CHANGE - ONE -> TWO LANGUAGEs
+	// BUBBER EDIT - CHANGE - 1 -> 2
+	TEST_ASSERT(length(initial_spoken) == 2, \
+		"Dummy should only speak two languages! Instead, it knew the following: [print_language_list(initial_spoken)]")
+	TEST_ASSERT(length(initial_understood) == 2, \
+		"Dummy should only understand two languages! Instead, it knew the following: [print_language_list(initial_understood)]")
 
 	dummy.set_species(/datum/species/lizard)
 
@@ -26,11 +27,13 @@
 
 	dummy.set_species(/datum/species/human)
 
-	TEST_ASSERT(length(initial_spoken & holder.spoken_languages) == 2, \ // BUBBER EDIT - CHANGE - PREVIOUS: 1
-		"Dummy did not speak Common and Uncommon after returning to human! Instead, it knew the following: [print_language_list(holder.spoken_languages)]") // BUBBER EDIT - CHANGE - ADDS UNCOMMON
+	// BUBBER EDIT - CHANGE - 1 -> 2 && ADDS UNCOMMON
+	TEST_ASSERT(length(initial_spoken & holder.spoken_languages) == 2, \
+		"Dummy did not speak Common and Uncommon after returning to human! Instead, it knew the following: [print_language_list(holder.spoken_languages)]")
 
-	TEST_ASSERT(length(initial_understood & holder.understood_languages) == 2, \ // BUBBER EDIT - CHANGE - PREVIOUS: 1
-		"Dummy did not understand Common and Uncommon after returning to human! Instead, it knew the following: [print_language_list(holder.understood_languages)]") // BUBBER EDIT - CHANGE - ADDS UNCOMMON
+		// BUBBER EDIT - CHANGE - 1 -> 2 && ADDS UNCOMMON
+	TEST_ASSERT(length(initial_understood & holder.understood_languages) == 2, \
+		"Dummy did not understand Common and Uncommon after returning to human! Instead, it knew the following: [print_language_list(holder.understood_languages)]")
 
 /// Tests species changes which are more complex are functional (e.g. from a species which speaks common to one which does not)
 /datum/unit_test/language_species_swap_complex

--- a/code/modules/unit_tests/language_transfer.dm
+++ b/code/modules/unit_tests/language_transfer.dm
@@ -11,10 +11,10 @@
 	var/list/initial_spoken = holder.spoken_languages.Copy()
 	var/list/initial_understood = holder.understood_languages.Copy()
 
-	TEST_ASSERT(length(initial_spoken) == 1, \
-		"Dummy should only speak one language! Instead, it knew the following: [print_language_list(initial_spoken)]")
-	TEST_ASSERT(length(initial_understood) == 1, \
-		"Dummy should only understand one language! Instead, it knew the following: [print_language_list(initial_understood)]")
+	TEST_ASSERT(length(initial_spoken) == 2, \ // BUBBER EDIT - CHANGE - PREVIOUS: 1
+		"Dummy should only speak two languages! Instead, it knew the following: [print_language_list(initial_spoken)]") // BUBBER EDIT - CHANGE - ONE -> TWO LANGUAGEs
+	TEST_ASSERT(length(initial_understood) == 2, \ // BUBBER EDIT - CHANGE - PREVIOUS: 1
+		"Dummy should only understand two languages! Instead, it knew the following: [print_language_list(initial_understood)]") // BUBBER EDIT - CHANGE - ONE -> TWO LANGUAGEs
 
 	dummy.set_species(/datum/species/lizard)
 
@@ -26,11 +26,11 @@
 
 	dummy.set_species(/datum/species/human)
 
-	TEST_ASSERT(length(initial_spoken & holder.spoken_languages) == 1, \
-		"Dummy did not speak Common after returning to human! Instead, it knew the following: [print_language_list(holder.spoken_languages)]")
+	TEST_ASSERT(length(initial_spoken & holder.spoken_languages) == 2, \ // BUBBER EDIT - CHANGE - PREVIOUS: 1
+		"Dummy did not speak Common and Uncommon after returning to human! Instead, it knew the following: [print_language_list(holder.spoken_languages)]") // BUBBER EDIT - CHANGE - ADDS UNCOMMON
 
-	TEST_ASSERT(length(initial_understood & holder.understood_languages) == 1, \
-		"Dummy did not understand Common after returning to human! Instead, it knew the following: [print_language_list(holder.understood_languages)]")
+	TEST_ASSERT(length(initial_understood & holder.understood_languages) == 2, \ // BUBBER EDIT - CHANGE - PREVIOUS: 1
+		"Dummy did not understand Common and Uncommon after returning to human! Instead, it knew the following: [print_language_list(holder.understood_languages)]") // BUBBER EDIT - CHANGE - ADDS UNCOMMON
 
 /// Tests species changes which are more complex are functional (e.g. from a species which speaks common to one which does not)
 /datum/unit_test/language_species_swap_complex

--- a/code/modules/unit_tests/language_transfer.dm
+++ b/code/modules/unit_tests/language_transfer.dm
@@ -162,12 +162,14 @@
 		"Holder A / Dummy A / Dummy B mind should only understand Common, Draconic, and Pirate! \
 		Instead, it knew the following: [print_language_list(holder_A.understood_languages)]")
 
-	TEST_ASSERT_EQUAL(length(holder_B.spoken_languages), 1, \
-		"Holder B / Dummy B / Dummy A mind should only speak 1 language - Common! \
+	// BUBBER EDIT - CHANGE: 1 -> 2
+	TEST_ASSERT_EQUAL(length(holder_B.spoken_languages), 2, \
+		"Holder B / Dummy B / Dummy A mind should only speak 2 languages - Common and Terran Uncommon! \
 		Instead, it knew the following: [print_language_list(holder_B.spoken_languages)]")
 
-	TEST_ASSERT_EQUAL(length(holder_B.understood_languages), 1, \
-		"Holder B / Dummy B / Dummy A mind only understand 1 language - Common! \
+	// BUBBER EDIT - CHANGE: 1 -> 2
+	TEST_ASSERT_EQUAL(length(holder_B.understood_languages), 2, \
+		"Holder B / Dummy B / Dummy A mind only understands 2 language - Common and Terran Uncommon! \
 		Instead, it knew the following: [print_language_list(holder_B.understood_languages)]")
 
 /// Tests that the book of babel, and by extension grant_all_languages, works as intended

--- a/modular_zubbers/code/modules/languages/_language_holder.dm
+++ b/modular_zubbers/code/modules/languages/_language_holder.dm
@@ -28,3 +28,15 @@
 		/datum/language/spinwarder = list(LANGUAGE_ATOM),
 	)
 	selected_language = /datum/language/spinwarder
+
+// Allows all species(?) to work with Common Second Language.
+/datum/language_holder/human_basic/New()
+	. = ..()
+	understood_languages |= list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/uncommon = list(LANGUAGE_ATOM),
+	)
+	spoken_languages |= list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/uncommon = list(LANGUAGE_ATOM),
+	)


### PR DESCRIPTION

## About The Pull Request
This PR (inspired by https://github.com/NovaSector/NovaSector/pull/6278, but reworked) allows every species to be able to select the Common Second Language quirk.

This also allows you to use any language you select as your second language (I'm not sure if that was already a thing, but if not, you can do it now).

When using the CSL quirk you MUST have at least two languages selected, or you will be UNABLE TO SPEAK.
## Why It's Good For The Game
More people can take a quirk.
## Proof Of Testing
This was on a ghoul. Ghouls used to be unable to take the quirk at all.
<img width="648" height="137" alt="image" src="https://github.com/user-attachments/assets/e5540b3e-87f7-48d8-ab93-51dd5aac82a5" />
## Changelog
:cl:
add: Humans, and everyone that uses human_basic for a language will now speak uncommon by default. This can still be removed in the language menu.
fix: Common Second Language (CSL) now works with every species. Make sure you have two languages selected for the quirk to work!
/:cl:
