### PR TITLE
Dusting Sickness fixes

### DIFF
--- a/modular_zubbers/code/datums/quirks/negative_quirks/bloodloss_dusting.dm
+++ b/modular_zubbers/code/datums/quirks/negative_quirks/bloodloss_dusting.dm
@@ -2,7 +2,7 @@
 	name = "Dusting Sickness"
 	desc = "If you run out of blood to the point where a normal person would die, you turn to dust."
 	value = -8
-	species_blacklist = list(SPECIES_PROTEAN, SPECIES_ABDUCTOR_STATION, SPECIES_PLASMAMAN)
+	species_blacklist = list(SPECIES_ABDUCTOR_STATION, SPECIES_PLASMAMAN)
 	gain_text = span_danger("You start to worry even more about running out of blood.")
 	lose_text = span_notice("You feel like running out of blood isn't /quite/ as scary.")
 	medical_record_text = "Patient's body has an extreme reaction to bloodloss to the point of crumbling to dust. Keeping blood levels steady is recommended."

--- a/modular_zubbers/code/datums/quirks/negative_quirks/bloodloss_dusting.dm
+++ b/modular_zubbers/code/datums/quirks/negative_quirks/bloodloss_dusting.dm
@@ -2,6 +2,7 @@
 	name = "Dusting Sickness"
 	desc = "If you run out of blood to the point where a normal person would die, you turn to dust."
 	value = -8
+	species_blacklist = list(SPECIES_PROTEAN, SPECIES_ABDUCTOR_STATION, SPECIES_PLASMAMAN)
 	gain_text = span_danger("You start to worry even more about running out of blood.")
 	lose_text = span_notice("You feel like running out of blood isn't /quite/ as scary.")
 	medical_record_text = "Patient's body has an extreme reaction to bloodloss to the point of crumbling to dust. Keeping blood levels steady is recommended."
@@ -17,8 +18,8 @@
 	if(source.blood_volume < BLOOD_VOLUME_SURVIVE)
 		to_chat(quirk_holder, span_danger("You ran out of blood!"))
 		quirk_holder.investigate_log("has been dusted by a lack of blood. Caused by [src.name] quirk", INVESTIGATE_DEATHS)
-		quirk_holder.drop_everything(del_on_drop = FALSE, force = TRUE, del_if_nodrop = TRUE)
 		quirk_holder.dust()
+		quirk_holder.drop_everything(del_on_drop = FALSE, force = TRUE, del_if_nodrop = TRUE)
 
 /datum/quirk/bloodloss_dusting/remove()
 	UnregisterSignal(quirk_holder, COMSIG_HUMAN_ON_HANDLE_BLOOD)

--- a/modular_zubbers/code/datums/quirks/negative_quirks/bloodloss_dusting.dm
+++ b/modular_zubbers/code/datums/quirks/negative_quirks/bloodloss_dusting.dm
@@ -17,6 +17,7 @@
 	if(source.blood_volume < BLOOD_VOLUME_SURVIVE)
 		to_chat(quirk_holder, span_danger("You ran out of blood!"))
 		quirk_holder.investigate_log("has been dusted by a lack of blood. Caused by [src.name] quirk", INVESTIGATE_DEATHS)
+		quirk_holder.drop_everything(del_on_drop = FALSE, force = TRUE, del_if_nodrop = TRUE)
 		quirk_holder.dust()
 
 /datum/quirk/bloodloss_dusting/remove()


### PR DESCRIPTION
## About The Pull Request

I have fixed a couple issues with the quirk as is; firstly, plasmamen and abductors can no longer pick this quirk, to not instantly kill them upon spawning (as they technically don't have blood). Secondly, being dusted now makes you drop your things the moment before, instead of dusting them with you.

## Why It's Good For The Game

The species not being restricted seemed like an oversight.

Making it so that the quirk doesn't delete your items makes the quirk a lot less of a pain for heads of staff specifically, as it could lead to the loss of critical and/or unique items.
## Proof Of Testing

Here's Cpt. Pinkmann (any correlation to the Breaking Bad character is purely coincidental) being syphoned of their precious blood. Don't worry, they're fine.

https://github.com/user-attachments/assets/8538a13c-3853-4956-b6c1-f4b1d843d664

</details>

## Changelog
:cl:
balance: Being dusted via Dusting Sickness now makes you drop your equipment.
fix: Abductors and Plasmamen are now blacklisted from picking the Dusting Sickness quirk.
/:cl:
