### PR TITLE
Fixes synthetic taur body pref checkbox not making organic taur bodies synthetic sometimes

### DIFF
--- a/modular_zubbers/modules/taur_mechanics/preferences.dm
+++ b/modular_zubbers/modules/taur_mechanics/preferences.dm
@@ -41,3 +41,4 @@
 	if (istype(taur))
 		taur.organ_flags &= ~ORGAN_ORGANIC
 		taur.organ_flags |= ORGAN_ROBOTIC
+		taur.on_mob_insert(target, special = TRUE, movement_flags = TRUE) //Reinsert the taur body now that we have preferences?


### PR DESCRIPTION

## About The Pull Request

Fixes #3957. This glitch was caused by the on_mob_insert() for the taur body organ being run before the mob had a mind, which meant it couldn't read prefs from that mind. The end result of this was that the game checked if the taur body should have synth legs before the body was made synthetic, and it couldn't read preferences to fix it otherwise.

The fix is just to rerun the part of the code that adds legs to the taur body, once the taur body is made synthetic.

## Why It's Good For The Game

Fixes a bug that was causing taur bodies intended to be synthetic to not be synthetic.

## Proof Of Testing

<img width="538" height="99" alt="image" src="https://github.com/user-attachments/assets/36c00e52-df7f-4e08-b75d-5b9735f82291" />

## Changelog
:cl:
fix: "Taur (Synthetic)" checkbox in the character creator now properly makes your legs synthetic.
/:cl:
