### PR TITLE
minor daimyo modsuit tweaks

### DIFF
--- a/modular_zubbers/code/modules/syndicate_offstation/equipment_items/mod_types.dm
+++ b/modular_zubbers/code/modules/syndicate_offstation/equipment_items/mod_types.dm
@@ -24,20 +24,22 @@
 
 /obj/item/mod/control/pre_equipped/daimyo
 	theme = /datum/mod_theme/daimyo
-	applied_cell = /obj/item/stock_parts/power_store/cell/hyper
+	applied_cell = /obj/item/stock_parts/power_store/cell/bluespace
 	starting_frequency = MODLINK_FREQ_SYNDICATE
 	applied_modules = list(
 		/obj/item/mod/module/storage/syndicate,
-		/obj/item/mod/module/dna_lock,
-		/obj/item/mod/module/longfall,
+		/obj/item/mod/module/welding/syndicate,
 		/obj/item/mod/module/shock_absorber,
 		/obj/item/mod/module/emp_shield/advanced,
-		/obj/item/mod/module/magnetic_harness,
 		/obj/item/mod/module/noslip,
+		/obj/item/mod/module/dna_lock,
+		/obj/item/mod/module/longfall,
+		/obj/item/mod/module/magnetic_harness,
 		/obj/item/mod/module/jetpack/advanced,
 		/obj/item/mod/module/shove_blocker,
+		/obj/item/mod/module/pathfinder,
 		/obj/item/mod/module/night,
-		/obj/item/mod/module/welding/syndicate,
+		/obj/item/mod/module/hat_stabilizer/syndicate,
 	)
 	default_pins = list(
 		/obj/item/mod/module/jetpack/advanced,
@@ -58,6 +60,7 @@
 		A tag on the core reads 'This is the most expensive piece of equipment you'll ever handle in your life, \
 		do NOT lose it.' -Ruggero"
 	default_skin = "daimyo"
+	hardlight_theme = CONTRACTOR_RED
 	armor_type = /datum/armor/mod_theme_daimyo
 	resistance_flags = FIRE_PROOF|ACID_PROOF|LAVA_PROOF
 	atom_flags = PREVENT_CONTENTS_EXPLOSION_1


### PR DESCRIPTION
## About The Pull Request

Sets the hardlight color to red. Reorients some of the modules. Adds a pathfinder and elite hat stabilizer module. Replaces the cell with a bluespace one so it's like the elite suit.

## Why It's Good For The Game

Hardlight wasn't supposed to be blue.

## Proof Of Testing
Works just fine.
Before:
<img width="121" height="152" alt="image" src="https://github.com/user-attachments/assets/e2f98045-2660-4246-b528-3a30d6fdb965" />
<img width="757" height="757" alt="image" src="https://github.com/user-attachments/assets/2ec71af8-ee8d-4f89-8018-a9f9313d7949" />

After:
<img width="126" height="153" alt="image" src="https://github.com/user-attachments/assets/15842b04-d219-4baa-ae88-0320bf43affb" />
<img width="755" height="758" alt="image" src="https://github.com/user-attachments/assets/cd852679-e516-48ac-81dc-e092f8de5107" />

## Changelog
:cl:
add: Daimyo modsuit has red hardlight now.
add: Daimyo modsuit now uses a bluespace cell by default.
add: Daimyo modsuit now has a pathfinder and elite hat stabilizer along with the modules being reorganized a little.
/:cl:
