### PR TITLE
Gibbing a synth no longer fucks up their brain

### DIFF
--- a/modular_skyrat/modules/synths/code/bodyparts/brain.dm
+++ b/modular_skyrat/modules/synths/code/bodyparts/brain.dm
@@ -32,7 +32,7 @@
 
 /obj/item/organ/brain/synth/Remove(mob/living/carbon/organ_owner, special = FALSE, movement_flags)
 	. = ..()
-	if(!istype(stored_mmi) || special)
+	if(!istype(stored_mmi) || special || loc == null)
 		return
 	stored_mmi.brain = src
 	organ_flags |= ORGAN_FROZEN


### PR DESCRIPTION
## About The Pull Request

Reported by LYDIA

Being gibbed or in other ways special organ handled might mean your brain is in nullspace. This would make all the following brain/Remove() handling fuckup and make you deaf and mute. 

Also seemingly fixes the weird humanification of synthbrains upon being reinserted.

## Why It's Good For The Game

Bugfix good

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

<img width="280" height="244" alt="image" src="https://github.com/user-attachments/assets/77cb4206-4785-41c3-9f2f-e9f27a07cda5" />

</details>

## Changelog

:cl:
fix: Getting gibbed as synth no longer fucks up your brain in ways that make maintainers cry from nightmares at 3 AM
/:cl:

