### PR TITLE
Fix Mr. Fluff donator pet not responding to owner commands

### DIFF
--- a/modular_zubbers/code/modules/loadout/categories/inhands.dm
+++ b/modular_zubbers/code/modules/loadout/categories/inhands.dm
@@ -12,6 +12,17 @@
 /datum/loadout_item/inhand/pet/mrfluff_mothroach
 	name = "Mr. Fluff"
 	item_path = /obj/item/mob_holder/pet/donator/centralsmith
+	ckeywhitelist = list("centralsmith")
+
+/// ckeywhitelist above means only I can take him, so befriending whoever equips him is safe.
+/datum/loadout_item/inhand/pet/mrfluff_mothroach/on_equip_item(obj/item/equipped_item, list/item_details, mob/living/carbon/human/equipper, datum/outfit/outfit, visuals_only = FALSE)
+	. = ..()
+	if(visuals_only)
+		return
+	var/obj/item/mob_holder/pet/holder = equipped_item
+	if(!istype(holder) || isnull(holder.held_mob))
+		return
+	holder.held_mob.befriend(equipper)
 
 /datum/loadout_item/inhand/saddlebags
 	name = "Saddlebags"


### PR DESCRIPTION
## About The Pull Request

Mr. Fluff was the BEST BOY ever but, unfortunately, he couldn't follow commands. To remove the fluff from his...ears? Antennae? His befriend() call was never invoked, so this fixes that.

Mr. Fluff is now a Friend at loadout equip time instead. It skips character-preview mannequins though, for avoidance of shenanigans.

He's also now my moff only, no spawning with him if you're not me. This makes befriending the equipper the safe option.

## Why It's Good For The Game

Mr. Fluff is the best moff, and should be able to behave like the best moff!

## Proof Of Testing

Tested in game on a local server. Mr. Fluff recognises his owner and responds to pet commands - both spoken ("follow", "sit") and via the Shift-hover radial menu.

<details>
<summary>Screenshots/Videos</summary>

https://github.com/user-attachments/assets/49354751-1241-4edc-8581-a74076a36a96

</details>

*Written with Claude Code assistance, testing completed by me!*

## Changelog

:cl:
fix: Mr. Fluff now recognises his owner and responds to pet commands.
/:cl:

