### PR TITLE
Fixes lycan bane again, slightly reduces the overall damage it does

### DIFF
--- a/modular_zubbers/code/modules/customization/species/lycans/_lycan_species.dm
+++ b/modular_zubbers/code/modules/customization/species/lycans/_lycan_species.dm
@@ -1,4 +1,5 @@
 #define DOAFTER_SOURCE_LYCAN_DOOR_PRY "lycan door pry"
+#define FORCE_TO_BURN_RATIO 1.5
 
 /datum/species/lycan
 	id = SPECIES_LYCAN
@@ -194,11 +195,14 @@
 
 	// already lost the limb shit
 
-/datum/species/lycan/proc/on_baned(mob/living/carbon/human/baned, mob/user)
+/datum/species/lycan/proc/on_baned(mob/living/carbon/human/baned, obj/source, mob/user)
 	SIGNAL_HANDLER
 
 	baned.visible_message(span_warning("[baned] seems to react negatively to the silver, [baned.p_their()] flesh scorching and burning on contact!"), ignored_mobs = list(baned))
 	to_chat(baned, span_bolddanger("The sister moon casts its light on you, and you feel your flesh scorch!"))
 	INVOKE_ASYNC(baned, TYPE_PROC_REF(/mob, emote), "scream")
 
+	baned.apply_damage(source.force * FORCE_TO_BURN_RATIO, BURN, attacking_item = source)
+
 #undef DOAFTER_SOURCE_LYCAN_DOOR_PRY
+#undef FORCE_TO_BURN_RATIO

--- a/modular_zubbers/code/modules/customization/species/lycans/_lycan_species.dm
+++ b/modular_zubbers/code/modules/customization/species/lycans/_lycan_species.dm
@@ -202,7 +202,12 @@
 	to_chat(baned, span_bolddanger("The sister moon casts its light on you, and you feel your flesh scorch!"))
 	INVOKE_ASYNC(baned, TYPE_PROC_REF(/mob, emote), "scream")
 
-	baned.apply_damage(source.force * FORCE_TO_BURN_RATIO, BURN, attacking_item = source)
+	var/target_zone
+	var/mob/living/living_user = user
+	if (istype(living_user))
+		target_zone = living_user.zone_selected
+
+	baned.apply_damage(source.force * FORCE_TO_BURN_RATIO, BURN, target_zone, attacking_item = source)
 
 #undef DOAFTER_SOURCE_LYCAN_DOOR_PRY
 #undef FORCE_TO_BURN_RATIO

--- a/modular_zubbers/code/modules/customization/species/lycans/materials.dm
+++ b/modular_zubbers/code/modules/customization/species/lycans/materials.dm
@@ -9,7 +9,4 @@
 		)
 
 /proc/is_viable_for_lycan_bane(atom/target)
-	if (!iscarbon(target))
-		return FALSE
-
 	return islycan(target)

--- a/modular_zubbers/code/modules/customization/species/lycans/materials.dm
+++ b/modular_zubbers/code/modules/customization/species/lycans/materials.dm
@@ -1,15 +1,15 @@
-/*
-//Silver debuff Code vs Lycans temporarily disabled for for the bane refactor.
-
 /datum/material/silver/on_applied(atom/source, mat_amount, multiplier, from_slot)
 	. = ..()
 
 	if (isitem(source))
-		source.AddElement(/datum/element/bane, /datum/species/lycan, damage_multiplier = 2, requires_combat_mode = FALSE, bane_damage_override = BURN)
+		source.AddComponent( \
+			/datum/component/bane, \
+			should_bane_callback = CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(is_viable_for_lycan_bane)), \
+			damage_multiplier = 1.25, \
+		)
 
-/datum/material/silver/on_removed(atom/source, mat_amount, multiplier, from_slot)
-	. = ..()
+/proc/is_viable_for_lycan_bane(atom/target)
+	if (!iscarbon(target))
+		return FALSE
 
-	source.RemoveElement(/datum/element/bane, /datum/species/lycan, damage_multiplier = 2, requires_combat_mode = FALSE, bane_damage_override = BURN)
-
- */
+	return islycan(target)


### PR DESCRIPTION

## About The Pull Request

Title.

Due to how TG has implemented the bane component, I now dont have access to def_zone. This means it will pick one at random. A shame.

Its about a 25% decrease in burn damage, but compensated by a 25% increase in brute damage
## Why It's Good For The Game

Bugs bad.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="361" height="179" alt="image" src="https://github.com/user-attachments/assets/051d606e-6305-4c18-8d5a-83784747d676" />

</details>

## Changelog
:cl:
fix: Silver hurts lycans more again
/:cl:
