### PR TITLE
Ash Accretion no longer drops from maint loot

### DIFF
--- a/modular_zubbers/code/_globalvars/lists/maintenance_loot_uncommon.dm
+++ b/modular_zubbers/code/_globalvars/lists/maintenance_loot_uncommon.dm
@@ -366,7 +366,6 @@ GLOBAL_LIST_INIT(uncommon_loot, list(//uncommon: useful items
 		/obj/item/mod/construction/plating/engineering = 3,
 		/obj/item/mod/construction/plating/medical = 3,
 		/obj/item/mod/construction/plating/security = 1,
-		/obj/item/mod/module/ash_accretion = 5,
 		/obj/item/mod/module/atrocinator = 5,
 		/obj/item/mod/module/balloon = 100,
 		/obj/item/mod/module/bikehorn = 75,


### PR DESCRIPTION
## About The Pull Request

They're now innate to mining modsuits and are not intended to be obtained in other ways

closes #5012

## Why It's Good For The Game

Consistency fix.

## Proof Of Testing

Not really testable, it's a loot table change

## Changelog

:cl:
fix: Ash Accretion is now consistently innate to the mining mod and can't magically appear in maints
/:cl: