### PR TITLE
Fixes an old Skyrat bug with epi-pens/alt-click interactions [NOVA PORT]

### DIFF
--- a/modular_skyrat/master_files/code/modules/reagents/reagent_containers.dm
+++ b/modular_skyrat/master_files/code/modules/reagents/reagent_containers.dm
@@ -1,4 +1,6 @@
 /obj/item/reagent_containers/click_alt(mob/living/user)
+	if(!has_variable_transfer_amount)
+		return NONE
 	if(length(possible_transfer_amounts) <= 2) // If there's only two choices, just swap between them.
 		change_transfer_amount(user, FORWARD)
 		return CLICK_ACTION_SUCCESS


### PR DESCRIPTION

## About The Pull Request
Original PR: https://github.com/NovaSector/NovaSector/pull/5806
Makes it so you can't alt-click epi-pens, which makes your epi-pen get stuck dispensing 5u.
## Why It's Good For The Game
Bugs bad.
## Proof Of Testing
I couldn't test this since I'm in a car right now, but it's 1:1 with the Nova PR so it should work.
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl: xPokee, vinylspiders
fix: Fixed some objects (epi-pens) having the ability to be alt-clicked to change reagent amounts, which they shouldn't be able to do.
/:cl:
