### PR TITLE
Re-arrange and add options to the mounted med-station

### DIFF
--- a/modular_skyrat/modules/deforest_medical_items/code/medstation_designs/medical.dm
+++ b/modular_skyrat/modules/deforest_medical_items/code/medstation_designs/medical.dm
@@ -57,7 +57,7 @@
 	name = "Red Sun Balm"
 	id = "organic_sun_balm"
 	build_type = BIOGENERATOR
-	materials = list(/datum/material/biomass = 7) // 12 per stacks
+	materials = list(/datum/material/biomass = 9) // 12 per stacks
 	build_path = /obj/item/stack/medical/ointment/red_sun
 	category = list(
 		RND_CATEGORY_INITIAL,

--- a/modular_skyrat/modules/deforest_medical_items/code/medstation_designs/medical.dm
+++ b/modular_skyrat/modules/deforest_medical_items/code/medstation_designs/medical.dm
@@ -1,4 +1,4 @@
-/datum/design/organic_printer_bruise_pack
+/datum/design/organic_printer_bruise_pack 
 	name = "Bruise Packs"
 	id = "organic_bruise_packs"
 	build_type = BIOGENERATOR

--- a/modular_skyrat/modules/deforest_medical_items/code/medstation_designs/medical.dm
+++ b/modular_skyrat/modules/deforest_medical_items/code/medstation_designs/medical.dm
@@ -2,7 +2,7 @@
 	name = "Bruise Packs"
 	id = "organic_bruise_packs"
 	build_type = BIOGENERATOR
-	materials = list(/datum/material/biomass = 5) // 6 per stacks
+	materials = list(/datum/material/biomass = 4) // 6 per stacks
 	build_path = /obj/item/stack/medical/bruise_pack
 	category = list(
 		RND_CATEGORY_INITIAL,
@@ -13,7 +13,7 @@
 	name = "Ointment"
 	id = "organic_ointment"
 	build_type = BIOGENERATOR
-	materials = list(/datum/material/biomass = 4) // 8 per stacks
+	materials = list(/datum/material/biomass = 3) // 8 per stacks
 	build_path = /obj/item/stack/medical/ointment
 	category = list(
 		RND_CATEGORY_INITIAL,
@@ -24,7 +24,7 @@
 	name = "Suture"
 	id = "organic_suture"
 	build_type = BIOGENERATOR
-	materials = list(/datum/material/biomass = 6) // 10 per stacks
+	materials = list(/datum/material/biomass = 8) // 10 per stacks
 	build_path = /obj/item/stack/medical/suture
 	category = list(
 		RND_CATEGORY_INITIAL,
@@ -35,7 +35,7 @@
 	name = "Regenerative Mesh"
 	id = "organic_regenerative_mesh"
 	build_type = BIOGENERATOR
-	materials = list(/datum/material/biomass = 5) // 15 per stacks
+	materials = list(/datum/material/biomass = 6) // 15 per stacks
 	build_path = /obj/item/stack/medical/mesh
 	category = list(
 		RND_CATEGORY_INITIAL,

--- a/modular_skyrat/modules/deforest_medical_items/code/medstation_designs/medical.dm
+++ b/modular_skyrat/modules/deforest_medical_items/code/medstation_designs/medical.dm
@@ -68,7 +68,7 @@
 	name = "Sealed Aseptic Gauze"
 	id = "organic_aseptic_gauze"
 	build_type = BIOGENERATOR
-	materials = list(/datum/material/biomass = 5) // 6 per stacks
+	materials = list(/datum/material/biomass = 8) // 6 per stacks
 	build_path = /obj/item/stack/medical/wrap/gauze/sterilized
 	category = list(
 		RND_CATEGORY_INITIAL,

--- a/modular_skyrat/modules/deforest_medical_items/code/medstation_designs/medical.dm
+++ b/modular_skyrat/modules/deforest_medical_items/code/medstation_designs/medical.dm
@@ -1,4 +1,4 @@
-/datum/design/organic_printer_bruise_pack 
+/datum/design/organic_printer_bruise_pack
 	name = "Bruise Packs"
 	id = "organic_bruise_packs"
 	build_type = BIOGENERATOR

--- a/modular_skyrat/modules/deforest_medical_items/code/medstation_designs/medical.dm
+++ b/modular_skyrat/modules/deforest_medical_items/code/medstation_designs/medical.dm
@@ -1,8 +1,63 @@
+/datum/design/organic_printer_bruise_pack
+	name = "Bruise Packs"
+	id = "organic_bruise_packs"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 5) // 6 per stacks
+	build_path = /obj/item/stack/medical/bruise_pack
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_DEFOREST_MEDICAL,
+	)
+
+/datum/design/organic_printer_ointment
+	name = "Ointment"
+	id = "organic_ointment"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 4) // 8 per stacks
+	build_path = /obj/item/stack/medical/ointment
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_DEFOREST_MEDICAL,
+	)
+
+/datum/design/organic_printer_suture
+	name = "Suture"
+	id = "organic_suture"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 6) // 10 per stacks
+	build_path = /obj/item/stack/medical/suture
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_DEFOREST_MEDICAL,
+	)
+
+/datum/design/organic_printer_regenerative_mesh
+	name = "Regenerative Mesh"
+	id = "organic_regenerative_mesh"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 5) // 15 per stacks
+	build_path = /obj/item/stack/medical/mesh
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_DEFOREST_MEDICAL,
+	)
+
+/datum/design/organic_printer_medical_gauze
+	name = "Medical Gauze"
+	id = "organic_medical_gauze"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 5) // 6 per stacks
+	build_path = /obj/item/stack/medical/wrap/gauze
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_DEFOREST_MEDICAL,
+	)
+
 /datum/design/organic_printer_balm
 	name = "Red Sun Balm"
 	id = "organic_sun_balm"
 	build_type = BIOGENERATOR
-	materials = list(/datum/material/biomass = 50)
+	materials = list(/datum/material/biomass = 7) // 12 per stacks
 	build_path = /obj/item/stack/medical/ointment/red_sun
 	category = list(
 		RND_CATEGORY_INITIAL,
@@ -10,10 +65,10 @@
 	)
 
 /datum/design/organic_printer_gauze
-	name = "Sealed Aseptic Guaze"
-	id = "organic_gauze"
+	name = "Sealed Aseptic Gauze"
+	id = "organic_aseptic_gauze"
 	build_type = BIOGENERATOR
-	materials = list(/datum/material/biomass = 50)
+	materials = list(/datum/material/biomass = 5) // 6 per stacks
 	build_path = /obj/item/stack/medical/wrap/gauze/sterilized
 	category = list(
 		RND_CATEGORY_INITIAL,
@@ -24,30 +79,8 @@
 	name = "Coagulant-F Packet"
 	id = "organic_coagulant_pack"
 	build_type = BIOGENERATOR
-	materials = list(/datum/material/biomass = 50)
+	materials = list(/datum/material/biomass = 5) // 12 per stacks
 	build_path = /obj/item/stack/medical/suture/coagulant
-	category = list(
-		RND_CATEGORY_INITIAL,
-		RND_CATEGORY_DEFOREST_MEDICAL,
-	)
-
-/datum/design/organic_printer_ointment
-	name = "Ointment"
-	id = "organic_ointment"
-	build_type = BIOGENERATOR
-	materials = list(/datum/material/biomass = 25)
-	build_path = /obj/item/stack/medical/ointment
-	category = list(
-		RND_CATEGORY_INITIAL,
-		RND_CATEGORY_DEFOREST_MEDICAL,
-	)
-
-/datum/design/organic_printer_bruise_pack
-	name = "Bruise Packs"
-	id = "organic_bruise_packs"
-	build_type = BIOGENERATOR
-	materials = list(/datum/material/biomass = 25)
-	build_path = /obj/item/stack/medical/bruise_pack
 	category = list(
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_DEFOREST_MEDICAL,
@@ -68,7 +101,7 @@
 	name = "First Aid Bandage"
 	id = "organic_bandaid"
 	build_type = BIOGENERATOR
-	materials = list(/datum/material/biomass = 100)
+	materials = list(/datum/material/biomass = 25)
 	build_path = /obj/item/stack/medical/bandage
 	category = list(
 		RND_CATEGORY_INITIAL,
@@ -79,7 +112,7 @@
 	name = "Robotic Repair Patch"
 	id = "organic_repair_patch"
 	build_type = BIOGENERATOR
-	materials = list(/datum/material/biomass = 100)
+	materials = list(/datum/material/biomass = 25)
 	build_path = /obj/item/reagent_containers/applicator/pill/robotic_patch/synth_repair
 	category = list(
 		RND_CATEGORY_INITIAL,
@@ -90,7 +123,7 @@
 	name = "Robotic Repair Spray"
 	id = "organic_repair_foam"
 	build_type = BIOGENERATOR
-	materials = list(/datum/material/biomass = 100)
+	materials = list(/datum/material/biomass = 40) // 2 per stacks
 	build_path = /obj/item/stack/medical/wound_recovery/robofoam
 	category = list(
 		RND_CATEGORY_INITIAL,
@@ -101,7 +134,7 @@
 	name = "Bone Gel"
 	id = "organic_bone_gel"
 	build_type = BIOGENERATOR
-	materials = list(/datum/material/biomass = 100)
+	materials = list(/datum/material/biomass = 25) // 6 per stacks
 	build_path = /obj/item/stack/medical/bone_gel
 	category = list(
 		RND_CATEGORY_INITIAL,
@@ -112,7 +145,7 @@
 	name = "Surgical Tape"
 	id = "organic_surgical_tape"
 	build_type = BIOGENERATOR
-	materials = list(/datum/material/biomass = 100)
+	materials = list(/datum/material/biomass = 25) // 5 per stacks
 	build_path = /obj/item/stack/medical/wrap/sticky_tape/surgical
 	category = list(
 		RND_CATEGORY_INITIAL,


### PR DESCRIPTION
## About The Pull Request

Re-arrange options and add basic suture and regenerative mesh to the wall med-station, also see the numbers rebalanced around single-item printing(the numbers are overall higher than previously BUT you can print enough to refill your half-used tacks)


## Why It's Good For The Game

It allows medical staff to refill their first-aid medkit instead of having to go through the hops of re-requesting yet another kit through cargo, they still need to find something to restock the biomass of the machine.
Numbers have been reduced to match slightly higher than the old numbers when we could print full stacks AND also to make medical staff not mindumbingly stay in front of the machine and cheese dispenser to print 6 sutures.

## Proof Of Testing

compiles and run smoothly, screenshot from arrival medical area with a mounted med-station

<img width="1893" height="1005" alt="image" src="https://github.com/user-attachments/assets/d3e43f10-246e-410b-8e39-e90af8a6c3e6" />

## Changelog

:cl:
add: cargo's request wall mounted med-station can now print normal sutures and regenerative meshes.
balance: re-arrange items choice in the med-station, rebalance numbers around single-item printing(and the fact that you can't upgrade this machine either), no need to sit next to it for 2 minutes for printing 6 sutures
/:cl:

