### PR TITLE
THE WITCH IS DEAD (Mini egun is gone from cargo)

### DIFF
--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -39,7 +39,6 @@
 	ammo_x_offset = 2
 	charge_sections = 3
 	single_shot_type_overlay = FALSE
-	projectile_damage_multiplier = 0.8 // BUBBER EDIT ADDITION
 
 /obj/item/gun/energy/e_gun/mini/add_seclight_point()
 	// The mini energy gun's light comes attached but is unremovable.

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -39,6 +39,7 @@
 	ammo_x_offset = 2
 	charge_sections = 3
 	single_shot_type_overlay = FALSE
+	projectile_damage_multiplier = 0.8 // BUBBER EDIT ADDITION
 
 /obj/item/gun/energy/e_gun/mini/add_seclight_point()
 	// The mini energy gun's light comes attached but is unremovable.

--- a/modular_skyrat/master_files/code/modules/cargo/packs/security.dm
+++ b/modular_skyrat/master_files/code/modules/cargo/packs/security.dm
@@ -32,11 +32,3 @@
 	desc = "Contains two Ion Carbines, for when you need to deal with speedy space tiders, mechs, or upstart silicons."
 	contains = list(/obj/item/gun/energy/ionrifle/carbine = 2)
 	crate_name = "Ion Carbine Crate"
-
-/datum/supply_pack/security/miniegun
-	name = "Mini E-Gun Bulk Crate"
-	cost = CARGO_CRATE_VALUE * 5 // BUBBER EDIT CHANGE - * 5 from * 2
-	desc = "Contains three mini e-guns, cheap and semi-effective, for when you need to arm up on a budget."
-	contains = list(/obj/item/gun/energy/e_gun/mini = 3)
-	crate_name = "Mini E-Gun Bulk Crate"
-//You know the problem is literally nobody want to buy the mini-egun even if it was cheap

--- a/modular_skyrat/master_files/code/modules/cargo/packs/security.dm
+++ b/modular_skyrat/master_files/code/modules/cargo/packs/security.dm
@@ -35,7 +35,7 @@
 
 /datum/supply_pack/security/miniegun
 	name = "Mini E-Gun Bulk Crate"
-	cost = CARGO_CRATE_VALUE * 2
+	cost = CARGO_CRATE_VALUE * 5 // BUBBER EDIT CHANGE - * 5 from * 2
 	desc = "Contains three mini e-guns, cheap and semi-effective, for when you need to arm up on a budget."
 	contains = list(/obj/item/gun/energy/e_gun/mini = 3)
 	crate_name = "Mini E-Gun Bulk Crate"

--- a/modular_zubbers/code/modules/cargo/packs/goodies.dm
+++ b/modular_zubbers/code/modules/cargo/packs/goodies.dm
@@ -9,13 +9,6 @@
 	access_view = ACCESS_WEAPONS
 	contains = list(/obj/item/gun/energy/laser/carbine)
 
-/datum/supply_pack/goody/miniegun_single
-	name = "Mini E-Gun Single-Pack"
-	desc = "Contains one mini e-gun, for when your Bridge Officer loses theirs to the clown."
-	cost = PAYCHECK_COMMAND * 5
-	access_view = ACCESS_WEAPONS
-	contains = list(/obj/item/gun/energy/e_gun/mini)
-
 /datum/supply_pack/goody/wt550_single
 	name = "WT-551 Autorifle Single-Pack"
 	desc = "An NT-security grade autorifle, it comes with excellent heating and poses no health-related risks for the user. Comes as a single-pack with one WT-551 locked and loaded."


### PR DESCRIPTION

## About The Pull Request

Title.

## Why It's Good For The Game

Ok so the mini egun is just straight up better than the laser pistol in literally every single way except for charge speed. Does more damage, has more ammo, has a disabler, has a seclite, is SMALL (CAN FIT IN BOXES), and is only somewhat more expensive. You can hoard these in a box and get really silly.

By removing it from cargo altogether we can sidestep all of these issues by making it an exclusive item you cant easily replace. Balance doesnt matter as much when its limited in number.

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="1012" height="1007" alt="image" src="https://github.com/user-attachments/assets/f999a26c-57c9-4d04-b7d1-214090ba7fdd" />

</details>

## Changelog
:cl:
balance: Mini egun is gone from cargo
/:cl:
