### PR TITLE
Fixes Security Officers with departments assigned not having alternate titles

### DIFF
--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -137,7 +137,6 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 		SSid_access.apply_trim_to_card(worn_id, dep_trim)
 
 		// BUBBER EDIT ADDITION BEGIN - ALTERNATE JOB TITLES
-
 		// gets their preferred alt title
 		var/chosen_title = player_client?.prefs?.alt_job_titles?[title] || title
 		var/display_assignment = chosen_title
@@ -153,15 +152,15 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 
 		// Update PDA to match new trim.
 		var/obj/item/modular_computer/pda/pda = spawning.get_item_by_slot(ITEM_SLOT_BELT)
+		// BUBBER EDIT CHANGE BEGIN - ALTERNATE JOB TITLES
 		/*
-			var/assignment = worn_id.get_trim_assignment()
+		var/assignment = worn_id.get_trim_assignment()
 		if(istype(pda) && !isnull(assignment))
 			pda.imprint_id(spawning.real_name, assignment)
 		*/
-		// bubber edit - the above is changed as we assigned display_assignment earlier with their custom title, otherwise assignment is just 'security officer (department)'
+		// we assign display_assignment earlier with their custom title, otherwise assignment is just 'security officer (department)'
 		if(istype(pda))
 			pda.imprint_id(spawning.real_name, display_assignment)
-
 		// BUBBER EDIT CHANGE END - ALTERNATE JOB TITLES
 
 	var/spawn_point = pick(LAZYACCESS(GLOB.department_security_spawns, department))

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -136,6 +136,8 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 		var/obj/item/card/id/worn_id = spawning.get_idcard(hand_first = FALSE)
 		SSid_access.apply_trim_to_card(worn_id, dep_trim)
 
+		// BUBBER EDIT ADDITION BEGIN - ALTERNATE JOB TITLES
+
 		// gets their preferred alt title
 		var/chosen_title = player_client?.prefs?.alt_job_titles?[title] || title
 		var/display_assignment = chosen_title
@@ -146,12 +148,21 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 
 		worn_id.assignment = display_assignment
 		worn_id.update_label()
-		spawning.update_ID_card()
 
-		// Update PDA to match.
+		spawning.update_ID_card()
+	
+		// Update PDA to match new trim.
 		var/obj/item/modular_computer/pda/pda = spawning.get_item_by_slot(ITEM_SLOT_BELT)
+		/*
+		 	var/assignment = worn_id.get_trim_assignment()
+		if(istype(pda) && !isnull(assignment))
+			pda.imprint_id(spawning.real_name, assignment)
+		*/
+		// bubber edit - the above is changed as we assigned display_assignment earlier with their custom title, otherwise assignment is just 'security officer (department)'
 		if(istype(pda))
 			pda.imprint_id(spawning.real_name, display_assignment)
+
+		// BUBBER EDIT CHANGE END - ALTERNATE JOB TITLES
 
 	var/spawn_point = pick(LAZYACCESS(GLOB.department_security_spawns, department))
 

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -135,13 +135,23 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 	if(dep_trim)
 		var/obj/item/card/id/worn_id = spawning.get_idcard(hand_first = FALSE)
 		SSid_access.apply_trim_to_card(worn_id, dep_trim)
+
+		// gets their preferred alt title
+		var/chosen_title = player_client?.prefs?.alt_job_titles?[title] || title
+		var/display_assignment = chosen_title
+
+		// and adds the department
+		if(department)
+			display_assignment = "[chosen_title] ([department])"
+
+		worn_id.assignment = display_assignment
+		worn_id.update_label()
 		spawning.update_ID_card()
 
-		// Update PDA to match new trim.
+		// Update PDA to match.
 		var/obj/item/modular_computer/pda/pda = spawning.get_item_by_slot(ITEM_SLOT_BELT)
-		var/assignment = worn_id.get_trim_assignment()
-		if(istype(pda) && !isnull(assignment))
-			pda.imprint_id(spawning.real_name, assignment)
+		if(istype(pda))
+			pda.imprint_id(spawning.real_name, display_assignment)
 
 	var/spawn_point = pick(LAZYACCESS(GLOB.department_security_spawns, department))
 

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -150,11 +150,11 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 		worn_id.update_label()
 
 		spawning.update_ID_card()
-	
+
 		// Update PDA to match new trim.
 		var/obj/item/modular_computer/pda/pda = spawning.get_item_by_slot(ITEM_SLOT_BELT)
 		/*
-		 	var/assignment = worn_id.get_trim_assignment()
+			var/assignment = worn_id.get_trim_assignment()
 		if(istype(pda) && !isnull(assignment))
 			pda.imprint_id(spawning.real_name, assignment)
 		*/


### PR DESCRIPTION
## About The Pull Request

This is a downstream pull request fixing a bug where officers could not use alternate titles as the departmental assignment would overwrite it.

## Why It's Good For The Game

Allows officers to once again have alternate titles!

## Proof Of Testing

<img width="552" height="247" alt="Screenshot 2026-07-14 084915" src="https://github.com/user-attachments/assets/5685ac65-1325-4959-9725-ed884d05aacd" />
<img width="476" height="117" alt="Screenshot 2026-07-14 084928" src="https://github.com/user-attachments/assets/a7851640-c0b5-4fcd-afc7-5fe03aecbd20" />


## Changelog

:cl:Lucky
fix: Fixed security officers with assigned departments not being able to use alternate titles
/:cl: