### PR TITLE
Fix random hallucinations intermittently picking nothing

### DIFF
--- a/code/__HELPERS/hallucinations.dm
+++ b/code/__HELPERS/hallucinations.dm
@@ -125,6 +125,12 @@ GLOBAL_LIST_EMPTY(all_ongoing_hallucinations)
 /// Global weighted list of all hallucinations that can show up randomly.
 GLOBAL_LIST_INIT_TYPED(random_hallucination_weighted_list, /list, generate_hallucination_weighted_list())
 
+/// Multiplier applied to every hallucination weight when the weighted list is built.
+/// pick_weight() only behaves with integer weights - a pool that adds up to a fractional
+/// total can roll higher than the total and return null - but some hallucinations want to be
+/// rarer than a weight of 1 allows, so scale everything up instead of rounding them away.
+#define HALLUCINATION_WEIGHT_SCALING 10
+
 /// Generates the global weighted list of random hallucinations.
 /proc/generate_hallucination_weighted_list()
 	var/list/weighted_list = list()
@@ -136,24 +142,29 @@ GLOBAL_LIST_INIT_TYPED(random_hallucination_weighted_list, /list, generate_hallu
 		if(weight <= 0)
 			continue
 
-		LAZYSET(weighted_list["[initial(hallucination_type.hallucination_tier)]"], hallucination_type, weight)
+		// Anything that wanted a weight at all keeps at least 1, so tiny weights don't round away to unpickable.
+		var/scaled_weight = max(round(weight * HALLUCINATION_WEIGHT_SCALING), 1)
+		LAZYSET(weighted_list["[initial(hallucination_type.hallucination_tier)]"], hallucination_type, scaled_weight)
 
 	return weighted_list
+
+#undef HALLUCINATION_WEIGHT_SCALING
 
 /// Select a random hallucination from the hallucination pool
 ///
 /// * tier - the tier of hallucination to select from
 /// * strict - if true, only select from the passed tier. If false, select from the passed tier and all tiers below it.
 /proc/get_random_hallucination(tier = HALLUCINATION_TIER_COMMON, strict = FALSE)
-	if(!GLOB.random_hallucination_weighted_list[tier])
-		CRASH("get_random_hallucination - No hallucinations in tier \[[tier]\].")
+	var/list/pool = list()
+	var/lowest_tier = strict ? tier : HALLUCINATION_TIER_COMMON
+	for(var/checked_tier = tier, checked_tier >= lowest_tier, checked_tier--)
+		// A tier with nothing in it has no key at all, so read it out before touching it.
+		var/list/tier_pool = GLOB.random_hallucination_weighted_list["[checked_tier]"]
+		for(var/hallucination_type in tier_pool)
+			pool[hallucination_type] = tier_pool[hallucination_type]
 
-	var/list/pool = GLOB.random_hallucination_weighted_list["[tier]"].Copy()
-	if(!strict)
-		tier -= 1
-		while(tier >= HALLUCINATION_TIER_COMMON)
-			pool += GLOB.random_hallucination_weighted_list["[tier]"]
-			tier -= 1
+	if(!length(pool))
+		CRASH("get_random_hallucination - No hallucinations in tier \[[tier]\].")
 
 	return pick_weight(pool)
 

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -194,6 +194,7 @@
 #include "gloves_and_shoes_armor.dm"
 #include "greyscale_config.dm"
 #include "hallucination_icons.dm"
+#include "hallucination_weights.dm"
 #include "held_slowdown.dm"
 #include "heretic_knowledge.dm"
 #include "heretic_rituals.dm"

--- a/code/modules/unit_tests/hallucination_weights.dm
+++ b/code/modules/unit_tests/hallucination_weights.dm
@@ -1,0 +1,33 @@
+/**
+ * Tests that the random hallucination weighted list is actually pickable.
+ *
+ * pick_weight() only works with integer weights - a pool whose weights add up to a
+ * fractional total can roll a number higher than that total and hand back null, which
+ * then blows up in cause_hallucination() at random.
+ */
+/datum/unit_test/hallucination_weights
+
+/datum/unit_test/hallucination_weights/Run()
+	for(var/tier in GLOB.random_hallucination_weighted_list)
+		var/list/tier_pool = GLOB.random_hallucination_weighted_list[tier]
+		if(!length(tier_pool))
+			TEST_FAIL("Hallucination tier [tier] is present in the weighted list but has no hallucinations in it.")
+			continue
+
+		for(var/datum/hallucination/hallucination_type as anything in tier_pool)
+			var/weight = tier_pool[hallucination_type]
+			if(weight > 0 && weight == round(weight))
+				continue
+
+			TEST_FAIL("Hallucination [hallucination_type] has a weight of [weight] in tier [tier]. \
+				Weights in the random hallucination list must be positive integers, or pick_weight() can return null.")
+
+	// Every tier that can actually be rolled needs to hand back a real hallucination, strict or not.
+	for(var/tier in HALLUCINATION_TIER_COMMON to HALLUCINATION_TIER_VERYSPECIAL)
+		for(var/strict in list(TRUE, FALSE))
+			var/datum/hallucination/picked = get_random_hallucination(tier, strict)
+			if(ispath(picked, /datum/hallucination))
+				continue
+
+			TEST_FAIL("get_random_hallucination(tier = [tier], strict = [strict ? "TRUE" : "FALSE"]) \
+				returned [picked || "null"] instead of a hallucination type.")


### PR DESCRIPTION
## About The Pull Request

Fixes #5950, a flaky `create_and_destroy` failure:

```
Runtime in code/__HELPERS/hallucinations.dm,45: cause_hallucination was given a non-hallucination type. (Got: null)
```

`pick_weight()` documents that it only accepts integer weights. It sums the pool, rolls `rand(1, total)`, then walks the pool subtracting weights until the roll runs out. When `total` is fractional, `rand` rounds the bound up and can return a number *larger* than `total`, so the subtraction never reaches zero and the proc falls through to `return null`.

`/datum/hallucination/body/weird` sets `random_hallucination_weight = 0.1`, and its `freezer` subtype sets `0.3`. Split across tiers, those put a stray `.5` in the RARE pool's total, so `get_random_hallucination()` at that tier had roughly a 1-in-500 chance of returning null — which `_cause_hallucination()` then crashed on. The shaggoth in the issue reaches tier RARE through the `variable_tier` branch of the hallucination status effect.

The fix scales every weight by 10 when the weighted list is built, with a floor of 1 so a small weight can't round away to unpickable. Every current weight is a multiple of 0.1, so **relative probabilities are unchanged** — this is not a balance change.

Also fixes the emptiness guard in `get_random_hallucination()`, which indexed the list with a bare number. The tier keys are strings, so a numeric index read *by position* and validated the wrong thing; it would have gone out of bounds rather than crash usefully had a tier actually been empty.

Adds a unit test asserting every weight in the global list is a positive integer, and that all four rollable tiers return a real typepath both strict and non-strict. The integer assertion is the part that matters — without it, a future fractional weight silently reintroduces the same flake.

I deliberately kept this out of `pick_weight()` itself. Fixing it there (swapping `rand(1, total)` for a float roll, which would also drop a slight off-by-one bias it has today) touches hundreds of call sites and is a much more arguable change; hallucinations were the ones breaking the documented contract. Happy to write that separately if a maintainer would rather have it.

## Why It's Good For The Game

Stops a runtime that eats a hallucination roll at random, and removes a recurring source of flaky CI failures.

## Proof Of Testing

Compiles clean with `-DUNIT_TESTS` on 516.1679: 0 errors, only the 6 pre-existing warnings.

The underlying BYOND behaviour was confirmed with a standalone probe rather than assumed — 200,000 iterations each:

```
RAND:        min=1 max=21 rolls_above_20.5 = 4912/200000
PICK_WEIGHT: null results = 4817/200000     (pool totalling 20.5)
```

So `rand(1, 20.5)` does return 21, and `pick_weight`'s algorithm returns null on 2.4% of picks from a pool totalling 20.5. The real RARE pool has the same fractional 0.5 over a much larger total, which is why this surfaced as an occasional flake rather than a constant one.

## Changelog

No player-facing effect — weight ratios are identical before and after, and the only behavioural delta is that a rare hallucination tick now fires instead of silently no-opping and logging a runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
