### PR TITLE
Bounty selection no longer runtimes for Blacksmith and Prisoner jobs

### DIFF
--- a/code/game/machinery/civilian_bounty/civilian_bounty_trims.dm
+++ b/code/game/machinery/civilian_bounty/civilian_bounty_trims.dm
@@ -88,5 +88,14 @@
 		if(CIV_JOB_BITRUN)
 			return pick(subtypesof(/datum/bounty/item/bitrunning))
 
+//		Bubberstation edits begin here!
+
+		if(CIV_JOB_SMITH)
+			return pick(subtypesof(/datum/bounty/item/blacksmith))
+		if(CIV_JOB_PRISONER)
+			return pick(subtypesof(/datum/bounty/item/prisoner))
+
+//		Bubberstation edits end here!
+
 	stack_trace("Failed to get random bounty type for input type [input_bounty_type]")
 	return null

--- a/code/game/machinery/civilian_bounty/civilian_bounty_trims.dm
+++ b/code/game/machinery/civilian_bounty/civilian_bounty_trims.dm
@@ -88,14 +88,12 @@
 		if(CIV_JOB_BITRUN)
 			return pick(subtypesof(/datum/bounty/item/bitrunning))
 
-//		Bubberstation edits begin here!
-
+//	BUBBER EDIT - ADDITION - START
 		if(CIV_JOB_SMITH)
 			return pick(subtypesof(/datum/bounty/item/blacksmith))
 		if(CIV_JOB_PRISONER)
 			return pick(subtypesof(/datum/bounty/item/prisoner))
-
-//		Bubberstation edits end here!
+// BUBBER EDIT - ADDITION - END
 
 	stack_trace("Failed to get random bounty type for input type [input_bounty_type]")
 	return null


### PR DESCRIPTION

## About The Pull Request

Edits the new version of tgstation's civilian_bounty_trims.dm to add "if" cases for the Smith and Prisoner job types, as each job type check is hardcoded as "if" statements in the original file.


## Why It's Good For The Game
Once again allows Blacksmiths and Prisoners to get Personal Bounties, giving both roles a potential goal to do as non-antags to get some cash and fund the station.
On the backend, cuts down on runtime errors.

Risk: Blacksmithing bounties feel much easier and more lucrative than many other station jobs. **This does not address that issue,** so it's possible this fix does weird things to the station's economy.


## Proof Of Testing

<details>

Spawned as various jobs and inserted my ID into the Civilian Bounty Control Terminal, then clicked the New Bounty button. Two job-appropriate and one random bounty appeared on the resulting list.

Tested the following jobs to make sure bounties applied and no runtimes appeared:
- Blacksmith
- Prisoner
- Captain
- Nanotrasen Consultant
- Blueshield
- Barber
- Bitrunner
- Persistence Sanitation Technician
- Cardboard ID (doesn't slot into terminal)


<summary>Screenshots/Videos</summary>

<img width="571" height="371" alt="Bubber_BountyFix1" src="https://github.com/user-attachments/assets/d8568d78-f977-48a6-bd20-8165ccb62fc0" />
<img width="630" height="373" alt="Bubber_BountyFix2" src="https://github.com/user-attachments/assets/55af3125-1ed9-41ea-93b0-af60f2585161" />

</details>

## Changelog
:cl: Kaltren
fix: Blacksmiths and Prisoners can once again properly generate Personal Bounties.
/:cl:
