### PR TITLE
Fix NIFsoft installations

### DIFF
--- a/modular_skyrat/modules/modular_implants/code/nifs.dm
+++ b/modular_skyrat/modules/modular_implants/code/nifs.dm
@@ -316,7 +316,12 @@
 
 ///Installs the loaded_nifsoft to the parent NIF.
 /obj/item/organ/cyberimp/brain/nif/proc/install_nifsoft(datum/nifsoft/loaded_nifsoft)
-	if(broken || calibrating) //NIFSofts can't be installed to a broken NIF
+	if(broken)
+		send_message("The target device is not responding.", alert = TRUE)
+		return FALSE
+
+	if(calibrating)
+		send_message("Software can't be installed until calibration is complete!", alert = TRUE)
 		return FALSE
 
 	if(length(loaded_nifsofts) >= max_nifsofts)

--- a/modular_skyrat/modules/modular_implants/code/nifs.dm
+++ b/modular_skyrat/modules/modular_implants/code/nifs.dm
@@ -177,10 +177,10 @@
 		return FALSE
 
 	for(var/datum/nifsoft/preinstalled_nifsoft as anything in preinstalled_nifsofts)
-		new preinstalled_nifsoft(src)
+		new preinstalled_nifsoft(src, TRUE, TRUE)
 
 	for(var/stored_nifsoft in persistent_nifsofts)
-		var/datum/nifsoft/new_stored_nifsoft = new stored_nifsoft(src)
+		var/datum/nifsoft/new_stored_nifsoft = new stored_nifsoft(src, TRUE, TRUE)
 		new_stored_nifsoft.keep_installed = TRUE
 
 	return TRUE
@@ -315,13 +315,13 @@
 				stack_trace("persistence was not saved for [linked_mob]!")
 
 ///Installs the loaded_nifsoft to the parent NIF.
-/obj/item/organ/cyberimp/brain/nif/proc/install_nifsoft(datum/nifsoft/loaded_nifsoft)
+/obj/item/organ/cyberimp/brain/nif/proc/install_nifsoft(datum/nifsoft/loaded_nifsoft, skip_calibration = FALSE)
 	if(broken)
 		send_message("The target device is not responding.", alert = TRUE)
 		return FALSE
 
-	if(calibrating)
-		send_message("Software can't be installed until calibration is complete!", alert = TRUE)
+	if(calibrating && !skip_calibration)
+		send_message("The NIF is still calibrating, please wait!", alert = TRUE)
 		return FALSE
 
 	if(length(loaded_nifsofts) >= max_nifsofts)

--- a/modular_skyrat/modules/modular_implants/code/nifsofts.dm
+++ b/modular_skyrat/modules/modular_implants/code/nifsofts.dm
@@ -56,7 +56,7 @@
 	///Is it a lewd item?
 	var/lewd_nifsoft = FALSE
 
-/datum/nifsoft/New(obj/item/organ/cyberimp/brain/nif/recipient_nif, no_rewards_points = FALSE)
+/datum/nifsoft/New(obj/item/organ/cyberimp/brain/nif/recipient_nif, no_rewards_points = FALSE, skip_calibration = FALSE)
 	. = ..()
 
 	if(no_rewards_points) //This is mostly so that credits can't be farmed through printed or stolen NIFSoft disks
@@ -65,7 +65,7 @@
 	compatible_nifs += /obj/item/organ/cyberimp/brain/nif/debug
 	program_name = name
 
-	if(!recipient_nif.install_nifsoft(src))
+	if(!recipient_nif.install_nifsoft(src, skip_calibration))
 		qdel(src)
 		return
 

--- a/modular_skyrat/modules/modular_implants/code/nifsofts.dm
+++ b/modular_skyrat/modules/modular_implants/code/nifsofts.dm
@@ -67,6 +67,7 @@
 
 	if(!recipient_nif.install_nifsoft(src))
 		qdel(src)
+		return
 
 	parent_nif = WEAKREF(recipient_nif)
 	linked_mob = recipient_nif.linked_mob


### PR DESCRIPTION
## About The Pull Request

Fixed NIFsoft software always returning as success even when it fails. Also adds a skip_calibration flag because the NIF was runtiming trying to install its preinstalled_nifsofts

## Why It's Good For The Game

Fix bug. Closes https://github.com/Bubberstation/Bubberstation/issues/5854

## Changelog

:cl: LT3
fix: NIFsoft programs no longer consume the disk when installation fails
fix: Preinstalled NIFsoft programs should actually preinstall
/:cl:
