### PR TITLE
Nukes the necessity of having name1-name2-name3 for hydras in favor of having one full complete name, and then 3 seperate names for each head.

### DIFF
--- a/modular_skyrat/modules/hydra/code/neutral.dm
+++ b/modular_skyrat/modules/hydra/code/neutral.dm
@@ -30,8 +30,6 @@
 	QDEL_NULL(head_spell)
 	QDEL_NULL(reset_spell)
 	quirk_holder.real_name = original_name
-	QDEL_NULL(original_name)
-	QDEL_LIST(heads)
 
 /datum/quirk_constant_data/hydra
 	associated_typepath = /datum/quirk/hydra

--- a/modular_skyrat/modules/hydra/code/neutral.dm
+++ b/modular_skyrat/modules/hydra/code/neutral.dm
@@ -9,16 +9,12 @@
 	icon = FA_ICON_HORSE_HEAD
 	// remember what the name was before activation
 	var/original_name
+	var/heads_checked = FALSE
 	var/list/heads
 	var/datum/action/innate/hydra_head/head_spell
 	var/datum/action/innate/hydra_reset/reset_spell
 
 /datum/quirk/hydra/add(client/client_source)
-	heads = list(
-		client_source.prefs.read_preference(/datum/preference/text/hydra/name1),
-		client_source.prefs.read_preference(/datum/preference/text/hydra/name2),
-		client_source.prefs.read_preference(/datum/preference/text/hydra/name3),
-	)
 	head_spell = new()
 	reset_spell = new()
 	head_spell.Grant(quirk_holder)
@@ -67,10 +63,29 @@
 	var/datum/quirk/hydra/hydra_quirk = hydra.get_quirk(/datum/quirk/hydra)
 	if(!hydra_quirk.original_name) // sets the archived 'real' name if not set.
 		hydra_quirk.original_name = hydra.real_name
+
+	if(!hydra_quirk.heads_checked)
+		if(!hydra_quirk.check_heads())
+			to_chat(hydra, "Please set up all of your head names in the quirk menu to use this ability.")
+			return
+
+
 	var/selhead = tgui_input_list(hydra, "Who would you like to speak as?", "Head Selection", hydra_quirk.heads)
 	hydra.real_name = selhead
 	hydra.visible_message(span_notice("[hydra.name] pulls the rest of their heads back; and puts [selhead]'s forward."), \
 							span_notice("You are now talking as [selhead]!"), ignored_mobs=owner)
+
+/datum/quirk/hydra/proc/check_heads()
+	heads = list(
+		quirk_holder?.client?.prefs?.read_preference(/datum/preference/text/hydra/name1),
+		quirk_holder?.client?.prefs?.read_preference(/datum/preference/text/hydra/name2),
+		quirk_holder?.client?.prefs?.read_preference(/datum/preference/text/hydra/name3),
+	)
+	for(var/headname in heads)
+		if(headname == "")
+			return FALSE
+	heads_checked = TRUE
+	return TRUE
 
 /datum/action/innate/hydra_reset
 	name = "Reset Speech"

--- a/modular_skyrat/modules/hydra/code/neutral.dm
+++ b/modular_skyrat/modules/hydra/code/neutral.dm
@@ -38,6 +38,7 @@
 		/datum/preference/text/hydra/name2,
 		/datum/preference/text/hydra/name3,
 	)
+
 /datum/preference/text/hydra
 	abstract_type = /datum/preference/text/hydra
 	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED

--- a/modular_skyrat/modules/hydra/code/neutral.dm
+++ b/modular_skyrat/modules/hydra/code/neutral.dm
@@ -24,7 +24,7 @@
 	head_spell.Grant(quirk_holder)
 	reset_spell.Grant(quirk_holder)
 
-/datum/quirk/hydra/remove()
+/datum/quirk/hydra/remove(client/client_source)
 	head_spell.Remove(quirk_holder)
 	reset_spell.Remove(quirk_holder)
 	QDEL_NULL(head_spell)

--- a/modular_skyrat/modules/hydra/code/neutral.dm
+++ b/modular_skyrat/modules/hydra/code/neutral.dm
@@ -52,7 +52,7 @@
 /datum/preference/text/hydra/name3
 	savefile_key = "hydra__head_name3"
 
-/datum/preference/text/hydra/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences) //Unsure what this does. Revisit later
+/datum/preference/text/hydra/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	return FALSE
 
 /datum/action/innate/hydra_head

--- a/modular_skyrat/modules/hydra/code/neutral.dm
+++ b/modular_skyrat/modules/hydra/code/neutral.dm
@@ -30,6 +30,8 @@
 	QDEL_NULL(head_spell)
 	QDEL_NULL(reset_spell)
 	quirk_holder.real_name = original_name
+	QDEL_NULL(original_name)
+	QDEL_LIST(heads)
 
 /datum/quirk_constant_data/hydra
 	associated_typepath = /datum/quirk/hydra

--- a/modular_skyrat/modules/hydra/code/neutral.dm
+++ b/modular_skyrat/modules/hydra/code/neutral.dm
@@ -64,10 +64,9 @@
 	if(!hydra_quirk.original_name) // sets the archived 'real' name if not set.
 		hydra_quirk.original_name = hydra.real_name
 
-	if(!hydra_quirk.heads_checked)
-		if(!hydra_quirk.check_heads())
-			to_chat(hydra, "Please set up all of your head names in the quirk menu to use this ability.")
-			return
+	if(!hydra_quirk.check_heads())
+		to_chat(hydra, "Please set up all of your head names in the quirk menu to use this ability.")
+		return
 
 
 	var/selhead = tgui_input_list(hydra, "Who would you like to speak as?", "Head Selection", hydra_quirk.heads)
@@ -76,6 +75,8 @@
 							span_notice("You are now talking as [selhead]!"), ignored_mobs=owner)
 
 /datum/quirk/hydra/proc/check_heads()
+	if(hydra_quirk.heads_checked)
+		return TRUE
 	heads = list(
 		quirk_holder?.client?.prefs?.read_preference(/datum/preference/text/hydra/name1),
 		quirk_holder?.client?.prefs?.read_preference(/datum/preference/text/hydra/name2),

--- a/modular_skyrat/modules/hydra/code/neutral.dm
+++ b/modular_skyrat/modules/hydra/code/neutral.dm
@@ -9,10 +9,16 @@
 	icon = FA_ICON_HORSE_HEAD
 	// remember what the name was before activation
 	var/original_name
+	var/list/heads
 	var/datum/action/innate/hydra_head/head_spell
 	var/datum/action/innate/hydra_reset/reset_spell
 
 /datum/quirk/hydra/add(client/client_source)
+	heads = list(
+		quirk_holder.client.prefs.read_preference(/datum/preference/text/hydra/name1),
+		quirk_holder.client.prefs.read_preference(/datum/preference/text/hydra/name2),
+		quirk_holder.client.prefs.read_preference(/datum/preference/text/hydra/name3),
+	)
 	head_spell = new()
 	reset_spell = new()
 	head_spell.Grant(quirk_holder)
@@ -25,6 +31,30 @@
 	QDEL_NULL(reset_spell)
 	quirk_holder.real_name = original_name
 
+/datum/quirk_constant_data/hydra
+	associated_typepath = /datum/quirk/hydra
+	customization_options = list(
+		/datum/preference/text/hydra/name1,
+		/datum/preference/text/hydra/name2,
+		/datum/preference/text/hydra/name3,
+	)
+/datum/preference/text/hydra
+	abstract_type = /datum/preference/text/hydra
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_identifier = PREFERENCE_CHARACTER
+
+/datum/preference/text/hydra/name1
+	savefile_key = "hydra__head_name1"
+
+/datum/preference/text/hydra/name2
+	savefile_key = "hydra__head_name2"
+
+/datum/preference/text/hydra/name3
+	savefile_key = "hydra__head_name3"
+
+/datum/preference/text/hydra/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences) //Unsure what this does. Revisit later
+	return FALSE
+
 /datum/action/innate/hydra_head
 	name = "Switch head"
 	desc = "Switch between each of the heads on your body."
@@ -36,8 +66,7 @@
 	var/datum/quirk/hydra/hydra_quirk = hydra.get_quirk(/datum/quirk/hydra)
 	if(!hydra_quirk.original_name) // sets the archived 'real' name if not set.
 		hydra_quirk.original_name = hydra.real_name
-	var/list/names = splittext(hydra_quirk.original_name,"-")
-	var/selhead = input("Who would you like to speak as?","Heads:") in names
+	var/selhead = tgui_input_list(hydra, "Who would you like to speak as?", "Head Selection", hydra_quirk.heads)
 	hydra.real_name = selhead
 	hydra.visible_message(span_notice("[hydra.name] pulls the rest of their heads back; and puts [selhead]'s forward."), \
 							span_notice("You are now talking as [selhead]!"), ignored_mobs=owner)

--- a/modular_skyrat/modules/hydra/code/neutral.dm
+++ b/modular_skyrat/modules/hydra/code/neutral.dm
@@ -24,7 +24,7 @@
 	head_spell.Grant(quirk_holder)
 	reset_spell.Grant(quirk_holder)
 
-/datum/quirk/hydra/remove(client/client_source)
+/datum/quirk/hydra/remove()
 	head_spell.Remove(quirk_holder)
 	reset_spell.Remove(quirk_holder)
 	QDEL_NULL(head_spell)

--- a/modular_skyrat/modules/hydra/code/neutral.dm
+++ b/modular_skyrat/modules/hydra/code/neutral.dm
@@ -73,7 +73,7 @@
 							span_notice("You are now talking as [selhead]!"), ignored_mobs=owner)
 
 /datum/quirk/hydra/proc/check_heads()
-	if(hydra_quirk.heads_checked)
+	if(heads_checked)
 		return TRUE
 	heads = list(
 		quirk_holder?.client?.prefs?.read_preference(/datum/preference/text/hydra/name1),

--- a/modular_skyrat/modules/hydra/code/neutral.dm
+++ b/modular_skyrat/modules/hydra/code/neutral.dm
@@ -67,8 +67,6 @@
 	if(!hydra_quirk.check_heads())
 		to_chat(hydra, "Please set up all of your head names in the quirk menu to use this ability.")
 		return
-
-
 	var/selhead = tgui_input_list(hydra, "Who would you like to speak as?", "Head Selection", hydra_quirk.heads)
 	hydra.real_name = selhead
 	hydra.visible_message(span_notice("[hydra.name] pulls the rest of their heads back; and puts [selhead]'s forward."), \

--- a/modular_skyrat/modules/hydra/code/neutral.dm
+++ b/modular_skyrat/modules/hydra/code/neutral.dm
@@ -15,9 +15,9 @@
 
 /datum/quirk/hydra/add(client/client_source)
 	heads = list(
-		quirk_holder.client.prefs.read_preference(/datum/preference/text/hydra/name1),
-		quirk_holder.client.prefs.read_preference(/datum/preference/text/hydra/name2),
-		quirk_holder.client.prefs.read_preference(/datum/preference/text/hydra/name3),
+		client_source.prefs.read_preference(/datum/preference/text/hydra/name1),
+		client_source.prefs.read_preference(/datum/preference/text/hydra/name2),
+		client_source.prefs.read_preference(/datum/preference/text/hydra/name3),
 	)
 	head_spell = new()
 	reset_spell = new()

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/hydra.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/skyrat/hydra.tsx
@@ -1,0 +1,16 @@
+import { type Feature, FeatureShortTextInput } from '../../base';
+
+export const hydra__head_name1: Feature<string> = {
+  name: "First Head's name",
+  component: FeatureShortTextInput,
+};
+
+export const hydra__head_name2: Feature<string> = {
+  name: "Second Head's name",
+  component: FeatureShortTextInput,
+};
+
+export const hydra__head_name3: Feature<string> = {
+  name: "Third Head's name",
+  component: FeatureShortTextInput,
+};


### PR DESCRIPTION

## About The Pull Request
Title
## Why It's Good For The Game
Being locked into a name scheme is pretty limiting, and this allows players to do it the old way (by manually setting their name/head names to be like the old way) while also allowing players to choose a name for their character over all, and three sub-names for the three heads. 
## Proof Of Testing
<img width="1268" height="750" alt="image" src="https://github.com/user-attachments/assets/0493d6ef-f94f-4c27-bca4-44b82b573d42" />
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
qol: Hydra allows for a unique whole name, and choosable head names
/:cl:
