### PR TITLE
Fixes power cells being unable to receive plasma injections

### DIFF
--- a/code/modules/power/power_store.dm
+++ b/code/modules/power/power_store.dm
@@ -46,7 +46,8 @@
 
 /obj/item/stock_parts/power_store/is_injectable()
 	return !!reagents
-
+/obj/item/stock_parts/power_store/is_injectable()
+	return reagents
 /obj/item/stock_parts/power_store/Initialize(mapload, override_maxcharge)
 	. = ..()
 	create_reagents(5, INJECTABLE | DRAINABLE)

--- a/code/modules/power/power_store.dm
+++ b/code/modules/power/power_store.dm
@@ -45,9 +45,8 @@
 	return .
 
 /obj/item/stock_parts/power_store/is_injectable()
-	return !!reagents
-/obj/item/stock_parts/power_store/is_injectable()
 	return reagents
+
 /obj/item/stock_parts/power_store/Initialize(mapload, override_maxcharge)
 	. = ..()
 	create_reagents(5, INJECTABLE | DRAINABLE)

--- a/code/modules/power/power_store.dm
+++ b/code/modules/power/power_store.dm
@@ -44,6 +44,9 @@
 	. += NAMEOF(src, corrupted)
 	return .
 
+/obj/item/stock_parts/power_store/is_injectable()
+	return !!reagents
+
 /obj/item/stock_parts/power_store/Initialize(mapload, override_maxcharge)
 	. = ..()
 	create_reagents(5, INJECTABLE | DRAINABLE)


### PR DESCRIPTION
## About The Pull Request

Fixes plasma injection into charged power cells. TG introduced a bug via refractor where you could only inject plasma into a dead cell, which made the sabotage mechanic (inject plasma, put cell in thing, cell detonates on next use) basically impossible.

The root cause is a regression from TG upstream PR #94861, which rewrote the plasma rigging system from a `rigged` boolean with signal hooks into the current `spark_act` approach. Somewhere in that transition the `INJECTABLE` flag gets stripped from the reagents holder on charged cells specifically, leaving uncharged cells unaffected. The explosion mechanic itself is intact and a rigged cell still detonates correctly when its charge is altered but the injection step was broken.

The fix overrides `is_injectable` on `power_store` to bypass the flag check entirely, gating only on whether the reagents holder exists at all, which it does.

## Why It's Good For The Game

The plasma cell sabotage is funny. The mechanic only working on a dead cell was an unintentional restriction that made the mechanic worthless. 

## Proof Of Testing

<img width="830" height="430" alt="image" src="https://github.com/user-attachments/assets/f86a40bc-698c-4fc6-b868-6170c73b3b26" />


## Changelog

:cl:
fix: Plasma can once again be injected into charged power cells.
/:cl: