### PR TITLE
I have been informed that ERP is default set to on, should I have realized this way sooner? Yes. Did I? No.

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences/erp_preferences.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/erp_preferences.dm
@@ -15,7 +15,7 @@
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
 	savefile_key = "master_erp_pref"
 	savefile_identifier = PREFERENCE_PLAYER
-	default_value = TRUE
+	default_value = FALSE
 
 /datum/preference/toggle/master_erp_preferences/is_accessible(datum/preferences/preferences)
 	if (!..(preferences))
@@ -158,7 +158,7 @@
 	)
 
 /datum/preference/choiced/erp_status/create_default_value()
-	return "Ask (L)OOC"
+	return "No"
 
 /datum/preference/choiced/erp_status/is_accessible(datum/preferences/preferences)
 	if (!..(preferences))


### PR DESCRIPTION
ERP was set to default enabled/ask looc, whoops
## About The Pull Request
Sets the default ERP settings to OFF, and the default ERP status in character creator to NO.
## Why It's Good For The Game
Sexy times are fun and all, and we are an 18+ server, however our friends that do not engage in sins should not have to opt out, instead the system should be opt in.
## Proof Of Testing
<img width="237" height="28" alt="image" src="https://github.com/user-attachments/assets/b937f4aa-beef-4493-901e-aa78cce8ba6c" />

I'm ngl this is 100% a "Source:dude trust me" but I pawmise it works
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
config: ERP is now an Opt-In system, rather than an opt-out
/:cl:
