### PR TITLE
Fix nightmares (and spider infestations) being unable to spawn on Moonstation

### DIFF
--- a/_maps/map_files/moonstation/moonstation.dmm
+++ b/_maps/map_files/moonstation/moonstation.dmm
@@ -1701,6 +1701,14 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/checker,
 /area/station/hallway/secondary/exit/departure_lounge)
+"auS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "auW" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
@@ -15281,6 +15289,11 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/terracotta,
 /area/station/commons/storage/art)
+"dUq" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/lower)
 "dUr" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 8
@@ -26097,6 +26110,20 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/lower)
+"gJo" = (
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
+	color = "#ff0000";
+	dir = 8;
+	name = "Scrubbers multi deck pipe adapter"
+	},
+/obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
+	color = "#0000ff";
+	dir = 8;
+	name = "Supply multi deck pipe adapter"
+	},
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/bar)
 "gJO" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Prison Wing Cells Maintenance"
@@ -26366,6 +26393,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/checker,
 /area/station/hallway/primary/central/fore)
+"gMw" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "gMx" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
@@ -27659,6 +27691,13 @@
 /obj/structure/transport/linear/tram,
 /turf/open/floor/plating,
 /area/station/terminal/lobby)
+"hdZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "hec" = (
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 1
@@ -31614,6 +31653,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"ibm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical)
 "ibp" = (
 /obj/effect/turf_decal/box/white{
 	color = "#9FED58"
@@ -37756,6 +37805,13 @@
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
+"jIe" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/lower)
 "jIr" = (
 /obj/effect/turf_decal/caution/stand_clear/white,
 /obj/effect/turf_decal/sand/plating,
@@ -45184,6 +45240,11 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
+"lyh" = (
+/obj/structure/cable,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/department/public_mining)
 "lyl" = (
 /obj/machinery/door/airlock{
 	id_tag = "Toilet3";
@@ -59177,6 +59238,14 @@
 	},
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
+"pdm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/fore)
 "pdp" = (
 /obj/machinery/door/airlock/grunge,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -62613,6 +62682,17 @@
 /obj/effect/spawner/structure/window/survival_pod,
 /turf/open/floor/plating,
 /area/station/cargo/miningfoundry/event_protected)
+"pVP" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/dorms)
 "pVT" = (
 /obj/structure/reflector/box/anchored{
 	dir = 1
@@ -70479,6 +70559,13 @@
 /obj/machinery/camera/autoname/prison/directional/east,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/prison/work)
+"rUD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/department/chapel)
 "rUE" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/turf_decal/caution/white,
@@ -77906,6 +77993,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/medical/paramedic)
+"tRa" = (
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/chemistry)
 "tRd" = (
 /obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/plating,
@@ -187382,7 +187473,7 @@ wWj
 kbd
 jcE
 oqb
-tUm
+dUq
 gEk
 rNs
 kJH
@@ -198590,7 +198681,7 @@ mSI
 nmB
 ybk
 pUv
-mLS
+jIe
 ucZ
 oLK
 kvJ
@@ -201473,7 +201564,7 @@ fGf
 rFm
 nFN
 fbp
-oIO
+tRa
 azS
 oIO
 uoD
@@ -210179,7 +210270,7 @@ kJH
 kJH
 pfg
 kKx
-mWg
+lyh
 kdI
 kdI
 kdI
@@ -248243,7 +248334,7 @@ ckk
 eZj
 rbD
 rui
-rbD
+gMw
 gzN
 ckk
 hCI
@@ -256951,7 +257042,7 @@ lkv
 lkv
 dtq
 obG
-ilj
+gJo
 igY
 rZw
 rZw
@@ -258271,7 +258362,7 @@ gft
 sCg
 qlq
 alL
-uHj
+ibm
 sCg
 cnM
 juK
@@ -259490,7 +259581,7 @@ ajN
 ajN
 ktI
 ajN
-ajN
+pdm
 ajN
 ajN
 lZd
@@ -263638,7 +263729,7 @@ cpS
 xae
 ycI
 nyc
-iWg
+hdZ
 bSs
 vws
 vWS
@@ -268320,7 +268411,7 @@ lKm
 lKm
 lDi
 lKm
-lKm
+auS
 ooA
 elf
 dtZ
@@ -270569,7 +270660,7 @@ dmv
 ncl
 llX
 vJe
-dms
+pVP
 nXy
 nXy
 nXy
@@ -273426,7 +273517,7 @@ pqO
 iGo
 pqO
 pqO
-pqI
+rUD
 saR
 pqO
 lAK

--- a/modular_zubbers/code/modules/storyteller/event_defines/ghostset/nightmare.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/ghostset/nightmare.dm
@@ -14,7 +14,7 @@
 /datum/round_event_control/nightmare/can_spawn_event(players_amt, allow_magic = FALSE)
 	. = ..()
 	if(!.)
-		return .
+		return FALSE
 
 	// Nightmares can only spawn in unlit maintenance, so don't offer the event
 	// (and burn a ghost poll on it) when the station has nowhere dark to put one.

--- a/modular_zubbers/code/modules/storyteller/event_defines/ghostset/nightmare.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/ghostset/nightmare.dm
@@ -11,6 +11,15 @@
 	min_wizard_trigger_potency = 6
 	max_wizard_trigger_potency = 7
 
+/datum/round_event_control/nightmare/can_spawn_event(players_amt, allow_magic = FALSE)
+	. = ..()
+	if(!.)
+		return .
+
+	// Nightmares can only spawn in unlit maintenance, so don't offer the event
+	// (and burn a ghost poll on it) when the station has nowhere dark to put one.
+	return !isnull(find_maintenance_spawn(atmos_sensitive = TRUE, require_darkness = TRUE))
+
 /datum/round_event/ghost_role/nightmare
 	minimum_required = 1
 	role_name = "nightmare"


### PR DESCRIPTION
## About The Pull Request

Fixes #5988.

Nightmares cannot spawn on Moonstation. The event polls ghosts, fails to find a valid spawn, and returns:

`ADMIN LOG: nightmare cannot be spawned due to a map error.`

### Root Cause

The event uses:

```dm
find_maintenance_spawn(atmos_sensitive = TRUE, require_darkness = TRUE)
```

This only accepts maintenance landmarks with `get_lumcount() <= 0.2`.

Moonstation had 18 maintenance landmarks. All 18 were near working lights, so none passed the darkness check.

As a result:

- `find_maintenance_spawn()` returns null
- `spawn_role()` returns `MAP_ERROR`
- the ghost poll has already finished, so the selected player gets nothing

I confirmed this at roundstart:

**18 landmarks, 18 atmos-safe, 0 dark.**

Spider infestation uses the same spawn check, so it also failed on Moonstation.

### The Fix

This PR makes two changes.

First, it adds 12 maintenance landmarks on dark, enclosed, walkable tiles across both station levels. The lower level had no maintenance landmarks before this change.

Second, it adds a `can_spawn_event()` check. If no valid dark spawn exists, the storyteller skips the event instead of polling ghosts and failing later.

This follows the existing `alien_infestation` pattern.

## Why It's Good For The Game

Nightmares and spider infestations had a zero-percent chance to spawn on Moonstation.

This PR restores both events. It also prevents the nightmare event from polling ghosts when the map has no valid spawn.

## Proof Of Testing

https://github.com/user-attachments/assets/25160bec-d0ae-48e6-b72b-009d77d051dd

I built with `-DCIBUILDING` and ran DreamDaemon on Moonstation using the same deployed-tree process as `tools/ci/run_server.sh`.

I used a temporary unit test to check every maintenance landmark at roundstart. The test is not included in this PR.

| Run | Landmarks | Atmos-safe | Dark | Usable | Result |
|---|---:|---:|---:|---:|---|
| `master` | 18 | 18 | 0 | 0 | FAIL |
| this PR | 30 | 30 | 12 | 12 | PASS |

### Before

```text
MAP=Moon Station LANDMARKS=18 ATMOS_SAFE=18 DARK=0 USABLE=0
```

### After

```text
MAP=Moon Station LANDMARKS=30 ATMOS_SAFE=30 DARK=12 USABLE=12
picked (132,153,4) Fore Maintenance
```

Both runs produced the same three unrelated Lavaland ore-vent runtime errors.

### Other Checks

- DM compile: 0 errors
- Dreamchecker suite-1.11: 0 diagnostics
- `tools.maplint.source`: OK
- `mapmerge2.dmm_test`: OK

## Heads Up: KiloStation

A static check found only one maintenance landmark on KiloStation that is outside the range of a working light.

I did not test KiloStation in-game, so I left it out of this PR. It may need a separate fix later.

The new event guard will prevent the same failed ghost poll if that landmark becomes invalid.

## Changelog

:cl:
fix: Nightmares can spawn on Moonstation again.
fix: Spider infestations can spawn on Moonstation again.
map: Added 12 dark maintenance spawn points across both Moonstation levels.
fix: Nightmare events no longer poll ghosts when no valid dark spawn exists.
/:cl:

Written with Claude Code assistance. Testing was completed by me.
