### PR TITLE
Fixes the boulder refinery on our maps

### DIFF
--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -109898,7 +109898,8 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 9
 	},
-/obj/machinery/conveyor/inverted{
+/obj/machinery/conveyor{
+	dir = 1;
 	id = "brm_belt"
 	},
 /turf/open/floor/iron/smooth_edge,

--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -7493,17 +7493,11 @@
 /turf/open/floor/wood,
 /area/station/service/electronic_marketing_den)
 "bxP" = (
-/obj/structure/table,
-/obj/item/reagent_containers/cup/glass/bottle/beer{
-	pixel_x = 6;
-	pixel_y = 16
-	},
-/obj/item/cigarette{
-	pixel_y = 4
-	},
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/small,
 /area/station/cargo/miningdock)
 "bxS" = (
@@ -35049,14 +35043,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/upper)
-"gHB" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/maintenance/three,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 9
-	},
-/turf/open/floor/iron/dark/small,
-/area/station/cargo/miningdock)
 "gHC" = (
 /obj/machinery/flasher/directional/east{
 	id = "AI";
@@ -37087,7 +37073,11 @@
 /turf/closed/wall,
 /area/station/maintenance/clown_chamber)
 "hcm" = (
-/obj/machinery/conveyor_switch/oneway{
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 10
+	},
+/obj/machinery/conveyor/inverted{
+	dir = 6;
 	id = "brm_belt"
 	},
 /turf/open/floor/iron/smooth,
@@ -38856,9 +38846,11 @@
 	dir = 5
 	},
 /obj/machinery/light/directional/west,
-/obj/structure/closet/crate,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
+/obj/structure/chair/plastic{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/small,
 /area/station/cargo/miningdock)
 "htK" = (
@@ -51994,10 +51986,15 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 6
 	},
-/obj/structure/chair/plastic{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/structure/table,
+/obj/item/cigarette{
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/cup/glass/bottle/beer{
+	pixel_x = 6;
+	pixel_y = 16
+	},
 /turf/open/floor/iron/dark/small,
 /area/station/cargo/miningdock)
 "jUx" = (
@@ -61448,8 +61445,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "lKL" = (
-/obj/structure/closet/crate/secure/loot,
 /obj/effect/turf_decal/stripes/white/line,
+/obj/machinery/conveyor_switch/oneway{
+	id = "brm_belt"
+	},
 /turf/open/floor/iron/dark/small,
 /area/station/cargo/miningdock)
 "lKM" = (
@@ -72406,11 +72405,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/upper)
 "nSH" = (
-/obj/structure/chair/plastic{
-	dir = 8
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "brm_belt"
 	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 10
+/obj/machinery/bouldertech/refinery/smelter{
+	dir = 4
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/cargo/miningdock)
@@ -81508,7 +81508,7 @@
 	dir = 8;
 	id = "brm_belt"
 	},
-/turf/open/floor/iron/smooth,
+/turf/open/floor/iron/dark/small,
 /area/station/cargo/miningdock)
 "pEo" = (
 /obj/effect/turf_decal/tile/brown{
@@ -104075,14 +104075,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/hfr_room)
-"tPP" = (
-/obj/machinery/bouldertech/refinery,
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "brm_belt"
-	},
-/turf/open/floor/iron/smooth_edge,
-/area/station/cargo/miningdock)
 "tPS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -108409,12 +108401,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/upper)
 "uGt" = (
-/obj/machinery/bouldertech/refinery/smelter,
 /obj/machinery/conveyor{
-	dir = 9;
+	dir = 8;
 	id = "brm_belt"
 	},
-/turf/open/floor/iron/smooth,
+/obj/machinery/bouldertech/refinery{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/small,
 /area/station/cargo/miningdock)
 "uGz" = (
 /obj/item/stack/sheet/cardboard,
@@ -109900,8 +109894,11 @@
 /turf/closed/wall/r_wall,
 /area/station/science)
 "uWF" = (
-/obj/machinery/conveyor{
-	dir = 8;
+/obj/machinery/brm,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 9
+	},
+/obj/machinery/conveyor/inverted{
 	id = "brm_belt"
 	},
 /turf/open/floor/iron/smooth_edge,
@@ -115422,14 +115419,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
-"vYp" = (
-/obj/machinery/brm,
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "brm_belt"
-	},
-/turf/open/floor/iron/smooth_edge,
-/area/station/cargo/miningdock)
 "vYq" = (
 /obj/machinery/light/small/broken/directional/north,
 /turf/open/floor/iron,
@@ -169044,7 +169033,7 @@ ryA
 mYd
 txY
 nSH
-gHB
+jvp
 bti
 kyD
 pEc
@@ -169300,8 +169289,8 @@ ktY
 djJ
 djJ
 txY
-ktY
-uGt
+pEj
+jvp
 kgv
 kyD
 pEc
@@ -169557,8 +169546,8 @@ ktY
 vHy
 bvN
 txY
-ktY
-pEj
+uGt
+djJ
 sZm
 wYj
 pEc
@@ -170072,7 +170061,7 @@ gvD
 qFW
 kOB
 ktY
-tPP
+mMw
 bti
 kyD
 pEc
@@ -170329,7 +170318,7 @@ jVB
 tnT
 cLb
 wWq
-uWF
+mMw
 kgv
 kyD
 pEc
@@ -170586,7 +170575,7 @@ gbS
 gbS
 wvZ
 gEY
-vYp
+mMw
 leG
 kyD
 pEc

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -1830,13 +1830,12 @@
 /area/station/construction/mining/aux_base)
 "aoC" = (
 /obj/machinery/light_switch/directional/north,
-/obj/effect/turf_decal/tile/purple/opposingcorners{
-	dir = 1
+/obj/structure/closet/secure_closet/miner,
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/textured_large,
 /area/station/cargo/miningdock)
 "aoE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -4498,6 +4497,7 @@
 /obj/structure/table,
 /obj/item/stack/arcadeticket,
 /obj/item/stack/arcadeticket,
+/obj/item/coin/antagtoken,
 /turf/open/floor/eighties,
 /area/station/maintenance/abandon_arcade)
 "aBW" = (
@@ -16207,6 +16207,8 @@
 /obj/effect/landmark/blobstart,
 /obj/structure/chair/office/light,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/north,
+/obj/structure/sign/poster/contraband/pwr_game/directional/north,
 /turf/open/floor/wood,
 /area/station/maintenance/abandon_arcade)
 "bGr" = (
@@ -16514,17 +16516,12 @@
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "bHC" = (
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/head/collectable/kitty,
-/obj/machinery/light/small/directional/north,
-/obj/structure/sign/poster/contraband/pwr_game/directional/north,
-/turf/open/floor/wood,
-/area/station/maintenance/abandon_arcade)
+/turf/open/floor/iron/textured,
+/area/station/cargo/miningdock)
 "bHD" = (
-/obj/structure/table/wood,
-/obj/item/modular_computer/laptop/preset/civilian,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/displaycase/noalert{
+	start_showpiece_type = /obj/item/clothing/suit/costume/wellworn_shirt/messy/graphic/gamer
+	},
 /turf/open/floor/wood,
 /area/station/maintenance/abandon_arcade)
 "bHE" = (
@@ -26097,6 +26094,16 @@
 /obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"cRe" = (
+/obj/machinery/bouldertech/refinery{
+	dir = 4
+	},
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mining"
+	},
+/turf/open/floor/iron/textured_large,
+/area/station/cargo/miningdock)
 "cRh" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
@@ -27999,12 +28006,11 @@
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/burnchamber)
 "dym" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "boulderbelt"
-	},
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron/textured_large,
+/obj/machinery/conveyor{
+	id = "mining"
+	},
+/turf/open/floor/iron/textured,
 /area/station/cargo/miningdock)
 "dyA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -29193,9 +29199,7 @@
 /obj/machinery/light/directional/west,
 /obj/structure/closet/wardrobe/miner,
 /obj/machinery/wall_healer/directional/north,
-/obj/effect/turf_decal/siding/thinplating_new{
-	dir = 4
-	},
+/obj/effect/turf_decal/siding/thinplating_new/corner,
 /turf/open/floor/iron/textured_large,
 /area/station/cargo/miningdock)
 "dVI" = (
@@ -29271,6 +29275,18 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"dYy" = (
+/obj/machinery/conveyor_switch/oneway{
+	dir = 1;
+	id = "mining";
+	pixel_y = 10
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/iron/textured,
+/area/station/cargo/miningdock)
 "dYJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light_switch/directional/west,
@@ -35692,9 +35708,6 @@
 /turf/open/floor/grass,
 /area/station/security/prison)
 "gym" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
@@ -37917,8 +37930,8 @@
 /area/station/security/brig)
 "hna" = (
 /obj/machinery/conveyor{
-	dir = 4;
-	id = "boulderbelt"
+	dir = 8;
+	id = "mining"
 	},
 /turf/open/floor/iron/textured_large,
 /area/station/cargo/miningdock)
@@ -38181,7 +38194,6 @@
 /area/station/hallway/secondary/entry)
 "hrP" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/structure/table/wood,
 /obj/item/reagent_containers/cup/soda_cans/pwr_game{
 	pixel_x = -5;
 	pixel_y = 3
@@ -38191,6 +38203,13 @@
 	pixel_y = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/stack/arcadeticket,
+/obj/item/stack/arcadeticket,
+/obj/item/stack/arcadeticket,
+/obj/item/stack/arcadeticket,
+/obj/item/stack/arcadeticket,
+/obj/item/stack/arcadeticket,
+/obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/station/maintenance/abandon_arcade)
 "hrW" = (
@@ -39623,14 +39642,14 @@
 	},
 /area/station/engineering/supermatter/room)
 "hUR" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "boulderbelt"
-	},
 /obj/machinery/camera/directional/west{
 	c_tag = "Mining Dock Smeltery";
 	network = list("ss13","cargo");
 	dir = 1
+	},
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "mining"
 	},
 /turf/open/floor/iron/textured_large,
 /area/station/cargo/miningdock)
@@ -42206,6 +42225,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/item/food/pizza/sassysage,
+/obj/item/clothing/head/collectable/kitty,
 /turf/open/floor/eighties,
 /area/station/maintenance/abandon_arcade)
 "iOA" = (
@@ -42705,7 +42725,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "iXR" = (
-/obj/structure/closet/secure_closet/miner,
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 8
 	},
@@ -45112,16 +45131,15 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "jPk" = (
-/obj/item/storage/toolbox/emergency{
-	pixel_x = -1;
-	pixel_y = 8
-	},
-/obj/structure/table,
-/obj/item/multitool,
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 9
 	},
-/turf/open/floor/iron/textured_large,
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/rubble,
+/obj/structure/closet/cardboard/metal{
+	opened = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/cargo/miningdock)
 "jPp" = (
 /obj/machinery/oven/range,
@@ -49021,6 +49039,7 @@
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 8
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/textured_large,
 /area/station/cargo/miningdock)
 "lms" = (
@@ -49487,11 +49506,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "ltH" = (
-/obj/machinery/conveyor/inverted{
+/obj/machinery/conveyor{
 	dir = 6;
-	id = "boulderbelt"
+	id = "mining"
 	},
-/turf/open/floor/iron/textured_large,
+/turf/open/floor/iron/textured,
 /area/station/cargo/miningdock)
 "ltN" = (
 /obj/structure/table/wood/fancy,
@@ -49928,13 +49947,12 @@
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
 "lCd" = (
+/obj/structure/table,
 /obj/structure/railing{
 	dir = 5
 	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/conveyor_switch/oneway{
-	id = "boulderbelt"
-	},
+/obj/item/stack/ducts,
+/obj/item/construction/plumbing/mining,
 /turf/open/floor/iron/textured,
 /area/station/cargo/miningdock)
 "lCi" = (
@@ -53528,12 +53546,11 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/command/vault)
 "mRT" = (
-/obj/machinery/conveyor/inverted{
+/obj/machinery/conveyor{
 	dir = 10;
-	id = "boulderbelt"
+	id = "mining"
 	},
-/obj/machinery/bouldertech/refinery,
-/turf/open/floor/iron/textured_large,
+/turf/open/floor/iron/textured,
 /area/station/cargo/miningdock)
 "mSk" = (
 /obj/machinery/light/directional/west,
@@ -62901,10 +62918,9 @@
 /area/station/hallway/primary/central/fore)
 "quG" = (
 /obj/machinery/conveyor{
-	dir = 8;
-	id = "boulderbelt"
+	dir = 4;
+	id = "mining"
 	},
-/obj/machinery/bouldertech/refinery/smelter,
 /turf/open/floor/iron/textured_large,
 /area/station/cargo/miningdock)
 "quJ" = (
@@ -65971,6 +65987,7 @@
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 8
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/textured_large,
 /area/station/cargo/miningdock)
 "rHS" = (
@@ -66205,7 +66222,6 @@
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 6
 	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/textured_large,
 /area/station/cargo/miningdock)
 "rLK" = (
@@ -66858,9 +66874,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "rWi" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/start/shaft_miner,
 /obj/effect/turf_decal/tile/purple/opposingcorners{
@@ -67323,7 +67336,6 @@
 /area/station/hallway/primary/central)
 "shn" = (
 /obj/machinery/airalarm/directional/east,
-/obj/structure/table,
 /obj/item/paper_bin{
 	pixel_x = 0;
 	pixel_y = 3
@@ -67332,6 +67344,7 @@
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 10
 	},
+/obj/structure/table,
 /turf/open/floor/iron/textured_large,
 /area/station/cargo/miningdock)
 "shv" = (
@@ -67889,13 +67902,15 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/cryo)
 "sqM" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "boulderbelt"
-	},
-/obj/machinery/brm,
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 8
+	},
+/obj/machinery/bouldertech/refinery/smelter{
+	dir = 4
+	},
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mining"
 	},
 /turf/open/floor/iron/textured_large,
 /area/station/cargo/miningdock)
@@ -73620,12 +73635,17 @@
 /turf/open/floor/iron/chapel,
 /area/station/service/chapel)
 "uyF" = (
-/obj/structure/displaycase/noalert{
-	start_showpiece_type = /obj/item/clothing/suit/costume/wellworn_shirt/messy/graphic/gamer
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/station/maintenance/abandon_arcade)
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
+/area/station/cargo/miningdock)
 "uyU" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -74075,7 +74095,6 @@
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 5
 	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/textured_large,
 /area/station/cargo/miningdock)
 "uFm" = (
@@ -77539,6 +77558,12 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/obj/structure/table,
+/obj/item/storage/toolbox/emergency{
+	pixel_x = -1;
+	pixel_y = 8
+	},
+/obj/item/wrench,
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
@@ -81487,11 +81512,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "xkg" = (
-/obj/structure/railing{
-	dir = 1
-	},
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 8
+	},
+/obj/structure/railing/corner/end/flip{
+	dir = 4
 	},
 /turf/open/floor/iron/textured,
 /area/station/cargo/miningdock)
@@ -81808,15 +81833,9 @@
 /area/station/command/heads_quarters/hos)
 "xqX" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/structure/table/wood,
-/obj/item/coin/antagtoken,
-/obj/item/stack/arcadeticket,
-/obj/item/stack/arcadeticket,
-/obj/item/stack/arcadeticket,
-/obj/item/stack/arcadeticket,
-/obj/item/stack/arcadeticket,
-/obj/item/stack/arcadeticket,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/modular_computer/laptop/preset/civilian,
 /turf/open/floor/wood,
 /area/station/maintenance/abandon_arcade)
 "xrh" = (
@@ -84244,14 +84263,14 @@
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "ymj" = (
-/obj/effect/decal/cleanable/rubble,
-/obj/structure/closet/cardboard/metal{
-	opened = 1
-	},
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "mining"
+	},
+/obj/machinery/brm,
 /turf/open/floor/iron/textured_large,
 /area/station/cargo/miningdock)
 
@@ -107023,7 +107042,7 @@ pgq
 wye
 wFT
 qlR
-wye
+uyF
 rTf
 wye
 dpW
@@ -107538,7 +107557,7 @@ bxy
 ymj
 xkg
 sqM
-bxy
+bHC
 nQl
 nQl
 nQl
@@ -107793,10 +107812,10 @@ cay
 rFJ
 bxy
 quG
-fGJ
+dYy
 hna
-bxy
-bHD
+fGJ
+nQl
 uAj
 abU
 hjX
@@ -108051,9 +108070,9 @@ cjI
 bxy
 hUR
 lCd
-hna
-bxy
+cRe
 bHC
+nQl
 bGo
 hrP
 kdz
@@ -108309,9 +108328,9 @@ bxy
 ltH
 dym
 mRT
-bxy
-uyF
-uAj
+fGJ
+nQl
+bHD
 xqX
 xYi
 hgn

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -3081,11 +3081,16 @@
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "aZd" = (
-/obj/machinery/bouldertech/refinery,
-/obj/machinery/conveyor/inverted{
-	dir = 6;
-	id = "mining"
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
 	},
+/obj/machinery/light/small/directional/east,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/stack/ducts,
+/obj/item/construction/plumbing/mining,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "aZe" = (
@@ -3799,7 +3804,6 @@
 /area/station/maintenance/starboard/fore)
 "bov" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "boE" = (
@@ -5273,11 +5277,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
 "bRg" = (
-/obj/structure/ore_box,
-/obj/machinery/light/small/directional/west,
-/obj/structure/railing{
-	dir = 5
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mining"
 	},
+/obj/structure/railing,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "bRh" = (
@@ -11383,10 +11387,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "dMH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -14073,12 +14075,12 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "eJy" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/airlock/maintenance{
 	name = "Mining Dock Maintenance"
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "eJE" = (
@@ -20055,9 +20057,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "gzD" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "mining"
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
@@ -27735,9 +27739,11 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "iRq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/rubble,
+/turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "iRt" = (
 /obj/effect/spawner/xmastree,
@@ -32119,12 +32125,13 @@
 /obj/item/flashlight,
 /obj/item/flashlight/flare,
 /obj/item/flashlight/flare,
-/obj/item/stock_parts/power_store/cell/high,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/obj/item/storage/box/bandages,
+/obj/item/stock_parts/power_store/cell/high,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "kpH" = (
@@ -32552,11 +32559,12 @@
 /turf/open/floor/iron,
 /area/station/service/chapel/dock)
 "kwn" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/structure/railing{
+/obj/machinery/bouldertech/refinery/smelter{
 	dir = 4
+	},
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mining"
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
@@ -32688,6 +32696,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "kyR" = (
@@ -44473,14 +44482,13 @@
 /area/station/hallway/primary/central/fore)
 "oqM" = (
 /obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
 	},
-/obj/machinery/bouldertech/refinery/smelter,
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "mining"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "oqN" = (
@@ -46348,11 +46356,6 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/fore)
 "oXK" = (
-/obj/structure/table,
-/obj/item/hand_labeler,
-/obj/item/crowbar/red,
-/obj/item/gps/mining,
-/obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch/directional/north,
 /obj/machinery/light/small/directional/north,
@@ -46360,9 +46363,11 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
-/obj/item/storage/box/bandages,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/machinery/computer/shuttle/mining{
+	req_access = null
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
@@ -48187,16 +48192,11 @@
 /area/station/security/warden)
 "pBc" = (
 /obj/structure/cable,
-/obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
-	},
-/obj/machinery/conveyor_switch/oneway{
-	id = "mining";
-	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
@@ -52244,6 +52244,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "qTY" = (
@@ -53679,11 +53680,8 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "mining"
-	},
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "rqV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -57919,11 +57917,18 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/brig)
 "sFY" = (
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "mining"
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/conveyor_switch/oneway{
+	id = "mining";
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "sGF" = (
@@ -61712,16 +61717,12 @@
 /turf/open/floor/plating,
 /area/station/tcommsat/computer)
 "tMq" = (
-/obj/machinery/computer/shuttle/mining{
+/obj/machinery/conveyor{
 	dir = 8;
-	req_access = null
+	id = "mining"
 	},
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 1
+/obj/machinery/bouldertech/refinery{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
@@ -61854,10 +61855,11 @@
 /turf/open/floor/iron,
 /area/station/security/processing)
 "tOj" = (
-/obj/machinery/conveyor{
-	dir = 1;
+/obj/machinery/conveyor/inverted{
+	dir = 6;
 	id = "mining"
 	},
+/obj/machinery/brm,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "tOo" = (
@@ -62256,6 +62258,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/obj/item/wrench,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "tVu" = (
@@ -66463,16 +66466,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "vnj" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/machinery/brm,
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "mining"
-	},
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningoffice)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard)
 "vns" = (
 /obj/machinery/air_sensor/plasma_tank,
 /turf/open/floor/engine/plasma,
@@ -66910,6 +66909,7 @@
 /area/station/engineering/atmos)
 "vuu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "vuy" = (
@@ -117414,7 +117414,7 @@ dry
 lDu
 xZL
 xZL
-rZV
+eJy
 pBc
 hbC
 chT
@@ -117671,7 +117671,7 @@ dty
 lDu
 lDu
 xZL
-eJy
+rZV
 dMF
 iRq
 aLI
@@ -117930,8 +117930,8 @@ lDu
 xZL
 rZV
 rqU
-chT
-chT
+kwn
+bov
 kwl
 rNT
 qAR
@@ -118188,7 +118188,7 @@ kxT
 rZV
 oqM
 tMq
-bov
+chT
 mjW
 pmk
 qAR
@@ -118444,8 +118444,8 @@ oLH
 wCY
 sJS
 sFY
+bRg
 qAR
-oUz
 dez
 oUz
 gKI
@@ -118702,7 +118702,7 @@ mrt
 sJS
 gzD
 bRg
-kwn
+oUz
 hBa
 kpE
 oUz
@@ -118959,7 +118959,7 @@ xZL
 rZV
 aZd
 tOj
-vnj
+oUz
 iVn
 xzI
 oUz
@@ -119211,12 +119211,12 @@ rdl
 roI
 oPX
 lDu
-wCY
+vnj
 rZV
 rZV
 gKI
+gKI
 rLR
-oUz
 fxY
 oUz
 fae

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -10931,8 +10931,8 @@
 /obj/machinery/bouldertech/refinery/smelter{
 	dir = 4
 	},
-/obj/machinery/conveyor/inverted{
-	dir = 4;
+/obj/machinery/conveyor{
+	dir = 8;
 	id = "mining"
 	},
 /turf/open/floor/iron/checker,
@@ -51046,7 +51046,8 @@
 /obj/machinery/bouldertech/refinery{
 	dir = 1
 	},
-/obj/machinery/conveyor/inverted{
+/obj/machinery/conveyor{
+	dir = 1;
 	id = "mining"
 	},
 /turf/open/floor/iron/checker,
@@ -76914,9 +76915,9 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor3/port)
 "tbt" = (
-/obj/machinery/conveyor/inverted{
-	id = "mining";
-	dir = 4
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mining"
 	},
 /turf/open/floor/iron/checker,
 /area/station/cargo/miningdock)

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -10928,8 +10928,11 @@
 /area/station/command/heads_quarters/hop)
 "cGM" = (
 /obj/structure/cable,
-/obj/machinery/conveyor{
-	dir = 5;
+/obj/machinery/bouldertech/refinery/smelter{
+	dir = 1
+	},
+/obj/machinery/conveyor/inverted{
+	dir = 4;
 	id = "mining"
 	},
 /turf/open/floor/iron/checker,
@@ -29533,6 +29536,10 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/wrench,
+/obj/item/stack/ducts,
+/obj/item/construction/plumbing/mining,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "hte" = (
@@ -51034,6 +51041,16 @@
 	dir = 6
 	},
 /area/station/hallway/floor3/fore)
+"mFi" = (
+/obj/structure/cable,
+/obj/machinery/bouldertech/refinery{
+	dir = 1
+	},
+/obj/machinery/conveyor/inverted{
+	id = "mining"
+	},
+/turf/open/floor/iron/checker,
+/area/station/cargo/miningdock)
 "mFp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -76897,11 +76914,9 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor3/port)
 "tbt" = (
-/obj/structure/cable,
-/obj/machinery/bouldertech/refinery/smelter,
 /obj/machinery/conveyor/inverted{
-	dir = 10;
-	id = "mining"
+	id = "mining";
+	dir = 4
 	},
 /turf/open/floor/iron/checker,
 /area/station/cargo/miningdock)
@@ -84185,11 +84200,6 @@
 /area/station/hallway/floor3/fore)
 "uSC" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/bouldertech/refinery,
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "mining"
-	},
 /turf/open/floor/iron/checker,
 /area/station/cargo/miningdock)
 "uSL" = (
@@ -89499,10 +89509,6 @@
 /area/station/maintenance/floor1/port)
 "wgu" = (
 /obj/structure/cable,
-/obj/machinery/conveyor{
-	dir = 9;
-	id = "mining"
-	},
 /turf/open/floor/iron/checker,
 /area/station/cargo/miningdock)
 "wgO" = (
@@ -130639,7 +130645,7 @@ quB
 myd
 ehG
 sQH
-vHa
+tbt
 uSC
 vHa
 nVs
@@ -130896,8 +130902,8 @@ quB
 mRt
 dAc
 sBK
-tbt
 tkZ
+mFi
 nKc
 qas
 jwr

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -10929,7 +10929,7 @@
 "cGM" = (
 /obj/structure/cable,
 /obj/machinery/bouldertech/refinery/smelter{
-	dir = 1
+	dir = 4
 	},
 /obj/machinery/conveyor/inverted{
 	dir = 4;

--- a/_maps/map_files/Ouroboros/Ouroboros.dmm
+++ b/_maps/map_files/Ouroboros/Ouroboros.dmm
@@ -165,12 +165,11 @@
 /turf/open/floor/carpet/black,
 /area/station/command/heads_quarters/qm)
 "acL" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "mining"
-	},
-/obj/machinery/bouldertech/refinery,
-/turf/open/floor/plating,
+/obj/structure/rack,
+/obj/item/stack/ducts,
+/obj/item/construction/plumbing/mining,
+/obj/item/wrench,
+/turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "adr" = (
 /obj/effect/turf_decal/bot,
@@ -23305,13 +23304,13 @@
 /area/station/maintenance/starboard/greater)
 "gOA" = (
 /obj/machinery/conveyor{
+	dir = 8;
 	id = "mining"
 	},
-/obj/structure/railing{
+/obj/machinery/bouldertech/refinery{
 	dir = 4
 	},
-/obj/machinery/brm,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "gOP" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -32710,6 +32709,13 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/white,
 /area/station/ai/upload/chamber)
+"jwD" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "mining";
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/office)
 "jwG" = (
 /obj/item/kirbyplants/organic/plant22,
 /obj/effect/turf_decal/siding/dark/end{
@@ -33293,6 +33299,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/machinery/vending/wardrobe/cargo_wardrobe,
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
 "jER" = (
@@ -35652,13 +35659,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "kod" = (
-/obj/machinery/conveyor{
-	dir = 9;
-	id = "mining"
-	},
 /obj/machinery/light/directional/south,
 /obj/item/radio/intercom/directional/south,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "koe" = (
 /obj/structure/rack,
@@ -37714,14 +37723,15 @@
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/science/robotics/lab)
 "kQu" = (
-/obj/machinery/conveyor{
-	dir = 10;
-	id = "mining"
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
 	},
-/obj/structure/railing{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/station/cargo/office)
 "kQv" = (
 /obj/structure/disposalpipe/segment{
@@ -39465,11 +39475,13 @@
 /area/station/security/brig/entrance)
 "loF" = (
 /obj/machinery/conveyor{
-	id = "mining";
-	dir = 1
+	dir = 9;
+	id = "mining"
 	},
-/obj/machinery/bouldertech/refinery/smelter,
-/turf/open/floor/plating,
+/obj/machinery/bouldertech/refinery/smelter{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "loO" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
@@ -49450,7 +49462,15 @@
 /area/station/medical/break_room)
 "ogU" = (
 /obj/machinery/holopad,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/station/cargo/office)
 "ogV" = (
 /obj/effect/mapping_helpers/broken_floor,
@@ -49910,19 +49930,13 @@
 /turf/open/floor/wood/large,
 /area/station/service/library)
 "onC" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/station/cargo/office)
 "onE" = (
 /obj/effect/spawner/random/engineering/flashlight,
@@ -56446,6 +56460,11 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/glass,
 /area/station/ai/satellite/chamber)
+"qkY" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/rubble,
+/turf/open/floor/iron/dark,
+/area/station/cargo/office)
 "qkZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -59897,8 +59916,12 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "rox" = (
-/obj/machinery/vending/wardrobe/cargo_wardrobe,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/station/cargo/office)
 "roB" = (
 /obj/structure/disposalpipe/junction/flip{
@@ -61694,7 +61717,7 @@
 	location = "QM #2"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/station/cargo/office)
 "rSp" = (
 /obj/structure/railing/corner{
@@ -63754,12 +63777,14 @@
 "swl" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 4
+	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/station/cargo/office)
 "sws" = (
 /obj/effect/turf_decal/tile/purple{
@@ -70402,7 +70427,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light/warm/directional/north,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/station/cargo/office)
 "usn" = (
 /obj/effect/spawner/random/structure/crate,
@@ -71113,11 +71138,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "uBX" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "mining";
-	dir = 1
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mining"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "uCb" = (
 /obj/structure/railing/corner/end{
@@ -80807,8 +80832,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "xlL" = (
-/obj/structure/chair{
-	dir = 4
+/obj/machinery/brm,
+/obj/machinery/conveyor{
+	dir = 10;
+	id = "mining"
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
@@ -83155,17 +83182,11 @@
 /turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "xYE" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/station/cargo/office)
 "xYT" = (
 /obj/structure/disposalpipe/segment{
@@ -170291,7 +170312,7 @@ ujP
 ujP
 wbT
 wQS
-dqM
+qkY
 loF
 kod
 rSI
@@ -170548,9 +170569,9 @@ qlt
 kKK
 uCl
 edK
-dqM
-uBX
 acL
+uBX
+edK
 cLc
 uzt
 hfb
@@ -170807,7 +170828,7 @@ tNm
 edK
 dqM
 gOA
-kQu
+edK
 dgR
 rUy
 fff
@@ -171062,9 +171083,9 @@ tNm
 tNm
 tNm
 bye
-dqM
+jwD
 xlL
-rox
+edK
 cLc
 ivj
 rlE
@@ -171320,8 +171341,8 @@ tNm
 vBE
 swl
 ogU
-dqM
-dqM
+kQu
+rox
 mFq
 dTp
 juW

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -4148,14 +4148,13 @@
 	},
 /area/station/service/chapel)
 "byV" = (
+/obj/machinery/conveyor/inverted{
+	dir = 5;
+	id = "mining"
+	},
 /obj/structure/railing{
-	dir = 8
+	dir = 1
 	},
-/obj/machinery/conveyor{
-	id = "mining";
-	dir = 8
-	},
-/obj/machinery/bouldertech/refinery/smelter,
 /turf/open/floor/iron/smooth,
 /area/station/cargo/warehouse)
 "byY" = (
@@ -5157,8 +5156,11 @@
 /area/station/asteroid)
 "bQw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	dir = 8
+/obj/machinery/conveyor{
+	id = "mining"
+	},
+/obj/machinery/bouldertech/refinery{
+	dir = 1
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
@@ -9042,6 +9044,9 @@
 	c_tag = "Cargo - Warehouse";
 	network = list("ss13","cargo")
 	},
+/obj/structure/table,
+/obj/item/stack/ducts,
+/obj/item/construction/plumbing/mining,
 /turf/open/floor/iron/smooth,
 /area/station/cargo/warehouse)
 "dgy" = (
@@ -12880,14 +12885,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/security/courtroom)
-"eAU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/conveyor{
-	id = "mining";
-	dir = 1
-	},
-/turf/open/floor/iron/smooth,
-/area/station/cargo/warehouse)
 "eAX" = (
 /turf/closed/wall/mineral/titanium/interior,
 /area/station/maintenance/aft)
@@ -35071,6 +35068,9 @@
 /area/station/maintenance/starboard/lower)
 "mlo" = (
 /obj/machinery/light/floor,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
 "mlq" = (
@@ -44082,10 +44082,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "pze" = (
-/obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/maintenance,
 /obj/item/screwdriver,
 /obj/item/crowbar,
+/obj/effect/decal/cleanable/rubble,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
 "pzj" = (
@@ -45589,15 +45590,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
-"qaU" = (
-/obj/structure/railing,
-/obj/machinery/conveyor{
-	id = "mining";
-	dir = 1
-	},
-/obj/machinery/brm,
-/turf/open/floor/iron/smooth,
-/area/station/cargo/warehouse)
 "qaW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45712,8 +45704,11 @@
 /area/station/cargo/storage)
 "qcX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/railing{
-	dir = 10
+/obj/machinery/conveyor{
+	id = "mining"
+	},
+/obj/machinery/bouldertech/refinery/smelter{
+	dir = 1
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
@@ -57701,6 +57696,7 @@
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
+/obj/item/wrench,
 /turf/open/floor/iron/smooth,
 /area/station/cargo/warehouse)
 "tWk" = (
@@ -58956,10 +58952,12 @@
 "uqN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor{
-	id = "mining";
-	dir = 8
+	dir = 8;
+	id = "mining"
 	},
-/obj/machinery/bouldertech/refinery,
+/obj/structure/railing{
+	dir = 1
+	},
 /turf/open/floor/iron/smooth,
 /area/station/cargo/warehouse)
 "uqP" = (
@@ -67290,8 +67288,9 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "xjk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/machinery/conveyor{
+	dir = 10;
+	id = "mining"
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
@@ -68786,9 +68785,13 @@
 /area/station/biodome)
 "xJf" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/conveyor/inverted{
-	dir = 6;
+/obj/machinery/brm,
+/obj/machinery/conveyor{
+	dir = 8;
 	id = "mining"
+	},
+/obj/structure/railing{
+	dir = 1
 	},
 /turf/open/floor/iron/smooth,
 /area/station/cargo/warehouse)
@@ -118430,7 +118433,7 @@ byV
 bQw
 qcX
 xjk
-jSN
+fGr
 jSN
 fqq
 rdT
@@ -118684,7 +118687,7 @@ vtU
 vtU
 dAF
 uqN
-fGr
+jSN
 mlo
 rYo
 jSN
@@ -118941,8 +118944,8 @@ cCZ
 cCZ
 dAF
 xJf
-eAU
-qaU
+cte
+hSC
 dgl
 paM
 frw


### PR DESCRIPTION
## About The Pull Request

Upstream changed boulder refineries to take in chems and output waste, this PR gives those refineries on our stations extra room and a mining plumber to work on that. This should also fix some refineries facing the wrong direction.

This does not change Moon Station or Pubby Station (because its TM'd)

## Why It's Good For The Game

Less of a headache for shaft miners/cargo techs that have to re-construct the refinery for ore.


## Proof Of Testing


<details>
<summary> Strongdmm screenshots </summary>

Boxstation:
<img width="912" height="628" alt="image" src="https://github.com/user-attachments/assets/cccc64d7-0cf1-4445-a22f-501b879704f3" />

Biodome:
<img width="768" height="898" alt="image" src="https://github.com/user-attachments/assets/c2e9c316-5c88-40be-a455-8c647a655b1f" />

Ringworm:
<img width="714" height="634" alt="image" src="https://github.com/user-attachments/assets/c067d85c-6732-4b20-b527-82955738a764" />

Northstar:
<img width="540" height="704" alt="image" src="https://github.com/user-attachments/assets/ed9150ee-9876-4230-8dbe-54209f93f738" />

</details>

## Changelog

:cl:
fix: fixes boulder refineries on Bubberstation maps
/:cl: