### PR TITLE
Normalizer Accessories Tweaks

### DIFF
--- a/modular_zubbers/code/modules/clothing/clothing.dm
+++ b/modular_zubbers/code/modules/clothing/clothing.dm
@@ -7,6 +7,8 @@
 	playsound(resizer, 'sound/effects/magic.ogg', 50, 1)
 	flash_lighting_fx(3, 3, LIGHT_COLOR_PURPLE)
 	resizer.visible_message(span_warning("A flash of purple light engulfs [resizer], before they change to normal!"), span_notice("You feel warm for a moment, before everything scales to your size..."))
+	if(resizer.get_quirk(/datum/quirk/oversized))
+		resizer.remove_quirk(/datum/quirk/oversized)
 	resizer.dna.features["body_size"] = RESIZE_DEFAULT_SIZE
 	resizer.dna.update_body_size()
 	resizer.normalized = TRUE
@@ -17,9 +19,10 @@
 		playsound(resizer,'sound/items/weapons/emitter2.ogg', 50, 1)
 		flash_lighting_fx(3, 3, LIGHT_COLOR_YELLOW)
 		resizer.visible_message(span_warning("Golden light engulfs [resizer], and they shoot back to their default height!"), span_notice("Energy rushes through your body, and you return to normal."))
-		if(resizer.get_quirk(/datum/quirk/oversized))
-			resizer.dna.features["body_size"] = 2
-		else
+		for(var/datum/quirk/oversized/oversized as anything in resizer?.client?.prefs?.all_quirks)
+			if(oversized)
+				resizer.add_quirk(/datum/quirk/oversized, announce = FALSE)
+		if(!resizer.get_quirk(/datum/quirk/oversized))
 			resizer.dna.features["body_size"] = resizer?.client?.prefs?.read_preference(/datum/preference/numeric/body_size)
-		resizer.dna.update_body_size()
+			resizer.dna.update_body_size()
 		resizer.normalized = FALSE

--- a/modular_zubbers/code/modules/vending/clothesmate.dm
+++ b/modular_zubbers/code/modules/vending/clothesmate.dm
@@ -70,6 +70,11 @@
 				/obj/item/clothing/neck/robe_cape = 5,
 				/obj/item/clothing/neck/scarf/pride = 5,
 				/obj/item/clothing/neck/wide_cape = 5,
+				/obj/item/clothing/neck/syntech = 5,
+				/obj/item/clothing/neck/syntech/choker = 5,
+				/obj/item/clothing/neck/syntech/collar = 5,
+				/obj/item/clothing/gloves/ring/syntech = 5,
+				/obj/item/clothing/gloves/ring/syntech/band = 5,
 			),
 		),
 


### PR DESCRIPTION

## About The Pull Request
Adds normalizer accessories to the clothesmate and also makes it so that they add/remove the oversized quirk on wearing/dropping if you already had the quirk.
## Why It's Good For The Game
I was told that it is kind of useless in its current state because the clothing can burn off and can't be replaced, and also oversized users previously just got resized meaning they kept their debuffs which made no sense.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

https://github.com/user-attachments/assets/e4cbfdec-6130-4cff-85f0-fad1ff96d2ec

<img width="431" height="253" alt="image" src="https://github.com/user-attachments/assets/2ed99064-eeed-475b-83a5-d4a460fb5237" />

</details>

## Changelog
:cl:
add: Added normalizer accessories to the ClothesMate.
balance: Normalizer accessories now remove the oversized quirk (if you have it) when equipped and re-add it when dropped.
/:cl:
