### PR TITLE
Allows Lycans to wear underwear

### DIFF
--- a/modular_zubbers/code/modules/customization/species/lycans/_lycan_species.dm
+++ b/modular_zubbers/code/modules/customization/species/lycans/_lycan_species.dm
@@ -39,7 +39,6 @@
 		TRAIT_CAN_STRIP,
 		TRAIT_LITERATE,
 		TRAIT_MUTANT_COLORS_2,
-		TRAIT_NO_UNDERWEAR, // They should still be able to toggle genitals if needed.
 		// Lycan Specific Things
 		TRAIT_LUPINE,
 		TRAIT_BEAST_FORM,


### PR DESCRIPTION

## About The Pull Request
Does as the title says.
## Why It's Good For The Game
I don't want to flash bang people with my genitals every time I transform, and I'd reckon some people don't want to be flash banged by lycan genitals either. Also, @nikothedude told me that them not having underwear causes a genital visibility issue of some sort.
## Proof Of Testing
See below.
<details>
<summary>Screenshots/Videos</summary>
<img width="266" height="266" alt="image" src="https://github.com/user-attachments/assets/daf8cfe8-5826-4eb4-8fa7-eaac9e61ae24" />

</details>

## Changelog
:cl:
add: Lycans can now wear underwear.
/:cl:
