### PR TITLE
Moves genital appearance preferences to the character visuals tab, renames "mutant body colors" to "body colors"

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences/genitals.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/genitals.dm
@@ -19,7 +19,7 @@
 	return erp_allowed && passed_initial_check
 
 /datum/preference/choiced/genital
-	category = PREFERENCE_CATEGORY_CHARACTER_BASICS
+	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
 	savefile_identifier = PREFERENCE_CHARACTER
 	abstract_type = /datum/preference/choiced/genital
 
@@ -74,7 +74,7 @@
 	return assoc_to_keys_features(SSaccessories.sprite_accessories[relevant_mutant_bodypart])
 
 /datum/preference/toggle/genital_skin_tone
-	category = PREFERENCE_CATEGORY_CHARACTER_BASICS
+	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
 	savefile_identifier = PREFERENCE_CHARACTER
 	default_value = FALSE
 	abstract_type = /datum/preference/toggle/genital_skin_tone
@@ -91,7 +91,7 @@
 	return erp_allowed && (passed_initial_check || allowed)
 
 /datum/preference/toggle/genital_skin_color
-	category = PREFERENCE_CATEGORY_CHARACTER_BASICS
+	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
 	savefile_identifier = PREFERENCE_CHARACTER
 	default_value = FALSE
 	abstract_type = /datum/preference/toggle/genital_skin_color
@@ -123,7 +123,7 @@
 
 
 /datum/preference/tri_color/genital
-	category = PREFERENCE_CATEGORY_CHARACTER_BASICS
+	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
 	savefile_identifier = PREFERENCE_CHARACTER
 	check_mode = TRICOLOR_CHECK_ACCESSORY
 	abstract_type = /datum/preference/tri_color/genital

--- a/modular_skyrat/master_files/code/modules/client/preferences/genitals.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/genitals.dm
@@ -3,7 +3,7 @@
 // ABSTRACT TYPES
 
 /datum/preference/toggle/allow_genitals
-	category = PREFERENCE_CATEGORY_CHARACTER_BASICS
+	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "allow_genitals_toggle"
 	default_value = TRUE

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/bubbers/species_features.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/bubbers/species_features.tsx
@@ -4,6 +4,7 @@ import {
   type FeatureChoiced,
   FeatureShortTextInput,
   FeatureTextInput,
+  FeatureTriColorInput,
   type FeatureToggle,
 } from '../../base';
 import { FeatureDropdownInput } from '../../dropdowns';
@@ -185,4 +186,10 @@ export const art_ref_nsfw: FeatureToggle = {
   name: 'Art Reference (NSFW)',
   description: 'Is your reference picture NSFW?',
   component: CheckboxInput,
+};
+
+export const mutant_colors_color: Feature<string[]> = {
+  name: 'Body Colors',
+  component: FeatureTriColorInput,
+  description: 'Body color used for non-human species.',
 };

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/species_features.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/species_features.tsx
@@ -163,12 +163,6 @@ export const eyes_opacity: Feature<number> = {
   component: FeatureNumberInput,
 };
 
-export const mutant_colors_color: Feature<string[]> = {
-  name: 'Mutant Colors',
-  component: FeatureTriColorInput,
-  description: 'Body color used for non-human species.',
-};
-
 export const body_markings_toggle: FeatureToggle = {
   name: 'Body Markings',
   component: CheckboxInput,


### PR DESCRIPTION
## About The Pull Request

I will be perfectly honest with you. The idea that I select what breasts I want in the appearance tab, and then I have to go to the character basics tab to select their appearance is a jarring one.

Also, renames "mutant body colors" to just "body colors" because I have seen too many new players be confused by that. Why was it named "mutant" body colors in the first place? Though I haven't changed the internal name of it, cuz I think that's not necessary. Unless a maintainer asks me to then I can do it.

## Why It's Good For The Game

Makes the character preferences menu easier to navigate

## Proof Of Testing

<img width="755" height="675" alt="image" src="https://github.com/user-attachments/assets/59438a7f-5680-43aa-acbe-94b3bef99060" />

Type, colors, skin tone setting and many others for genitals visible in the appearance tab.


<img width="823" height="215" alt="image" src="https://github.com/user-attachments/assets/e666e3bb-bad2-42aa-8220-7c64bc5c66c1" />

Mutant body colors renamed

## Changelog

:cl: Swan
qol: Renames the "mutant body colors" pref to just "body colors", moves most genital appearance settings to the visuals tab of the character creator
/:cl: