### PR TITLE
adds soup pots to rapid construction fabs so ghost roles can get them…

### DIFF
--- a/modular_skyrat/modules/colony_fabricator/code/design_datums/equipment.dm
+++ b/modular_skyrat/modules/colony_fabricator/code/design_datums/equipment.dm
@@ -12,8 +12,17 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SERVICE
 
-// Lets colony fabricators make soup pots, removes bluespace crystal requirement.
-/datum/design/soup_pot/New()
-	build_type |= COLONY_FABRICATOR
-	materials -= /datum/material/bluespace
-	return ..()
+// works, old code was fucked
+/datum/design/soup_pot
+	name = "Soup Pot"
+	id = "soup_pot"
+	build_type = COLONY_FABRICATOR
+	materials = list(
+		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 12, // for balance, a roundstart-ish 200u beaker would be a little strong
+	)
+	build_path = /obj/item/reagent_containers/cup/soup_pot
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_KITCHEN,
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SERVICE


### PR DESCRIPTION
… (e.g lizard gas and percy)
## About The Pull Request

tested and works

## Why It's Good For The Game
Saw someone complain in OOC about it not being printable. Turns out they were printable, but the code for it was bugged. 12 iron due to it being a 200u beaker that can be got near roundstart.

## Proof Of Testing
<img width="845" height="721" alt="works" src="https://github.com/user-attachments/assets/216dd027-0164-4aa2-a690-f9eb72a68a7e" />

## Changelog

Fixes

:cl:
fix: fixed a few things

:cl:
