### PR TITLE
Fix flaky cable powernets unit tests

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -49429,12 +49429,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"rse" = (
-/obj/structure/frame/machine/secured,
-/obj/item/circuitboard/machine/smes,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "rsy" = (
 /obj/effect/turf_decal/box/white{
 	color = "#9FED58"
@@ -51127,7 +51121,7 @@
 /area/station/service/abandoned_gambling_den)
 "stQ" = (
 /obj/structure/sign/departments/science/directional/north,
-/obj/item/stack/cable_coil/five,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "stR" = (
@@ -84561,7 +84555,7 @@ cab
 jPf
 oFI
 bva
-rse
+fSx
 uIn
 mIa
 qdj

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -27698,7 +27698,6 @@
 /turf/open/floor/plating,
 /area/station/security/execution/education)
 "dVJ" = (
-/obj/structure/cable,
 /obj/machinery/camera/directional/north{
 	c_tag = "Engineering Power Storage"
 	},
@@ -30190,17 +30189,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
-"ftY" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "garbage"
-	},
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/disposal)
 "fuf" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -49442,7 +49430,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "rse" = (
-/obj/machinery/power/smes/engineering,
+/obj/structure/frame/machine/secured,
+/obj/item/circuitboard/machine/smes,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
@@ -51138,10 +51127,7 @@
 /area/station/service/abandoned_gambling_den)
 "stQ" = (
 /obj/structure/sign/departments/science/directional/north,
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/cable,
+/obj/item/stack/cable_coil/five,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "stR" = (
@@ -57754,7 +57740,6 @@
 	id = "garbage"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
@@ -59418,7 +59403,6 @@
 	name = "Danger: Conveyor Access";
 	req_access = list("maint_tunnels")
 	},
-/obj/effect/decal/cleanable/blood/splatter,
 /obj/machinery/conveyor/inverted{
 	dir = 10;
 	id = "garbage"
@@ -112023,7 +112007,7 @@ bbP
 wFq
 ycT
 dSx
-ftY
+hEc
 cMl
 wPw
 ezn

--- a/_maps/map_files/biodome/biodome.dmm
+++ b/_maps/map_files/biodome/biodome.dmm
@@ -37264,9 +37264,7 @@
 /area/station/maintenance/port/lower)
 "naC" = (
 /obj/structure/cable,
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
+/obj/machinery/power/smes/super/full,
 /turf/open/floor/circuit,
 /area/station/ai/satellite/chamber)
 "naO" = (


### PR DESCRIPTION
## About The Pull Request

some SMES' on our stations were a culprit in some wires having no power. This should fix https://github.com/Bubberstation/Bubberstation/issues/5797 .

## Why It's Good For The Game

This is mostly better for contributors who open pull requests, this will likely prevent their PR from failing checks from maps they didn't touch.

## Proof Of Testing

green means go, I think.
<img width="175" height="53" alt="image" src="https://github.com/user-attachments/assets/83477fa2-03ee-4f53-98dd-4a67f6037697" />