### PR TITLE
Pull #96417 from tg - Fixes diamond and bluespace artifact boulders not containing any diamonds/bluespace crystals

### DIFF
--- a/code/game/objects/structures/lavaland/ore_vent.dm
+++ b/code/game/objects/structures/lavaland/ore_vent.dm
@@ -555,7 +555,7 @@
 	Shake(duration = 1.5 SECONDS)
 
 	//decorate the boulder with materials
-	var/list/mats_list = list()
+	var/list/mats_list = new_rock.custom_materials?.Copy() || list()
 	for(var/iteration in 1 to MINERALS_PER_BOULDER)
 		var/datum/material/material = pick_weight(mineral_breakdown)
 		mats_list[material] += ore_quantity_function(iteration)


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/tgstation/pull/96417
## Why It's Good For The Game

bugs bad
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

tis a upstream pull

</details>

## Changelog
:cl:
fix: Fixed diamond and bluespace artifact boulders not containing any diamonds/bluespace crystals
/:cl:
