### PR TITLE
Adds BubberGuessr event winners to the golden pinwheel hat whitelist

### DIFF
--- a/modular_zubbers/code/modules/loadout/categories/~donator/donator_personal.dm
+++ b/modular_zubbers/code/modules/loadout/categories/~donator/donator_personal.dm
@@ -8,12 +8,13 @@
 /datum/loadout_item/head/pinwheel_hat/gold //sprites by Keila.
 	name = "Magnificent Pinwheel Hat"
 	item_path = /obj/item/clothing/head/helmet/toggleable/pinwheel/gold
-	ckeywhitelist = list("malice69", "miniusAreas", "gavla", "hydrosatan", "nevimer", "naruga", "OmegaTracing", "KeRSe", "CprlEvergreen", "RiskyBusiness", "Slouista", "SapphoQueer", "LordGingy", "ARandomHyena", "LiuJr", "jamiemundy", "snajper202", "snaffle15", "sonicgotnuked", "fellis", "laetex", "especiallystrange", "ghostie_dwagons", "Kidkirby", "Destrucktoid", "Vulpesishot")
+	ckeywhitelist = list("malice69", "miniusAreas", "gavla", "hydrosatan", "nevimer", "naruga", "OmegaTracing", "KeRSe", "CprlEvergreen", "RiskyBusiness", "Slouista", "SapphoQueer", "LordGingy", "ARandomHyena", "LiuJr", "jamiemundy", "snajper202", "snaffle15", "sonicgotnuked", "fellis", "laetex", "especiallystrange", "ghostie_dwagons", "Kidkirby", "Destrucktoid", "Vulpesishot", "cababge", "leathergnome", "Dawn.JPG", "ABoxFox", "2bro2b", "JohnPawson", "user_interface143")
 
 //11/08/23: Added as a reward to people who have recommended friends to Bubberstation. Add to this list as you please, you can offer this as a reward for basically anything.
 //Please mark the date and what this was awarded for in code comments here. For example:
 //XX/XX/XX: Added as a reward for EXAMPLE EVENT's winners.
 //6/21/2025: Given as a reward to the duo winners of toolbox tournament held on the same day. Vulpesishot and Destrucktoid.
+//7/17/2026: Given to the winners of the Bubberguessr tournament: cababge, leathergnome, Dawn.JPG, ABoxFox, 2bro2b, JohnPawson, and user_interface143
 
 /datum/loadout_item/head/idmaberet
 	name = "IDMA Beret"


### PR DESCRIPTION

## About The Pull Request
Does exactly as the title suggests.
## Why It's Good For The Game
Event winners get their prizes.
## Proof Of Testing
N/A
