### PR TITLE
Fixes charging holsters not changing name to reflect their item, fixes their remove proc not being called, spellchecks their feedback

### DIFF
--- a/modular_skyrat/modules/reagent_forging/code/forge_belts.dm
+++ b/modular_skyrat/modules/reagent_forging/code/forge_belts.dm
@@ -185,15 +185,16 @@
 /datum/storage/charging_holster/attempt_insert(obj/item/to_insert, mob/user, override = FALSE, force = STORAGE_NOT_LOCKED, messages = TRUE)
 	. = ..()
 	if(.)
+		parent.name += " ([to_insert.name])"
 		parent.update_overlays()
 		timer_id = addtimer(CALLBACK(my_charger, TYPE_PROC_REF(/obj/machinery/recharger/belt_charger, activate_with_item)), delay_before_charging, TIMER_STOPPABLE | TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_DELETE_ME)
 
-/datum/storage/charging_holster/attempt_remove(obj/item/thing, atom/remove_to_loc, silent = FALSE, visual_updates = TRUE)
+/datum/storage/charging_holster/remove_and_refresh(atom/movable/gone)
 	. = ..()
-	if(.)
-		my_charger.charging = null
-		parent.update_overlays()
-		deltimer(timer_id)
+	parent.name = initial(parent.name)
+	my_charger.charging = null
+	parent.update_overlays()
+	deltimer(timer_id)
 
 /obj/machinery/recharger/belt_charger
 	name = "belt charger"

--- a/modular_skyrat/modules/reagent_forging/code/forge_belts.dm
+++ b/modular_skyrat/modules/reagent_forging/code/forge_belts.dm
@@ -212,7 +212,7 @@
 
 /obj/machinery/recharger/belt_charger/proc/activate_with_item()
 	if(length(my_belt?.real_storage?.contents) > 0)
-		say("charging...")
+		say("Charging...")
 		charging = my_belt.real_storage.contents[1]
 		playsound(src, 'sound/machines/ping.ogg', 30, TRUE, frequency = 0.8)
 		START_PROCESSING(SSmachines, src)


### PR DESCRIPTION

## About The Pull Request

Title.

This was always part of their design. Also, it was using the wrong proc.
## Why It's Good For The Game

No more hiding lethals on green
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="673" height="159" alt="image" src="https://github.com/user-attachments/assets/2a3eb35c-bf8a-4be9-9d7d-4c38d15c784a" />

</details>

## Changelog
:cl:
fix: Charging holsters now change their name to reflect the item inside them
spellcheck: Capitalized some stuff the charging holster says
/:cl:
