### PR TITLE
Allows wirecutters to cut through spider webs

### DIFF
--- a/modular_zubbers/code/game/objects/effects/spiderwebs.dm
+++ b/modular_zubbers/code/game/objects/effects/spiderwebs.dm
@@ -1,0 +1,6 @@
+/obj/structure/spider/stickyweb/wirecutter_act(mob/living/user, obj/item/tool)
+	. = ..()
+	if(tool.use_tool(src, user, 1.5 SECONDS, volume = 50))
+		if(QDELETED(src))
+			return
+		qdel(src)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9278,6 +9278,7 @@
 #include "modular_zubbers\code\game\objects\effects\landmarks.dm"
 #include "modular_zubbers\code\game\objects\effects\overlays.dm"
 #include "modular_zubbers\code\game\objects\effects\shark_infested_waters.dm"
+#include "modular_zubbers\code\game\objects\effects\spiderwebs.dm"
 #include "modular_zubbers\code\game\objects\effects\decals\blood.dm"
 #include "modular_zubbers\code\game\objects\effects\decals\cleanable.dm"
 #include "modular_zubbers\code\game\objects\effects\decals\turfdecal\tilecoloring.dm"


### PR DESCRIPTION

## About The Pull Request
It takes 1.5 seconds for the web to be cut with wirecutters.
## Why It's Good For The Game
If you've ever been on a station with the duct spider trait, or just gotten unlucky and had a duct spider vent clog you'll know very quickly how unfun it is to clean up spider webs. Especially when using a welding tool costs 1u of fuel per web. Making it less painful to clean up webs from unchecked duct spiders will make dealing with them a lot better.
## Proof Of Testing
See below.
<details>
<summary>Screenshots/Videos</summary>

https://github.com/user-attachments/assets/27289337-4a83-4333-a63f-956c73789080

</details>

## Changelog
:cl:
balance: You can now cut through spider webs using wirecutters.
/:cl:
