### PR TITLE
makes the long range gas analyzer pocketable like the normal range one

### DIFF
--- a/modular_zubbers/code/game/Items/tools.dm
+++ b/modular_zubbers/code/game/Items/tools.dm
@@ -92,3 +92,5 @@
 	icon_state = "pn_welder"
 	toolspeed = 0.25
 
+/obj/item/analyzer/ranged
+	w_class = WEIGHT_CLASS_SMALL


### PR DESCRIPTION

## About The Pull Request
title
## Why It's Good For The Game
atmos gaming - there's like no reason for this thing not to be pocketable
## Proof Of Testing
it works
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
qol: long range gas analyzer is pocketable like short range
/:cl:
