### PR TITLE
[BOUNTY] Removes the pairing mechanic from sec dept rolls

### DIFF
--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -320,7 +320,7 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 	 * This is the function that is responsible for taking the list of preferences,
 	 * and spitting out what to put them in.
 	 *
-	 * However, it should, wherever possible, prevent solo departments.
+	 * However, it should, wherever possible, prevent solo departments. // BUBBER EDIT: This was patched out, allowing solo departments
 	 * That means that if there's one medical officer, and one engineering officer,
 	 * that they should be put onto the same department (either medical or engineering).
 	 *
@@ -463,6 +463,8 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 	return selection
 
 /proc/get_distribution(candidates, departments)
+	// BUBBER EDIT BEGIN - REMOVES THE PAIRING CODE.
+	/*
 	var/number_of_twos = min(departments, round(candidates / 2))
 	var/redistribute = candidates - (2 * number_of_twos)
 
@@ -471,10 +473,18 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 	for (var/index in 1 to number_of_twos)
 		distribution[index] = 2
 
+	*/
+	var/distribution_size = min(departments, candidates)
+	var/redistribute = candidates - distribution_size
+	var/distribution[max(1, distribution_size)]
+	for (var/index in 1 to distribution_size)
+		distribution[index] = 1
+
 	for (var/index in 0 to redistribute - 1)
 		distribution[(index % departments) + 1] += 1
 
 	return distribution
+	// BUBBER EDIT END
 
 /proc/get_new_officer_distribution_from_late_join(
 	preference,
@@ -516,9 +526,13 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 	for (var/department in amount_in_departments)
 		var/amount = amount_in_departments[department]
 
+		// BUBBER EDIT BEGIN - REMOVES THE PAIRING CODE.
+		/*
 		if (amount == 1)
 			return department
-		else if (lowest_amount > amount)
+		else*/
+		if (lowest_amount > amount)
+		// BUBBER EDIT END
 			lowest_departments = list(department)
 			lowest_amount = amount
 		else if (lowest_amount == amount)

--- a/code/modules/unit_tests/security_officer_distribution.dm
+++ b/code/modules/unit_tests/security_officer_distribution.dm
@@ -6,6 +6,8 @@
 	"d" = SEC_DEPT_SUPPLY, \
 ))
 
+// BUBBER EDIT BEGIN REMOVAL - We don't distribute in a special pairing system
+/*
 /// Test that security officers with specific distributions get their departments.
 /datum/unit_test/security_officer_roundstart_distribution
 
@@ -106,6 +108,6 @@
 	test("a", list("a", "a", "b"), "b")
 	test("a", list("a", "a", "b", "b"), "c")
 	test("a", list("a", "a", "b", "b", "c", "c", "d", "d"), "a")
-
+*/
 #undef SECURITY_OFFICER_DEPARTMENTS
 #undef SECURITY_OFFICER_DEPARTMENTS_TO_NAMES


### PR DESCRIPTION
## About The Pull Request

This completely does away with the pairing system for security department rolls. The pairing system always forced you together with someone if they were going to be alone as a department sec.

What this means is sec officers will be distributed among all the departments, with the system trying to put preference first, but if there's two going for the same one, one will inevitably lose out and be given to another department.

- Benefits are that more departments get their secoffs.
- Disadvantage is that, well, you're still not guaranteed to get your preferred dept, but it at least makes sense now and won't just force you together with someone.

This PR has an alternative version, this is Option 1 and my personally preferred and endorsed option.

closes #6033 (alternative PR)

## Why It's Good For The Game

It makes the system less confusing by no longer forcing you in with someone even though your preferred department was empty. Also makes it that more departments get their secoffs.

## Proof Of Testing

This works in theory, and the procs do react as they should in testing, but I can't simply summon 7 secoffs to my test server so I need this TMd to be sure

## Changelog

:cl:
balance: Sec officers no longer get forced into a department with another officer when an empty department is available, making the dept preference system make sense.
/:cl:
