### PR TITLE
Stops Paramedics from being antags

### DIFF
--- a/modular_zubbers/code/modules/protected_roles/code/antag_restricted_jobs.dm
+++ b/modular_zubbers/code/modules/protected_roles/code/antag_restricted_jobs.dm
@@ -3,3 +3,6 @@
 
 /datum/job/bridge_assistant
 	antagonist_restricted = TRUE
+
+/datum/job/paramedic
+	antagonist_restricted = TRUE


### PR DESCRIPTION
## About The Pull Request

see title

## Why It's Good For The Game

ill be honest - paramedic is in an awful state
you need access to do your job; if you have access, everyone loses their shit
there has been a series of nerfs heaped down on paramedics, and any attempt to make the job less miserable is met with people screaming about evil paratiders stealing their mother or something

so, i propose a trade deal:
no antag paramedics
in exchange we can make the job not be a crawling through broken glass simulator

## Proof Of Testing

did you know that the striped hyena's scientific name is hyena hyena?

## Changelog

:cl:
add: paramedic is antagonist_restricted
/:cl: