### PR TITLE
QA repair PR Alpha. 

### DIFF
--- a/code/modules/unit_tests/create_and_destroy.dm
+++ b/code/modules/unit_tests/create_and_destroy.dm
@@ -63,10 +63,22 @@ GLOBAL_VAR_INIT(running_create_and_destroy, FALSE)
 			creation = null
 
 		//There's a lot of stuff that either spawns stuff in on create, or removes stuff on destroy. Let's cut it all out so things are easier to deal with
+		// BUBBER EDIT REMOVAL START - this loop leaves refs on the stack, see the addition below
+		/*
 		var/list/to_del = spawn_at.contents - cached_contents
 		if(length(to_del))
 			for(var/atom/to_kill in to_del)
 				qdel(to_kill)
+		*/
+		// BUBBER EDIT REMOVAL END
+		// BUBBER EDIT ADDITION START - stack refs held across the gc sleep hard delete the last atom in our slice
+		var/list/to_del = spawn_at.contents - cached_contents
+		for(var/i in 1 to length(to_del))
+			qdel(to_del[i])
+			//the list outlives the loop and byond won't drop it for us
+			to_del[i] = null
+		to_del = null
+		// BUBBER EDIT ADDITION END
 
 	GLOB.running_create_and_destroy = FALSE
 


### PR DESCRIPTION
## About The Pull Request

`create_and_destroy` is currently failing a **lot** across random shit across most open PRs, and the atom is usually nothing to do with the PR. One of mine "broke" a hypospray by adding something to cargo.

Bad news: the leak detector? leakingggggg. It holds onto the last thing it cleans up, so that thing can never be collected, and the test reports it as a failure.

The tell is in the log. It says the atom has a ref count of three, then the search finds one ref, and that one does not count. So two refs exist that the search cannot find. The ref search looks through globals, atoms, datums and clients. It does not look at the stack of the proc that is currently running.

Here is the cleanup at the bottom of each loop in the test:

```dm
var/list/to_del = spawn_at.contents - cached_contents
if(length(to_del))
	for(var/atom/to_kill in to_del)
		qdel(to_kill)
```

Two things here stay alive after the loop ends: the `to_del` list, which still contains the atom, and `to_kill`, which still points at it. Then the test sleeps for the whole garbage collection wait while still holding both. That is two refs, in the one place nobody is looking, on the last atom the runner touched.

Three, minus the one that does not count, leaves two. There are exactly two.

Ten lines further up, the same file already nulls `creation` for this exact reason, and the comment there says [sic] byond is fucking sinful. Somebody hit this before and fixed half of it. The list right underneath never got the same treatment. Upstream has the same loop.

The fix deletes by index, clears each slot as it goes, and drops the list before the sleep. Same atoms, same order, nothing left holding on.

**Why it looks random:** the test is split across the CI runners, so each runner does a chunk. Only the last atom in a chunk gets stuck. Add or remove any type anywhere in the game and every chunk boundary moves, so a different unlucky atom takes the hit. Hence a cargo item breaking a hypospray.

That hypospray is a neat example, actually. The chunk in that run ended on `/obj/item/storage/hypospraykit/cmo`. When that kit is deleted it drops any indestructible item inside it onto the floor, and the CMO hypo is indestructible. So the kit dies, the hypo lands on the turf, the cleanup loop picks it up, and then never lets go. The comment on that `Destroy()` proc says it is a large block to stop the CI Gods smiting us, so somebody was already at least vaguely aware of this.

# Side note, upstream comparison

I went and looked at tg's copy of this file to ask the question "WHY THE FUCK DOESN'T THIS HAPPEN TO THEM TOO?"

First, the bug is actually technically there too.

Second, and much more insightfully,: tg's is programmed to delete the leftovers with qdel(to_kill, force = TRUE). We do qdel(to_kill). The "force" got dropped somewhere along the way and there's no BUBBER EDIT marker on it so I have no idea who to blame, so let's just say for the sake of argument that I think the file just drifted from an older tg version and nobody noticed. That matters because without force, an item that's flagged indestructible can go "nuh uh", which is exactly what the CMO hypo does. I've left that out of this PR on purpose for scope reasons, but would be happy to as a follow up if people want it.

As for why this hurts us and not them: we have so much wacky goddamn bullshit packed into this codebase that it's coming out of the walls. Nearly thirty thousand atom types, because our code is tg plus Skyrat plus Zubbers plus... Probably some other shit who knows. The bug only manifests when the last item in a test leaves something behind on the floor when it dies, and downstream content does that a lot more than tg content does. Kits, cases, storage items, things that drop their contents. The item that broke my PR is a Skyrat dohicky:tm: that doesn't exist on TG. 

So tg has the same minefield, we just boldly decided we wanted to add more landmines to make it interesting over a period of like, uh, how old is our codebase? 

## Why It's Good For The Game

Red CI that means nothing teaches everyone to ignore red CI. A new contributor's first experience here should not be a test failure about kudzu seeds on a PR that adds a hat. It also just generally wastes everyone's time for no good reason.

If this holds up it is worth sending to tg, since they have the same loop. Somebody who isn't me will have to do it because I resent TG. 

## Proof Of Testing or lack thereof

Being upfront: this is a test-only change and I literally can't possibly test it.

I cannot reproduce it locally in any useful way. My PC can't and won't be able to reproduce this error no matter what, as far as I can tell. 

What I can offer instead:

1. The count. Three refs reported, one found, one of those does not count. Two missing. There are exactly two things held on the stack across that sleep. I cannot come up with another explanation for that.
2. A prediction you can check. If I've managed to do this right, every past failure of this nature should be the last type in the chunk range the test prints, or something that type leaves on the floor when it dies. The hypospray fits exactly. If anyone has an old failure that does not match the pattern, please show me, because that would mean there is a second thing going on and this is only part of the answer.
3. This PR's own CI run, which is the same test on the same setup.

If I'm right, this fix will touch one unit test file and never compiles into a live server. The new loop deletes the same things in the same order as the old one. If I am wrong about the cause, CI just stays as flaky as it already is. This shouldn't be able to break the game or fuck the test up so severely that it no longer functions for the purpose of actually catching problems.

Happy to be told I have misread it; would **love** to be told that I fucked up and that I need to do XYZ instead. I would rather be corrected than have this terrifying "Do surgery on your own neurosurgeon while lying down on an operating table" tier change. **PLEASE CHECK MY WORK FOR THE LOVE OF GOD**

<img width="264" height="350" alt="image" src="https://github.com/user-attachments/assets/d19ec8e2-1889-4aba-a852-ea13478efa19" />


## Changelog

:cl: Aeri
code: create_and_destroy no longer holds onto the last atom it cleans up, which was causing unrelated hard delete failures across a wide array of PRs
/:cl: