### PR TITLE
Blacksmith bounty balance tweak

### DIFF
--- a/code/game/machinery/civilian_bounty/civilian_bounty_trims.dm
+++ b/code/game/machinery/civilian_bounty/civilian_bounty_trims.dm
@@ -88,5 +88,14 @@
 		if(CIV_JOB_BITRUN)
 			return pick(subtypesof(/datum/bounty/item/bitrunning))
 
+//		Bubberstation edits begin here!
+
+		if(CIV_JOB_SMITH)
+			return pick(subtypesof(/datum/bounty/item/blacksmith))
+		if(CIV_JOB_PRISONER)
+			return pick(subtypesof(/datum/bounty/item/prisoner))
+
+//		Bubberstation edits end here!
+
 	stack_trace("Failed to get random bounty type for input type [input_bounty_type]")
 	return null

--- a/code/game/machinery/civilian_bounty/civilian_bounty_trims.dm
+++ b/code/game/machinery/civilian_bounty/civilian_bounty_trims.dm
@@ -88,14 +88,5 @@
 		if(CIV_JOB_BITRUN)
 			return pick(subtypesof(/datum/bounty/item/bitrunning))
 
-//		Bubberstation edits begin here!
-
-		if(CIV_JOB_SMITH)
-			return pick(subtypesof(/datum/bounty/item/blacksmith))
-		if(CIV_JOB_PRISONER)
-			return pick(subtypesof(/datum/bounty/item/prisoner))
-
-//		Bubberstation edits end here!
-
 	stack_trace("Failed to get random bounty type for input type [input_bounty_type]")
 	return null

--- a/modular_zubbers/code/modules/cargo/bounties/blacksmith.dm
+++ b/modular_zubbers/code/modules/cargo/bounties/blacksmith.dm
@@ -31,7 +31,7 @@ Todo: Refactor upstream code so that item deletion is decided at the bounty leve
 
 /datum/bounty/item/blacksmith/charging_holster
 	name = "Charging Holster"
-	description = "Our security team doesn't want to deal with finding rechargers. Send us a recharging holster. Only legendary blacksmiths need apply."
+	description = "Our security team doesn't want to deal with finding rechargers. Send us a charging holster. Only legendary blacksmiths need apply."
 	reward = CARGO_CRATE_VALUE * 10
 	required_count = 1
 	wanted_types = list(/obj/item/storage/belt/hip_holster/charging = TRUE)

--- a/modular_zubbers/code/modules/cargo/bounties/blacksmith.dm
+++ b/modular_zubbers/code/modules/cargo/bounties/blacksmith.dm
@@ -29,12 +29,12 @@ Todo: Refactor upstream code so that item deletion is decided at the bounty leve
 
 */
 
-/datum/bounty/item/blacksmith/charging_holster
-	name = "Charging Holster"
-	description = "Our security team doesn't want to deal with finding rechargers. Send us a charging holster. Only legendary blacksmiths need apply."
-	reward = CARGO_CRATE_VALUE * 10
-	required_count = 1
-	wanted_types = list(/obj/item/storage/belt/hip_holster/charging = TRUE)
+/datum/bounty/item/blacksmith/rail_track
+	name = "Railroad Tracks"
+	description = "The tram broke down again. Make us some railroad tracks to help us get around."
+	reward = CARGO_CRATE_VALUE * 9.75
+	required_count = 20
+	wanted_types = list(/obj/item/stack/rail_track = TRUE)
 
 /datum/bounty/item/blacksmith/cuffs
 	name = "Handcuffs"

--- a/modular_zubbers/code/modules/cargo/bounties/blacksmith.dm
+++ b/modular_zubbers/code/modules/cargo/bounties/blacksmith.dm
@@ -29,38 +29,38 @@ Todo: Refactor upstream code so that item deletion is decided at the bounty leve
 
 */
 
-/datum/bounty/item/blacksmith/cage
-	name = "Cortical Borer Cage"
-	description = "One of Nanotrasen's partner stations is undergoing a borer infestation and would like to capture some life specimen for research. Ship some off to CentCom right away."
-	reward = CARGO_CRATE_VALUE * 14
-	required_count = 2
-	wanted_types = list(/obj/item/cortical_cage = TRUE)
+/datum/bounty/item/blacksmith/charging_holster
+	name = "Charging Holster"
+	description = "Our security team doesn't want to deal with finding rechargers. Send us a recharging holster. Only legendary blacksmiths need apply."
+	reward = CARGO_CRATE_VALUE * 10
+	required_count = 1
+	wanted_types = list(/obj/item/storage/belt/hip_holster/charging = TRUE)
 
 /datum/bounty/item/blacksmith/cuffs
 	name = "Handcuffs"
 	description = "One of our wardens lost all the handcuffs again. Help restore order and ship some off for a reward."
-	reward = CARGO_CRATE_VALUE * 8
+	reward = CARGO_CRATE_VALUE * 15
 	required_count = 3
 	wanted_types = list(/obj/item/restraints/handcuffs = TRUE) //This includes reagent cuffs
 
 /datum/bounty/item/blacksmith/staff
 	name = "Staff"
 	description = "A respected religious figure is visiting CentCom, but lost their staff on the way there! Send a replacement as soon as possible."
-	reward = CARGO_CRATE_VALUE * 5
+	reward = CARGO_CRATE_VALUE * 5.25
 	wanted_types = list(/obj/item/melee/forged_reagent_weapon/staff = TRUE)
 
 /datum/bounty/item/blacksmith/swords
 	name = "Swords"
 	description = "Our interns' mosins have broken down, ship some swords so they have something to fight with."
 	required_count = 3
-	reward = CARGO_CRATE_VALUE * 24
+	reward = CARGO_CRATE_VALUE * 17
 	wanted_types = list(/obj/item/melee/forged_reagent_weapon/sword = TRUE)
 
 /datum/bounty/item/blacksmith/armor
 	name = "Armor piece"
 	description = "Our security commander wants a new piece of plate armor to decorate his office. Send them some immeadiately"
 	required_count = 2
-	reward = CARGO_CRATE_VALUE * 20
+	reward = CARGO_CRATE_VALUE * 13
 	wanted_types = list(/obj/item/clothing/shoes/forging_plate_boots = TRUE,
 						/obj/item/clothing/head/helmet/forging_plate_helmet = TRUE,
 						/obj/item/clothing/gloves/forging_plate_gloves = TRUE,
@@ -70,5 +70,5 @@ Todo: Refactor upstream code so that item deletion is decided at the bounty leve
 /datum/bounty/item/blacksmith/katana
 	name = "Katana"
 	description = "One of our Researchers is going to a Space Anime Convention and wants to show off a real katana! Ship one so he stops pestering us."
-	reward = CARGO_CRATE_VALUE * 6
+	reward = CARGO_CRATE_VALUE * 5.5
 	wanted_types = list(/obj/item/melee/forged_reagent_weapon/katana = TRUE)


### PR DESCRIPTION

## About The Pull Request

~~Won't do anything player-visible without PR #5969 !!! (because the bounties are just plain broken)~~
The above PR is now merged, so no longer a concern.

In the Blacksmithing bounty list, removes the obsolete Cortical Borer Cage and ~~adds the Charging Holster instead, both as a way to point novice blacksmith players to "wait, I can make that?" and to give a high-material, high-cooperation, and low-time bounty to chase~~ replaces it with 20x Railroad Tracks (requiring two Rail Nail smithing completions).

In addition, rebalances the blacksmithing bounties a little, to make the time, clicks, and materials roughly similar ~~(aside from the Charging Holster, which removes the time requirement in favor of unusual collaboration with security)~~.


**Note: In the below table, Glass Globes are a point of reference for effort-value calculations, and are not used in blacksmithing bounties. All values at Legendary Smithing (or Production for the glass globe).**
```
Item        | OldVal | NewVal | Time | Mats
Glass Globe |   1000 |   1000 |  36s | 1 glass -- (Note: Not bounty, but exportable on cargo shuttle)
3x Cuffs    |   1600 |   3000 | 102s | 3 [any]
Staff       |   1000 |   1050 |  34s | 1 [any], 2 wood
3x Sword    |   4800 |   3400 | 102s | 3 [any], 6 wood
2x Armor    |   4000 |   2600 |  68s | 2 [any], 2 lthr
Katana      |   1200 |   1100 |  34s | 1 [any], 2 wood
Rlrd Trcks  |    N/A |   1950 |  50s | 2 [any], 4 wood
```



## Why It's Good For The Game
This prevents a scenario in which blacksmith players choose a Cortical Borer Cage from the bounty list, then find out they're unable to make them.
~~It also soft-advertises the existence of (and ability to make) Charging Holsters, and tells players that it requires Legendary in the skill to do so.~~ [EDIT: We ended up going with something other than Charging Holsters here.]
Finally, it brings the bounty values more in line with each other, with a mild nerf to the top end.

Per discussions with @ArrisFairburne , in the longer term, we probably want to do more with blacksmithing bounties, since the goal should be to have them interact with the crew and make things the crew wants, rather than just making a bunch of stuff to sell to CentCom. That said, I don't think we should wait for that to swap out the cortical borer cages, and swapping out the cortical borer cages is a good opportunity to make the bounties a _little_ less lucrative.


## Proof Of Testing
<details>

Manually verified the following bounty values by selecting bounties from the bounty terminal, creating the items via blacksmithing, and sending the items, then noting the values on the bounty cubes. PlrVal is the value shown to the player, while CbeVal is the value of the bounty cube as a whole. (This doesn't include the speedy return bonus.)

```
Item      | PlrVal | CbeVal |
3x Cuffs  |    900 |   3000 | Tested
Staff     |    315 |   1050 | Tested
3x Sword  |   1020 |   3400 | Tested
2x Armor  |    780 |   2600 | Tested
Katana    |    330 |   1100 | Tested
Rail Trx  |    585 |   1950 | Tested
```

<summary>Screenshots/Videos</summary>

<img width="183" height="116" alt="image" src="https://github.com/user-attachments/assets/d8a15d46-2522-4344-be49-7982065b3c38" />
<img width="674" height="343" alt="image" src="https://github.com/user-attachments/assets/9e0f3b8f-83f1-4d83-8c5c-2bd62f4f4136" />
<img width="673" height="304" alt="image" src="https://github.com/user-attachments/assets/894430e4-e998-426c-8744-9f19609ed2c2" />
<img width="1612" height="385" alt="image" src="https://github.com/user-attachments/assets/eabfb138-c01a-4bed-8ccd-7a4d3274cdfa" />


1950 + 390 (20%) bonus = 2340
30% of 2340 = 702
2340 - 702 = 1638

</details>

## Changelog
:cl: Kaltren
fix: Cortical Borer Cage is no longer in the blacksmithing bounty list, as it's no longer smithable.
balance: 20x Railroad Tracks are now in the blacksmithing bounty list, worth 1950 total credits (585 player cut).
balance: 3x Handcuffs blacksmithing bounty is now worth 3000 total credits, up from 1600.
balance: 3x Sword blacksmithing bounty is now worth 3400 total credits, down from 4800.
balance: 2x Armor blacksmithing bounty is now worth 2600 total credits, down from 4000.
balance: Staff blacksmithing bounty is now worth 1050 total credits, up from 1000.
balance: Katana blacksmithing bounty is now worth 1100 total credits, down from 1200.
/:cl:
