### PR TITLE
fixes body_size incrementally updating the transform

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences/body_size.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/body_size.dm
@@ -11,7 +11,7 @@
 	return passed_initial_check
 
 /datum/preference/numeric/body_size/apply_to_human(mob/living/carbon/human/target, value)
-	target.update_transform(value)
+	target.update_transform(value / target.current_size)
 
 /datum/preference/numeric/body_size/create_default_value()
 	return RESIZE_DEFAULT_SIZE


### PR DESCRIPTION

## About The Pull Request

<img width="306" height="297" alt="image" src="https://github.com/user-attachments/assets/6ec090d0-110e-40e7-8a74-12c8f45a68f5" />

A recent change switched the variable assignment to a proc that changes the transform, but it is incrementally transforming it rather than setting a fixed size which now ends up with the scale being multiplied each time you change something in the character screen.
## Why It's Good For The Game

the character preview no longer changes the size at every change.

this also closes #6057
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

before:

https://github.com/user-attachments/assets/9032fd23-9d00-43dd-9e10-687971b5b879

after:

https://github.com/user-attachments/assets/a7bee087-c9ae-42d2-aa64-1bda539aa7db

</details>

## Changelog
:cl:
fix: body_size being reapplied multiple times
/:cl:
