### PR TITLE
Acolyte balance & bugfix patch one - fixes crucible soul exploit, nerfs cosmic, a few more tweaks

### DIFF
--- a/code/modules/antagonists/heretic/items/keyring.dm
+++ b/code/modules/antagonists/heretic/items/keyring.dm
@@ -170,6 +170,7 @@
 	portal_one = new(get_turf(door2), door2, inverted)
 	portal_two = new(get_turf(door1), door1, inverted)
 	portal_one.destination = portal_two
+
 	RegisterSignal(portal_one, COMSIG_QDELETING, PROC_REF(clear_portal_refs))  //we only really need to register one because they already qdel both portals if one is destroyed
 	portal_two.destination = portal_one
 	balloon_alert(user, "[message]")

--- a/code/modules/antagonists/heretic/items/keyring.dm
+++ b/code/modules/antagonists/heretic/items/keyring.dm
@@ -167,7 +167,6 @@
 	if(portal_one || portal_two)
 		clear_portals()
 		message += ", previous cleared"
-
 	portal_one = new(get_turf(door2), door2, inverted)
 	portal_two = new(get_turf(door1), door1, inverted)
 	portal_one.destination = portal_two
@@ -207,6 +206,12 @@
 	var/reference_resolved = link?.resolve()
 	if(reference_resolved == target)
 		return ITEM_INTERACT_BLOCKING
+
+	// BUBBER EDIT ADDITION BEGIN - cant use it for insta escapes
+	user.balloon_alert_to_viewers("linking...")
+	if (!do_after(user, 5 SECONDS, user, IGNORE_HELD_ITEM))
+		return ITEM_INTERACT_BLOCKING
+	// BUBBER EDIT ADDITION END
 
 	if(reference_resolved)
 		make_portal(user, reference_resolved, target)

--- a/code/modules/antagonists/heretic/magic/cosmic_expansion.dm
+++ b/code/modules/antagonists/heretic/magic/cosmic_expansion.dm
@@ -9,7 +9,7 @@
 
 	sound = 'sound/effects/magic/cosmic_expansion.ogg'
 	school = SCHOOL_FORBIDDEN
-	cooldown_time = 15 SECONDS
+	cooldown_time = 60 SECONDS // BUBBER EDIT CHANGE - from 15 to 60 secs, now more of a panic button
 
 	invocation = "C'SM'S 'XP'ND!"
 	invocation_type = INVOCATION_SHOUT

--- a/code/modules/antagonists/heretic/magic/star_blast.dm
+++ b/code/modules/antagonists/heretic/magic/star_blast.dm
@@ -44,6 +44,11 @@
 	if(!active_ball)
 		build_all_button_icons(UPDATE_OVERLAYS)
 		return ..()
+	// BUBBER EDIT ADDITION BEGIN - you need LOS to jaunt to your ball
+	if (!(active_ball in view(cast_range, owner)))
+		owner.balloon_alert(owner, "need line of sight on the ball!")
+		return // abort entirely
+	// BUBBER EDIT ADDITION ENDs
 
 	pull_victims()
 	do_teleport(owner, active_ball)

--- a/modular_zubbers/code/modules/antagonists/heretic/antimagic_collar.dm
+++ b/modular_zubbers/code/modules/antagonists/heretic/antimagic_collar.dm
@@ -26,7 +26,7 @@
 
 	speech_span = SPAN_ROBOT
 
-	max_integrity = 50
+	max_integrity = 100
 	integrity_failure = 0.5
 
 	clothing_traits = list(TRAIT_MANSUS_INHIBITION)
@@ -45,7 +45,7 @@
 
 /datum/armor/antimagic_collar
 	acid = 50
-	fire = 70
+	fire = 75
 	bomb = 50
 
 /obj/item/clothing/neck/antimagic_collar/Destroy()

--- a/modular_zubbers/code/modules/antagonists/heretic/paths/cosmic.dm
+++ b/modular_zubbers/code/modules/antagonists/heretic/paths/cosmic.dm
@@ -1,0 +1,6 @@
+/datum/action/cooldown/spell/cosmic_rune/before_cast(atom/cast_on)
+	. = ..()
+
+	owner.balloon_alert_to_viewers("invoking rune...")
+	if (!do_after(owner, 5 SECONDS, owner, IGNORE_HELD_ITEM))
+		return SPELL_CANCEL_CAST

--- a/modular_zubbers/code/modules/antagonists/heretic/paths/void.dm
+++ b/modular_zubbers/code/modules/antagonists/heretic/paths/void.dm
@@ -227,6 +227,13 @@
 		Afterwards, they will be returned to the mortal plane. Can be self-cast."
 
 /datum/action/cooldown/spell/pointed/void_prison/is_valid_target(atom/cast_on)
+	if (!ismob(cast_on))
+		return FALSE
+	var/mob/target_mob = cast_on
+	if (target_mob.has_status_effect(/datum/status_effect/crucible_soul))
+		owner.balloon_alert(owner, "cant use while phased out!")
+		return FALSE
+
 	return TRUE // self cast
 
 /datum/status_effect/void_prison

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9477,6 +9477,7 @@
 #include "modular_zubbers\code\modules\antagonists\heretic\objectives\wildcard\steal_money.dm"
 #include "modular_zubbers\code\modules\antagonists\heretic\objectives\wildcard\supermatter_ritual.dm"
 #include "modular_zubbers\code\modules\antagonists\heretic\paths\ash.dm"
+#include "modular_zubbers\code\modules\antagonists\heretic\paths\cosmic.dm"
 #include "modular_zubbers\code\modules\antagonists\heretic\paths\heretic_paths.dm"
 #include "modular_zubbers\code\modules\antagonists\heretic\paths\lock.dm"
 #include "modular_zubbers\code\modules\antagonists\heretic\paths\moon.dm"


### PR DESCRIPTION

## About The Pull Request

Title.

Void prison no longer can be used if the target is phased out.
Cosmic expansion now takes 60 seconds to cooldown. Its now a panic button instead of a total area denial tool.
Star blast now cannot be jaunted to if you cant see it. I intend to crack down aon all forms of freeform mobility acolyte gets like this.
Cosmic rune & The lock ID card now have a 5 second do after to prevent use as spontanious escape tools. Still good for bases.
The antimagic collar has double durability now. I had the pleasure or removing one via ethanol and a lighter the ot her day... it really wasnt as oppressive as I wanted it to be.
## Why It's Good For The Game

Bugs bad.

Cosmic expansion is a bit too powerful from what Ive seen and theorize.

I want to remove all forms of freeform cross-wall jaunting from heretic. Void phase, blade breaking, ashen passage, star blast... its not fun for anyone except the person bypassing walls.
Cosmic rune and lock ID card have this same issue, being extremely useful cross-station tps that noone can easily follow through.
I want it to be difficult to remove the collar. It was designed as something you have to endagner yourself to remove, but its not really that...
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

https://github.com/user-attachments/assets/5aafda3a-bf14-4b7d-8692-45f0037c5e8c


</details>

## Changelog
:cl:
fix: Void prison cannot be used to counteract the crucible soul ripcord
balance: Antimagic collar now has 100 intergirty
balance: Cosmic rune and lock ID card now have a brief period before they make their portal/rune
balance: Star blast now requires LOS to recast
balance: Cosmic expansion CD: 15 -> 60
/:cl:
