### PR TITLE
Makes those abducted by contractors unable to remember it

### DIFF
--- a/code/modules/antagonists/traitor/contractor/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/contractor/syndicate_contract.dm
@@ -254,3 +254,5 @@
 	victim.adjust_eye_blur(3 SECONDS)
 	victim.adjust_dizzy(3.5 SECONDS)
 	victim.adjust_confusion(2 SECONDS)
+	//Bubberstation change, adds flavourtext that they forget who contracted them.
+	to_chat(victim, span_big(span_hypnophrase("You don't remember anything leading up to being abducted by the syndicate - All you can remember is a million voices echoing through your mind and pain whenever you try to think of anything further.")))


### PR DESCRIPTION

## About The Pull Request

Simple PR that adds hypno flavour-text after being successfully sent off by a contractor stating that you cannot remember who sent you or what lead up to it.

## Why It's Good For The Game

Imagine perfectly abducting someone. Let's say you sleepypen them and they don't notice or maybe instead you manage to disrupt their comms, baton them and drag them off to the pod. Either way of you getting them to the pod and doing your job, you manage to do it all without a single soul noticing!

Now they come back and out you because guess what? Despite how clever and stealthy you were, it doesn't matter because they don't forget the lead up to you abducting them.

## Proof Of Testing

Simple one line to_chat addition, unable to test locally due to needing a contract target. It does compile though and should (in theory) work.

## Changelog
:cl:
add: Thanks to new enhanced interrogation techniques acquired in collaboration with the Space Ninja Dojo. The Syndicate now make targets that get successfully sent to them alive by their on site Contractors unable to remember the lead up to their abduction.
/:cl:
