### PR TITLE
reverts the change that removed the healing factor on the bluelens emitter beams

### DIFF
--- a/modular_zubbers/code/modules/projectiles/beams.dm
+++ b/modular_zubbers/code/modules/projectiles/beams.dm
@@ -1,2 +1,0 @@
-/obj/projectile/beam/emitter/hitscan/bluelens
-	integrity_heal = 0

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10095,7 +10095,6 @@
 #include "modular_zubbers\code\modules\primitive_catgirls\code\spawner.dm"
 #include "modular_zubbers\code\modules\primitive_structures\code\wall_torch.dm"
 #include "modular_zubbers\code\modules\privacy_policy\privacy_policy.dm"
-#include "modular_zubbers\code\modules\projectiles\beams.dm"
 #include "modular_zubbers\code\modules\projectiles\ammunition\ballistic\arrows.dm"
 #include "modular_zubbers\code\modules\projectiles\ammunition\ballistic\pistol.dm"
 #include "modular_zubbers\code\modules\projectiles\ammunition\ballistic\rifle.dm"


### PR DESCRIPTION

## About The Pull Request
Title
## Why It's Good For The Game
A) No one uses the diode disks anyway (booooo)
B) This lens reduces SM power as well as healing the SM, so you can't only use them
C) this was the worst PR that I ever made and Idk why I actually made it.
## Proof Of Testing
 it worky for sure
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
balance: reverts bluelens to TG base
/:cl:
