### PR TITLE
Adds a minimum pop requirement for Space Vines

### DIFF
--- a/modular_zubbers/code/modules/storyteller/event_defines/moderate/moderate_overrides.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/moderate/moderate_overrides.dm
@@ -35,6 +35,7 @@
 
 /datum/round_event_control/spacevine
 	tags = list(TAG_COMMUNAL, TAG_COMBAT, TAG_CHAOTIC)
+	min_players = 35
 
 /datum/round_event_control/portal_storm_syndicate
 	tags = list(TAG_COMBAT, TAG_CHAOTIC)


### PR DESCRIPTION
## About The Pull Request

For use in conjunction with https://github.com/Bubberstation/Bubberstation/pull/5739

## Why It's Good For The Game

lol just watch it on a lowpop round

## Changelog

:cl: LT3
balance: Space vines event now require a minimum of 35 pop
/:cl: