### PR TITLE
Adds red text as a new chat feature.

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -269,6 +269,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	ENCODE_HTML_EMPHASIS(input, "\\+", "b", bold)
 	ENCODE_HTML_EMPHASIS(input, "\\_", "u", underline)
 	ENCODE_HTML_EMPHASIS(input, "\\^", "small", small)
+	ENCODE_HTML_EMPHASIS(input, "\\`", "font color= 'red'", redtext) //MONKESTATION PORT: makes your text red
 	var/static/regex/remove_escape_backlashes = regex("\\\\(\\_|\\+|\\||\\^)", "g") // Removes backslashes used to escape text modification.
 	input = remove_escape_backlashes.Replace_char(input, "$1")
 	return input

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -269,7 +269,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	ENCODE_HTML_EMPHASIS(input, "\\+", "b", bold)
 	ENCODE_HTML_EMPHASIS(input, "\\_", "u", underline)
 	ENCODE_HTML_EMPHASIS(input, "\\^", "small", small)
-	ENCODE_HTML_EMPHASIS(input, "\\`", "font color= 'red'", redtext) //MONKESTATION PORT: makes your text red
+	ENCODE_HTML_EMPHASIS(input, "\\`", "font color= 'red'", redtext) // BUBBERSTATION EDIT - ADDITION
 	var/static/regex/remove_escape_backlashes = regex("\\\\(\\_|\\+|\\||\\^)", "g") // Removes backslashes used to escape text modification.
 	input = remove_escape_backlashes.Replace_char(input, "$1")
 	return input


### PR DESCRIPTION
## About The Pull Request

This makes it so putting text between ` makes your text red, allowing for more text flavor!
## Why It's Good For The Game

More variety means people can put more meaning into their sentences.

## Proof Of Testing

<img width="183" height="143" alt="Screenshot 2026-07-13 080204" src="https://github.com/user-attachments/assets/fbb11df2-4f51-46a4-89b7-528c94737c32" />
<img width="288" height="143" alt="Screenshot 2026-07-13 080219" src="https://github.com/user-attachments/assets/e671965c-e5e2-4988-9abc-4d84ae67dd74" />
<img width="387" height="39" alt="Screenshot 2026-07-13 080225" src="https://github.com/user-attachments/assets/486f5310-2d04-4105-bd3b-1c25cb2486ce" />

## Changelog

:cl:
add: Added the ability to speak in red text.
/:cl: