### PR TITLE
Fine, I'll do it myself: Teshari Limbs in the Limb Grower

### DIFF
--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -293,6 +293,10 @@
 		path = "/obj/item/bodypart/[part_type]"
 	else
 		path = "/obj/item/bodypart/[part_type]/[species]"
+//BUBBER ADDITION BEGIN - Mutant limb types.
+		if(!text2path(path) && part_type)
+			path = "/obj/item/bodypart/[part_type]/mutant/[species]"
+//BUBBER ADDITION END
 	return text2path(path)
 
 /obj/machinery/limbgrower/RefreshParts()

--- a/modular_skyrat/modules/teshari/code/_teshari.dm
+++ b/modular_skyrat/modules/teshari/code/_teshari.dm
@@ -59,6 +59,7 @@
 	)
 
 /obj/item/organ/tongue/teshari
+	name = "teshari tongue"
 	liked_foodtypes = SEAFOOD | VEGETABLES | NUTS
 	disliked_foodtypes = GROSS | GRAIN
 

--- a/modular_zubbers/code/modules/designs/limbgrower_designs.dm
+++ b/modular_zubbers/code/modules/designs/limbgrower_designs.dm
@@ -75,9 +75,62 @@
 	name = "Tajaran Organ Design Disk"
 	limb_designs = list(/datum/design/tajaran_eyes, /datum/design/tajaran_tongue, /datum/design/tajaran_ears)
 
+//Teshari organs
+//Pour one out for the birds.
+/datum/design/leftarm/New()
+	category += list(SPECIES_TESHARI)
+	return ..()
+
+/datum/design/rightarm/New()
+	category += list(SPECIES_TESHARI)
+	return ..()
+
+/datum/design/leftleg/New()
+	category += list(SPECIES_TESHARI)
+	return ..()
+
+/datum/design/rightleg/New()
+	category += list(SPECIES_TESHARI)
+	return ..()
+
+/datum/design/teshari_eyes
+	name = "Teshari eyes"
+	id = "tesharieyes"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10)
+	build_path = /obj/item/organ/eyes/teshari
+	category = list(SPECIES_TESHARI)
+
+/datum/design/teshari_ears
+	name = "Teshari ears"
+	id = "teshariears"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10)
+	build_path = /obj/item/organ/ears/teshari
+	category = list(SPECIES_TESHARI)
+
+/datum/design/teshari_tongue
+	name = "Teshari tongue"
+	id = "tesharitongue"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10)
+	build_path = /obj/item/organ/tongue/teshari
+	category = list(SPECIES_TESHARI)
+
+/datum/design/limb_disk/teshari
+	name = "Teshari Organ Design Disk"
+	desc = "Contains designs for teshari organs for the limbgrower - Ears, tounges, and eyes."
+	id = "limbdesign_teshari"
+	build_path = /obj/item/disk/design_disk/limbs/teshari
+
+/obj/item/disk/design_disk/limbs/teshari
+	name = "Teshari Organ Design Disk"
+	limb_designs = list(/datum/design/teshari_eyes, /datum/design/teshari_ears, /datum/design/teshari_tongue)
+
 /obj/machinery/limbgrower/Initialize(mapload)
 	categories += list(
 		SPECIES_HEMOPHAGE,
-		SPECIES_TAJARAN
+		SPECIES_TAJARAN,
+		SPECIES_TESHARI
 	)
 	. = ..()

--- a/modular_zubbers/code/modules/designs/limbgrower_designs.dm
+++ b/modular_zubbers/code/modules/designs/limbgrower_designs.dm
@@ -117,6 +117,14 @@
 	build_path = /obj/item/organ/tongue/teshari
 	category = list(SPECIES_TESHARI)
 
+/datum/design/cold_lungs
+	name = "Cold-Adapted Lungs"
+	id = "coldlungs"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 20)
+	build_path = /obj/item/organ/lungs/adaptive/cold
+	category = list(SPECIES_TESHARI)
+
 /datum/design/limb_disk/teshari
 	name = "Teshari Organ Design Disk"
 	desc = "Contains designs for teshari organs for the limbgrower - Ears, tounges, and eyes."
@@ -125,7 +133,7 @@
 
 /obj/item/disk/design_disk/limbs/teshari
 	name = "Teshari Organ Design Disk"
-	limb_designs = list(/datum/design/teshari_eyes, /datum/design/teshari_ears, /datum/design/teshari_tongue)
+	limb_designs = list(/datum/design/teshari_eyes, /datum/design/teshari_ears, /datum/design/teshari_tongue, /datum/design/cold_lungs)
 
 /obj/machinery/limbgrower/Initialize(mapload)
 	categories += list(

--- a/modular_zubbers/code/modules/research/techweb/all_nodes.dm
+++ b/modular_zubbers/code/modules/research/techweb/all_nodes.dm
@@ -69,6 +69,7 @@
 	design_ids += list(
 		"limbdesign_hemophage",
 		"limbdesign_tajaran",
+		"limbdesign_teshari",
 	)
 
 /datum/techweb_node/cyber/cyber_implants/New()


### PR DESCRIPTION

## About The Pull Request
Adds teshari limbs to the limb grower. What more needs to be said? Well, actually this changes limbgrower.dm so that it falls back to `path = "/obj/item/bodypart/[part_type]/mutant/[species]"` if `path = "/obj/item/bodypart/[part_type]/[species]"` doesn't exist. This means that other species like vox, skrell, ect can get the same treatment as teshari now (although I think the limb grower ui would need a rework for all the extra tabs that'd make).
## Why It's Good For The Game
No more suffering for the birds. No longer do you have to go all the way to robotics when you need a new limb that fits on you.
## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>
<img width="677" height="373" alt="image" src="https://github.com/user-attachments/assets/45531ba1-d8d6-4d7b-bb69-96800d65e181" />

</details>

## Changelog

:cl: Robwo
add: Limb growers can print teshari limbs/organs now.
/:cl:
