### PR TITLE
Biodome CEs request console fix

### DIFF
--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -25383,7 +25383,12 @@
 /obj/effect/turf_decal/siding/thinplating_new/light{
 	dir = 10
 	},
-/obj/machinery/requests_console/directional/east,
+/obj/machinery/requests_console/directional/east{
+	department = "Chief Engineer's Desk"
+	},
+/obj/effect/mapping_helpers/requests_console/announcement,
+/obj/effect/mapping_helpers/requests_console/supplies,
+/obj/effect/mapping_helpers/requests_console/information,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "jbV" = (


### PR DESCRIPTION
## About The Pull Request

The CEs request console on biodome was listed as "unknown" and could make no announcements. This PR fixes that.

## Why It's Good For The Game

Fixes a map bug

## Proof Of Testing

<img width="909" height="780" alt="image" src="https://github.com/user-attachments/assets/67b6453c-02c3-4443-b299-5c3e9ed02e95" />
CEs request console labeled and able to make announcements.

## Changelog

:cl: Swan
fix: fixed the CEs request console on biodome not being able to make announcements
/:cl: