### PR TITLE
Adds radiation and welding protection to elder atmos armor.

### DIFF
--- a/modular_zubbers/code/modules/clothing/head/helmet.dm
+++ b/modular_zubbers/code/modules/clothing/head/helmet.dm
@@ -682,8 +682,13 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	min_cold_protection_temperature = FIRE_HELM_MIN_TEMP_PROTECT
 	resistance_flags = FIRE_PROOF
+	flash_protect = FLASH_PROTECTION_WELDER
 	flags_inv = HIDEFACE | HIDEFACIALHAIR | HIDEHAIR | HIDEMASK | HIDEEYES | HIDEEARS
 	custom_materials = list(/datum/material/metalhydrogen = SHEET_MATERIAL_AMOUNT * 3)
+
+/obj/item/clothing/head/helmet/elder_atmosian/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/radiation_protected_clothing)
 
 /datum/armor/helmet_elder_atmosian
 	melee = 40

--- a/modular_zubbers/code/modules/clothing/suits/armor.dm
+++ b/modular_zubbers/code/modules/clothing/suits/armor.dm
@@ -99,6 +99,7 @@
 	allowed += list(
 		/obj/item/fireaxe/metal_h2_axe,
 	)
+	AddElement(/datum/element/radiation_protected_clothing)
 
 /datum/armor/armor_elder_atmosian
 	melee = 40


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

This is how it was intended to function, since the prerequisite helmet had welding protection but this doesn't for some reason and also it doesn't protect against radiation even though you're near the most radioactive things in the game so I fixed that.

## Proof Of Testing

<img width="471" height="45" alt="image" src="https://github.com/user-attachments/assets/752f90a6-16fd-40d4-94d1-f531ecf7b308" />
<img width="510" height="411" alt="Screenshot 2026-08-06 163545" src="https://github.com/user-attachments/assets/e3b62d2b-b426-4cc1-bf6a-75a6a3cfc739" />
<img width="461" height="415" alt="Screenshot 2026-08-06 163631" src="https://github.com/user-attachments/assets/3eb6c64e-8bd4-45af-a9ee-5d59171639ee" />


## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Adds welding and radiation protection to the elder atmosian armor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
