### PR TITLE
Fixes bug with mindswap mod module

### DIFF
--- a/modular_zubbers/code/modules/mod/modules.dm
+++ b/modular_zubbers/code/modules/mod/modules.dm
@@ -2,7 +2,6 @@
 	name = "MOD Neural Transference module"
 	desc = "Swaps the MOD wearer's and Assistant AI's neural pathways."
 	removable = FALSE
-	required_slots = list(ITEM_SLOT_FEET, ITEM_SLOT_GLOVES, ITEM_SLOT_OCLOTHING, ITEM_SLOT_HEAD)
 	module_type = MODULE_ACTIVE
 	//Who's in control of the wearer's body
 	var/ai_control = FALSE


### PR DESCRIPTION

## About The Pull Request
Since MODsuits got changed to where parts do not retract instantly + do not get deployed when turning off the MODsuit, undeploying the suit then turning it off left user's trapped in their other user's body, when they are supposed to swap back.
## Why It's Good For The Game
bug fix brrr
## Proof Of Testing
it worky I promise
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: Fixed Modwearers/assistant AIs getting trapped in each others bodies when undeploying suit parts then turning off modsuit while undeployed.
/:cl:
