### PR TITLE
Fixes the synthbrain transfer on special

### DIFF
--- a/modular_skyrat/modules/synths/code/bodyparts/brain.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/brain.dm
@@ -54,6 +54,7 @@
 	. = ..()
 	if(stored_mmi?.brainmob?.mind && stored_mmi.brainmob.mind.current == stored_mmi.brainmob)
 		stored_mmi.brainmob.mind.transfer_to(brain_owner)
+		QDEL_NULL(stored_mmi.brainmob)
 
 	if(brain_owner.stat == DEAD && ishuman(brain_owner))
 		var/mob/living/carbon/human/user_human = brain_owner
@@ -65,7 +66,8 @@
 
 /obj/item/organ/brain/synth/on_mob_remove(mob/living/carbon/organ_owner, special, movement_flags)
 	. = ..()
-	cache_brainmob_into_stored_mmi(organ_owner)
+	if(!(movement_flags & NO_ID_TRANSFER))
+		cache_brainmob_into_stored_mmi(organ_owner)
 
 	UnregisterSignal(organ_owner, COMSIG_MOB_EQUIPPED_ITEM)
 	UnregisterSignal(organ_owner, COMSIG_HUMAN_UNEQUIPPED_ITEM)


### PR DESCRIPTION
## About The Pull Request

I love sitting down for a 30 minute bugfix, waiter, waiter, more issues please

closes #5953

The NO_ID_TRANSFER flag was not being respected by the silly MMI code, meaning your brainmob was set and deleted, kicking you out of your body.

Should also fix the ambience null runtime error, as that was caused by the same thing (special removed brains are in nullspace -> NO_ID brains shouldn't have a brainmob -> NO_ID special removed brains are QDEL'd in /datum/species/proc/regenerate_organs -> deleting one with an MMI brainmob that shouldn't be there kills the brainmob first -> killing the brainmob checks the loc for soundbased things, including ambience -> loc is null, runtime)

## Why It's Good For The Game

Bugfix good

## Proof Of Testing

[Screencast_20260803_161536.webm](https://github.com/user-attachments/assets/16f86ebd-0e05-4998-90d2-699d2d025e86)

## Changelog

:cl:
fix: Changing back to organic from synth no longer kicks you out of your body 
/:cl:

