### PR TITLE
Blocks favorite ghouling Proteans, an oversite that allows them to become a bloodsucker.

### DIFF
--- a/modular_zubbers/code/modules/antagonists/bloodsucker/clans/clan.dm
+++ b/modular_zubbers/code/modules/antagonists/bloodsucker/clans/clan.dm
@@ -277,6 +277,9 @@
 	if(!ghouldatum.owner.can_make_special(creator = bloodsuckerdatum.owner))
 		to_chat(master, span_notice("This Ghoul is unable to gain a Special rank due to innate features."))
 		return FALSE
+	if(isprotean(servant))
+		to_chat(master, span_notice("You are unable to make this species your favorite Ghoul."))
+		return FALSE
 	if(bloodsuckerdatum.GetBloodVolume() < SPECIAL_GHOUL_COST)
 		to_chat(master, span_notice("You need at least 150 blood to make a Ghoul a Favorite Ghoul."))
 		return FALSE


### PR DESCRIPTION
## About The Pull Request

This is an oversight. The event block is still functional. But you can convert a Protean into a bloodsucker. This stops that.

## Why It's Good For The Game

This species is restricted on the event because they're effectively immortal.

## Proof Of Testing

It works

## Changelog

:cl:
fix: Fixes an oversight that allows Proteans to become bloodsuckers by blocking favorite ghouling.
/:cl:
