### PR TITLE
Fix flatpacked stationary batteries being unusable

### DIFF
--- a/modular_skyrat/modules/colony_fabricator/code/machines/power_storage_unit.dm
+++ b/modular_skyrat/modules/colony_fabricator/code/machines/power_storage_unit.dm
@@ -39,20 +39,6 @@
 	if(!mapload)
 		flick("smes_deploy", src)
 
-/obj/machinery/power/smes/battery_pack/default_deconstruction_screwdriver(mob/user, icon_state_open, icon_state_closed, obj/item/screwdriver)
-	if(screwdriver.tool_behaviour != TOOL_SCREWDRIVER)
-		return FALSE
-
-	screwdriver.play_tool_sound(src, 50)
-	toggle_panel_open()
-	if(panel_open)
-		icon_state = icon_state_open
-		to_chat(user, span_notice("You open the maintenance hatch of [src]."))
-	else
-		icon_state = icon_state_closed
-		to_chat(user, span_notice("You close the maintenance hatch of [src]."))
-	return TRUE
-
 // previously NO_DECONSTRUCTION
 /obj/machinery/power/smes/battery_pack/default_deconstruction_crowbar(obj/item/crowbar, ignore_panel, custom_deconstruct)
 	return NONE


### PR DESCRIPTION
## About The Pull Request

Fixes #5922.

`/obj/machinery/power/smes/battery_pack` overrides `default_deconstruction_screwdriver()`. The override uses the old four-argument signature from before tg [#95408](https://github.com/tgstation/tgstation/pull/95408):

```dm
/obj/machinery/power/smes/battery_pack/default_deconstruction_screwdriver(mob/user, icon_state_open, icon_state_closed, obj/item/screwdriver)
	if(screwdriver.tool_behaviour != TOOL_SCREWDRIVER)
```

The base proc now takes two arguments. That change came from the tg PR "The big tooltype_act de-cargo-cult-ing". It arrived here in the upstream sync of 2026-05-16 (21b4095dfd6):

```dm
/obj/machinery/proc/default_deconstruction_screwdriver(mob/user, obj/item/screwdriver)
```

The SMES parent calls the proc as `default_deconstruction_screwdriver(user, tool)`. DM binds arguments by position against the parameter list of the override. The screwdriver goes into `icon_state_open`, and the `screwdriver` parameter stays null. The next line reads a var on null and causes a runtime error. DM compiles an override with a different argument count without an error, so nobody saw this.

Three effects together make the machine useless:

1. The runtime error returns null to the caller. `tool_act()` reports no interaction, and the click continues into the attack chain. The player hits the battery with the screwdriver instead of opening the panel. This also happens with combat mode off.
2. `can_place_terminal()` requires `panel_open`. No player can install a terminal.
3. `/obj/machinery/power/smes/Initialize()` calls `atom_break()` when the machine has no terminal. Every deployed battery starts in a broken state.

### The fix

This PR deletes the override. The override is no longer necessary. `small_battery.dmi` and `large_battery.dmi` both contain the `smes` and `smes-o` states. The inherited `update_icon_state()` produces exactly these two states, and `set_panel_open()` calls `update_appearance()`. The deletion restores the panel toggle, the correct icons, and the standard balloon alert.

The `default_deconstruction_crowbar()` override and `NO_DEBRIS_AFTER_DECONSTRUCTION` still block deconstruction, as intended.

## Why It's Good For The Game

Flatpacked stationary batteries do not work at all today. They deploy in a broken state, and no player action repairs them. This PR restores a full part of the colony fabricator power kit.

## Proof Of Testing

I used a temporary focused unit test. This PR does not include that test. The goal was to confirm the behavior, not to add to the test suite. I also recorded a video of the fix in a live round.

<details>
<summary>Screenshots/Videos</summary>


https://github.com/user-attachments/assets/5210971e-4785-419a-862b-c8aaaf9b9be4



</details>

Before the fix, the test fails. The runtime log shows the argument problem. The screwdriver sits in slot 2, and two null values follow it:

```
Runtime in modular_skyrat/modules/colony_fabricator/code/machines/power_storage_unit.dm,43: Cannot read null.tool_behaviour
  proc name: default deconstruction screwdriver (/obj/machinery/power/smes/battery_pack/default_deconstruction_screwdriver)
  src: the stationary battery (/obj/machinery/power/smes/battery_pack)
  call stack:
  the stationary battery: default deconstruction screwdriver(John Doe, the screwdriver, null, null)
  the stationary battery: screwdriver act(John Doe, the screwdriver)
  the stationary battery: tool act(John Doe, the screwdriver, null)
  the stationary battery: base item interaction(John Doe, the screwdriver, null)
  the screwdriver: melee attack chain(John Doe, the stationary battery, null, /list)
```

The attack log from the same run shows the hit. Combat mode was `FALSE`. This matches the description in the issue:

```
ATTACK: (John Doe) attacked [stationary battery] with the screwdriver (Test Room (126,126,14))
```

After the fix, the same test passes. The panel opens and closes. `icon_state` changes correctly between `smes` and `smes-o`.

I ran two more checks. `tools/build/build.bat dm` compiles with 0 errors. Dreamchecker (SpacemanDMM suite-1.11) reports 0 diagnostics.

## Changelog

:cl:
fix: Flatpacked stationary batteries can have their maintenance panel screwed open again, so you can connect a power terminal to them.
/:cl:

Written with Claude Code assistance, testing completed by me!