### PR TITLE
Pubbystation cargo updates

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -211,23 +211,12 @@
 /area/station/engineering/main)
 "abc" = (
 /obj/structure/table,
-/obj/item/stamp/granted{
-	pixel_x = -8;
-	pixel_y = 3
-	},
-/obj/item/stamp/denied{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/pen/red{
-	pixel_y = 7
-	},
-/obj/item/dest_tagger{
-	pixel_x = 9;
-	pixel_y = -1
-	},
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
+	},
+/obj/machinery/fax{
+	fax_name = "Cargo Office";
+	name = "Cargo Office Fax Machine"
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -11601,12 +11590,23 @@
 /area/station/hallway/primary/central/fore)
 "aXs" = (
 /obj/structure/table,
-/obj/machinery/fax{
-	fax_name = "Cargo Office";
-	name = "Cargo Office Fax Machine"
-	},
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
+	},
+/obj/item/stamp/granted{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/obj/item/stamp/denied{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/dest_tagger{
+	pixel_x = 9;
+	pixel_y = -1
+	},
+/obj/item/pen/red{
+	pixel_y = 7
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
@@ -12011,9 +12011,6 @@
 /obj/structure/window/reinforced/spawner/directional/north{
 	pixel_y = 4
 	},
-/obj/structure/disposaloutlet{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -12021,6 +12018,9 @@
 	dir = 1
 	},
 /obj/machinery/light/small/directional/east,
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "aZn" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -1950,7 +1950,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "aiJ" = (
-/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/spawner/directional/east,
 /obj/machinery/door/firedoor,
 /obj/machinery/gbp_redemption,
 /turf/open/floor/iron,
@@ -3212,6 +3212,7 @@
 /area/station/maintenance/department/security/brig)
 "anu" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/crate_abandoned,
 /turf/open/floor/iron,
 /area/station/cargo/miningfoundry)
 "anw" = (
@@ -9546,12 +9547,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "aNQ" = (
-/obj/structure/sign/warning/directional/south,
-/obj/machinery/mech_bay_recharge_port{
-	dir = 1
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/mining{
+	name = "Cargo Bay Foundry"
 	},
-/turf/open/floor/plating,
-/area/station/cargo/miningfoundry)
+/obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "aNT" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/red/half/contrasted,
@@ -9563,7 +9565,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
@@ -10637,8 +10639,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/supply/general,
-/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
+/obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -12924,8 +12925,7 @@
 	name = "Cargo Bay"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/supply/general,
-/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
+/obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
 	},
@@ -15379,9 +15379,7 @@
 /turf/open/floor/iron/dark,
 /area/station/science/research)
 "bqi" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
-/obj/structure/sign/poster/random/directional/north,
+/obj/machinery/computer/mech_bay_power_console,
 /turf/open/floor/iron,
 /area/station/cargo/miningfoundry)
 "bql" = (
@@ -15823,9 +15821,13 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
 "bsR" = (
-/obj/vehicle/sealed/mecha/ripley/cargo,
-/turf/open/floor/iron/recharge_floor,
-/area/station/cargo/miningfoundry)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = "warehouse";
+	name = "Warehouse Shutter"
+	},
+/turf/open/floor/plating,
+/area/station/cargo/storage)
 "bsV" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
@@ -24191,15 +24193,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "cqh" = (
-/obj/structure/window/spawner/directional/west,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "QMLoad2"
 	},
-/obj/structure/window/spawner/directional/north,
-/obj/machinery/disposal/delivery_chute{
-	dir = 4
-	},
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/cargo/storage)
 "cqk" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -26462,6 +26460,7 @@
 	dir = 4;
 	id = "QMLoad"
 	},
+/obj/structure/plasticflaps,
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "dbj" = (
@@ -27823,13 +27822,18 @@
 /turf/closed/wall,
 /area/station/medical/treatment_center)
 "dYl" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted,
-/obj/structure/reagent_dispensers/fueltank,
-/obj/structure/disposalpipe/segment{
+/obj/structure/window/spawner/directional/west,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/window/spawner/directional/north,
+/obj/machinery/disposal/delivery_chute{
 	dir = 4
 	},
 /obj/machinery/light,
-/obj/machinery/firealarm/directional/south,
+/obj/machinery/status_display/supply{
+	pixel_y = -32
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "dYm" = (
@@ -28219,7 +28223,7 @@
 	dir = 8;
 	pixel_y = -2
 	},
-/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/spawner/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "elj" = (
@@ -29953,7 +29957,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/spawner/random/structure/crate_abandoned,
+/obj/machinery/firealarm/directional/north,
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/station/cargo/miningfoundry)
 "flQ" = (
@@ -30075,6 +30081,8 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/cargo/miningfoundry)
 "fqv" = (
@@ -30496,6 +30504,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "fEU" = (
@@ -32687,7 +32696,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/cargo/miningfoundry)
 "gYY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
@@ -33882,9 +33891,8 @@
 /area/station/maintenance/department/cargo)
 "hOI" = (
 /obj/machinery/light/small/directional/west,
-/obj/structure/closet/crate/freezer,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/iron,
+/obj/vehicle/sealed/mecha/ripley/cargo,
+/turf/open/floor/iron/recharge_floor,
 /area/station/cargo/miningfoundry)
 "hOL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -38595,16 +38603,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "kRa" = (
-/obj/machinery/door/window/left/directional/west{
-	pixel_x = -4;
-	name = "Deliveries Transfer Chute"
-	},
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "QMLoad2"
-	},
-/turf/open/floor/plating,
-/area/station/cargo/storage)
+/obj/structure/closet/crate/freezer,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/iron,
+/area/station/cargo/miningfoundry)
 "kRk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -39816,13 +39818,14 @@
 /area/station/science/genetics)
 "lEm" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted,
-/obj/structure/reagent_dispensers/watertank,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_y = -26
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "lEn" = (
@@ -42143,7 +42146,7 @@
 "ndU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/piratepad/civilian,
-/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/spawner/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "nei" = (
@@ -42569,9 +42572,9 @@
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "nsH" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
-/obj/machinery/firealarm/directional/west,
+/obj/machinery/mech_bay_recharge_port{
+	dir = 2
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningfoundry)
 "nsJ" = (
@@ -43325,9 +43328,6 @@
 "nSz" = (
 /obj/machinery/light_switch/directional/south,
 /obj/machinery/light/small/directional/south,
-/obj/machinery/computer/mech_bay_power_console{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/station/cargo/miningfoundry)
 "nTk" = (
@@ -46729,7 +46729,7 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/cargo/miningfoundry)
 "pOE" = (
 /obj/structure/rack,
@@ -47229,8 +47229,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/supply/general,
-/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
+/obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
 	},
@@ -54381,7 +54380,7 @@
 	name = "Deliveries"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -58314,6 +58313,7 @@
 	dir = 8;
 	id = "QMLoad2"
 	},
+/obj/structure/plasticflaps,
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "wCi" = (
@@ -102749,18 +102749,18 @@ aEj
 uXX
 aEj
 fln
-vBZ
+kRa
 ney
-bsR
+vBZ
+vBZ
 aNQ
-bbG
 jQv
 asK
 cCB
 cCB
 cCB
 cCB
-cCB
+acx
 lEm
 bbG
 aaa
@@ -103017,7 +103017,7 @@ aTr
 vrX
 aTr
 aTr
-cCB
+cpo
 dYl
 bbG
 aht
@@ -103267,7 +103267,7 @@ anu
 aQo
 jBh
 bMV
-aTy
+bsR
 pcy
 gnh
 baD
@@ -103276,7 +103276,7 @@ aXA
 aXA
 hvF
 cqh
-bbG
+aTy
 aaa
 aaa
 aaa
@@ -103524,7 +103524,7 @@ rmO
 xog
 lmw
 wPU
-aTy
+bsR
 pcy
 aKh
 cCB
@@ -103532,7 +103532,7 @@ vFu
 cCB
 cCB
 cpo
-kRa
+poF
 aTy
 aaa
 aaa
@@ -103781,7 +103781,7 @@ aEj
 btg
 coL
 aQp
-aTy
+bsR
 pcy
 bTu
 cCB
@@ -104038,7 +104038,7 @@ aEj
 hkA
 ylY
 wZg
-bbG
+bsR
 pcy
 bUX
 qof
@@ -104301,10 +104301,10 @@ fHp
 bbG
 fHp
 kIV
+bbG
 aTy
 aTy
-aTy
-aTy
+bbG
 aaa
 aaa
 aaa
@@ -104558,7 +104558,7 @@ vsO
 aTy
 iYH
 wBY
-aTy
+bbG
 aht
 aht
 aht
@@ -104815,7 +104815,7 @@ jTV
 bbG
 jTV
 kIV
-aTy
+bbG
 aaa
 aaa
 aaa


### PR DESCRIPTION
## About The Pull Request

- Updates some airlock access helpers for consistency
- Adds an airlock to the forge area
- Adds plastic flaps
- Adds a shuttle timer display on the south wall
- Swaps the stamps table and fax machine in lobby

## Why It's Good For The Game

Cargo QoL

## Proof Of Testing

<img width="1390" height="1115" alt="image" src="https://github.com/user-attachments/assets/65d27996-1410-4a89-ab9a-7dcbbc8d3be3" />

</details>

## Changelog

:cl: LT3
map: QoL improvements to PubbyStation cargo area
/:cl: