### PR TITLE
Forwards PDA messages to the AI core to the shell they currently inhabit because security PDAd me then raided my core when I didn't respond

### DIFF
--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -751,12 +751,20 @@
 			reply = "\[Automated Message\]"
 		else
 			reply = "(<a href='byond://?src=[REF(src)];choice=[reply_href];skiprefresh=1;target=[REF(chat)]'>Reply</a>)"
-
+		//BUBBER EDIT BEGIN - forward PDA messages to AIs to their shells
+		var/forwarded_message = FALSE
 		if (isAI(messaged_mob))
 			sender_title = "<a href='byond://?src=[REF(messaged_mob)];track=[html_encode(sender_name)]'>[sender_title]</a>"
 
-		var/inbound_message = "[signal.format_message()]"
+			var/mob/living/silicon/ai/ai_receiver = messaged_mob
+			if(ai_receiver.deployed_shell)
+				messaged_mob = ai_receiver.deployed_shell
+				forwarded_message = TRUE
 
+		var/inbound_message = "[signal.format_message()]"
+		if(forwarded_message)
+			inbound_message += " - Forwarded from the AI Core PDA"
+		//BUBBER EDIT END - forward PDA messages to AIs to their shells
 		var/photo_message = signal.data["photo"] ? " (<a href='byond://?src=[REF(src)];choice=[photo_href];skiprefresh=1;target=[REF(chat)]'>Photo Attached</a>)" : ""
 		// BUBBER EDIT CHANGE BEGIN - SUBTLE MESSAGES
 		if(is_subtle)


### PR DESCRIPTION

## About The Pull Request
title
## Why It's Good For The Game
When I play AI and I'm in a shell I miss PDA messages because I get no notification
## Proof Of Testing
<img width="598" height="35" alt="image" src="https://github.com/user-attachments/assets/fac3eace-0b87-4f0a-b596-bd51af86bb89" />

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
qol: AI core PDA messages get forwarded to their deployed shell
/:cl:
