### PR TITLE
Blocks the Departmental Baton from crafting recipes.

### DIFF
--- a/code/datums/components/crafting/_recipes.dm
+++ b/code/datums/components/crafting/_recipes.dm
@@ -77,7 +77,7 @@
 		/obj/item/weldingtool/largetank/cyborg,
 		/obj/item/wirecutters/cyborg,
 		/obj/item/wrench/cyborg,
-		/obj/item/melee/baton/loaded/departmental, // BUBBER EDIT
+		/obj/item/melee/baton/security/loaded/departmental, // BUBBER EDIT
 	))
 
 /datum/crafting_recipe/New()

--- a/code/datums/components/crafting/_recipes.dm
+++ b/code/datums/components/crafting/_recipes.dm
@@ -77,6 +77,7 @@
 		/obj/item/weldingtool/largetank/cyborg,
 		/obj/item/wirecutters/cyborg,
 		/obj/item/wrench/cyborg,
+		/obj/item/melee/baton/loaded/departmental, // BUBBER EDIT
 	))
 
 /datum/crafting_recipe/New()

--- a/code/datums/components/crafting/_recipes.dm
+++ b/code/datums/components/crafting/_recipes.dm
@@ -77,7 +77,6 @@
 		/obj/item/weldingtool/largetank/cyborg,
 		/obj/item/wirecutters/cyborg,
 		/obj/item/wrench/cyborg,
-		/obj/item/melee/baton/security/loaded/departmental, // BUBBER EDIT
 	))
 
 /datum/crafting_recipe/New()

--- a/code/datums/components/crafting/melee_weapon.dm
+++ b/code/datums/components/crafting/melee_weapon.dm
@@ -49,7 +49,13 @@
 		/obj/item/claymore/weak,
 		/obj/item/claymore/weak/ceremonial,
 		/obj/item/claymore/highlander/robot,
-		/obj/item/melee/baton/security/loaded/departmental // BUBBER EDIT
+		/obj/item/melee/baton/security/loaded/departmental, // BUBBER EDIT START
+		/obj/item/melee/baton/security/loaded/departmental/service,
+		/obj/item/melee/baton/security/loaded/departmental/cargo,
+		/obj/item/melee/baton/security/loaded/departmental/engineering,
+		/obj/item/melee/baton/security/loaded/departmental/prison,
+		/obj/item/melee/baton/security/loaded/departmental/science,
+		/obj/item/melee/baton/security/loaded/departmental/medical, // BUBBER EDIT END
 	)
 	tool_behaviors = list(TOOL_WELDER)
 	time = 10 SECONDS
@@ -62,7 +68,16 @@
 		/obj/item/katana = 1,
 		/obj/item/melee/baton/security = 1,
 	)
-	blacklist = list(/obj/item/melee/baton/security/loaded/departmental) // BUBBER EDIT
+	// BUBBER EDIT START
+	blacklist = list(
+		/obj/item/melee/baton/security/loaded/departmental,
+		/obj/item/melee/baton/security/loaded/departmental/service,
+		/obj/item/melee/baton/security/loaded/departmental/cargo,
+		/obj/item/melee/baton/security/loaded/departmental/engineering,
+		/obj/item/melee/baton/security/loaded/departmental/prison,
+		/obj/item/melee/baton/security/loaded/departmental/science,
+		/obj/item/melee/baton/security/loaded/departmental/medical,
+	) // BUBBER EDIT END
 	tool_behaviors = list(TOOL_WELDER)
 	crafting_flags = parent_type::crafting_flags | CRAFT_SKIP_MATERIALS_PARITY
 	time = 10 SECONDS

--- a/code/datums/components/crafting/melee_weapon.dm
+++ b/code/datums/components/crafting/melee_weapon.dm
@@ -48,7 +48,8 @@
 		/obj/item/claymore/highlander,
 		/obj/item/claymore/weak,
 		/obj/item/claymore/weak/ceremonial,
-		/obj/item/claymore/highlander/robot
+		/obj/item/claymore/highlander/robot,
+		/obj/item/melee/baton/security/loaded/departmental // BUBBER EDIT
 	)
 	tool_behaviors = list(TOOL_WELDER)
 	time = 10 SECONDS
@@ -61,6 +62,7 @@
 		/obj/item/katana = 1,
 		/obj/item/melee/baton/security = 1,
 	)
+	blacklist = list(/obj/item/melee/baton/security/loaded/departmental) // BUBBER EDIT
 	tool_behaviors = list(TOOL_WELDER)
 	crafting_flags = parent_type::crafting_flags | CRAFT_SKIP_MATERIALS_PARITY
 	time = 10 SECONDS

--- a/modular_zubbers/code/datums/components/crafting/crafting/melee_weapon.dm
+++ b/modular_zubbers/code/datums/components/crafting/crafting/melee_weapon.dm
@@ -41,7 +41,13 @@
 		/obj/item/melee/baton/security/cattleprod/teleprod,
 		/obj/item/melee/baton/security/boomerang,
 		/obj/item/melee/baton/security/stunsword,
-		/obj/item/melee/baton/security/loaded/departmental
+		/obj/item/melee/baton/security/loaded/departmental,
+		/obj/item/melee/baton/security/loaded/departmental/service,
+		/obj/item/melee/baton/security/loaded/departmental/cargo,
+		/obj/item/melee/baton/security/loaded/departmental/engineering,
+		/obj/item/melee/baton/security/loaded/departmental/prison,
+		/obj/item/melee/baton/security/loaded/departmental/science,
+		/obj/item/melee/baton/security/loaded/departmental/medical,
 	)
 	tool_behaviors = list(TOOL_WELDER, TOOL_WRENCH)
 	time = 15 SECONDS

--- a/modular_zubbers/code/datums/components/crafting/crafting/melee_weapon.dm
+++ b/modular_zubbers/code/datums/components/crafting/crafting/melee_weapon.dm
@@ -40,7 +40,8 @@
 		/obj/item/melee/baton/security/cattleprod/telecrystalprod,
 		/obj/item/melee/baton/security/cattleprod/teleprod,
 		/obj/item/melee/baton/security/boomerang,
-		/obj/item/melee/baton/security/stunsword
+		/obj/item/melee/baton/security/stunsword,
+		/obj/item/melee/baton/security/loaded/departmental
 	)
 	tool_behaviors = list(TOOL_WELDER, TOOL_WRENCH)
 	time = 15 SECONDS


### PR DESCRIPTION
## About The Pull Request

Makes it so you can't craft stun swords and stun sticks with the departmental baton, effectively bypassing its restrictions.

## Why It's Good For The Game

I feel like you should need to get an actual baton to be crafting these items. Especially when you can order these batons as any department and effectively get a free baton with little effort.

## Proof Of Testing

It works.

## Changelog
:cl:
balance: Departmental batons can no longer be used in crafting.
/:cl:
