### PR TITLE
Fixes a duplicate sprite error primarily on firearms.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -663,7 +663,14 @@ There are several things that need to be remembered:
 		var/held_index = get_held_index_of_item(worn_item)
 		if(client && hud_used && hud_used.hud_version != HUD_STYLE_NOHUD)
 			worn_item.screen_loc = ui_hand_position(held_index)
-			client.screen += worn_item
+			// BUBBER EDIT REMOVAL BEGIN - pushing the held item onto our own client's screen here is how
+			// hand slots worked before the inventory slot rewrite. That rewrite draws the held item through
+			// the hand slot's vis_contents, so this drew a second copy of everything you hold. Sprites at
+			// pixel_x 0 stacked exactly and hid it; anything wider than a tile carries a negative
+			// base_pixel_x to centre itself, so the copies separated and the doubling became visible.
+			// The observer push below is kept, since ghosts have no hand slot of their own to draw into.
+			// ORIGINAL: client.screen += worn_item
+			// BUBBER EDIT REMOVAL END
 			if(observers?.len)
 				for(var/M in observers)
 					var/mob/dead/observe = M

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -664,10 +664,7 @@ There are several things that need to be remembered:
 		if(client && hud_used && hud_used.hud_version != HUD_STYLE_NOHUD)
 			worn_item.screen_loc = ui_hand_position(held_index)
 			// BUBBER EDIT REMOVAL BEGIN - pushing the held item onto our own client's screen here is how
-			// hand slots worked before the inventory slot rewrite. That rewrite draws the held item through
-			// the hand slot's vis_contents, so this drew a second copy of everything you hold. Sprites at
-			// pixel_x 0 stacked exactly and hid it; anything wider than a tile carries a negative
-			// base_pixel_x to centre itself, so the copies separated and there was an ugly duplicate sprite visible.
+			// hand slots worked before the inventory slot rewrite. This alternate behavior is needed to stop duplicate item sprites appearing inhand.
 			// ORIGINAL: client.screen += worn_item
 			// BUBBER EDIT REMOVAL END
 			if(observers?.len)

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -667,8 +667,7 @@ There are several things that need to be remembered:
 			// hand slots worked before the inventory slot rewrite. That rewrite draws the held item through
 			// the hand slot's vis_contents, so this drew a second copy of everything you hold. Sprites at
 			// pixel_x 0 stacked exactly and hid it; anything wider than a tile carries a negative
-			// base_pixel_x to centre itself, so the copies separated and the doubling became visible.
-			// The observer push below is kept, since ghosts have no hand slot of their own to draw into.
+			// base_pixel_x to centre itself, so the copies separated and there was an ugly duplicate sprite visible.
 			// ORIGINAL: client.screen += worn_item
 			// BUBBER EDIT REMOVAL END
 			if(observers?.len)


### PR DESCRIPTION
## About The Pull Request

Some guns (Probably other items too) have been seeing double for a while now and this isn't just because you're an alcoholic. With certain guns, a Miecz, a Lanca, a Renoster, a Kiboko, the VARS launcher, and the hand slot shows you two sprites offset by about eight pixels, OK actually 8 pixels exactly because that's what the code told it to do. Hold a disabler or a WT-550 and everything is perfectly fine. That was the clue.

Every affected gun suffering from this defect drew from an "oversized" sprite sheet. `guns_48.dmi` is 48 pixels wide instead of 32, and a sprite that wide had to carry a negative `base_pixel_x` to sit centered on its tile. Every gun that was fine is a plain 32 by 32 vanilla one sitting at zero. TG doesn't have as many ginormous guns (actually, there are probably a few, but I didn't test every possible gun, that would take too long)

**The reason that this matters**: your held item is drawn twice behind the scenes `/mob/living/carbon/human/get_held_overlays()` shoves the item onto your client's screen with a `screen_loc`, which is how hand slots used to work. Hand slots don't work that way any more; someone rewrote inventory slots which now draw the item through the slot's `vis_contents` instead, and upstream deleted their copy of this line at the time. As a downstream, Bubber did not. 

So both paths have been drawing your item this whole time. Anything sitting at pixel offset zero lands in exactly the same spot twice is invisible. Anything wider than a tile is shifted 8 pixels over, the two copies separate, and you get a freakish mutant ghost gun.

This deletes the one line that pushes the item onto your own screen. The observer push underneath it stays so it doesn't break observing people.

One line fix, a whole afternoon of fucking around to get there. 

## Why It's Good For The Game

Guns stop being haunted. The possibility of adding intentionally haunted guns at a later date yet remains. 

More usefully, this could theoretically afflict any item with a sprite bigger than one tile, not just guns. Guns are simply the most common "oversized sprite" incidence, so that's where it showed up.

## Testing

Tested a wide array of items and weapons to make sure the fix works and didn't have any unforeseen negative consequences.  Swapped hands, dropped and picked back up, took the item and put it on my vest and took it back out, checked items still stay in the inventory slot properly every time. Ghosted and observed a player holding a gun, still renders correctly. 

I will note that some sprites still sit very slightly left of centr inside the box, because they keep the offset that centres them on a tile. That's cosmetic and I think it was there before; if anyone actually turns out to care that is a separate issue that will require a separate fix. 

## Changelog

:cl:
fix: Certain items no longer render a doubled ghost copy in your hand slot.
/:cl: