### PR TITLE
Fix ghost cafe lava burning items and fishing up hostile fauna

### DIFF
--- a/modular_zubbers/maps/offstation/ghostcafe/ghostcafeturf.dm
+++ b/modular_zubbers/maps/offstation/ghostcafe/ghostcafeturf.dm
@@ -3,13 +3,38 @@
 	desc = "Go on. Step in it. Maybe you'll be like some sort of Lava based Jesus."
 	planetary_atmos = TRUE
 	initial_gas_mix = OPENTURF_DEFAULT_ATMOS
+	baseturfs = /turf/open/lava/fake
 	lava_damage = 0
 	lava_firestacks = 0
 	temperature_damage = 0
 	slowdown = 0
 	immunity_trait = TRAIT_GHOSTROLE
 	immunity_resistance_flags = LAVA_PROOF
-	var/give_turf_traits = list(TRAIT_TURF_IGNORE_SLOWDOWN, TRAIT_LAVA_STOPPED, TRAIT_IMMERSE_STOPPED)
+	fish_source_type = /datum/fish_source/lavaland/cafe
+
+/turf/open/lava/fake/Initialize(mapload)
+	// burn_stuff() only checks TRAIT_LAVA_STOPPED. Zeroing lava_damage/temperature_damage does not
+	// spare objects, because do_burn() force-flags them FLAMMABLE and strips FIRE_PROOF regardless.
+	// Added before the parent call, which runs Entered() on anything already mapped onto us.
+	ADD_TRAIT(src, TRAIT_LAVA_STOPPED, INNATE_TRAIT)
+	return ..()
+
+/// The cafe's lava is decoration, so it fishes like lavaland minus everything that surfaces wanting to kill you.
+/datum/fish_source/lavaland/cafe
+	catalog_description = null //it's just the lavaland table with the teeth pulled, no need to list it twice
+	fish_source_flags = FISH_SOURCE_FLAG_EXPLOSIVE_MALUS | FISH_SOURCE_FLAG_NO_BLUESPACE_ROD
+	fish_table = list(
+		FISHING_DUD = 5,
+		/obj/item/stack/ore/slag = 15,
+		/obj/item/fish/lavaloop = 15,
+		/obj/item/stack/sheet/animalhide/goliath_hide = 15,
+		/obj/item/stack/sheet/bone = 15,
+		/obj/item/stack/sheet/sinew = 15,
+		/obj/structure/closet/crate/necropolis/tendril = 1,
+		/obj/item/skeleton_key = 1,
+		/obj/item/stack/sheet/mineral/runite = 1,
+		/obj/effect/mob_spawn/corpse/human/charredskeleton = 1,
+	)
 
 /turf/open/floor/plating/vox
 	name = "nitrogen-filled plating"

--- a/modular_zubbers/maps/offstation/ghostcafe/ghostcafeturf.dm
+++ b/modular_zubbers/maps/offstation/ghostcafe/ghostcafeturf.dm
@@ -13,10 +13,7 @@
 	fish_source_type = /datum/fish_source/lavaland/cafe
 
 /turf/open/lava/fake/Initialize(mapload)
-	// burn_stuff() only checks TRAIT_LAVA_STOPPED. Zeroing lava_damage/temperature_damage does not
-	// spare objects, because do_burn() force-flags them FLAMMABLE and strips FIRE_PROOF regardless.
-	// Added before the parent call, which runs Entered() on anything already mapped onto us.
-	ADD_TRAIT(src, TRAIT_LAVA_STOPPED, INNATE_TRAIT)
+	ADD_TRAIT(src, TRAIT_LAVA_STOPPED, INNATE_TRAIT) // Doesn't burn items
 	return ..()
 
 /// The cafe's lava is decoration, so it fishes like lavaland minus everything that surfaces wanting to kill you.


### PR DESCRIPTION
## About The Pull Request

Fixes #6020.

The ghost cafe has decorative lava near the ash walker nest. It's meant to be ambiance. It is currently burning items and fishing up legions, which is not very ambiance.

### Items Burn In Fake Lava

`/turf/open/lava/fake` zeros out its damage values, but `burn_stuff()` doesn't care about damage values - it goes through `is_safe()`, which checks for `TRAIT_LAVA_STOPPED`.

The fake lava type does declare that trait:

```dm
var/give_turf_traits = list(TRAIT_TURF_IGNORE_SLOWDOWN, TRAIT_LAVA_STOPPED, TRAIT_IMMERSE_STOPPED)
```

...but `give_turf_traits` belongs to an element that attaches to movable atoms, not turfs. It's never applied. Just vibes.

Fix applies `TRAIT_LAVA_STOPPED` in `Initialize()`, before the parent call, so objects already mapped onto the turf are covered too.

Left the other two traits from that unused variable alone:
- `TRAIT_TURF_IGNORE_SLOWDOWN` - turf already has no slowdown, unnecessary.
- `TRAIT_IMMERSE_STOPPED` - would change how the lava looks.

Also set `baseturfs` to `/turf/open/lava/fake` so the turf can't later expose real lava.

### Fishing Can Spawn Hostile Mobs

The turf inherited `/datum/fish_source/lavaland` - the same table as actual Lavaland, legions and brimdemons included. So you could sit down for a relaxing fish in the ghost cafe's chill OOC lounge and reel in something that wants to kill you.

This PR adds `/datum/fish_source/lavaland/cafe`, same as the normal Lavaland table but with the hostile mob entries removed. It's excluded from the fishing catalog and the bluespace rod's random pool. Real Lavaland fishing is untouched.

## Why It's Good For The Game

The ghost cafe is an OOC no-combat area. Decorative lava shouldn't burn your stuff, and the fishing shouldn't hand you a legion.

## Proof Of Testing

<img width="632" height="595" alt="Screenshot 2026-07-28 073932" src="https://github.com/user-attachments/assets/1d50f827-f2f5-47da-ad24-83590e2567c5" />

Dropped a fuel tank and some items onto the fake lava - nothing caught fire. Real lava still works. Fishing testing isn't shown because proving something does *not* spawn would require a long video of nothing happening, but the hostile entries are gone from the cafe table.

*Written with Claude Code assistance, testing completed by me!*

## Changelog

:cl:
fix: Items dropped into the ghost cafe lava no longer burn, including the high-capacity fuel tank.
fix: Fishing in the ghost cafe lava no longer produces legions or brimdemons.
/:cl:
