### PR TITLE
Fixes Pinwheel Hats

### DIFF
--- a/modular_zubbers/code/modules/clothing/head/helmet.dm
+++ b/modular_zubbers/code/modules/clothing/head/helmet.dm
@@ -59,6 +59,7 @@
 	icon = 'modular_zubbers/icons/obj/clothing/head/hats.dmi'
 	worn_icon = 'modular_zubbers/icons/mob/clothing/head/hats.dmi'
 	icon_state = "pinwheel"
+	base_icon_state = "pinwheel"
 	inhand_icon_state = null
 	lefthand_file = null
 	righthand_file = null
@@ -80,9 +81,9 @@
 
 /obj/item/clothing/head/helmet/toggleable/pinwheel/gold
 	name = "magnificent pinwheel hat"
-	desc = "The strongest possible pinwheel pinwheel hat. Such is fate that the silliest things in the world are also the most beautiful; others may not see the shine in you, but the magnificent pinwheel hat does. It appreciates you for who you are and what you've done. It feels alive, and makes you feel alive too. You see the totality of existence reflected in the golden shimmer of the pin." //Does literally nothing more than the regular pinwheel hat. Just for emphasis.
+	desc = "The strongest possible pinwheel hat. Such is fate that the silliest things in the world are also the most beautiful; others may not see the shine in you, but the magnificent pinwheel hat does. It appreciates you for who you are and what you've done. It feels alive, and makes you feel alive too. You see the totality of existence reflected in the golden shimmer of the pin." //Does literally nothing more than the regular pinwheel hat. Just for emphasis.
 	icon_state = "pinwheel_gold"
-
+	base_icon_state = "pinwheel_gold"
 
 //Clussy and Jester sprites from Splurt.
 /obj/item/clothing/head/costume/bubber/jester


### PR DESCRIPTION

## About The Pull Request
They spin once again.
## Why It's Good For The Game
Fixes https://github.com/Bubberstation/Bubberstation/issues/5961
## Proof Of Testing
See below.
<details>
<summary>Screenshots/Videos</summary>

https://github.com/user-attachments/assets/a8d81b6c-9639-47ae-97b2-6c7ef11ab6b5

</details>

## Changelog
:cl:
fix: Pinwheel Hats and Magnificent Pinwheel Hats can spin once again.
spellcheck: Fixed the same word appearing twice in a row in the Magnificent Pinwheel Hat's description.
/:cl:
