### PR TITLE
Fix icon cutter errors not failing CI

### DIFF
--- a/tools/icon_cutter/check.py
+++ b/tools/icon_cutter/check.py
@@ -76,10 +76,10 @@ output_hash = {}
 files = []
 if platform.system() == "Windows":
     files = glob.glob(f"{path_to_us}\\..\\..\\icons\\**\\*.toml", recursive = True)
-    files += glob.glob(f"{path_to_us}\..\\..\\modular_zubbers\\icons\\**\*.toml", recursive = True) # BUBBER EDIT ADDITION: Modular icon cutter
+    files += glob.glob(f"{path_to_us}\\..\\..\\modular_zubbers\\icons\\**\\*.toml", recursive = True) # BUBBER EDIT ADDITION: Modular icon cutter
 else:
     files = glob.glob(f"{path_to_us}/../../icons/**/*.toml", recursive = True)
-    files += glob.glob(f"{path_to_us}\../../modular_zubbers/icons/**\*.toml", recursive = True) # BUBBER EDIT ADDITION: Modular icon cutter
+    files += glob.glob(f"{path_to_us}/../../modular_zubbers/icons/**/*.toml", recursive = True) # BUBBER EDIT ADDITION: Modular icon cutter
 for cutter_template in files:
     resource_name = re.sub(chop_extension, r"\1", cutter_template, count = 1)
     if not os.path.isfile(resource_name):


### PR DESCRIPTION

## About The Pull Request

The escaping for path in these lines were broken and it was causing errors in icon cutter to not count as errored for CI. The errors uncovered by this change are fixed in #5818

## Why It's Good For The Game

Fix

## Proof Of Testing

if its red

## Changelog

N/A
