### PR TITLE
Spider Webs no longer deal stamina damage when you cross them because I fell once.

### DIFF
--- a/code/game/objects/effects/spiderwebs.dm
+++ b/code/game/objects/effects/spiderwebs.dm
@@ -110,7 +110,7 @@
 		loc.balloon_alert(victim, "stuck in web!")
 		victim.Shake(duration = 0.2 SECONDS)
 
-	victim.adjust_stamina_loss(rand(10, 15))
+	// victim.adjust_stamina_loss(rand(10, 15)) BUBBERSTATION CHANGE: SPIDER WEBS NO LONGER DEAL STAMINA DAMAGE
 
 /// Web made by geneticists, needs special handling to allow them to pass through their own webs
 /obj/structure/spider/stickyweb/genetic


### PR DESCRIPTION

## About The Pull Request

Spider Webs no longer deal stamina damage when you cross them. Note that they can still knock you down if you walk through them with low stamina.

## Why It's Good For The Game

Spider webs dealing stamina damage is pretty much a nerf that only really negatively affects antagonists. If you're fighting spiders, chances are you're not going to go in the webs anyways and instead focus on just destroying them.

## Proof Of Testing

If it compiles, it werks.

## Changelog

:cl: BurgerBB
balance: Spider Webs no longer deal stamina damage when you cross them. Note that they can still knock you down if you walk through them with low stamina.
/:cl:

