### PR TITLE
Makes lycan TF sound a variable

### DIFF
--- a/modular_zubbers/code/modules/customization/species/lycans/lycan_status.dm
+++ b/modular_zubbers/code/modules/customization/species/lycans/lycan_status.dm
@@ -51,7 +51,7 @@
 			target_client.prefs.load_character(lycan_brain.last_slot)
 
 	ADD_TRAIT(human_owner, TRAIT_BEAST_FORM, SPECIES_TRAIT)
-	playsound(human_owner, 'modular_zubbers/code/modules/customization/species/lycans/transform.ogg', 50)
+	playsound(human_owner, lycan_brain.to_lycan_sfx, 50)
 
 /datum/status_effect/beast_form/on_remove()
 	. = ..()
@@ -79,7 +79,7 @@
 		human_owner.set_species(initial_species, TRUE, TRUE, FALSE)
 
 	REMOVE_TRAIT(human_owner, TRAIT_BEAST_FORM, SPECIES_TRAIT)
-	playsound(human_owner, 'modular_zubbers/code/modules/customization/species/lycans/transform.ogg', 50)
+	playsound(human_owner, lycan_brain.to_human_sfx, 50)
 
 /datum/status_effect/beast_form/tick(seconds_between_ticks)
 	. = ..()

--- a/modular_zubbers/code/modules/customization/species/lycans/organs/lycan_brain.dm
+++ b/modular_zubbers/code/modules/customization/species/lycans/organs/lycan_brain.dm
@@ -3,6 +3,8 @@
 	desc = "A larger than average, albeit slightly smoother brain. The hypothalamus seems larger than normal." // I read in a random medical artical that the hypothalamus controls aggression.
 	actions_types = list(/datum/action/cooldown/spell/beast_form)
 	var/last_slot
+	var/to_human_sfx = 'modular_zubbers/code/modules/customization/species/lycans/transform.ogg'
+	var/to_lycan_sfx = 'modular_zubbers/code/modules/customization/species/lycans/transform.ogg'
 
 /obj/item/organ/brain/lycan/on_mob_insert(mob/living/carbon/brain_owner, special, movement_flags)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Title.

2 vars added to the lycan brain - from lycan to human, human to lycan.
## Why It's Good For The Game

Lets admins var edit it at runtime and do silliness,
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

The maroon 5 is just proof you can varedit it and it works

https://github.com/user-attachments/assets/f962be9e-9559-4dd4-a630-43e208490c48

</details>

## Changelog
:cl:
code: Lycan transformation sfx is now a variable on the brain
/:cl:
