### PR TITLE
Adds Piss system

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -166,9 +166,11 @@
 #define LOADOUT_FLAG_GREYSCALING_ALLOWED (1<<2)
 /// Allows the item to be renamed by the player.
 #define LOADOUT_FLAG_ALLOW_NAMING (1<<3)
+// BUBBER EDIT ADDITION START - Automatic reskin detection
 /// Prevents automatic detection of reskin support on this loadout item.
 /// Use when the item inherits a reskin component whose skins don't suit it, or when its skins are deliberately gated in game.
 #define LOADOUT_FLAG_BLOCK_RESKIN (1<<4)
+// BUBBER EDIT ADDITION END
 
 // Loadout item info keys
 // Changing these will break existing loadouts

--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -166,6 +166,9 @@
 #define LOADOUT_FLAG_GREYSCALING_ALLOWED (1<<2)
 /// Allows the item to be renamed by the player.
 #define LOADOUT_FLAG_ALLOW_NAMING (1<<3)
+/// Prevents automatic detection of reskin support on this loadout item.
+/// Use when the item inherits a reskin component whose skins don't suit it, or when its skins are deliberately gated in game.
+#define LOADOUT_FLAG_BLOCK_RESKIN (1<<4)
 
 // Loadout item info keys
 // Changing these will break existing loadouts

--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -166,9 +166,6 @@
 #define LOADOUT_FLAG_GREYSCALING_ALLOWED (1<<2)
 /// Allows the item to be renamed by the player.
 #define LOADOUT_FLAG_ALLOW_NAMING (1<<3)
-/// Prevents automatic detection of reskin support on this loadout item.
-/// Use when the item inherits a reskin component whose skins don't suit it, or when its skins are deliberately gated in game.
-#define LOADOUT_FLAG_BLOCK_RESKIN (1<<4)
 
 // Loadout item info keys
 // Changing these will break existing loadouts

--- a/code/modules/loadout/loadout_items.dm
+++ b/code/modules/loadout/loadout_items.dm
@@ -55,9 +55,6 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 	/// Base typepath to what reskin datum this item can use to reskin into
 	/// Doesn't verify that the item_path actually has these reskins
 	var/datum/atom_skin/reskin_datum
-	// BUBBER EDIT ADDITION - Tracks whether reskin auto detection has already run for this datum.
-	var/reskin_datum_checked = FALSE
-	// BUBBER EDIT ADDITION END
 	/// A list of greyscale colors that are used for items that have greyscale support, but don't allow full customization.
 	/// This is an assoc list of /datum/job_department -> colors, or /datum/job -> colors, allowing for preset colors based on player chosen job.
 	/// Jobs are prioritized over departments.
@@ -336,7 +333,6 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 /datum/loadout_item/proc/on_equip_item(obj/item/equipped_item, list/item_details, mob/living/carbon/human/equipper, datum/outfit/outfit, visuals_only = FALSE)
 	if(isnull(equipped_item))
 		return NONE
-	try_detect_reskin() // BUBBER EDIT ADDITION - Populate reskin_datum before applying a saved skin
 
 	if(!visuals_only)
 		ADD_TRAIT(equipped_item, TRAIT_ITEM_OBJECTIVE_BLOCKED, TRAIT_SOURCE_LOADOUT)
@@ -368,18 +364,14 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 
 	if(reskin_datum && item_details?[INFO_RESKIN])
 		var/skin_chosen = item_details[INFO_RESKIN]
-		// BUBBER EDIT CHANGE START - Prefer the component when the item has one
-		// Applying a skin directly leaves the component untouched: current_skin stays null and
-		// COMSIG_OBJ_RESKIN never fires, so items that track their own colour var never learn about
-		// the change and revert the moment something calls update_icon_state(). Going through the
-		// component takes the same path an in game alt click would.
-		var/datum/component/reskinable_item/reskin_comp = equipped_item.GetComponent(/datum/component/reskinable_item)
-		if(reskin_comp)
-			reskin_comp.set_skin_by_name(skin_chosen)
-			// Mirror reskin_obj(): a component that only allows one skin is spent once that skin is
-			// picked, so drop it. Leaving it alive would swallow every later alt click on the item.
-			if(!reskin_comp.get_infinite_reskin())
-				qdel(reskin_comp)
+		var/list/atom_skins = get_atom_skins()
+		for(var/datum/atom_skin/skin_path as anything in valid_subtypesof(reskin_datum))
+			if(skin_path::preview_name != skin_chosen)
+				continue
+			if(skin_path::preview_name != skin_chosen)
+				continue
+			var/datum/atom_skin/skin_instance = atom_skins[skin_path]
+			skin_instance.apply(equipped_item)
 			if(istype(equipped_item, /obj/item/clothing/accessory))
 				// Snowflake handing for accessories, because we need to update the thing it's attached to instead
 				if(isclothing(equipped_item.loc))
@@ -388,63 +380,15 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 					update_flag |= (ITEM_SLOT_OCLOTHING|ITEM_SLOT_ICLOTHING)
 			else
 				update_flag |= equipped_item.slot_flags
-		else
-			var/list/atom_skins = get_atom_skins()
-			for(var/datum/atom_skin/skin_path as anything in valid_subtypesof(reskin_datum))
-				if(skin_path::preview_name != skin_chosen)
-					continue
-				var/datum/atom_skin/skin_instance = atom_skins[skin_path]
-				skin_instance.apply(equipped_item)
-				if(istype(equipped_item, /obj/item/clothing/accessory))
-					// Snowflake handing for accessories, because we need to update the thing it's attached to instead
-					if(isclothing(equipped_item.loc))
-						var/obj/item/clothing/under/attached_to = equipped_item.loc
-						attached_to.update_accessory_overlay()
-						update_flag |= (ITEM_SLOT_OCLOTHING|ITEM_SLOT_ICLOTHING)
-				else
-					update_flag |= equipped_item.slot_flags
-				break
-		// BUBBER EDIT CHANGE END
+			break
 
 	return update_flag
-
-// BUBBER EDIT ADDITION START - Automatic reskin detection
-/**
- * Checks item_path for a reskinable_item component and adopts its skin type, so that any item
- * which supports alt click reskinning in game also offers skin selection in the loadout.
- *
- * This cannot run in New(). Loadout datums are built by GLOBAL_LIST_INIT, which fires before
- * SSatoms initialises, and at that point atom/New() deliberately skips Initialize(). No
- * Initialize means no setup_reskins(), so the component would not exist yet to be found.
- * Running on first use instead means SSatoms has long since finished.
- *
- * Only probes once per datum. Datums that declare reskin_datum themselves are left alone,
- * as are those flagged LOADOUT_FLAG_BLOCK_RESKIN.
- */
-/datum/loadout_item/proc/try_detect_reskin()
-	if(reskin_datum_checked || reskin_datum || (loadout_flags & LOADOUT_FLAG_BLOCK_RESKIN))
-		return
-	reskin_datum_checked = TRUE
-	if(!ispath(item_path, /obj/item))
-		return
-	var/obj/item/probe = new item_path(null)
-	// Some items delete themselves during Initialize (a lewd NIFSoft datadisk does exactly this when
-	// the lewd content config is off), and new() still hands back the reference. Touching it would
-	// runtime, and qdel'ing it a second time would throw.
-	if(QDELETED(probe))
-		return
-	var/datum/component/reskinable_item/reskin_comp = probe.GetComponent(/datum/component/reskinable_item)
-	if(reskin_comp)
-		reskin_datum = reskin_comp.get_base_reskin_type()
-	qdel(probe)
-// BUBBER EDIT ADDITION END
 
 /**
  * Returns a formatted list of data for this loadout item.
  */
 /datum/loadout_item/proc/to_ui_data() as /list
 	SHOULD_CALL_PARENT(TRUE)
-	try_detect_reskin() // BUBBER EDIT ADDITION - Populate reskin_datum before the UI data is built
 
 	var/list/formatted_item = list()
 	var/list/information = list()

--- a/code/modules/loadout/loadout_items.dm
+++ b/code/modules/loadout/loadout_items.dm
@@ -55,9 +55,6 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 	/// Base typepath to what reskin datum this item can use to reskin into
 	/// Doesn't verify that the item_path actually has these reskins
 	var/datum/atom_skin/reskin_datum
-	// BUBBER EDIT ADDITION - Tracks whether reskin auto detection has already run for this datum.
-	var/reskin_datum_checked = FALSE
-	// BUBBER EDIT ADDITION END
 	/// A list of greyscale colors that are used for items that have greyscale support, but don't allow full customization.
 	/// This is an assoc list of /datum/job_department -> colors, or /datum/job -> colors, allowing for preset colors based on player chosen job.
 	/// Jobs are prioritized over departments.
@@ -336,7 +333,6 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 /datum/loadout_item/proc/on_equip_item(obj/item/equipped_item, list/item_details, mob/living/carbon/human/equipper, datum/outfit/outfit, visuals_only = FALSE)
 	if(isnull(equipped_item))
 		return NONE
-	try_detect_reskin() // BUBBER EDIT ADDITION - Populate reskin_datum before applying a saved skin
 
 	if(!visuals_only)
 		ADD_TRAIT(equipped_item, TRAIT_ITEM_OBJECTIVE_BLOCKED, TRAIT_SOURCE_LOADOUT)
@@ -420,23 +416,20 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
  * Checks item_path for a reskinable_item component and adopts its skin type, so that any item
  * which supports alt click reskinning in game also offers skin selection in the loadout.
  *
- * This cannot run in New(). Loadout datums are built by GLOBAL_LIST_INIT, which fires before
- * SSatoms initialises, and at that point atom/New() deliberately skips Initialize(). No
- * Initialize means no setup_reskins(), so the component would not exist yet to be found.
- * Running on first use instead means SSatoms has long since finished.
+ * This is called from to_ui_data() rather than New(), because it depends on the probe item below
+ * running its own Initialize(). Loadout datums are built by GLOBAL_LIST_INIT, which fires before
+ * SSatoms, and while SSatoms.initialized is INITIALIZATION_INSSATOMS every atom/New() skips
+ * InitAtom entirely. A probe built that early would never run setup_reskins(), so its component
+ * would not exist yet to be found. By the time the preferences data is assembled SSatoms is done.
  *
- * Only probes once per datum. Datums that declare reskin_datum themselves are left alone,
- * as are those flagged LOADOUT_FLAG_BLOCK_RESKIN.
+ * Datums that declare reskin_datum themselves are left alone, as are those flagged
+ * LOADOUT_FLAG_BLOCK_RESKIN.
  */
 /datum/loadout_item/proc/try_detect_reskin()
-	if(reskin_datum_checked || reskin_datum || (loadout_flags & LOADOUT_FLAG_BLOCK_RESKIN))
+	if(reskin_datum || (loadout_flags & LOADOUT_FLAG_BLOCK_RESKIN))
 		return
-	reskin_datum_checked = TRUE
 	if(!ispath(item_path, /obj/item))
 		return
-	// Mob holders carry a live creature. Building one spawns the creature inside it, and deleting it
-	// then tries to drop that creature on the floor. There is no floor here, so it throws. They never
-	// have skins anyway, so leave them alone.
 	if(ispath(item_path, /obj/item/mob_holder))
 		return
 	var/obj/item/probe = new item_path(null)

--- a/code/modules/loadout/loadout_items.dm
+++ b/code/modules/loadout/loadout_items.dm
@@ -386,9 +386,8 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 			if(istype(equipped_item, /obj/item/clothing/accessory))
 				// Snowflake handing for accessories, because we need to update the thing it's attached to instead
 				if(isclothing(equipped_item.loc))
-					var/obj/item/clothing/under/attached_to = equipped_item.loc
-					attached_to.update_accessory_overlay()
-					update_flag |= (ITEM_SLOT_OCLOTHING|ITEM_SLOT_ICLOTHING)
+					var/obj/item/clothing/attached_to = equipped_item.loc
+					update_flag |= attached_to.slot_flags
 			else
 				update_flag |= equipped_item.slot_flags
 		else
@@ -401,9 +400,8 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 				if(istype(equipped_item, /obj/item/clothing/accessory))
 					// Snowflake handing for accessories, because we need to update the thing it's attached to instead
 					if(isclothing(equipped_item.loc))
-						var/obj/item/clothing/under/attached_to = equipped_item.loc
-						attached_to.update_accessory_overlay()
-						update_flag |= (ITEM_SLOT_OCLOTHING|ITEM_SLOT_ICLOTHING)
+						var/obj/item/clothing/attached_to = equipped_item.loc
+						update_flag |= attached_to.slot_flags
 				else
 					update_flag |= equipped_item.slot_flags
 				break

--- a/code/modules/loadout/loadout_items.dm
+++ b/code/modules/loadout/loadout_items.dm
@@ -55,6 +55,9 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 	/// Base typepath to what reskin datum this item can use to reskin into
 	/// Doesn't verify that the item_path actually has these reskins
 	var/datum/atom_skin/reskin_datum
+	// BUBBER EDIT ADDITION - Tracks whether reskin auto detection has already run for this datum.
+	var/reskin_datum_checked = FALSE
+	// BUBBER EDIT ADDITION END
 	/// A list of greyscale colors that are used for items that have greyscale support, but don't allow full customization.
 	/// This is an assoc list of /datum/job_department -> colors, or /datum/job -> colors, allowing for preset colors based on player chosen job.
 	/// Jobs are prioritized over departments.
@@ -333,6 +336,7 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 /datum/loadout_item/proc/on_equip_item(obj/item/equipped_item, list/item_details, mob/living/carbon/human/equipper, datum/outfit/outfit, visuals_only = FALSE)
 	if(isnull(equipped_item))
 		return NONE
+	try_detect_reskin() // BUBBER EDIT ADDITION - Populate reskin_datum before applying a saved skin
 
 	if(!visuals_only)
 		ADD_TRAIT(equipped_item, TRAIT_ITEM_OBJECTIVE_BLOCKED, TRAIT_SOURCE_LOADOUT)
@@ -364,14 +368,18 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 
 	if(reskin_datum && item_details?[INFO_RESKIN])
 		var/skin_chosen = item_details[INFO_RESKIN]
-		var/list/atom_skins = get_atom_skins()
-		for(var/datum/atom_skin/skin_path as anything in valid_subtypesof(reskin_datum))
-			if(skin_path::preview_name != skin_chosen)
-				continue
-			if(skin_path::preview_name != skin_chosen)
-				continue
-			var/datum/atom_skin/skin_instance = atom_skins[skin_path]
-			skin_instance.apply(equipped_item)
+		// BUBBER EDIT CHANGE START - Prefer the component when the item has one
+		// Applying a skin directly leaves the component untouched: current_skin stays null and
+		// COMSIG_OBJ_RESKIN never fires, so items that track their own colour var never learn about
+		// the change and revert the moment something calls update_icon_state(). Going through the
+		// component takes the same path an in game alt click would.
+		var/datum/component/reskinable_item/reskin_comp = equipped_item.GetComponent(/datum/component/reskinable_item)
+		if(reskin_comp)
+			reskin_comp.set_skin_by_name(skin_chosen)
+			// Mirror reskin_obj(): a component that only allows one skin is spent once that skin is
+			// picked, so drop it. Leaving it alive would swallow every later alt click on the item.
+			if(!reskin_comp.get_infinite_reskin())
+				qdel(reskin_comp)
 			if(istype(equipped_item, /obj/item/clothing/accessory))
 				// Snowflake handing for accessories, because we need to update the thing it's attached to instead
 				if(isclothing(equipped_item.loc))
@@ -380,15 +388,63 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 					update_flag |= (ITEM_SLOT_OCLOTHING|ITEM_SLOT_ICLOTHING)
 			else
 				update_flag |= equipped_item.slot_flags
-			break
+		else
+			var/list/atom_skins = get_atom_skins()
+			for(var/datum/atom_skin/skin_path as anything in valid_subtypesof(reskin_datum))
+				if(skin_path::preview_name != skin_chosen)
+					continue
+				var/datum/atom_skin/skin_instance = atom_skins[skin_path]
+				skin_instance.apply(equipped_item)
+				if(istype(equipped_item, /obj/item/clothing/accessory))
+					// Snowflake handing for accessories, because we need to update the thing it's attached to instead
+					if(isclothing(equipped_item.loc))
+						var/obj/item/clothing/under/attached_to = equipped_item.loc
+						attached_to.update_accessory_overlay()
+						update_flag |= (ITEM_SLOT_OCLOTHING|ITEM_SLOT_ICLOTHING)
+				else
+					update_flag |= equipped_item.slot_flags
+				break
+		// BUBBER EDIT CHANGE END
 
 	return update_flag
+
+// BUBBER EDIT ADDITION START - Automatic reskin detection
+/**
+ * Checks item_path for a reskinable_item component and adopts its skin type, so that any item
+ * which supports alt click reskinning in game also offers skin selection in the loadout.
+ *
+ * This cannot run in New(). Loadout datums are built by GLOBAL_LIST_INIT, which fires before
+ * SSatoms initialises, and at that point atom/New() deliberately skips Initialize(). No
+ * Initialize means no setup_reskins(), so the component would not exist yet to be found.
+ * Running on first use instead means SSatoms has long since finished.
+ *
+ * Only probes once per datum. Datums that declare reskin_datum themselves are left alone,
+ * as are those flagged LOADOUT_FLAG_BLOCK_RESKIN.
+ */
+/datum/loadout_item/proc/try_detect_reskin()
+	if(reskin_datum_checked || reskin_datum || (loadout_flags & LOADOUT_FLAG_BLOCK_RESKIN))
+		return
+	reskin_datum_checked = TRUE
+	if(!ispath(item_path, /obj/item))
+		return
+	var/obj/item/probe = new item_path(null)
+	// Some items delete themselves during Initialize (a lewd NIFSoft datadisk does exactly this when
+	// the lewd content config is off), and new() still hands back the reference. Touching it would
+	// runtime, and qdel'ing it a second time would throw.
+	if(QDELETED(probe))
+		return
+	var/datum/component/reskinable_item/reskin_comp = probe.GetComponent(/datum/component/reskinable_item)
+	if(reskin_comp)
+		reskin_datum = reskin_comp.get_base_reskin_type()
+	qdel(probe)
+// BUBBER EDIT ADDITION END
 
 /**
  * Returns a formatted list of data for this loadout item.
  */
 /datum/loadout_item/proc/to_ui_data() as /list
 	SHOULD_CALL_PARENT(TRUE)
+	try_detect_reskin() // BUBBER EDIT ADDITION - Populate reskin_datum before the UI data is built
 
 	var/list/formatted_item = list()
 	var/list/information = list()

--- a/code/modules/loadout/loadout_items.dm
+++ b/code/modules/loadout/loadout_items.dm
@@ -55,6 +55,9 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 	/// Base typepath to what reskin datum this item can use to reskin into
 	/// Doesn't verify that the item_path actually has these reskins
 	var/datum/atom_skin/reskin_datum
+	// BUBBER EDIT ADDITION - Tracks whether reskin auto detection has already run for this datum.
+	var/reskin_datum_checked = FALSE
+	// BUBBER EDIT ADDITION END
 	/// A list of greyscale colors that are used for items that have greyscale support, but don't allow full customization.
 	/// This is an assoc list of /datum/job_department -> colors, or /datum/job -> colors, allowing for preset colors based on player chosen job.
 	/// Jobs are prioritized over departments.
@@ -333,6 +336,7 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 /datum/loadout_item/proc/on_equip_item(obj/item/equipped_item, list/item_details, mob/living/carbon/human/equipper, datum/outfit/outfit, visuals_only = FALSE)
 	if(isnull(equipped_item))
 		return NONE
+	try_detect_reskin() // BUBBER EDIT ADDITION - Populate reskin_datum before applying a saved skin
 
 	if(!visuals_only)
 		ADD_TRAIT(equipped_item, TRAIT_ITEM_OBJECTIVE_BLOCKED, TRAIT_SOURCE_LOADOUT)
@@ -364,14 +368,25 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 
 	if(reskin_datum && item_details?[INFO_RESKIN])
 		var/skin_chosen = item_details[INFO_RESKIN]
-		var/list/atom_skins = get_atom_skins()
-		for(var/datum/atom_skin/skin_path as anything in valid_subtypesof(reskin_datum))
-			if(skin_path::preview_name != skin_chosen)
-				continue
-			if(skin_path::preview_name != skin_chosen)
-				continue
-			var/datum/atom_skin/skin_instance = atom_skins[skin_path]
-			skin_instance.apply(equipped_item)
+		// BUBBER EDIT CHANGE START - Prefer the component when the item has one
+		// Applying a skin directly leaves the component untouched: current_skin stays null and
+		// COMSIG_OBJ_RESKIN never fires, so items that track their own colour var never learn about
+		// the change and revert the moment something calls update_icon_state(). Going through the
+		// component takes the same path an in game alt click would.
+		// The item can carry more than one of these. The pride pin does: it has the base game's set of
+		// flags plus a second set added downstream. Match on the skin type we actually want, or we
+		// might hand the chosen name to the wrong set and get nothing.
+		var/datum/component/reskinable_item/reskin_comp
+		for(var/datum/component/reskinable_item/candidate as anything in equipped_item.GetComponents(/datum/component/reskinable_item))
+			if(candidate.get_base_reskin_type() == reskin_datum)
+				reskin_comp = candidate
+				break
+		if(reskin_comp)
+			reskin_comp.set_skin_by_name(skin_chosen)
+			// Mirror reskin_obj(): a component that only allows one skin is spent once that skin is
+			// picked, so drop it. Leaving it alive would swallow every later alt click on the item.
+			if(!reskin_comp.get_infinite_reskin())
+				qdel(reskin_comp)
 			if(istype(equipped_item, /obj/item/clothing/accessory))
 				// Snowflake handing for accessories, because we need to update the thing it's attached to instead
 				if(isclothing(equipped_item.loc))
@@ -380,15 +395,66 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 					update_flag |= (ITEM_SLOT_OCLOTHING|ITEM_SLOT_ICLOTHING)
 			else
 				update_flag |= equipped_item.slot_flags
-			break
+		else
+			var/list/atom_skins = get_atom_skins()
+			for(var/datum/atom_skin/skin_path as anything in valid_subtypesof(reskin_datum))
+				if(skin_path::preview_name != skin_chosen)
+					continue
+				var/datum/atom_skin/skin_instance = atom_skins[skin_path]
+				skin_instance.apply(equipped_item)
+				if(istype(equipped_item, /obj/item/clothing/accessory))
+					// Snowflake handing for accessories, because we need to update the thing it's attached to instead
+					if(isclothing(equipped_item.loc))
+						var/obj/item/clothing/under/attached_to = equipped_item.loc
+						attached_to.update_accessory_overlay()
+						update_flag |= (ITEM_SLOT_OCLOTHING|ITEM_SLOT_ICLOTHING)
+				else
+					update_flag |= equipped_item.slot_flags
+				break
+		// BUBBER EDIT CHANGE END
 
 	return update_flag
+
+// BUBBER EDIT ADDITION START - Automatic reskin detection
+/**
+ * Checks item_path for a reskinable_item component and adopts its skin type, so that any item
+ * which supports alt click reskinning in game also offers skin selection in the loadout.
+ *
+ * This cannot run in New(). Loadout datums are built by GLOBAL_LIST_INIT, which fires before
+ * SSatoms initialises, and at that point atom/New() deliberately skips Initialize(). No
+ * Initialize means no setup_reskins(), so the component would not exist yet to be found.
+ * Running on first use instead means SSatoms has long since finished.
+ *
+ * Only probes once per datum. Datums that declare reskin_datum themselves are left alone,
+ * as are those flagged LOADOUT_FLAG_BLOCK_RESKIN.
+ */
+/datum/loadout_item/proc/try_detect_reskin()
+	if(reskin_datum_checked || reskin_datum || (loadout_flags & LOADOUT_FLAG_BLOCK_RESKIN))
+		return
+	reskin_datum_checked = TRUE
+	if(!ispath(item_path, /obj/item))
+		return
+	var/obj/item/probe = new item_path(null)
+	// Some items delete themselves during Initialize (a lewd NIFSoft datadisk does exactly this when
+	// the lewd content config is off), and new() still hands back the reference. Touching it would
+	// runtime, and qdel'ing it a second time would throw.
+	if(QDELETED(probe))
+		return
+	// An item is allowed more than one of these, so ask for the list. If there is more than one we
+	// take the first, since the loadout menu only has room for a single set of styles.
+	var/list/found = probe.GetComponents(/datum/component/reskinable_item)
+	if(length(found))
+		var/datum/component/reskinable_item/reskin_comp = found[1]
+		reskin_datum = reskin_comp.get_base_reskin_type()
+	qdel(probe)
+// BUBBER EDIT ADDITION END
 
 /**
  * Returns a formatted list of data for this loadout item.
  */
 /datum/loadout_item/proc/to_ui_data() as /list
 	SHOULD_CALL_PARENT(TRUE)
+	try_detect_reskin() // BUBBER EDIT ADDITION - Populate reskin_datum before the UI data is built
 
 	var/list/formatted_item = list()
 	var/list/information = list()

--- a/code/modules/loadout/loadout_items.dm
+++ b/code/modules/loadout/loadout_items.dm
@@ -55,9 +55,6 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 	/// Base typepath to what reskin datum this item can use to reskin into
 	/// Doesn't verify that the item_path actually has these reskins
 	var/datum/atom_skin/reskin_datum
-	// BUBBER EDIT ADDITION - Tracks whether reskin auto detection has already run for this datum.
-	var/reskin_datum_checked = FALSE
-	// BUBBER EDIT ADDITION END
 	/// A list of greyscale colors that are used for items that have greyscale support, but don't allow full customization.
 	/// This is an assoc list of /datum/job_department -> colors, or /datum/job -> colors, allowing for preset colors based on player chosen job.
 	/// Jobs are prioritized over departments.
@@ -336,7 +333,6 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 /datum/loadout_item/proc/on_equip_item(obj/item/equipped_item, list/item_details, mob/living/carbon/human/equipper, datum/outfit/outfit, visuals_only = FALSE)
 	if(isnull(equipped_item))
 		return NONE
-	try_detect_reskin() // BUBBER EDIT ADDITION - Populate reskin_datum before applying a saved skin
 
 	if(!visuals_only)
 		ADD_TRAIT(equipped_item, TRAIT_ITEM_OBJECTIVE_BLOCKED, TRAIT_SOURCE_LOADOUT)
@@ -368,25 +364,14 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 
 	if(reskin_datum && item_details?[INFO_RESKIN])
 		var/skin_chosen = item_details[INFO_RESKIN]
-		// BUBBER EDIT CHANGE START - Prefer the component when the item has one
-		// Applying a skin directly leaves the component untouched: current_skin stays null and
-		// COMSIG_OBJ_RESKIN never fires, so items that track their own colour var never learn about
-		// the change and revert the moment something calls update_icon_state(). Going through the
-		// component takes the same path an in game alt click would.
-		// The item can carry more than one of these. The pride pin does: it has the base game's set of
-		// flags plus a second set added downstream. Match on the skin type we actually want, or we
-		// might hand the chosen name to the wrong set and get nothing.
-		var/datum/component/reskinable_item/reskin_comp
-		for(var/datum/component/reskinable_item/candidate as anything in equipped_item.GetComponents(/datum/component/reskinable_item))
-			if(candidate.get_base_reskin_type() == reskin_datum)
-				reskin_comp = candidate
-				break
-		if(reskin_comp)
-			reskin_comp.set_skin_by_name(skin_chosen)
-			// Mirror reskin_obj(): a component that only allows one skin is spent once that skin is
-			// picked, so drop it. Leaving it alive would swallow every later alt click on the item.
-			if(!reskin_comp.get_infinite_reskin())
-				qdel(reskin_comp)
+		var/list/atom_skins = get_atom_skins()
+		for(var/datum/atom_skin/skin_path as anything in valid_subtypesof(reskin_datum))
+			if(skin_path::preview_name != skin_chosen)
+				continue
+			if(skin_path::preview_name != skin_chosen)
+				continue
+			var/datum/atom_skin/skin_instance = atom_skins[skin_path]
+			skin_instance.apply(equipped_item)
 			if(istype(equipped_item, /obj/item/clothing/accessory))
 				// Snowflake handing for accessories, because we need to update the thing it's attached to instead
 				if(isclothing(equipped_item.loc))
@@ -395,66 +380,15 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 					update_flag |= (ITEM_SLOT_OCLOTHING|ITEM_SLOT_ICLOTHING)
 			else
 				update_flag |= equipped_item.slot_flags
-		else
-			var/list/atom_skins = get_atom_skins()
-			for(var/datum/atom_skin/skin_path as anything in valid_subtypesof(reskin_datum))
-				if(skin_path::preview_name != skin_chosen)
-					continue
-				var/datum/atom_skin/skin_instance = atom_skins[skin_path]
-				skin_instance.apply(equipped_item)
-				if(istype(equipped_item, /obj/item/clothing/accessory))
-					// Snowflake handing for accessories, because we need to update the thing it's attached to instead
-					if(isclothing(equipped_item.loc))
-						var/obj/item/clothing/under/attached_to = equipped_item.loc
-						attached_to.update_accessory_overlay()
-						update_flag |= (ITEM_SLOT_OCLOTHING|ITEM_SLOT_ICLOTHING)
-				else
-					update_flag |= equipped_item.slot_flags
-				break
-		// BUBBER EDIT CHANGE END
+			break
 
 	return update_flag
-
-// BUBBER EDIT ADDITION START - Automatic reskin detection
-/**
- * Checks item_path for a reskinable_item component and adopts its skin type, so that any item
- * which supports alt click reskinning in game also offers skin selection in the loadout.
- *
- * This cannot run in New(). Loadout datums are built by GLOBAL_LIST_INIT, which fires before
- * SSatoms initialises, and at that point atom/New() deliberately skips Initialize(). No
- * Initialize means no setup_reskins(), so the component would not exist yet to be found.
- * Running on first use instead means SSatoms has long since finished.
- *
- * Only probes once per datum. Datums that declare reskin_datum themselves are left alone,
- * as are those flagged LOADOUT_FLAG_BLOCK_RESKIN.
- */
-/datum/loadout_item/proc/try_detect_reskin()
-	if(reskin_datum_checked || reskin_datum || (loadout_flags & LOADOUT_FLAG_BLOCK_RESKIN))
-		return
-	reskin_datum_checked = TRUE
-	if(!ispath(item_path, /obj/item))
-		return
-	var/obj/item/probe = new item_path(null)
-	// Some items delete themselves during Initialize (a lewd NIFSoft datadisk does exactly this when
-	// the lewd content config is off), and new() still hands back the reference. Touching it would
-	// runtime, and qdel'ing it a second time would throw.
-	if(QDELETED(probe))
-		return
-	// An item is allowed more than one of these, so ask for the list. If there is more than one we
-	// take the first, since the loadout menu only has room for a single set of styles.
-	var/list/found = probe.GetComponents(/datum/component/reskinable_item)
-	if(length(found))
-		var/datum/component/reskinable_item/reskin_comp = found[1]
-		reskin_datum = reskin_comp.get_base_reskin_type()
-	qdel(probe)
-// BUBBER EDIT ADDITION END
 
 /**
  * Returns a formatted list of data for this loadout item.
  */
 /datum/loadout_item/proc/to_ui_data() as /list
 	SHOULD_CALL_PARENT(TRUE)
-	try_detect_reskin() // BUBBER EDIT ADDITION - Populate reskin_datum before the UI data is built
 
 	var/list/formatted_item = list()
 	var/list/information = list()

--- a/code/modules/loadout/loadout_items.dm
+++ b/code/modules/loadout/loadout_items.dm
@@ -55,6 +55,9 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 	/// Base typepath to what reskin datum this item can use to reskin into
 	/// Doesn't verify that the item_path actually has these reskins
 	var/datum/atom_skin/reskin_datum
+	// BUBBER EDIT ADDITION - Tracks whether reskin auto detection has already run for this datum.
+	var/reskin_datum_checked = FALSE
+	// BUBBER EDIT ADDITION END
 	/// A list of greyscale colors that are used for items that have greyscale support, but don't allow full customization.
 	/// This is an assoc list of /datum/job_department -> colors, or /datum/job -> colors, allowing for preset colors based on player chosen job.
 	/// Jobs are prioritized over departments.
@@ -333,6 +336,7 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 /datum/loadout_item/proc/on_equip_item(obj/item/equipped_item, list/item_details, mob/living/carbon/human/equipper, datum/outfit/outfit, visuals_only = FALSE)
 	if(isnull(equipped_item))
 		return NONE
+	try_detect_reskin() // BUBBER EDIT ADDITION - Populate reskin_datum before applying a saved skin
 
 	if(!visuals_only)
 		ADD_TRAIT(equipped_item, TRAIT_ITEM_OBJECTIVE_BLOCKED, TRAIT_SOURCE_LOADOUT)
@@ -364,14 +368,25 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 
 	if(reskin_datum && item_details?[INFO_RESKIN])
 		var/skin_chosen = item_details[INFO_RESKIN]
-		var/list/atom_skins = get_atom_skins()
-		for(var/datum/atom_skin/skin_path as anything in valid_subtypesof(reskin_datum))
-			if(skin_path::preview_name != skin_chosen)
-				continue
-			if(skin_path::preview_name != skin_chosen)
-				continue
-			var/datum/atom_skin/skin_instance = atom_skins[skin_path]
-			skin_instance.apply(equipped_item)
+		// BUBBER EDIT CHANGE START - Prefer the component when the item has one
+		// Applying a skin directly leaves the component untouched: current_skin stays null and
+		// COMSIG_OBJ_RESKIN never fires, so items that track their own colour var never learn about
+		// the change and revert the moment something calls update_icon_state(). Going through the
+		// component takes the same path an in game alt click would.
+		// The item can carry more than one of these. The pride pin does: it has the base game's set of
+		// flags plus a second set added downstream. Match on the skin type we actually want, or we
+		// might hand the chosen name to the wrong set and get nothing.
+		var/datum/component/reskinable_item/reskin_comp
+		for(var/datum/component/reskinable_item/candidate as anything in equipped_item.GetComponents(/datum/component/reskinable_item))
+			if(candidate.get_base_reskin_type() == reskin_datum)
+				reskin_comp = candidate
+				break
+		if(reskin_comp)
+			reskin_comp.set_skin_by_name(skin_chosen)
+			// Mirror reskin_obj(): a component that only allows one skin is spent once that skin is
+			// picked, so drop it. Leaving it alive would swallow every later alt click on the item.
+			if(!reskin_comp.get_infinite_reskin())
+				qdel(reskin_comp)
 			if(istype(equipped_item, /obj/item/clothing/accessory))
 				// Snowflake handing for accessories, because we need to update the thing it's attached to instead
 				if(isclothing(equipped_item.loc))
@@ -380,15 +395,71 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 					update_flag |= (ITEM_SLOT_OCLOTHING|ITEM_SLOT_ICLOTHING)
 			else
 				update_flag |= equipped_item.slot_flags
-			break
+		else
+			var/list/atom_skins = get_atom_skins()
+			for(var/datum/atom_skin/skin_path as anything in valid_subtypesof(reskin_datum))
+				if(skin_path::preview_name != skin_chosen)
+					continue
+				var/datum/atom_skin/skin_instance = atom_skins[skin_path]
+				skin_instance.apply(equipped_item)
+				if(istype(equipped_item, /obj/item/clothing/accessory))
+					// Snowflake handing for accessories, because we need to update the thing it's attached to instead
+					if(isclothing(equipped_item.loc))
+						var/obj/item/clothing/under/attached_to = equipped_item.loc
+						attached_to.update_accessory_overlay()
+						update_flag |= (ITEM_SLOT_OCLOTHING|ITEM_SLOT_ICLOTHING)
+				else
+					update_flag |= equipped_item.slot_flags
+				break
+		// BUBBER EDIT CHANGE END
 
 	return update_flag
+
+// BUBBER EDIT ADDITION START - Automatic reskin detection
+/**
+ * Checks item_path for a reskinable_item component and adopts its skin type, so that any item
+ * which supports alt click reskinning in game also offers skin selection in the loadout.
+ *
+ * This cannot run in New(). Loadout datums are built by GLOBAL_LIST_INIT, which fires before
+ * SSatoms initialises, and at that point atom/New() deliberately skips Initialize(). No
+ * Initialize means no setup_reskins(), so the component would not exist yet to be found.
+ * Running on first use instead means SSatoms has long since finished.
+ *
+ * Only probes once per datum. Datums that declare reskin_datum themselves are left alone,
+ * as are those flagged LOADOUT_FLAG_BLOCK_RESKIN.
+ */
+/datum/loadout_item/proc/try_detect_reskin()
+	if(reskin_datum_checked || reskin_datum || (loadout_flags & LOADOUT_FLAG_BLOCK_RESKIN))
+		return
+	reskin_datum_checked = TRUE
+	if(!ispath(item_path, /obj/item))
+		return
+	// Mob holders carry a live creature. Building one spawns the creature inside it, and deleting it
+	// then tries to drop that creature on the floor. There is no floor here, so it throws. They never
+	// have skins anyway, so leave them alone.
+	if(ispath(item_path, /obj/item/mob_holder))
+		return
+	var/obj/item/probe = new item_path(null)
+	// Some items delete themselves during Initialize (a lewd NIFSoft datadisk does exactly this when
+	// the lewd content config is off), and new() still hands back the reference. Touching it would
+	// runtime, and qdel'ing it a second time would throw.
+	if(QDELETED(probe))
+		return
+	// An item is allowed more than one of these, so ask for the list. If there is more than one we
+	// take the first, since the loadout menu only has room for a single set of styles.
+	var/list/found = probe.GetComponents(/datum/component/reskinable_item)
+	if(length(found))
+		var/datum/component/reskinable_item/reskin_comp = found[1]
+		reskin_datum = reskin_comp.get_base_reskin_type()
+	qdel(probe)
+// BUBBER EDIT ADDITION END
 
 /**
  * Returns a formatted list of data for this loadout item.
  */
 /datum/loadout_item/proc/to_ui_data() as /list
 	SHOULD_CALL_PARENT(TRUE)
+	try_detect_reskin() // BUBBER EDIT ADDITION - Populate reskin_datum before the UI data is built
 
 	var/list/formatted_item = list()
 	var/list/information = list()

--- a/modular_skyrat/master_files/code/modules/loadout/categories/donator_personal.dm
+++ b/modular_skyrat/master_files/code/modules/loadout/categories/donator_personal.dm
@@ -25,9 +25,6 @@
 /datum/loadout_item/uniform/black_turtleneck
 	name = "Black turtleneck"
 	item_path = /obj/item/clothing/under/syndicate/tacticool/black
-	// This variant has its own icon file. The skins it inherits from tacticool point at states in the
-	// parent's file, so applying one breaks its sprite.
-	loadout_flags = parent_type::loadout_flags | LOADOUT_FLAG_BLOCK_RESKIN
 	//ckeywhitelist = list("thedragmeme")
 
 /datum/loadout_item/suit/ryddid

--- a/modular_skyrat/master_files/code/modules/loadout/categories/donator_personal.dm
+++ b/modular_skyrat/master_files/code/modules/loadout/categories/donator_personal.dm
@@ -25,6 +25,9 @@
 /datum/loadout_item/uniform/black_turtleneck
 	name = "Black turtleneck"
 	item_path = /obj/item/clothing/under/syndicate/tacticool/black
+	// This variant has its own icon file. The skins it inherits from tacticool point at states in the
+	// parent's file, so applying one breaks its sprite.
+	loadout_flags = parent_type::loadout_flags | LOADOUT_FLAG_BLOCK_RESKIN
 	//ckeywhitelist = list("thedragmeme")
 
 /datum/loadout_item/suit/ryddid

--- a/modular_skyrat/modules/modular_implants/code/nifsofts.dm
+++ b/modular_skyrat/modules/modular_implants/code/nifsofts.dm
@@ -183,11 +183,6 @@
 
 	name = "[initial(loaded_nifsoft.name)] datadisk"
 
-/// Datadisks use their own icon file, so the coloured skins inherited from /obj/item/disk do not
-/// exist for them. Applying one blanks the sprite, so don't offer them at all.
-/obj/item/disk/nifsoft_uploader/setup_reskins()
-	return
-
 /obj/item/disk/nifsoft_uploader/examine(mob/user)
 	. = ..()
 

--- a/modular_skyrat/modules/modular_implants/code/nifsofts.dm
+++ b/modular_skyrat/modules/modular_implants/code/nifsofts.dm
@@ -183,6 +183,11 @@
 
 	name = "[initial(loaded_nifsoft.name)] datadisk"
 
+/// Datadisks use their own icon file, so the coloured skins inherited from /obj/item/disk do not
+/// exist for them. Applying one blanks the sprite, so don't offer them at all.
+/obj/item/disk/nifsoft_uploader/setup_reskins()
+	return
+
 /obj/item/disk/nifsoft_uploader/examine(mob/user)
 	. = ..()
 

--- a/modular_zubbers/code/datums/components/reskinnable_atom.dm
+++ b/modular_zubbers/code/datums/components/reskinnable_atom.dm
@@ -35,3 +35,12 @@
 
 /datum/component/reskinable_item/proc/has_skin()
 	return current_skin != null
+
+/// Returns the abstract skin type this component was set up with.
+/// Lets the loadout system detect reskin support without every loadout datum declaring it by hand.
+/datum/component/reskinable_item/proc/get_base_reskin_type()
+	return base_reskin_type
+
+/// Returns whether this component permits unlimited reskins.
+/datum/component/reskinable_item/proc/get_infinite_reskin()
+	return infinite_reskin

--- a/modular_zubbers/code/datums/components/reskinnable_atom.dm
+++ b/modular_zubbers/code/datums/components/reskinnable_atom.dm
@@ -35,12 +35,3 @@
 
 /datum/component/reskinable_item/proc/has_skin()
 	return current_skin != null
-
-/// Returns the abstract skin type this component was set up with.
-/// Lets the loadout system detect reskin support without every loadout datum declaring it by hand.
-/datum/component/reskinable_item/proc/get_base_reskin_type()
-	return base_reskin_type
-
-/// Returns whether this component permits unlimited reskins.
-/datum/component/reskinable_item/proc/get_infinite_reskin()
-	return infinite_reskin

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/loadout/ItemDisplay.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/loadout/ItemDisplay.tsx
@@ -18,9 +18,21 @@ type Props = {
 };
 
 export function ItemIcon(props: Props) {
+  const { data } = useBackend<LoadoutManagerData>();
   const { item, scale = 3 } = props;
-  const icon_to_use = item.icon;
-  const icon_state_to_use = item.icon_state;
+  let icon_to_use = item.icon;
+  let icon_state_to_use = item.icon_state;
+  // BUBBER EDIT ADDITION START - Show the picked style on the item's icon
+  const loadout_list = data.character_preferences.misc.loadout_lists.loadout;
+  const selected = loadout_list?.[item.path];
+  if (item.reskins && selected && !Array.isArray(selected)) {
+    const picked = item.reskins.find((skin) => skin.name === selected.reskin);
+    if (picked) {
+      icon_to_use = picked.skin_icon || item.icon;
+      icon_state_to_use = picked.skin_icon_state;
+    }
+  }
+  // BUBBER EDIT ADDITION END
   //BUBBER EDIT START - dyamic uniforms
   if (item.image) {
     return (


### PR DESCRIPTION
## About The Pull Request

That's right. The brand new Pre-Initialization Skin System!

<img width="602" height="328" alt="image" src="https://github.com/user-attachments/assets/26653912-7c54-4980-b397-cfd241d8d33e" />

A lot of items in this codebase have alternate skins. The mech pilot suit is the obvious one and also the most important one for me particularly: red, white, blue, black. Normally, you get at them by alt-clicking the item in game. This is kind of a pain in the ass if you happen to have multiple items which require reskinning in your loadout (Every damn shift!!!), and I saw the potential to make things just a little more frictionless. When I started investigating the issue, I saw it:  the loadout menu already had a skin picker for this. The sprite buttons, the "Reskinnable" badge, the saving, the applying at spawn. 

Everything I needed, all of it, already built, sitting right there next to Rename and the GAGS colors. The problem is that the loadout menu only switched this function on if a loadout entry declared `reskin_datum` by hand, and exactly one item in the entire codebase ever did that: the pride pin.

What this PR does is make the functionality automatic by default. Any item that already has a `reskinable_item` component now offers its skins in the loadout config screen automatically. Items that can be reskinned in this way have a color swatch icon on them. 

### Opting out

If, for some unknowable reason you don't want an item you add to be reskinnable, I really cannot fathom why you would want this. I thought of that too and `LOADOUT_FLAG_BLOCK_RESKIN` can be appended to your item to turn detection off for a single loadout entry. Two things needed it because they're made in a way where the game thinks they have alternate sprites, but don't actually. 

1. NIFSoft datadisks inherit the colored floppy disk skins. Picking one made the disk invisible. This issue is fixed as collateral of this PR. 
2. The black turtleneck donator variant tries to use the "tacticool" skins, but it cannot actually do that. So it fails, I took the easy way out because I didn't want to devote any additional time to solving the problem. 

I checked other items for this problem, but only those two are loadout items, and I already solved the problem, this is just something to bear in mind if you happen to be adding reskinnable loadout items spcifically. 

## Why It's Good For The Game

Getting a character set up at round start is annoying. The game already tends to spawn our colorful blorbos wearing a whole mess of things they immediately trash because they don't actually want to wear them. One small solution is this, reducing the need to alt-click half your loadout to put it back the way you like it (Dtramatization). There is no decision in that, and no gameplay in it either. It is just a small tedium task. 

The other half of it is that this feature was already made. Someone built the whole thing and connected it to one item. This PR just enables vestigial functionality. 

## Proof Of Testing

Compiled and run locally. Loaded myself up with as many reskinnable items as possible before joining, and it worked just fine. 

<img width="1686" height="818" alt="image" src="https://github.com/user-attachments/assets/66fa7d3d-3e15-4a92-84f3-394dfecf10c7" />
<img width="702" height="484" alt="image" src="https://github.com/user-attachments/assets/b4597573-0da5-4561-9216-a39c27edf17c" />

## Changelog

:cl: Aeri
qol: You can set an item's alternate skin in the loadout menu now, in the same place you rename it or pick its colors. Anything you could alt-click to reskin in game will offer its skins up front.
/:cl: