### PR TITLE
Fixes Radstorm Dorms Check

### DIFF
--- a/modular_zubbers/code/datums/weather/weather_types/radiation_storm.dm
+++ b/modular_zubbers/code/datums/weather/weather_types/radiation_storm.dm
@@ -21,6 +21,7 @@
 	if(!GLOB.emergency_access)
 		maint_flipped = TRUE
 		addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(make_maint_all_access), TRUE), 0.5 SECONDS) // timed to match the status display
+	dorms_check()
 
 /datum/weather/rad_storm/end()
 	. = ..()

--- a/modular_zubbers/code/modules/events/ev_roleplay_check.dm
+++ b/modular_zubbers/code/modules/events/ev_roleplay_check.dm
@@ -5,17 +5,13 @@ GLOBAL_LIST_EMPTY(dorms_areas)
 	. = ..()
 	GLOB.dorms_areas[src] = TRUE
 
-/datum/weather/proc/enhanced_roleplay_filter(list/affectareas)
-	return affectareas
+/datum/weather/rad_storm/proc/dorms_check(mob/player)
+	var/turf/player_turf = get_turf(player)
 
-/datum/weather/rad_storm/enhanced_roleplay_filter(list/affectareas)
-	var/list/filtered_areas = affectareas
-	for(var/area/engaged_roleplay_area as anything in GLOB.dorms_areas)
-		for(var/mob/living/carbon/human/roleplayer in engaged_roleplay_area.contents)
-			if(engaged_role_play_check(player = roleplayer, station = FALSE, dorms = TRUE))
-				LAZYREMOVE(filtered_areas, engaged_roleplay_area)
-				break
-	return filtered_areas
+	if(player_turf && length(GLOB.dorms_areas))
+		var/area/player_area = player_turf.loc
+		if(GLOB.dorms_areas[player_area])
+			protected_areas += player_area
 
 /datum/weather/rad_storm/send_alert(alert_msg, alert_sfx, alert_sfx_vol = 100)
 	for(var/area/impacted_area as anything in impacted_areas)


### PR DESCRIPTION

## About The Pull Request
I was going to add dorms to the radstorm protected areas but turns out we already had a check for this. It was just broken. This fixes it.
## Why It's Good For The Game
While it is kind of funny, ERPers getting radiation blasted is probably bad for the game.
## Proof Of Testing
The area around Mr. Ghoul in the attached screenshot is `/area/station/commons/dorms`. I just couldn't get Metastation to load on my local environment.
<details>
<summary>Screenshots/Videos</summary>

<img width="1010" height="867" alt="image" src="https://github.com/user-attachments/assets/07f4a93c-1958-4420-96ab-936fce646d84" />

</details>

## Changelog
:cl:
fix: Dorms that are occupied are once again safe from radstorms.
/:cl:
