### PR TITLE
Adds soap and autopsie scanner to medical borgs

### DIFF
--- a/modular_skyrat/modules/deforest_medical_items/code/treatment_zone_projector.dm
+++ b/modular_skyrat/modules/deforest_medical_items/code/treatment_zone_projector.dm
@@ -46,4 +46,6 @@
 /obj/item/robot_model/medical/New(loc, ...)
 	. = ..()
 	var/obj/item/holosign_creator/medical/treatment_zone/new_holosign = new(src)
-	basic_modules.Add(new_holosign)
+	var/obj/item/soap/nanotrasen/cyborg/new_soap = new(src)
+	var/obj/item/autopsy_scanner/new_scanner = new(src)
+	basic_modules.Add(new_holosign, new_soap, new_scanner)


### PR DESCRIPTION

## About The Pull Request
Title
## Why It's Good For The Game
The soap allows for limited cleaning, good for a medical borg after surgeries or just general shift start cleaning within medbay, definitely not enough to make a janiborg obselete.

the autopsie scanner at present requires someone with hands, as medical borgs don't have them, this is mostly a low pop QoL since some research is locked behind it.
## Proof Of Testing
<img width="673" height="345" alt="image" src="https://github.com/user-attachments/assets/4ab3acdc-1e6e-40b6-ab6d-3235492bda1a" />
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
qol: added soap and autopsie scanner to medical borg
/:cl:
