### PR TITLE
Buffs the Protean Lowerpower movespeed

### DIFF
--- a/modular_zubbers/code/modules/customization/species/proteans/protean_status_effects.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/protean_status_effects.dm
@@ -19,7 +19,7 @@
 	owner.remove_movespeed_modifier(/datum/movespeed_modifier/protean_slowdown_low_power)
 
 /datum/movespeed_modifier/protean_slowdown_low_power
-	multiplicative_slowdown = 5
+	multiplicative_slowdown = 2
 
 /datum/status_effect/protean_low_power_mode/reform
 	duration = 7 SECONDS

--- a/modular_zubbers/code/modules/customization/species/proteans/protean_status_effects.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/protean_status_effects.dm
@@ -19,7 +19,7 @@
 	owner.remove_movespeed_modifier(/datum/movespeed_modifier/protean_slowdown_low_power)
 
 /datum/movespeed_modifier/protean_slowdown_low_power
-	multiplicative_slowdown = 2
+	multiplicative_slowdown = 3
 
 /datum/status_effect/protean_low_power_mode/reform
 	duration = 7 SECONDS


### PR DESCRIPTION
## About The Pull Request

Buffs the movespeed modifier from 5 -> 3

## Why It's Good For The Game

There's a lot of player friction with this species.

Running out of metal as a protean is extremely punishing, and you have to consume a lot of metal.

Low power mode itself helps offset that, but I feel like this is way more friction and punishing then it should be. Instead I feel like it should drop you to walking speed so you're allowed to reasonably move around the station without running any marathons.

You still are not able to power your suit in this mode.

## Proof Of Testing

It works

## Changelog

:cl:
balance: increased Protean low power mode walking speed from a modifier of 5 to 3 (our current walking speed)
/:cl: