### PR TITLE
Maybe bioscramblers SHOULDN'T give you genitals

### DIFF
--- a/code/__DEFINES/research/anomalies.dm
+++ b/code/__DEFINES/research/anomalies.dm
@@ -46,7 +46,8 @@ GLOBAL_LIST_INIT(bioscrambler_organs_blacklist, typecacheof(list (
 	/obj/item/organ/empowered_borer_egg, // SKYRAT EDIT ADDITION
 	/obj/item/organ/eyes/robotic, // SKYRAT EDIT ADDITION
 	/obj/item/organ/eyes/night_vision/cyber, // SKYRAT EDIT ADDITION
-	/obj/item/organ/taur_body // BUBBER EDIT ADDITION
+	/obj/item/organ/taur_body, // BUBBER EDIT ADDITION
+	/obj/item/organ/genital // BUBBER EDIT - ADDITION
 )))
 
 /// List of body parts we can apply to people


### PR DESCRIPTION

## About The Pull Request
When looking at the causes of flaky errors I saw https://github.com/Bubberstation/Bubberstation/issues/5754 which upon investigation seems to be caused by genitals not being a blacklisted organ. Even if it doesn't fix the flaky test failure, bioscramblers definitely shouldn't give you genitalia.
## Why It's Good For The Game
Bugs that prefbreak me are bad.
## Proof Of Testing
Untested.
## Changelog
Not player facing.
