### PR TITLE
Change all mentions of antimagic collar to irreality collar

### DIFF
--- a/code/__DEFINES/~~bubber_defines/traits/declarations.dm
+++ b/code/__DEFINES/~~bubber_defines/traits/declarations.dm
@@ -71,7 +71,7 @@
 #define TRAIT_TRICKSTER_TASTE "trickster_taste"
 /// Used by The Blacksmith's Hammer heretic ritual - tracks if their funny hand will emag the next thing they right click with
 #define TRAIT_EMAGGING_HAND "emagging_hand"
-/// Used by the antimagic collar - prevents use of rituals and most spells from Acolytes.
+/// Used by the irreality collar - prevents use of rituals and most spells from Acolytes.
 #define TRAIT_MANSUS_INHIBITION "mansus_inhibition"
 
 /// Trait that gives your brain traumas more resilance

--- a/modular_zubbers/code/modules/antagonists/heretic/antimagic_collar.dm
+++ b/modular_zubbers/code/modules/antagonists/heretic/antimagic_collar.dm
@@ -165,7 +165,7 @@
 	locked = new_status
 	balloon_alert_to_viewers("[locked ? "locked!" : "unlocked!"]")
 	if (!isnull(key) && !locked)
-		radio.talk_into(src, "irreality collar [set_id] unlocked using a key.", RADIO_CHANNEL_SECURITY, list(speech_span))
+		radio.talk_into(src, "Irreality collar [set_id] unlocked using a key.", RADIO_CHANNEL_SECURITY, list(speech_span))
 	if (user)
 		to_chat(user, span_warning("You [locked ? "lock" : "unlock"] the collar."))
 

--- a/modular_zubbers/code/modules/antagonists/heretic/antimagic_collar.dm
+++ b/modular_zubbers/code/modules/antagonists/heretic/antimagic_collar.dm
@@ -165,7 +165,7 @@
 	locked = new_status
 	balloon_alert_to_viewers("[locked ? "locked!" : "unlocked!"]")
 	if (!isnull(key) && !locked)
-		radio.talk_into(src, "Antimagic collar [set_id] unlocked using a key.", RADIO_CHANNEL_SECURITY, list(speech_span))
+		radio.talk_into(src, "irreality collar [set_id] unlocked using a key.", RADIO_CHANNEL_SECURITY, list(speech_span))
 	if (user)
 		to_chat(user, span_warning("You [locked ? "lock" : "unlock"] the collar."))
 
@@ -185,8 +185,8 @@
 	..()
 
 /obj/item/key/collar/antimagic
-	name = "antimagic collar key"
-	desc = "The only kind of key that will open an antimagic collar. Hard to come across organically."
+	name = "irreality collar key"
+	desc = "The only kind of key that will open an irreality collar. Hard to come across organically."
 
 /obj/item/key/collar/antimagic/attack(mob/living/target_mob, mob/living/user, list/modifiers, list/attack_modifiers)
 	var/obj/item/clothing/neck/antimagic_collar/collar = target_mob.get_item_by_slot(ITEM_SLOT_NECK)
@@ -199,7 +199,7 @@
 	return TRUE
 
 /obj/item/storage/box/antimagic
-	name = "antimagic collar box"
+	name = "irreality collar box"
 	desc = "Contains a pair of anti-Acolyte collars, as well as a key to unlock them with."
 	icon_state = "secbox"
 	illustration = "heart_black"
@@ -210,9 +210,9 @@
 	new /obj/item/key/collar/antimagic(src)
 
 /datum/supply_pack/security/antimagic_collar
-	name = "Antimagic Collars"
+	name = "irreality collars"
 	desc = "Contains a pair of Anti-Acolyte collars, as well as a key to unlock them with."
 	cost = CARGO_CRATE_VALUE * 5
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/storage/box/antimagic = 1)
-	crate_name = "antimagic collar crate"
+	crate_name = "irreality collar crate"

--- a/modular_zubbers/code/modules/antagonists/heretic/spells.dm
+++ b/modular_zubbers/code/modules/antagonists/heretic/spells.dm
@@ -1,3 +1,3 @@
 /datum/action/cooldown/spell
-	/// If TRUE, marks this simulatniously as a focusless heretic spell and makes antimagic collars inhibit it.
+	/// If TRUE, marks this simulatniously as a focusless heretic spell and makes irreality collars inhibit it.
 	var/focusless_inhibitable = FALSE


### PR DESCRIPTION

## About The Pull Request

Title.
## Why It's Good For The Game

Antimagic is misleading. The collar only inhibits mansus spells.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

rename pr, it comnpiles

</details>

## Changelog
:cl:
spellcheck: All mentions of antimagic collar are changed to irreality collar
/:cl:
