### PR TITLE
Issue 5898 -- Allow Accented Letters

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -207,7 +207,7 @@
 					continue
 				last_char_group = APOSTROPHE_DETECTED
 
-			// '  -  .
+			// -  .
 			if(45,46) //Common name punctuation
 				if(last_char_group == NO_CHARS_DETECTED)
 					if(strict)

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -149,7 +149,7 @@
 #define SYMBOLS_DETECTED 2
 #define NUMBERS_DETECTED 3
 #define LETTERS_DETECTED 4
-#define APOSTROPHE_DETECTED 5 // BLUBBER EDIT ADDITION -- Issue 5898 Allow Accented Letters & Do Not Autocapitalize After Apostrophe
+#define APOSTROPHE_DETECTED 5 // BLUBBER EDIT ADDITION -- Allow Accented Letters & Do Not Autocapitalize After Apostrophe
 
 /**
  * Filters out undesirable characters from names.
@@ -178,7 +178,7 @@
 	for(var/i = 1, i <= t_len, i += length(char))
 		char = t_in[i]
 		switch(text2ascii(char))
-			// BUBBER EDIT BEGIN -- Issue 5898 Allow Accented Letters & Do Not Autocapitalize After Apostrophe
+			// BUBBER EDIT BEGIN -- Allow Accented Letters & Do Not Autocapitalize After Apostrophe
 			// A  .. Z, Latin-1 Supplement Letters
 			if(65 to 90,192 to 214,216 to 222) //Uppercase Letters
 				number_of_alphanumeric++
@@ -200,7 +200,6 @@
 				number_of_alphanumeric++
 				last_char_group = NUMBERS_DETECTED
 
-			// '
 			if (39) //Apostrophes are common in non-English names to represent glottal stop -- should not force capitalization
 				if(last_char_group == NO_CHARS_DETECTED)
 					if(strict)

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -149,6 +149,7 @@
 #define SYMBOLS_DETECTED 2
 #define NUMBERS_DETECTED 3
 #define LETTERS_DETECTED 4
+#define APOSTROPHE_DETECTED 5 // BLUBBER EDIT -- Issue 5898 Allow Accented Letters & Do Not Autocapitalize After Apostrophe
 
 /**
  * Filters out undesirable characters from names.
@@ -177,7 +178,7 @@
 	for(var/i = 1, i <= t_len, i += length(char))
 		char = t_in[i]
 		switch(text2ascii(char))
-			// BUBBER EDIT BEGIN -- Issue 5898 Allow Accented Letters
+			// BUBBER EDIT BEGIN -- Issue 5898 Allow Accented Letters & Do Not Autocapitalize After Apostrophe
 			// A  .. Z, Latin-1 Supplement Letters
 			if(65 to 90,192 to 214,216 to 222) //Uppercase Letters
 				number_of_alphanumeric++
@@ -189,7 +190,6 @@
 					char = uppertext(char)
 				number_of_alphanumeric++
 				last_char_group = LETTERS_DETECTED
-			// BUBBER EDIT END
 
 			// 0  .. 9
 			if(48 to 57) //Numbers
@@ -199,8 +199,17 @@
 					continue
 				number_of_alphanumeric++
 				last_char_group = NUMBERS_DETECTED
+
+			// '
+			if (39) //Apostrophes are common in non-English names to represent glottal stop -- should not force capitalization
+				if(last_char_group == NO_CHARS_DETECTED)
+					if(strict)
+						return
+					continue
+				last_char_group = APOSTROPHE_DETECTED
+
 			// '  -  .
-			if(39,45,46) //Common name punctuation
+			if(45,46) //Common name punctuation
 				if(last_char_group == NO_CHARS_DETECTED)
 					if(strict)
 						return
@@ -223,7 +232,6 @@
 					continue
 				last_char_group = SPACES_DETECTED
 
-			// BUBBER EDIT BEGIN -- Issue 5898 Allow Accented Letters
 			if(127 to 191,215,247,256 to INFINITY)
 				if(ascii_only)
 					if(strict)

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -149,7 +149,7 @@
 #define SYMBOLS_DETECTED 2
 #define NUMBERS_DETECTED 3
 #define LETTERS_DETECTED 4
-#define APOSTROPHE_DETECTED 5 // BLUBBER EDIT -- Issue 5898 Allow Accented Letters & Do Not Autocapitalize After Apostrophe
+#define APOSTROPHE_DETECTED 5 // BLUBBER EDIT ADDITION -- Issue 5898 Allow Accented Letters & Do Not Autocapitalize After Apostrophe
 
 /**
  * Filters out undesirable characters from names.

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -177,18 +177,19 @@
 	for(var/i = 1, i <= t_len, i += length(char))
 		char = t_in[i]
 		switch(text2ascii(char))
-
-			// A  .. Z
-			if(65 to 90) //Uppercase Letters
+			// BUBBER EDIT BEGIN -- Issue 5898 Allow Accented Letters
+			// A  .. Z, Latin-1 Supplement Letters
+			if(65 to 90,192 to 214,216 to 222) //Uppercase Letters
 				number_of_alphanumeric++
 				last_char_group = LETTERS_DETECTED
 
-			// a  .. z
-			if(97 to 122) //Lowercase Letters
+			// a  .. z, Latin-1 Supplement Letters
+			if(97 to 122,223 to 246,248 to 255) //Lowercase Letters
 				if(((last_char_group == NO_CHARS_DETECTED || last_char_group == SPACES_DETECTED) && cap_at_start) || (cap_after_symbols && last_char_group == SYMBOLS_DETECTED)) //start of a word
 					char = uppertext(char)
 				number_of_alphanumeric++
 				last_char_group = LETTERS_DETECTED
+			// BUBBER EDIT END
 
 			// 0  .. 9
 			if(48 to 57) //Numbers
@@ -222,12 +223,14 @@
 					continue
 				last_char_group = SPACES_DETECTED
 
-			if(127 to INFINITY)
+			// BUBBER EDIT BEGIN -- Issue 5898 Allow Accented Letters
+			if(127 to 191,215,247,256 to INFINITY)
 				if(ascii_only)
 					if(strict)
 						return
 					continue
 				last_char_group = SYMBOLS_DETECTED //for now, we'll treat all non-ascii characters like symbols even though most are letters
+			// BUBBER EDIT END
 
 			else
 				continue


### PR DESCRIPTION

## About The Pull Request

resolves: https://github.com/Bubberstation/Bubberstation/issues/5898

Extend _HELPERS/text.dm reject_bad_name to allow for the first block of extended Latin characters. All characters not permissed by this new block are still treated as "symbol." E.g. Ň (which looks similar to Ñ) is in the second block of extended characters and will continue to be treated as a symbol with the undefined behavior that entails.

Scope Creep: Also disable auto-capitalization after an apostrophe so that names with glottal stops can be correctly formatted.

## Why It's Good For The Game

Players should be allowed more flexibility to have non-English names for their characters. While it is impractical to allow every single non-English character, especially since this would encourage a form of intrusive naming abuse, I believe this first block of Latin characters allowed for much more flexibility in character naming without being too chaotic.

Scope Creep: Correctly format names with glottal stops, for similar reasons.
## Proof Of Testing

Not much to show off.
<details>
<summary>Screenshots/Videos</summary>
<img width="1090" height="150" alt="image" src="https://github.com/user-attachments/assets/d4e741aa-aa6d-46d4-ade5-156a0f689ea9" />

<img width="1148" height="139" alt="image" src="https://github.com/user-attachments/assets/cb24e870-8eab-4e13-a1ef-0150e3b6f42c" />
</details>

## Changelog
:cl:
add: Ability to use the most common accented Latin letters in character names.
del: Auto-capitalization after apostrophe.
/:cl:
