### PR TITLE
Fix horns getting hidden in modsuits

### DIFF
--- a/code/modules/surgery/organs/external/_visual_organs.dm
+++ b/code/modules/surgery/organs/external/_visual_organs.dm
@@ -126,8 +126,10 @@ Unlike normal organs, we're actually inside a persons limbs at all times
 	dyable = TRUE
 	draw_on_husks = HUSK_OVERLAY_NORMAL
 
+/* BUBBER EDIT REMOVE BEGIN - Customization
 /datum/bodypart_overlay/mutant/horns/can_draw_on_bodypart(obj/item/bodypart/bodypart_owner, mob/living/carbon/owner, is_husked = FALSE)
 	return ..() && !(bodypart_owner.owner?.obscured_slots & HIDEHAIR)
+*/// BUBBER EDIT REMOVE END
 
 ///The frills of a lizard (like weird fin ears)
 /obj/item/organ/frills

--- a/modular_skyrat/modules/customization/modules/surgery/organs/horns.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/organs/horns.dm
@@ -12,10 +12,3 @@
 /datum/bodypart_overlay/mutant/horns/override_color(rgb_value)
 	return draw_color
 
-/datum/bodypart_overlay/mutant/horns/can_draw_on_bodypart(obj/item/bodypart/bodypart_owner)
-	if(!..(bodypart_owner))
-		return FALSE
-	var/mob/living/carbon/human/human = bodypart_owner.owner
-	if(!human)
-		return TRUE
-	return !sprite_datum.is_hidden(human)

--- a/modular_zubbers/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
+++ b/modular_zubbers/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
@@ -86,13 +86,13 @@
 	return sprite_datum?.feature_key_override || feature_key
 
 
-/datum/bodypart_overlay/mutant/can_draw_on_bodypart(obj/item/bodypart/bodypart_owner)
+/datum/bodypart_overlay/mutant/can_draw_on_bodypart(obj/item/bodypart/bodypart_owner, mob/living/carbon/owner, is_husked)
 	if(!..())
 		return FALSE
-	var/mob/living/carbon/human/human = bodypart_owner.owner
-	if(!istype(human))
+	var/mob/living/carbon/human/human_owner = owner
+	if(!istype(human_owner))
 		return TRUE
-	return !isnull(sprite_datum) && !sprite_datum.is_hidden(human)
+	return !isnull(sprite_datum) && !sprite_datum.is_hidden(human_owner)
 
 
 /// Get the images we need to draw on the person. Called from get_overlay() which is called from _bodyparts.dm.


### PR DESCRIPTION

## About The Pull Request

Couple things going on here but basically boils down to the `/datum/bodypart_overlay/mutant/horns/can_draw_on_bodypart` proc in `_visual_organs.dm` blocking horns if outfit has `HIDEHAIR` flagged which mods do, this is all fine and dandy but we have a specific carve-out for mods because of the hardlight overlays they add, problem is that the latter check was taking precedence over the carve-out (`is_deely_bopper_hidden`). I commented out this check because `is_deely_bopper_hidden` does everything it does and more, so we don't need it. Also deleted a redundant skyrat override on `/datum/bodypart_overlay/mutant/horns/can_draw_on_bodypart` because the parent `/datum/bodypart_overlay/mutant/can_draw_on_bodypart` override does the same thing.
## Why It's Good For The Game

Fixes #5631 

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="75" height="100" alt="image" src="https://github.com/user-attachments/assets/e2939c50-39de-48de-8ffa-da648fa9df85" />

</details>

## Changelog
:cl:
fix: fixed modsuits hiding horns
/:cl:
