### PR TITLE
Moves Bridge Assistant To The Assistants Tab

### DIFF
--- a/code/modules/jobs/job_types/bridge_assistant.dm
+++ b/code/modules/jobs/job_types/bridge_assistant.dm
@@ -21,8 +21,8 @@
 	liver_traits = list(TRAIT_PRETENDER_ROYAL_METABOLISM)
 
 	display_order = JOB_DISPLAY_ORDER_BRIDGE_ASSISTANT
-	department_for_prefs = /datum/job_department/captain
-	departments_list = list(/datum/job_department/command)
+	department_for_prefs = /datum/job_department/assistant // BUBBER EDIT ADDITION
+//	departments_list = list(/datum/job_department/command) // BUBBER EDIT REMOVAL
 
 	family_heirlooms = list(/obj/item/banner/command/mundane)
 


### PR DESCRIPTION

## About The Pull Request
Makes Bridge Assistants count for non-departmental hours rather than command hours as well as moving them to the Assistants tab. I also marked a Bubber addition to the file that hadn't been modularly marked previously.
## Why It's Good For The Game
People who only play Bridge Assistant are realistically not going to know how to play captain and it shouldn't be able to be unlocked just from playing BA. Also staff requested it.
## Proof Of Testing
See below.
<details>
<summary>Screenshots/Videos</summary>

<img width="1084" height="783" alt="image" src="https://github.com/user-attachments/assets/96cb28b3-de06-429d-8742-a46b7dfba79c" />

<img width="1009" height="891" alt="image" src="https://github.com/user-attachments/assets/bd2a22c5-3898-4d04-afb1-6311911d37b5" />

</details>

## Changelog
:cl:
balance: Bridge Assistant hours no longer count as Command hours.
/:cl:
