### PR TITLE
EORG but awesome

### DIFF
--- a/_maps/bubber/automapper/automapper_config.toml
+++ b/_maps/bubber/automapper/automapper_config.toml
@@ -178,7 +178,7 @@ trait_name = "CentCom"
 map_files = ["centcom_debug_area.dmm"]
 directory = "_maps/bubber/automapper/templates/centcom/"
 required_map = "CentCom.dmm"
-coordinates = [130, 13, 1]
+coordinates = [130, 13, 2]
 trait_name = "CentCom"
 
 # DELTASTATION MAP EDITS

--- a/_maps/bubber/automapper/automapper_config.toml
+++ b/_maps/bubber/automapper/automapper_config.toml
@@ -177,8 +177,8 @@ trait_name = "CentCom"
 [templates.centcom_debug_area]
 map_files = ["centcom_debug_area.dmm"]
 directory = "_maps/bubber/automapper/templates/centcom/"
-required_map = "CentCom.dmm"
-coordinates = [130, 13, 2]
+required_map = "builtin"
+coordinates = [130, 13, 1]
 trait_name = "CentCom"
 
 # DELTASTATION MAP EDITS

--- a/_maps/bubber/automapper/automapper_config.toml
+++ b/_maps/bubber/automapper/automapper_config.toml
@@ -173,6 +173,14 @@ required_map = "CentCom_skyrat_z2.dmm"
 coordinates = [51, 167, 2]
 trait_name = "CentCom"
 
+# CC Debug fun zone addition
+[templates.centcom_debug_area]
+map_files = ["centcom_debug_area.dmm"]
+directory = "_maps/bubber/automapper/templates/centcom/"
+required_map = "CentCom.dmm"
+coordinates = [130, 13, 1]
+trait_name = "CentCom"
+
 # DELTASTATION MAP EDITS
 # Deltastation Armory
 [templates.deltastation_armory]

--- a/_maps/bubber/automapper/templates/centcom/centcom_debug_area.dmm
+++ b/_maps/bubber/automapper/templates/centcom/centcom_debug_area.dmm
@@ -1,0 +1,3861 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ad" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/automatic/smart_machine_gun/unrestricted,
+/obj/item/gun/ballistic/automatic/smart_machine_gun/unrestricted,
+/obj/item/gun/energy/e_gun/nuclear,
+/obj/item/gun/energy/e_gun/nuclear,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"an" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plasmarglass,
+/obj/item/card/id/advanced/black/syndicate_command/captain_id,
+/obj/item/card/id/advanced/black/syndicate_command/captain_id/syndie_spare,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"bb" = (
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 4
+	},
+/obj/effect/light_emitter/thunderdome,
+/turf/open/floor/iron,
+/area/centcom/tdome/arena)
+"be" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/generic/style_random,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
+"bq" = (
+/obj/structure/rack,
+/obj/item/clothing/under/color/green,
+/obj/item/clothing/shoes/sneakers/brown,
+/obj/item/clothing/suit/armor/vest,
+/obj/item/clothing/head/helmet/swat,
+/obj/item/gun/energy/laser,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/light_emitter/thunderdome,
+/turf/open/floor/iron,
+/area/centcom/tdome/arena)
+"bu" = (
+/obj/effect/landmark/thunderdome/one,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/light_emitter/thunderdome,
+/turf/open/floor/iron,
+/area/centcom/tdome/arena)
+"bY" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/melee/baton/telescopic/bronze,
+/obj/item/melee/baton/telescopic/contractor_baton/upgraded,
+/obj/item/melee/baton/telescopic/gold,
+/obj/item/melee/baton/telescopic/silver,
+/obj/item/hierophant_club,
+/obj/item/spear/explosive,
+/obj/item/spear/military,
+/obj/item/spear/dragonator,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"cc" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/autosurgeon/syndicate/laser_arm,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"ci" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"ct" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair/sofa/bench/left{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"cz" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/portable_atmospherics/canister/goblin,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"cM" = (
+/obj/effect/landmark/thunderdome/two,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/light_emitter/thunderdome,
+/turf/open/floor/iron,
+/area/centcom/tdome/arena)
+"cP" = (
+/obj/structure/table/wood,
+/obj/item/clipboard,
+/obj/item/radio/headset/headset_cent,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"da" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"dc" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/portable_atmospherics/canister/proto_nitrate,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"dh" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/pointy/style_random,
+/obj/machinery/light/directional/south,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas)
+"dB" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/flora/tree/pine/xmas/presents/unlimited,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"dF" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/vending/medical/syndicate/cybersun,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"dY" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/autosurgeon/syndicate/baton,
+/obj/item/autosurgeon/syndicate/reviver,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"eD" = (
+/obj/effect/landmark/thunderdome/one,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/light_emitter/thunderdome,
+/turf/open/floor/iron,
+/area/centcom/tdome/arena)
+"eR" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"eX" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/book/granter/action/spell/blind,
+/obj/item/book/granter/action/spell/knock,
+/obj/item/book/granter/action/spell/mindswap,
+/obj/item/book/granter/action/spell/summonitem,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"fd" = (
+/obj/item/kirbyplants/organic/plant21,
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"fs" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/grenade/clusterbuster/clf3,
+/obj/item/grenade/clusterbuster/emp,
+/obj/item/grenade/clusterbuster/facid,
+/obj/item/grenade/clusterbuster/inferno,
+/obj/item/grenade/clusterbuster/spawner_manhacks,
+/obj/item/grenade/clusterbuster/spawner_spesscarp,
+/obj/item/grenade/clusterbuster/syndieminibomb,
+/obj/item/grenade/clusterbuster/teargas,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"fA" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/light/directional/north,
+/obj/item/advanced_choice_beacon/nri/heavy,
+/obj/item/advanced_choice_beacon/nri/engineer,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"fN" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/portable_atmospherics/canister/miasma,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"fQ" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/door/airlock/grunge,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"fS" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/generic/style_random,
+/obj/machinery/light/directional/east,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas)
+"fW" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/autosurgeon/syndicate/contraband_sechud,
+/obj/item/autosurgeon/syndicate/xray_eyes,
+/obj/item/autosurgeon/surgery,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"gf" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/card/id/advanced/black/syndicate_command/captain_id,
+/obj/item/card/id/advanced/black/syndicate_command/captain_id,
+/obj/item/card/id/advanced/black/syndicate_command/captain_id,
+/obj/item/card/id/advanced/black/syndicate_command/captain_id,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"gl" = (
+/obj/machinery/computer/security/telescreen,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"gm" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/gift/anything,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"go" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/portable_atmospherics/canister/freon,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"gp" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/vending/magivend,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"gs" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/gift/anything,
+/obj/item/gift/anything,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"gu" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/automatic/wt550,
+/obj/item/gun/ballistic/automatic/wt550/burst,
+/obj/item/gun/ballistic/automatic/wt550/dmr,
+/obj/item/gun/energy/laser/captain/scattershot,
+/obj/item/gun/energy/laser/captain/scattershot,
+/obj/item/gun/energy/laser/cybersun/unrestricted,
+/obj/item/gun/energy/laser/cybersun/unrestricted,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"hi" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair/sofa/corp{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"hK" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plasmarglass,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/flashbang/clusterbang,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/flashbang/tearstache,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/silenced,
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/laser,
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/pulse,
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/cryo,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"hN" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/automatic/c20r,
+/obj/item/gun/ballistic/automatic/c20r/unrestricted,
+/obj/item/gun/medbeam,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"ie" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"il" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair/sofa/bench{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"iO" = (
+/turf/closed/indestructible/riveted,
+/area/centcom/central_command_areas)
+"ja" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/vehicle/sealed/mecha/marauder/loaded,
+/turf/open/floor/iron/recharge_floor,
+/area/centcom/central_command_areas)
+"je" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/portable_atmospherics/canister/pluoxium,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"jf" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/pipe_dispenser/bluespace,
+/obj/item/pipe_dispenser/bluespace,
+/obj/item/pipe_dispenser/bluespace,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"jp" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"js" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/vehicle/sealed/mecha/marauder/mauler/loaded,
+/turf/open/floor/iron/recharge_floor,
+/area/centcom/central_command_areas)
+"jt" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/vending/liberationstation,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"jx" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"jQ" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/autosurgeon/syndicate/esword_arm,
+/obj/item/autosurgeon/toolset,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"ku" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/pointy/style_random,
+/obj/machinery/nuclearbomb/syndicate/bananium,
+/obj/machinery/light/directional/south,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas)
+"kJ" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/vehicle/sealed/mecha/ripley/paddy/preset,
+/turf/open/floor/iron/recharge_floor,
+/area/centcom/central_command_areas)
+"kS" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/storage/box/debugtools,
+/obj/item/storage/box/syndie_kit/tuberculosisgrenade,
+/obj/item/storage/box/syndie_kit/throwing_weapons,
+/obj/item/storage/box/syndie_kit/sniper_surplus,
+/obj/item/storage/box/syndie_kit/smoke,
+/obj/item/storage/box/syndie_kit/sleepytime,
+/obj/item/storage/box/syndie_kit/shotgun_surplus,
+/obj/item/storage/box/syndie_kit/romerol,
+/obj/item/storage/box/syndie_kit/rebarxbowsyndie,
+/obj/item/storage/box/syndie_kit/manhack_grenades,
+/obj/item/storage/box/syndie_kit/feral_cat_grenades,
+/obj/item/storage/box/syndie_kit/demoman,
+/obj/item/storage/box/syndie_kit/bioterror,
+/obj/item/storage/box/syndie_kit/carnivorous_blood,
+/obj/item/storage/box/syndicate/sleeping_carp,
+/obj/item/storage/box/syndicate/contract_kit,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"kX" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/autosurgeon/syndicate/hackerman,
+/obj/item/autosurgeon/xeno,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"lw" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/magic/wand/resurrection/debug,
+/obj/item/godstaff,
+/obj/item/gun/magic/staff/chaos/true_wabbajack,
+/obj/item/gun/magic/hook/contractor,
+/obj/item/gun/magic/staff/locker,
+/obj/item/gun/magic/staff/spellblade,
+/obj/item/gun/magic/wand/missile,
+/obj/item/gun/magic/wand/plague,
+/obj/item/gun/magic/wand/resurrection/debug,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"me" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/pointy/style_random,
+/obj/machinery/light/directional/south,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
+"mq" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/autosurgeon/syndicate/anti_stun,
+/obj/item/autosurgeon/syndicate/nodrop,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"mA" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/gun/ballistic/revolver/reverse/mateba,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"mB" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/ferny/style_random,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron{
+	dir = 6;
+	icon_state = "asteroid8";
+	name = "sand"
+	},
+/area/centcom/tdome/administration)
+"mY" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/vending/hotdog,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"nl" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/automatic/tommygun,
+/obj/item/gun/ballistic/automatic/tommygun,
+/obj/item/gun/energy/laser/assault,
+/obj/item/gun/energy/laser/assault,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"np" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair/sofa/bench/right{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"nw" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/syndicate_contacts,
+/obj/item/syndicate_contacts,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"nS" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/guardian_creator/wizard,
+/obj/item/guardian_creator/tech/choose,
+/obj/item/guardian_creator/carp,
+/obj/item/guardian_creator/miner,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"nV" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plasmarglass,
+/obj/item/card/id/advanced/black/deathsquad,
+/obj/item/card/id/advanced/centcom/ert/commander,
+/obj/item/card/id/advanced/centcom/ert/militia/general,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"og" = (
+/obj/effect/landmark/thunderdome/admin,
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/iron/grimy,
+/area/centcom/tdome/administration)
+"op" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/portable_atmospherics/canister/healium,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"oL" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/book/granter/action/spell/charge,
+/obj/item/book/granter/action/spell/lightningbolt,
+/obj/item/book/granter/action/spell/sacredflame,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"oT" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/book_of_babel,
+/obj/item/teleportation_scroll,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"pb" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas)
+"pd" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/mod/control/pre_equipped/responsory/clown,
+/obj/item/mod/control/pre_equipped/responsory/commander,
+/obj/item/mod/control/pre_equipped/responsory/engineer,
+/obj/item/mod/control/pre_equipped/responsory/inquisitory/chaplain,
+/obj/item/mod/control/pre_equipped/responsory/inquisitory/commander,
+/obj/item/mod/control/pre_equipped/responsory/inquisitory/medic,
+/obj/item/mod/control/pre_equipped/responsory/inquisitory/security,
+/obj/item/mod/control/pre_equipped/responsory/inquisitory/syndie,
+/obj/item/mod/control/pre_equipped/responsory/milsim/medic,
+/obj/item/mod/control/pre_equipped/responsory/milsim/trooper,
+/obj/item/mod/control/pre_equipped/responsory/milsim/trapper,
+/obj/item/mod/control/pre_equipped/traitor_elite,
+/obj/item/mod/control/pre_equipped/voskhod,
+/obj/item/mod/control/pre_equipped/stealth_operative,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"pr" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/claymore/dragonslayer,
+/obj/item/clothing/gloves/gauntlets,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"pz" = (
+/obj/machinery/button/door/indestructible{
+	id = "thunderdomehea";
+	name = "Heavy Supply Control";
+	req_access = list("cent_thunder")
+	},
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"qo" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/automatic/sol_rifle/marksman,
+/obj/item/gun/ballistic/automatic/sol_rifle/marksman,
+/obj/item/gun/energy/e_gun/turret,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"qq" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair/sofa/corp/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"qE" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair/sofa/corp{
+	dir = 8
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"qK" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/pointy/style_random,
+/obj/item/gun/magic/wand/death/debug,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas)
+"rg" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair/sofa/bench/right{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"rB" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/autosurgeon/syndicate/emaggedsurgerytoolset,
+/obj/item/autosurgeon/syndicate/xray_eyes,
+/obj/item/autosurgeon/paperwork,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"rM" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/rocketlauncher/unrestricted,
+/obj/item/gun/ballistic/rocketlauncher/unrestricted,
+/obj/item/gun/energy/meteorgun,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"rN" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/effect/light_emitter/thunderdome,
+/turf/open/floor/iron,
+/area/centcom/tdome/arena)
+"rP" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/automatic/sol_smg/evil,
+/obj/item/gun/ballistic/automatic/sol_smg/evil,
+/obj/item/gun/energy/event_horizon,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"rY" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/light_emitter/thunderdome,
+/turf/open/floor/iron,
+/area/centcom/tdome/arena)
+"sr" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/revolver/shotgun_revolver,
+/obj/item/gun/ballistic/revolver/shotgun_revolver,
+/obj/item/gun/energy/laser/musket/prime,
+/obj/item/gun/energy/laser/musket/prime,
+/obj/item/gun/energy/laser/musket/repeater,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"sv" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/light/directional/west,
+/obj/item/gun/magic/wand/death/debug,
+/obj/item/teleport_rod/admin,
+/obj/item/gun/magic/staff/flying,
+/obj/item/gun/magic/staff/chaos/unrestricted,
+/obj/item/gun/magic/staff/babel,
+/obj/item/gun/magic/bloodchill,
+/obj/item/gun/magic/staff/healing/unrestricted,
+/obj/item/gun/magic/staff/necropotence,
+/obj/item/gun/magic/staff/wipe,
+/obj/item/gun/magic/wand/anti_tank,
+/obj/item/gun/magic/wand/polymorph,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"sD" = (
+/obj/structure/table/wood,
+/obj/item/phone{
+	desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in.";
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/cigarette/cigar/cohiba{
+	pixel_x = 6
+	},
+/obj/item/cigarette/cigar/havana{
+	pixel_x = 2
+	},
+/obj/item/cigarette/cigar{
+	pixel_x = 4.5
+	},
+/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"sI" = (
+/obj/effect/light_emitter/thunderdome,
+/turf/closed/indestructible/fakeglass,
+/area/centcom/tdome/administration)
+"th" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"tC" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/vehicle/sealed/mecha/gygax/dark/loaded,
+/turf/open/floor/iron/recharge_floor,
+/area/centcom/central_command_areas)
+"tJ" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/generic/style_random,
+/obj/machinery/light/directional/north,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas)
+"tT" = (
+/obj/structure/table/wood,
+/obj/item/storage/fancy/donut_box,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"uf" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair/sofa/bench/left{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"ux" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas)
+"uB" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/pointy/style_random,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
+"uF" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/automatic/m90/unrestricted,
+/obj/item/gun/ballistic/automatic/m90/unrestricted,
+/obj/item/gun/energy/photon,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"uU" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/portable_atmospherics/canister/halon,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"vc" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/gift/anything,
+/obj/item/gift/anything,
+/obj/item/gift/anything,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"vd" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"vh" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/wood/fancy/red,
+/obj/item/melee/supermatter_sword,
+/obj/item/greentext,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas)
+"vs" = (
+/obj/effect/light_emitter/thunderdome,
+/turf/open/floor/iron,
+/area/centcom/tdome/arena)
+"vx" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/portable_atmospherics/canister/tritium,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"vB" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/light/directional/south,
+/obj/item/implanter/beacon,
+/obj/item/implanter/emp,
+/obj/item/implanter/explosive,
+/obj/item/implanter/explosive_macro,
+/obj/item/implanter/freedom,
+/obj/item/implanter/induction_implant,
+/obj/item/implanter/interdyne,
+/obj/item/implanter/kaza_ruk,
+/obj/item/implanter/mortis,
+/obj/item/implanter/radio/syndicate,
+/obj/item/implanter/smoke,
+/obj/item/implanter/spell,
+/obj/item/implanter/stealth,
+/obj/item/implanter/tacmap/nuclear,
+/obj/item/implanter/tactical_deniability,
+/obj/item/implanter/uplink/precharged,
+/obj/item/implanter/uplink/precharged,
+/obj/item/shield/adamantineshield,
+/obj/item/shield/big_bertha,
+/obj/item/shield/riot/pointman/hecu,
+/obj/item/shield/roman,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"vG" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/automatic/mini_uzi,
+/obj/item/gun/ballistic/shotgun/china_lake,
+/obj/item/gun/energy/pulse/carbine/lethal,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"vY" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/rifle/sniper_rifle/syndicate,
+/obj/item/gun/ballistic/rifle/sniper_rifle/syndicate,
+/obj/item/gun/energy/laser/thermal/cryo,
+/obj/item/gun/energy/laser/thermal/inferno,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"we" = (
+/turf/open/floor/iron/grimy,
+/area/centcom/central_command_areas)
+"wg" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/light/directional/north,
+/obj/item/melee/baseball_bat/ablative,
+/obj/item/melee/baseball_bat/british,
+/obj/item/melee/baseball_bat/homerun,
+/obj/item/melee/baton/security/stunsword/loaded,
+/obj/item/melee/beesword,
+/obj/item/highfrequencyblade/wizard,
+/obj/item/storage/belt/sheath/sabre/gunpowered,
+/obj/item/storage/belt/sheath/multi,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"ws" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/mod/control/pre_equipped/debug,
+/obj/item/mod/control/pre_equipped/empty/syndicate/honkerative,
+/obj/item/mod/control/pre_equipped/empty/syndicate/honkerative,
+/obj/item/mod/control/pre_equipped/empty/syndicate,
+/obj/item/mod/control/pre_equipped/empty/syndicate,
+/obj/item/storage/backpack/holding/satchel,
+/obj/item/storage/backpack/holding/duffel,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"ww" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/card/id/advanced/debug/bst,
+/obj/item/card/id/advanced/debug/bst,
+/obj/item/card/id/advanced/debug/bst,
+/obj/item/card/id/advanced/debug/bst,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"wA" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/vending/dorms,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"wW" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/melee/energy/sword/bananium,
+/obj/item/melee/energy/sword/pirate,
+/obj/item/melee/energy/sword/saber,
+/obj/item/melee/energy/sword/saber/red,
+/obj/item/dualsaber/red,
+/obj/item/dualsaber/green,
+/obj/item/pneumatic_cannon/pie/selfcharge,
+/obj/item/spear/skybulge,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"xd" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/automatic/rom_smg,
+/obj/item/gun/ballistic/automatic/rom_smg,
+/obj/item/gun/energy/e_gun/blueshield/specop,
+/obj/item/gun/energy/e_gun/blueshield/specop,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"xj" = (
+/obj/machinery/button/door/indestructible{
+	id = "thunderdome";
+	name = "Main Blast Doors Control";
+	req_access = list("cent_thunder")
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/status_display/ai/directional/south,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"xk" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/vehicle/sealed/mecha/marauder/seraph,
+/turf/open/floor/iron/recharge_floor,
+/area/centcom/central_command_areas)
+"xp" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"xv" = (
+/obj/structure/chair/comfy/brown{
+	color = "#66b266";
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"xI" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/automatic/ar/modular/m44a,
+/obj/item/gun/ballistic/automatic/ar/modular/m44a/grenadelauncher,
+/obj/item/gun/ballistic/automatic/ar/modular/m44a/scoped,
+/obj/item/gun/ballistic/automatic/ar/modular/m44a/shotgun,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"xJ" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"ya" = (
+/obj/effect/landmark/thunderdome/two,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/light_emitter/thunderdome,
+/turf/open/floor/iron,
+/area/centcom/tdome/arena)
+"yb" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/automatic/xhihao_smg,
+/obj/item/gun/ballistic/automatic/xhihao_smg,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"yj" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/melee/cultblade,
+/obj/item/melee/cultblade/dagger,
+/obj/item/melee/cultblade/ghost,
+/obj/item/melee/cultblade/halberd,
+/obj/item/melee/cultblade/haunted,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"yC" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/clothing/suit/space/freedom,
+/obj/item/clothing/suit/space/hev_suit/nri,
+/obj/item/clothing/suit/space/hev_suit/nri/captain,
+/obj/item/clothing/suit/space/hev_suit/nri/engineer,
+/obj/item/clothing/suit/space/hev_suit/nri/medic,
+/obj/item/clothing/suit/space/hev_suit/pcv,
+/obj/item/clothing/suit/space/hunter,
+/obj/item/clothing/suit/space/voskhod,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"yG" = (
+/turf/open/space/basic,
+/area/space)
+"yO" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/showtime{
+	req_access = list("cent_thunder")
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"yP" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/portable_atmospherics/canister/bz,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"yR" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/light_emitter/thunderdome,
+/turf/open/floor/iron,
+/area/centcom/tdome/arena)
+"zk" = (
+/obj/machinery/door/poddoor{
+	id = "thunderdomegen";
+	name = "General Supply"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/effect/light_emitter/thunderdome,
+/turf/open/floor/iron,
+/area/centcom/tdome/arena)
+"zo" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/uplink/nuclear/debug,
+/obj/item/uplink/debug,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"zx" = (
+/turf/closed/indestructible/riveted,
+/area/centcom/tdome/administration)
+"zz" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/melee/rune_carver,
+/obj/item/melee/sabre,
+/obj/item/melee/tomahawk,
+/obj/item/energy_katana,
+/obj/item/katana/ninja_blade,
+/obj/item/lead_pipe,
+/obj/item/phystool,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"zE" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/portable_atmospherics/canister/antinoblium,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"zF" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair/sofa/corp{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Am" = (
+/turf/open/floor/iron/grimy,
+/area/centcom/tdome/administration)
+"Ap" = (
+/obj/effect/landmark/thunderdome/two,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/light_emitter/thunderdome,
+/turf/open/floor/iron,
+/area/centcom/tdome/arena)
+"Ar" = (
+/obj/machinery/door/poddoor{
+	id = "thunderdomehea";
+	name = "Heavy Supply"
+	},
+/obj/effect/turf_decal/loading_area,
+/obj/effect/light_emitter/thunderdome,
+/turf/open/floor/iron,
+/area/centcom/tdome/arena)
+"AS" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/automatic/pistol/trappiste,
+/obj/item/gun/ballistic/automatic/pistol/trappiste,
+/obj/item/gun/energy/cell_loaded/medigun/upgraded,
+/obj/item/gun/energy/tesla_cannon,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Ba" = (
+/obj/item/radio{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/radio{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/radio,
+/obj/structure/table/wood,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"Bc" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/clothing/suit/armor/reactive/barricade,
+/obj/item/clothing/suit/armor/reactive/bioscrambling,
+/obj/item/clothing/suit/armor/reactive/ectoplasm,
+/obj/item/clothing/suit/armor/reactive/fire,
+/obj/item/clothing/suit/armor/reactive/hallucinating,
+/obj/item/clothing/suit/armor/reactive/psykerboost,
+/obj/item/clothing/suit/armor/reactive/repulse,
+/obj/item/clothing/suit/armor/reactive/stealth,
+/obj/item/clothing/suit/armor/reactive/table,
+/obj/item/clothing/suit/armor/reactive/teleport,
+/obj/item/clothing/suit/armor/reactive/tesla,
+/obj/item/clothing/suit/armor/reactive/weather,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Bm" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair/sofa/corp{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Bp" = (
+/obj/machinery/door/poddoor{
+	id = "thunderdome";
+	name = "Thunderdome Blast Door"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/effect/light_emitter/thunderdome,
+/turf/open/floor/iron,
+/area/centcom/tdome/arena)
+"BH" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome Administration"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/thunderdome,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"BN" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/book/granter/action/spell/barnyard,
+/obj/item/book/granter/action/spell/forcewall,
+/obj/item/book/granter/action/spell/mime/mimery_guns,
+/obj/item/book/granter/action/spell/summon_cheese,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"BP" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/automatic/lanca,
+/obj/item/gun/ballistic/automatic/lanca,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Cx" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/portable_atmospherics/canister/nob,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Cy" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/storage/toolbox/syndicate,
+/obj/item/storage/toolbox/syndicate,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"CE" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plasmarglass,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot,
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/disabler,
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/ion,
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/tesla,
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/thermal/inferno,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"CL" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas)
+"CZ" = (
+/obj/machinery/button/door/indestructible{
+	id = "thunderdomegen";
+	name = "General Supply Control";
+	req_access = list("cent_thunder")
+	},
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"De" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/portable_atmospherics/pipe_scrubber,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Dr" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Ds" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/generic/style_random,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas)
+"Du" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/reagent_containers/cup/glass/bottle/whiskey{
+	pixel_y = 5
+	},
+/obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"Dx" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/vehicle/sealed/mecha/honker/dark/loaded,
+/turf/open/floor/iron/recharge_floor,
+/area/centcom/central_command_areas)
+"DF" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/portable_atmospherics/canister/zauker,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"DS" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/light_emitter/thunderdome,
+/turf/open/floor/iron,
+/area/centcom/tdome/arena)
+"Ed" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/automatic/wylom,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Ey" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/clothing/suit/armor/bone/bleached,
+/obj/item/clothing/suit/armor/bone,
+/obj/item/clothing/suit/armor/elder_atmosian,
+/obj/item/clothing/suit/armor/nerd,
+/obj/item/clothing/suit/armor/riot/knight/warlord,
+/obj/item/clothing/suit/hooded/carp_costume/spaceproof,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"ED" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/vending/security/noaccess,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"EL" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/portable_atmospherics/canister/plasma,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"EP" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/floor,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"ER" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/automatic/pistol/sol/evil,
+/obj/item/gun/ballistic/automatic/pistol/sol/evil,
+/obj/item/gun/energy/cell_loaded/alltypes,
+/obj/item/gun/energy/shrink_ray,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"EU" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/generic/style_random,
+/obj/item/gun/energy/laser/instakill,
+/obj/machinery/light/directional/south,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas)
+"Fc" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"Fl" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/book/bible/syndicate,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Fn" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/effect/light_emitter/thunderdome,
+/turf/open/floor/iron,
+/area/centcom/tdome/arena)
+"Fr" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/storage/bag/garment/syndicate_scientist,
+/obj/item/storage/bag/garment/syndicate_roboticist,
+/obj/item/storage/bag/garment/syndicate_engie,
+/obj/item/storage/bag/garment/syndicate_medical,
+/obj/item/clothing/glasses/debug/architector_glasses,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"FF" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/ferny/style_random,
+/turf/open/floor/iron{
+	icon_state = "asteroid5";
+	name = "plating"
+	},
+/area/centcom/tdome/administration)
+"FP" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/book/granter/martial/plasma_fist,
+/obj/item/book/granter/martial/cqc,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"FR" = (
+/obj/structure/rack,
+/obj/item/clothing/under/color/red,
+/obj/item/clothing/shoes/sneakers/brown,
+/obj/item/clothing/suit/armor/tdome/red,
+/obj/item/clothing/head/helmet/thunderdome,
+/obj/item/melee/baton/security/loaded,
+/obj/item/melee/energy/sword/saber/red,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/light_emitter/thunderdome,
+/turf/open/floor/iron,
+/area/centcom/tdome/arena)
+"Gs" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/smoke_machine,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"GH" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"GI" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/revolver/badass/nuclear,
+/obj/item/gun/ballistic/revolver/badass,
+/obj/item/gun/ballistic/revolver/c38/the_law,
+/obj/item/gun/ballistic/revolver/cowboy/nuclear,
+/obj/item/gun/ballistic/revolver/mateba,
+/obj/item/gun/ballistic/revolver/ocelot,
+/obj/item/gun/ballistic/revolver/ocelot,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Hd" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/mod/control/pre_equipped/administrative,
+/obj/item/mod/control/pre_equipped/advanced,
+/obj/item/mod/control/pre_equipped/apocryphal,
+/obj/item/mod/control/pre_equipped/apocryphal/officer,
+/obj/item/mod/control/pre_equipped/asset_protection,
+/obj/item/mod/control/pre_equipped/blueshield,
+/obj/item/mod/control/pre_equipped/chrono,
+/obj/item/mod/control/pre_equipped/contractor/upgraded/adminbus,
+/obj/item/mod/control/pre_equipped/cosmohonk,
+/obj/item/mod/control/pre_equipped/corporate,
+/obj/item/mod/control/pre_equipped/daimyo,
+/obj/item/mod/control/pre_equipped/elite,
+/obj/item/mod/control/pre_equipped/elite/flamethrower,
+/obj/item/mod/control/pre_equipped/elite/unrestricted,
+/obj/item/mod/control/pre_equipped/emergency_medical/corpsman,
+/obj/item/mod/control/pre_equipped/empty/ninja,
+/obj/item/mod/control/pre_equipped/empty/syndicate,
+/obj/item/mod/control/pre_equipped/empty/syndicate/honkerative,
+/obj/item/mod/control/pre_equipped/empty/infiltrator,
+/obj/item/mod/control/pre_equipped/empty/elite,
+/obj/item/mod/control/pre_equipped/frontline/ert,
+/obj/item/mod/control/pre_equipped/magnate,
+/obj/item/mod/control/pre_equipped/responsory/chaplain,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"HB" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/centcom/tdome/administration)
+"HD" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas)
+"If" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/book/granter/martial/spider_bite,
+/obj/item/book/granter/martial/carp,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Ig" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair/sofa/bench{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Iy" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome Administration"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/all/admin/thunderdome,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"IR" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas)
+"IS" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/automatic/lahti,
+/obj/item/gun/energy/e_gun/nuclear_smg,
+/obj/item/gun/energy/e_gun/nuclear_smg,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"IZ" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/magic/wand/safety/debug,
+/obj/item/gun/magic/staff/door,
+/obj/item/gun/magic/staff/change/unrestricted,
+/obj/item/gun/magic/staff/animate,
+/obj/item/gun/magic/staff/honk,
+/obj/item/gun/magic/staff/shrink,
+/obj/item/gun/magic/wand/nothing,
+/obj/item/gun/magic/wand/repulse,
+/obj/item/gun/magic/wand/zap,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Kk" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/generic/style_random,
+/obj/machinery/nuclearbomb/syndicate,
+/obj/machinery/light/directional/south,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas)
+"Kl" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/portable_atmospherics/canister/helium,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Kp" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/automatic/l6_saw,
+/obj/item/gun/ballistic/automatic/l6_saw/unrestricted,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Kv" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/autosurgeon/syndicate/commsagent,
+/obj/item/autosurgeon/syndicate/thermal_eyes,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Kw" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/vehicle/sealed/mecha/reticence/loaded,
+/turf/open/floor/iron/recharge_floor,
+/area/centcom/central_command_areas)
+"KR" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/mecha_part_fabricator/interdyne,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"KW" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/melee/cleric_mace,
+/obj/item/chainsaw,
+/obj/item/claymore,
+/obj/item/mjollnir,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"La" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair/sofa/bench/right{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Le" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"Ln" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/generic/style_random,
+/obj/machinery/light/directional/south,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas)
+"Ls" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/melee/implantarmblade/energy,
+/obj/item/melee/implantarmblade,
+/obj/item/melee/ghost_sword,
+/obj/item/katana,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"LA" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/book/granter/action/origami,
+/obj/item/book/granter/action/spell/fireball,
+/obj/item/book/granter/action/spell/mime/mimery_blockade,
+/obj/item/book/granter/action/spell/smoke,
+/obj/item/book/granter/chuunibyou,
+/obj/item/spellbook,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"LP" = (
+/obj/item/kirbyplants/organic/plant21,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"LR" = (
+/obj/effect/light_emitter/thunderdome,
+/obj/machinery/camera/motion/thunderdome{
+	pixel_x = 10
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/arena)
+"LU" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/vending/assaultops_ammo,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"LY" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/clothing/gloves/kaza_ruk/combatglovesplus/maa,
+/obj/item/clothing/gloves/kaza_ruk/sec/warden,
+/obj/item/clothing/gloves/tackler/combat/insulated/blueshield,
+/obj/item/clothing/gloves/the_sleeping_carp,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Me" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair/sofa/bench{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Mu" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/pale/style_random,
+/turf/open/misc/asteroid,
+/area/centcom/tdome/administration)
+"MH" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/storage/belt/utility/chief/full/debug,
+/obj/item/storage/belt/holster/psyker,
+/obj/item/storage/belt/grenade/full,
+/obj/item/storage/belt/military/assault/full,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Nn" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/card/emag/bluespace,
+/obj/item/card/emag/bluespace,
+/obj/item/card/emag/battlecruiser,
+/obj/item/card/emag,
+/obj/item/card/emag/doorjack,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Nq" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/storage/bag/sheetsnatcher/debug,
+/obj/item/storage/belt/holster/detective/full/ert/the_law,
+/obj/item/storage/belt/holster/energy/laser_pistol,
+/obj/item/storage/belt/holster/nukie/cowboy/full,
+/obj/item/storage/belt/military/assault/full/m44a,
+/obj/item/storage/belt/military/expeditionary_corps/marksman,
+/obj/item/storage/belt/military/expeditionary_corps/pointman,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Nw" = (
+/obj/structure/table/wood,
+/obj/item/folder/red,
+/obj/item/lighter,
+/obj/machinery/newscaster/directional/south,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"Nx" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/automatic/pistol/deagle/camo,
+/obj/item/gun/ballistic/automatic/pistol/deagle/regal,
+/obj/item/gun/ballistic/shotgun/hook,
+/obj/item/gun/energy/pulse/destroyer,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"NL" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/chainsaw/doomslayer,
+/obj/item/house_edge,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"NZ" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/vehicle/sealed/mecha/ripley/deathripley/real,
+/turf/open/floor/iron/recharge_floor,
+/area/centcom/central_command_areas)
+"Oz" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"OG" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"ON" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/portable_atmospherics/canister/hydrogen,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Py" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/automatic/pistol/plasma_marksman,
+/obj/item/gun/ballistic/automatic/pistol/plasma_marksman,
+/obj/item/gun/ballistic/shotgun/riot,
+/obj/item/gun/energy/pulse/pistol/m1911,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"PB" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/generic/style_random,
+/obj/machinery/light/directional/south,
+/turf/open/floor/grass,
+/area/centcom/tdome/administration)
+"PO" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Qi" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/earthcracker,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Qp" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/chameleon,
+/obj/item/choice_beacon/ancient_milsim,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Qy" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/portable_atmospherics/canister/nitrium,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"QG" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/vending/tool/super,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"QQ" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair/sofa/bench/left{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"QY" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/grenade/stingbang/mega,
+/obj/item/grenade/stingbang/mega,
+/obj/item/grenade/stingbang/mega,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Rh" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/borg/upgrade/transform/syndicatejack,
+/obj/item/borg/upgrade/transform/syndicatejack,
+/obj/item/borg/upgrade/transform/syndicatejack,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Rn" = (
+/obj/machinery/button/flasher/indestructible{
+	id = "tdomeflash"
+	},
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"RN" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/vehicle/sealed/mecha/vim,
+/turf/open/floor/iron/recharge_floor,
+/area/centcom/central_command_areas)
+"Sf" = (
+/obj/structure/table/wood,
+/obj/item/folder/red,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/restraints/handcuffs,
+/obj/item/assembly/flash/handheld,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"Sl" = (
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"SB" = (
+/obj/machinery/door/poddoor{
+	id = "thunderdome";
+	name = "Thunderdome Blast Door"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/obj/effect/light_emitter/thunderdome,
+/turf/open/floor/iron,
+/area/centcom/tdome/arena)
+"Td" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/automatic/battle_rifle_basic,
+/obj/item/gun/ballistic/automatic/battle_rifle,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Te" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/vending/access/debug,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Tk" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/clothing/suit/armor/durability/barrelmelon/fire_resist,
+/obj/item/clothing/suit/armor/durability/holymelon/fire_resist,
+/obj/item/clothing/suit/armor/changeling/prototype,
+/obj/item/clothing/suit/armor/abductor/astrum,
+/obj/item/clothing/suit/armor/heavy/adamantine,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Ts" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair/sofa/corp/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Tu" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair/sofa/bench{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"TJ" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair/sofa/corp{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"TP" = (
+/obj/structure/rack,
+/obj/item/clothing/under/color/red,
+/obj/item/clothing/shoes/sneakers/brown,
+/obj/item/clothing/suit/armor/vest,
+/obj/item/clothing/head/helmet/swat,
+/obj/item/gun/energy/laser,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/light_emitter/thunderdome,
+/turf/open/floor/iron,
+/area/centcom/tdome/arena)
+"Ud" = (
+/turf/closed/indestructible/fakedoor{
+	name = "Thunderdome Admin"
+	},
+/area/centcom/central_command_areas)
+"Ue" = (
+/obj/item/storage/briefcase{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/storage/briefcase/secure,
+/obj/structure/table/wood,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"UJ" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/automatic/sol_rifle/machinegun,
+/obj/item/gun/ballistic/automatic/sol_rifle/machinegun,
+/obj/item/gun/energy/e_gun/stun/blueshield,
+/obj/item/gun/energy/e_gun/stun/blueshield,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Va" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/automatic/m6pdw,
+/obj/item/gun/ballistic/automatic/m6pdw,
+/obj/item/gun/energy/lasercannon,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Vv" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Vx" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Vz" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/storage/box/syndicate/contract_kit,
+/obj/item/storage/box/syndicate/contractor_loadout,
+/obj/item/storage/box/syndicate/henchmen_traitor_outfit,
+/obj/item/storage/box/syndicate/sleeping_carp,
+/obj/item/storage/box/syndicate/horse_box,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"VK" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/vehicle/sealed/mecha/savannah_ivanov,
+/turf/open/floor/iron/recharge_floor,
+/area/centcom/central_command_areas)
+"Wb" = (
+/obj/machinery/igniter/on,
+/obj/effect/turf_decal/delivery,
+/obj/effect/light_emitter/thunderdome,
+/turf/open/floor/iron,
+/area/centcom/tdome/arena)
+"Wk" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/melee/baton/nunchaku,
+/obj/item/melee/baton/security/boomerang/loaded,
+/obj/item/melee/baton/security/cattleprod/telecrystalprod,
+/obj/item/melee/baton/security/cattleprod/teleprod,
+/obj/item/melee/baton/security/staff/prime/loaded,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Wl" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Ws" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas)
+"WY" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/automatic/pistol/sec_glock/smart,
+/obj/item/gun/ballistic/automatic/pistol/sec_glock/smart,
+/obj/item/gun/ballistic/shotgun/riot/sol/evil,
+/obj/item/gun/ballistic/shotgun/riot/sol/evil,
+/obj/item/gun/energy/recharge/ebow,
+/obj/item/gun/energy/recharge/ebow/large,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Xm" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/pointy/style_random,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas)
+"Xw" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/automatic/proto/unrestricted,
+/obj/item/gun/ballistic/automatic/proto/unrestricted,
+/obj/item/gun/energy/disabler/smg,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"XF" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"XI" = (
+/obj/structure/bookcase/random,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
+"XS" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plasmarglass,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/breaching,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"YA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/centcom/central_command_areas)
+"YI" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair/sofa/corp/left{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"YJ" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/portable_atmospherics/canister/water_vapor,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Zc" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plasmarglass,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/banana_mortar/bombanana,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/banana_mortar,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/carbine,
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"Zl" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/obj/effect/light_emitter/thunderdome,
+/turf/open/floor/iron,
+/area/centcom/tdome/arena)
+"Zn" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/melee/moonlight_greatsword,
+/obj/item/melee/parsnip_sabre,
+/obj/item/melee/powerfist,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+"ZR" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/light/directional/south,
+/obj/item/grenade/antigravity,
+/obj/item/grenade/antigravity,
+/obj/item/grenade/c4/ninja,
+/obj/item/grenade/c4/ninja,
+/obj/item/grenade/c4/x4,
+/obj/item/grenade/c4/x4,
+/obj/item/grenade/gluon,
+/obj/item/grenade/gluon,
+/obj/item/grenade/spawnergrenade/manhacks,
+/obj/item/grenade/spawnergrenade/manhacks,
+/obj/item/grenade/spawnergrenade/manhacks/nri,
+/obj/item/grenade/spawnergrenade/manhacks/nri,
+/obj/item/grenade/syndieminibomb,
+/obj/item/grenade/syndieminibomb,
+/obj/item/grenade/syndieminibomb/concussion,
+/obj/item/grenade/syndieminibomb/concussion,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas)
+
+(1,1,1) = {"
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+iO
+iO
+iO
+iO
+iO
+iO
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+"}
+(2,1,1) = {"
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+KR
+hK
+HD
+CE
+KR
+iO
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+"}
+(3,1,1) = {"
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+Ws
+HD
+HD
+HD
+pb
+iO
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+"}
+(4,1,1) = {"
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+Zc
+th
+HD
+th
+XS
+iO
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+"}
+(5,1,1) = {"
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+nV
+th
+HD
+th
+an
+iO
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+"}
+(6,1,1) = {"
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+xk
+HD
+HD
+HD
+Kw
+iO
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+"}
+(7,1,1) = {"
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+Vx
+th
+HD
+th
+ci
+iO
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+iO
+iO
+iO
+iO
+iO
+iO
+iO
+iO
+yG
+"}
+(8,1,1) = {"
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+js
+HD
+HD
+HD
+NZ
+iO
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+ON
+fN
+Qy
+Oz
+vd
+Cx
+DF
+iO
+yG
+"}
+(9,1,1) = {"
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+th
+th
+HD
+th
+th
+iO
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+Kl
+HD
+HD
+HD
+HD
+HD
+YJ
+iO
+yG
+"}
+(10,1,1) = {"
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+ja
+HD
+HD
+HD
+kJ
+iO
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+op
+HD
+Wl
+De
+Wl
+HD
+vx
+iO
+yG
+"}
+(11,1,1) = {"
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+Vx
+th
+HD
+th
+ci
+iO
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+uU
+HD
+De
+iO
+jf
+HD
+dc
+iO
+yG
+"}
+(12,1,1) = {"
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+Dx
+HD
+HD
+HD
+VK
+iO
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+cz
+HD
+Wl
+Gs
+Wl
+HD
+je
+iO
+yG
+"}
+(13,1,1) = {"
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+th
+th
+HD
+th
+th
+iO
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+go
+HD
+HD
+HD
+HD
+HD
+EL
+iO
+yG
+"}
+(14,1,1) = {"
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+tC
+HD
+HD
+HD
+RN
+iO
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+jp
+yP
+zE
+HD
+da
+XF
+xp
+iO
+yG
+"}
+(15,1,1) = {"
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+iO
+iO
+fQ
+iO
+iO
+iO
+iO
+iO
+iO
+iO
+iO
+iO
+iO
+iO
+iO
+iO
+iO
+iO
+iO
+iO
+fQ
+iO
+iO
+iO
+iO
+yG
+"}
+(16,1,1) = {"
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+iO
+iO
+th
+HD
+ct
+Ig
+Ig
+rg
+th
+ct
+Ig
+Ig
+rg
+th
+uf
+Me
+Ig
+rg
+th
+th
+Vv
+HD
+th
+iO
+iO
+iO
+yG
+"}
+(17,1,1) = {"
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+tJ
+YA
+th
+HD
+HD
+HD
+HD
+HD
+HD
+HD
+HD
+HD
+HD
+HD
+HD
+HD
+HD
+HD
+HD
+HD
+HD
+HD
+th
+YA
+Ln
+iO
+yG
+"}
+(18,1,1) = {"
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+Xm
+YA
+th
+HD
+EP
+th
+th
+th
+th
+EP
+th
+th
+EP
+th
+th
+EP
+th
+th
+th
+th
+EP
+HD
+th
+YA
+Xm
+iO
+yG
+"}
+(19,1,1) = {"
+zx
+zx
+zx
+zx
+zx
+yG
+iO
+iO
+iO
+iO
+th
+HD
+th
+th
+th
+th
+th
+th
+th
+th
+th
+th
+th
+th
+th
+th
+th
+th
+th
+HD
+th
+iO
+iO
+iO
+iO
+"}
+(20,1,1) = {"
+Mu
+HB
+FF
+mB
+zx
+yG
+iO
+Ds
+YA
+th
+th
+HD
+th
+GH
+GH
+GH
+GH
+GH
+th
+LU
+jt
+th
+Dr
+Dr
+Dr
+Dr
+th
+th
+th
+HD
+th
+th
+YA
+Ds
+iO
+"}
+(21,1,1) = {"
+zx
+zx
+HB
+HB
+zx
+yG
+iO
+dh
+YA
+th
+HD
+HD
+th
+GH
+GH
+GH
+GH
+GH
+th
+Te
+gp
+th
+jx
+jx
+jx
+jx
+th
+th
+th
+HD
+HD
+th
+YA
+ku
+iO
+"}
+(22,1,1) = {"
+BH
+eR
+OG
+OG
+zx
+Ud
+iO
+Ds
+YA
+th
+HD
+th
+EP
+th
+th
+th
+th
+EP
+th
+th
+EP
+th
+th
+EP
+th
+th
+th
+YI
+hi
+Ts
+HD
+th
+YA
+Ds
+iO
+"}
+(23,1,1) = {"
+BH
+eR
+OG
+OG
+OG
+OG
+zx
+iO
+iO
+th
+HD
+th
+th
+th
+th
+gs
+th
+th
+th
+YA
+YA
+YA
+th
+th
+th
+th
+th
+th
+GH
+zF
+HD
+th
+iO
+iO
+iO
+"}
+(24,1,1) = {"
+zx
+zx
+OG
+OG
+OG
+OG
+eR
+fQ
+IR
+th
+HD
+th
+th
+th
+vc
+th
+vc
+th
+YA
+we
+HD
+we
+YA
+th
+th
+th
+th
+xJ
+TJ
+qq
+HD
+th
+YA
+Xm
+iO
+"}
+(25,1,1) = {"
+FR
+zx
+OG
+OG
+OG
+OG
+eR
+fQ
+ux
+HD
+HD
+th
+th
+vc
+mA
+dB
+gm
+th
+YA
+HD
+vh
+HD
+YA
+th
+th
+QG
+th
+th
+th
+th
+HD
+th
+YA
+EU
+iO
+"}
+(26,1,1) = {"
+zk
+zx
+zx
+zx
+OG
+OG
+eR
+fQ
+CL
+th
+HD
+th
+th
+th
+gs
+th
+vc
+th
+YA
+we
+HD
+we
+YA
+th
+th
+th
+th
+YI
+Bm
+Ts
+HD
+th
+YA
+qK
+iO
+"}
+(27,1,1) = {"
+ya
+Ar
+TP
+zx
+ie
+ie
+zx
+zx
+zx
+th
+HD
+th
+th
+th
+th
+gs
+th
+th
+th
+YA
+YA
+YA
+th
+th
+th
+th
+th
+th
+GH
+zF
+HD
+th
+iO
+iO
+iO
+"}
+(28,1,1) = {"
+Ap
+Ar
+TP
+zx
+OG
+OG
+HB
+be
+HB
+th
+HD
+th
+EP
+th
+th
+th
+th
+EP
+th
+th
+EP
+th
+th
+EP
+th
+th
+th
+xJ
+qE
+qq
+HD
+th
+YA
+Xm
+iO
+"}
+(29,1,1) = {"
+Ap
+Ar
+TP
+zx
+OG
+OG
+HB
+me
+HB
+th
+HD
+HD
+th
+GH
+GH
+GH
+GH
+GH
+th
+wA
+dF
+th
+Dr
+Dr
+Dr
+Dr
+th
+th
+th
+HD
+HD
+th
+YA
+Kk
+iO
+"}
+(30,1,1) = {"
+Ap
+Ar
+TP
+zx
+OG
+OG
+HB
+be
+HB
+th
+th
+HD
+th
+GH
+GH
+GH
+GH
+GH
+th
+ED
+mY
+th
+jx
+jx
+jx
+jx
+th
+th
+th
+HD
+th
+th
+YA
+Xm
+iO
+"}
+(31,1,1) = {"
+cM
+Ar
+TP
+zx
+OG
+OG
+zx
+zx
+zx
+iO
+th
+HD
+th
+th
+th
+th
+th
+th
+th
+th
+th
+th
+th
+th
+th
+th
+th
+th
+th
+HD
+th
+iO
+iO
+iO
+iO
+"}
+(32,1,1) = {"
+Bp
+zx
+zx
+zx
+zx
+Iy
+zx
+zx
+tJ
+YA
+th
+HD
+EP
+th
+th
+th
+th
+EP
+th
+th
+EP
+th
+th
+EP
+th
+th
+th
+th
+EP
+HD
+th
+YA
+Ln
+iO
+yG
+"}
+(33,1,1) = {"
+rN
+Wb
+sI
+Ba
+fd
+OG
+XI
+zx
+Xm
+YA
+th
+HD
+HD
+HD
+HD
+HD
+HD
+HD
+HD
+HD
+HD
+HD
+HD
+HD
+HD
+HD
+HD
+HD
+HD
+HD
+th
+YA
+Xm
+iO
+yG
+"}
+(34,1,1) = {"
+vs
+vs
+sI
+og
+Am
+OG
+Le
+zx
+zx
+zx
+th
+HD
+La
+il
+il
+QQ
+HD
+La
+il
+il
+QQ
+th
+np
+Tu
+il
+QQ
+th
+th
+PO
+HD
+th
+iO
+iO
+iO
+yG
+"}
+(35,1,1) = {"
+yR
+rY
+sI
+og
+Am
+OG
+Sf
+HB
+uB
+zx
+iO
+fQ
+iO
+iO
+iO
+iO
+fQ
+iO
+iO
+iO
+iO
+iO
+iO
+iO
+iO
+iO
+iO
+iO
+iO
+fQ
+iO
+iO
+iO
+yG
+yG
+"}
+(36,1,1) = {"
+Zl
+vs
+sI
+gl
+OG
+OG
+cP
+HB
+PB
+zx
+kS
+HD
+IZ
+sv
+lw
+zo
+HD
+Fr
+iO
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+vY
+rM
+HD
+Va
+uF
+iO
+yG
+yG
+"}
+(37,1,1) = {"
+DS
+vs
+sI
+og
+Am
+OG
+sD
+zx
+HB
+zx
+MH
+HD
+HD
+HD
+HD
+HD
+HD
+pd
+iO
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+sr
+HD
+HD
+HD
+vG
+iO
+yG
+yG
+"}
+(38,1,1) = {"
+DS
+vs
+sI
+og
+Am
+OG
+LP
+HB
+be
+zx
+Nq
+HD
+ww
+gf
+Cy
+nw
+HD
+Hd
+iO
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+GI
+HD
+xI
+HD
+Nx
+iO
+yG
+yG
+"}
+(39,1,1) = {"
+DS
+vs
+sI
+gl
+Fc
+OG
+pz
+HB
+uB
+zx
+ws
+HD
+Rh
+Fl
+Vz
+Nn
+HD
+QY
+iO
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+yb
+HD
+Td
+HD
+Py
+iO
+yG
+yG
+"}
+(40,1,1) = {"
+DS
+LR
+sI
+xv
+Sl
+OG
+xj
+zx
+HB
+zx
+wg
+HD
+HD
+HD
+HD
+HD
+HD
+vB
+iO
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+Ed
+HD
+hN
+HD
+WY
+iO
+yG
+yG
+"}
+(41,1,1) = {"
+DS
+vs
+sI
+Rn
+yO
+OG
+CZ
+HB
+uB
+zx
+Wk
+HD
+mq
+dY
+Kv
+fW
+HD
+nS
+iO
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+gu
+HD
+Kp
+HD
+ER
+iO
+yG
+yG
+"}
+(42,1,1) = {"
+DS
+vs
+sI
+og
+Am
+OG
+LP
+HB
+be
+zx
+bY
+HD
+cc
+kX
+jQ
+rB
+HD
+fs
+iO
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+nl
+HD
+BP
+HD
+AS
+iO
+yG
+yG
+"}
+(43,1,1) = {"
+DS
+vs
+sI
+og
+Am
+OG
+Nw
+zx
+HB
+zx
+KW
+HD
+HD
+HD
+HD
+HD
+HD
+oT
+iO
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+rP
+HD
+HD
+HD
+Xw
+iO
+yG
+yG
+"}
+(44,1,1) = {"
+Fn
+vs
+sI
+gl
+OG
+OG
+Ue
+HB
+me
+zx
+yj
+HD
+wW
+Ls
+LA
+BN
+HD
+If
+iO
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+qo
+UJ
+IS
+ad
+xd
+iO
+yG
+yG
+"}
+(45,1,1) = {"
+yR
+rY
+sI
+og
+Am
+OG
+tT
+HB
+be
+zx
+fA
+HD
+Zn
+zz
+oL
+eX
+HD
+FP
+iO
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+iO
+iO
+iO
+iO
+iO
+iO
+iO
+yG
+yG
+"}
+(46,1,1) = {"
+vs
+vs
+sI
+og
+Am
+OG
+Du
+zx
+zx
+zx
+Qp
+HD
+HD
+HD
+HD
+HD
+HD
+ZR
+iO
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+"}
+(47,1,1) = {"
+bb
+Wb
+sI
+Ba
+LP
+OG
+XI
+zx
+yG
+iO
+NL
+pr
+LY
+Tk
+Ey
+Bc
+yC
+Qi
+iO
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+"}
+(48,1,1) = {"
+SB
+zx
+zx
+zx
+zx
+Iy
+zx
+zx
+yG
+iO
+iO
+iO
+YA
+YA
+YA
+YA
+iO
+iO
+iO
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+"}
+(49,1,1) = {"
+bu
+Ar
+bq
+zx
+OG
+OG
+zx
+zx
+zx
+yG
+yG
+iO
+Ds
+Xm
+fS
+Xm
+iO
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+"}
+(50,1,1) = {"
+eD
+Ar
+bq
+zx
+OG
+OG
+HB
+be
+zx
+yG
+yG
+iO
+iO
+iO
+iO
+iO
+iO
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+yG
+"}

--- a/modular_zubbers/code/game/area/areas/centcom.dm
+++ b/modular_zubbers/code/game/area/areas/centcom.dm
@@ -1,2 +1,5 @@
 /area/centcom/central_command_areas/admin/interlink
 	name = "Interlink Administrative Office"
+
+/area/centcom/central_command_areas/debug_zone
+	name = "Central Command Testing Range" // For the added admin fun zone south of Central.


### PR DESCRIPTION
## About The Pull Request
(Re?) adds a debug/admin area that isnt just for admins. A place connected to CC south of the thunderdome full of toys for people to play with when the round ends. Full of things you might never see in a normal round, and with no rules to stop you from using them.

Highlights include: two live nukes, a supermatter sword, every wand and spell, every gun, every mech, you get the idea.
## Why It's Good For The Game
EOR fun time for all. head maint had this to say:

<img width="271" height="80" alt="image" src="https://github.com/user-attachments/assets/d9b9ccad-422b-44ac-9811-ef5da6a9ecad" />

they later followed up by saying yes but thats the important bit.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="810" height="822" alt="image" src="https://github.com/user-attachments/assets/991472bf-daf8-4a2b-8ec7-67219b8c549b" />

<img width="1006" height="639" alt="image" src="https://github.com/user-attachments/assets/83ec618e-8218-44cc-893e-923694cb779b" />

<img width="1287" height="883" alt="image" src="https://github.com/user-attachments/assets/fa4ae666-6142-41ed-ad3d-0005308da51c" />

<img width="1381" height="637" alt="image" src="https://github.com/user-attachments/assets/9fb0fbdb-5b15-4f92-aff0-e5ace80dad2a" />

<img width="1362" height="1165" alt="image" src="https://github.com/user-attachments/assets/51aee19d-f85c-4043-99ff-91569ec8037e" />

</details>

## Changelog
:cl:
add: An area full of toys to experiment in when the round ends.
/:cl:
