### PR TITLE
Malf AI can now pick AIs who are in their shells

### DIFF
--- a/code/modules/antagonists/malf_ai/malf_ai.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai.dm
@@ -26,6 +26,11 @@
 	src.give_objectives = give_objectives
 
 /datum/antagonist/malf_ai/on_gain()
+	//BUBBER EDIT START - Shells get malf
+	if(owner.current && istype(owner.current, /mob/living/silicon/robot/shell))
+		var/mob/living/silicon/robot/shell/chosen_one = owner.current
+		chosen_one.undeploy()
+	//BUBBER EDIT END
 	if(owner.current && !isAI(owner.current))
 		stack_trace("Attempted to give malf AI antag datum to \[[owner]\], who did not meet the requirements.")
 		return ..()

--- a/modular_zubbers/code/modules/storyteller/event_defines/crewset/malf.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/crewset/malf.dm
@@ -22,6 +22,8 @@
 /datum/round_event_control/antagonist/solo/malf/get_candidates()
 	var/list/candidates = list()
 	for(var/mob/living/silicon/ai/candidate as anything in GLOB.ai_list)
+		if(candidate.deployed_shell)
+			candidate = candidate.deployed_shell
 		if(QDELETED(candidate) || !candidate.key || !candidate.client || !candidate.mind)
 			continue
 		if(!(candidate.client.prefs) || !(antag_flag in candidate.client.prefs.be_special))


### PR DESCRIPTION

## About The Pull Request
When malf rolls, it checks to see if an AI is in a shell, and adds them to the candidate list, if they get chosen, it kicks them out of their shell and then gives them malf
## Why It's Good For The Game
Malf couldn't roll if you were in a shell, so if you're ROLEPLAY maxxing like a chad, you don't get to antag
## Proof Of Testing
<img width="1889" height="979" alt="image" src="https://github.com/user-attachments/assets/27ce05a7-5b88-42ed-9309-416925a70622" />
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: Malf AI rolls on shells
/:cl:
