### PR TITLE
Minor dusting sickness grammar check

### DIFF
--- a/modular_zubbers/code/datums/quirks/negative_quirks/bloodloss_dusting.dm
+++ b/modular_zubbers/code/datums/quirks/negative_quirks/bloodloss_dusting.dm
@@ -4,7 +4,7 @@
 	value = -8
 	gain_text = span_danger("You start to worry even more about running out of blood.")
 	lose_text = span_notice("You feel like running out of blood isn't /quite/ as scary.")
-	medical_record_text = "Patient's body has an extreme reaction to bloodloss to the point of crumbling to dust. Keeping blood levels steady recommended."
+	medical_record_text = "Patient's body has an extreme reaction to bloodloss to the point of crumbling to dust. Keeping blood levels steady is recommended."
 	icon = FA_ICON_DROPLET_SLASH
 
 /datum/quirk/bloodloss_dusting/add(client/client_source)


### PR DESCRIPTION

## About The Pull Request
Changed the `medical_record_text` from:
```
"Patient's body has an extreme reaction to bloodloss to the point of crumbling to dust. Keeping blood levels steady recommended."
```
to:
```
"Patient's body has an extreme reaction to bloodloss to the point of crumbling to dust. Keeping blood levels steady is recommended."
```
## Why It's Good For The Game
Easier to understand.
## Proof Of Testing
I'm on my laptop which is extremely slow, but it's a one line variable change.
## Changelog
:cl:
spellcheck: Updated the medical records text for the Dusting Sickness quirk.
/:cl:
