### PR TITLE
Fixes the size collar

### DIFF
--- a/code/__DEFINES/~~bubber_defines/mobs.dm
+++ b/code/__DEFINES/~~bubber_defines/mobs.dm
@@ -56,3 +56,7 @@
 #define PENIS_LAYER_OFFSET 0.03
 #define BELLY_LAYER_OFFSET 0.02
 #define BREASTS_LAYER_OFFSET 0.01
+
+// Maximum and minimum size we can set in the character creator
+#define BODY_SIZE_MIN (RESIZE_DEFAULT_SIZE * 0.8)
+#define BODY_SIZE_MAX (RESIZE_DEFAULT_SIZE * 1.5)

--- a/modular_skyrat/master_files/code/modules/client/preferences/body_size.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/body_size.dm
@@ -2,8 +2,8 @@
 	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "body_size"
-	minimum = RESIZE_DEFAULT_SIZE * 0.8
-	maximum = RESIZE_DEFAULT_SIZE * 1.5
+	minimum = BODY_SIZE_MIN
+	maximum = BODY_SIZE_MAX
 	step = 0.01
 
 /datum/preference/numeric/body_size/is_accessible(datum/preferences/preferences)
@@ -12,6 +12,7 @@
 
 /datum/preference/numeric/body_size/apply_to_human(mob/living/carbon/human/target, value)
 	target.update_transform(value)
+	target.dna.current_body_size = value
 
 /datum/preference/numeric/body_size/create_default_value()
 	return RESIZE_DEFAULT_SIZE

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/size_items.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_items/size_items.dm
@@ -83,7 +83,7 @@
 		return COMPONENT_INCOMPATIBLE
 
 	var/mob/living/carbon/human/human_parent = parent
-	original_size = human_parent.mob_size
+	original_size = human_parent.dna.current_body_size
 
 	if(!original_size) //If we aren't able to get the original size, we shouldn't exist.
 		return COMPONENT_INCOMPATIBLE
@@ -112,7 +112,7 @@
 	if(isteshari(human_parent) || isvoxprimalis(human_parent)) // We check if the human_parent is a Vox Primalis or Teshari & temporarily disable the bodysize restriction
 		human_parent.dna.species.body_size_restricted = FALSE
 
-	human_parent.update_transform(size_to_apply)
+	human_parent.update_transform(size_to_apply / human_parent.current_size)
 	return TRUE
 
 /datum/component/temporary_size/Destroy(force, silent)


### PR DESCRIPTION
## About The Pull Request

#6042 broke the size collar. The `original_size` variable was assigned improperly, resulting in the sprite size being doubled each time the size collar was unequipped. The PR also added a `current_body_size` variable to dna, but doesn't assign it to the dna upon character creation so I corrected that too (which I then used to assign the `original_size` variable in the size collar) That variable is used in one more place in code but from my limited testing my change SHOULDN'T break it.

That PR ALSO removed 2 defines that I think were pretty neat, so I brought them back too.

## Why It's Good For The Game

Fixes the size collar, removes some magic numbers.

## Proof Of Testing

<details>
<summary>Videos</summary>

https://github.com/user-attachments/assets/1cf8e05a-ec3f-4898-ace6-99fbb96ec823

</details>

## Changelog

:cl: Swan
fix: Fixes the size collar
/:cl: