### PR TITLE
The Return of the (printable) defib

### DIFF
--- a/modular_zubbers/code/modules/research/designs/medical_designs.dm
+++ b/modular_zubbers/code/modules/research/designs/medical_designs.dm
@@ -48,3 +48,15 @@
 	RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_MEDICAL_ALIEN
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+
+/datum/design/defibrillator
+	name = "Defibrillator"
+	desc = "A portable defibrillator, used for resuscitating recently deceased crew."
+	id = "defibrillator"
+	build_type = PROTOLATHE | AWAY_LATHE
+	build_path = /obj/item/defibrillator
+	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT*4, /datum/material/glass = SHEET_MATERIAL_AMOUNT*2, /datum/material/silver =SHEET_MATERIAL_AMOUNT * 1.5, /datum/material/gold =HALF_SHEET_MATERIAL_AMOUNT * 1.5)
+	category = list(
+		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_MEDICAL
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL

--- a/modular_zubbers/code/modules/research/techweb/all_nodes.dm
+++ b/modular_zubbers/code/modules/research/techweb/all_nodes.dm
@@ -77,6 +77,13 @@
 	design_ids += list(
 		"wound_scanner_internal"
 	)
+
+/datum/techweb_node/medbay_equip/New()
+	. = ..()
+	design_ids += list(
+		"defibrillator",
+	)
+
 //ENGINEERING
 /datum/techweb_node/atmos/New()
 	. = ..()


### PR DESCRIPTION

<img width="800" height="450" alt="image" src="https://github.com/user-attachments/assets/f507a677-760b-4295-ab0f-3fc9baa4e632" />


## About The Pull Request
With this I am reverting the removal of the printable defibrillator, a change made by /tg/ some time ago.
Only the **base** defibrillator is printable, not the compact/belt slot defibrillator. It will need to have a cell inserted to work.

## Why It's Good For The Game

The change was initially made to increase the amount of interactions with cargo, but I believe that this only makes the process of obtaining defibrillators bothersome, as the interdepartmental action solely involves pressing a single button on the order console...
Obtaining defibrillators through cargo is still possible; you'll get three with charged batteries in them, without having to spend resources. I'm simply re-adding the old way to get them. This change was disliked both on /tg/ and here.

## Proof Of Testing

<img width="623" height="253" alt="image" src="https://github.com/user-attachments/assets/eb6f7375-0336-4cf6-87cc-3ef4171a7ecd" />


## Changelog

:cl:
balance: Defibrillators are now printable once again from the medical techfab.
/:cl:
