### PR TITLE
Disable dynamic tweak event

### DIFF
--- a/modular_zubbers/code/modules/storyteller/event_defines/moderate/moderate_overrides.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/moderate/moderate_overrides.dm
@@ -62,3 +62,8 @@
 /datum/round_event_control/radiation_storm
 	track = EVENT_TRACK_MODERATE
 	tags = list(TAG_COMMUNAL)
+
+/datum/round_event_control/dynamic_tweak // no dynamic in this house
+	weight = 0
+	max_occurrences = 0
+	tags = list(TAG_CREW_ANTAG)


### PR DESCRIPTION
## About The Pull Request

Disables dynamic tweak, it doesn't do anything except waste a storyteller roll.

## Why It's Good For The Game

Fix bug

## Changelog

:cl: LT3
fix: Dynamic tweak will no longer try to run on storyteller
/:cl: