### PR TITLE
[BOUNTY] Removes distribution from sec dept rolls.

### DIFF
--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -234,6 +234,9 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 	signal.send_to_receivers()
 
 /datum/job/security_officer/proc/get_my_department(mob/character, preferred_department)
+	// BUBBER EDIT BEGIN - Replaces distribution systen with just giving out the preferred department.
+	// Original:
+	/*
 	var/department = GLOB.security_officer_distribution[REF(character)]
 
 	// This passes when they are a round start security officer.
@@ -245,6 +248,9 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 		shuffle(GLOB.available_depts),
 		GLOB.security_officer_distribution,
 	)
+	*/
+	return preferred_department
+	// BUBBER EDIT END
 
 /datum/outfit/job/security
 	name = "Security Officer"


### PR DESCRIPTION
## About The Pull Request

This simply makes it so you get whatever you chose as your department no matter what.
None thus predictably gives you nothing instead of random rolling.

- Advantage: No secoffs who get the wrong department
- Disadvantage: Some less popular departments will, inevitably, be left out.

This PR has an alternative version, this is Option 2. Personally I feel like this is the populist decision that isn't really good for the health of more intense rounds, because sec might end up way too concentrated in one spot and would prefer Option 1.

closes #6032 (alternative PR)

## Why It's Good For The Game

People get what they chose, with no weird system coupling them together with people

## Proof Of Testing

Worked on my machine, I forgot the screenshot. Unlike Option 1, this just bypasses the balancing system entirely so it doesn't really need a TM

## Changelog

:cl:
balance: Sec guard preferred department is always chosen, no matter the situation and officer distribution. People with None as their department will be given no department to guard.
/:cl:
