### PR TITLE
adds a monkey subtype that can wear all clothes for admin shenanigans

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/monkey.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/monkey.dm
@@ -18,3 +18,12 @@
 
 /datum/species/monkey/set_custom_worn_icon(item_slot, obj/item/item, icon/icon)
 	item.worn_icon_monkey = icon
+
+/datum/species/monkey/unrestricted //special species of monkey that is allowed to equip any item a normal person can
+	no_equip_flags = null
+
+/mob/living/carbon/human/species/monkey/unrestricted
+	race = /datum/species/monkey/unrestricted
+
+/mob/living/carbon/human/species/monkey/unrestricted/angry
+	ai_controller = /datum/ai_controller/monkey/angry


### PR DESCRIPTION

## About The Pull Request

Title. Adds a species subtype that just has the no_equip_flags set to null, allowing the monkey to equip anything. Adds two spawn instances of them too for admins, one normal, one angry.
## Why It's Good For The Game

It's not really good for the game as much as it is funny and allows for silly shenanigans.

## Proof Of Testing
Looks a little janky but that's just because of how monkey sprites are.
<img width="122" height="130" alt="image" src="https://github.com/user-attachments/assets/a04c97d7-7600-4d74-a811-afd4d84568da" />

## Changelog
:cl:
add: A horrifying monkey subtype that can wear anything.
/:cl:
