### PR TITLE
Disables The Summon Ghosts Wizard Spell

### DIFF
--- a/modular_zubbers/code/modules/spells/spell_types/disabled_spells.dm
+++ b/modular_zubbers/code/modules/spells/spell_types/disabled_spells.dm
@@ -17,3 +17,8 @@
 // 99% of slaughter demons just target medbay and it's not really fun for anyone except the slaughter demon (and ghost chat).
 /datum/spellbook_entry/item/bloodbottle
 	category = null
+
+// Summon Ghosts: Makes ghosts visible to all living players. Ghosts being visible sounds funny on paper, but since its free it almost always gets ran.
+// This is bad for antagonists that have invisibility and gets really awkward when a ghost inevitably orbits someone ERPing.
+/datum/spellbook_entry/summon/ghosts
+	category = null


### PR DESCRIPTION

## About The Pull Request
Does as the title would suggest. This **ONLY** disables it from being selected by wizards, it does not stop admins from running it.
## Why It's Good For The Game
While the idea of ghosts being visible is funny on paper, when ghosts start orbiting ERPers, invisible antagonists, or outright leading security to antagonists via pointing a path to them it becomes really unfun for the targets of the ghosts, and can be outright uncomfortable in the case of ghosts orbiting ERPers.
## Proof Of Testing
See below.
<details>
<summary>Screenshots/Videos</summary>

<img width="957" height="546" alt="image" src="https://github.com/user-attachments/assets/5f90a1d4-862c-4036-92d0-521c32ec1693" />

<img width="447" height="453" alt="image" src="https://github.com/user-attachments/assets/a4df6ecf-0295-49cd-82d5-f993c56c9536" />

</details>

## Changelog
:cl:
del: Removed 'Summon Ghosts' from the wizard spellbook. It is still available via adminbus.
/:cl:
