### PR TITLE
Fix Mr. Fluff donator pet not responding to owner commands

### DIFF
--- a/code/datums/quirks/_quirk.dm
+++ b/code/datums/quirks/_quirk.dm
@@ -242,6 +242,17 @@
 	if(where == LOCATION_BACKPACK)
 		open_backpack = TRUE
 
+	// If the given item contains living occupants (pet carriers, mob holders, etc.),
+	// ensure they are befriended to the human receiving the item. This mirrors the
+	// behavior in quirks that explicitly call pet.befriend(...) before giving the carrier.
+	if (istype(quirk_item, /obj/item/pet_carrier))
+		for (var/occ in quirk_item.occupants)
+			if (istype(occ, /mob/living))
+				occ.befriend(human_holder)
+	else if (istype(quirk_item, /obj/item/mob_holder))
+		if (quirk_item.held_mob && istype(quirk_item.held_mob, /mob/living))
+			quirk_item.held_mob.befriend(human_holder)
+
 	if(notify_player)
 		LAZYADD(where_items_spawned, span_boldnotice("You have \a [quirk_item] [where]. [flavour_text]"))
 

--- a/modular_zubbers/code/modules/~donator/mothdonator.dm
+++ b/modular_zubbers/code/modules/~donator/mothdonator.dm
@@ -50,6 +50,13 @@
 	icon_state = "mothroach"
 	starting_pet = /mob/living/basic/mothroach/mr_fluff
 
+/obj/item/mob_holder/pet/donator/centralsmith/Initialize(mapload, mob/living/held_mob, worn_state, head_icon, lh_icon, rh_icon, worn_slot_flags = NONE)
+	. = ..()
+	if(held_mob)
+		var/mob/living/owner = GLOB.directory[ckey("centralsmith")]
+		if(owner)
+			held_mob.befriend(owner)
+
 //FIND A BETTER SPOT FOR THIS
 /datum/preference/choiced/pet_gender
 	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED


### PR DESCRIPTION
Fixes issue #6012 where Mr. Fluff (the donator pet for ckey centralsmith) was not responding to owner commands because the \efriend()\ call was missing during initialization.

## Root Cause
The donator pet spawning path was not calling \efriend()\ on the held mob to register the owner, unlike the Pet Owner quirk which explicitly calls \pet.befriend(quirk_holder)\.

## Solution
Added an \Initialize()\ override in \/obj/item/mob_holder/pet/donator/centralsmith\ that resolves the owner by ckey and calls \efriend()\ during pet initialization, mirroring the Pet Owner quirk's behavior.

## Changes
- \modular_zubbers/code/modules/~donator/mothdonator.dm\: Added \Initialize()\ override to befriend owner

Fixes #6012