### PR TITLE
Various Cargoborg bugfixes

### DIFF
--- a/modular_skyrat/modules/borgs/code/robot_items.dm
+++ b/modular_skyrat/modules/borgs/code/robot_items.dm
@@ -372,13 +372,13 @@
 	return ITEM_INTERACT_SUCCESS
 
 
-/obj/item/borg/paperplane_crossbow/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+/obj/item/borg/paperplane_crossbow/ranged_interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	check_amount()
 	if(!iscyborg(user))
 		return ITEM_INTERACT_BLOCKING
 
 	var/mob/living/silicon/robot/robot_user = user
-	if(!robot_user.cell.use(10))
+	if(!robot_user.cell.use(STANDARD_CELL_CHARGE * 0.1))
 		to_chat(user, span_warning("Not enough power."))
 		return ITEM_INTERACT_BLOCKING
 	return shoot(interacting_with, user)

--- a/modular_skyrat/modules/borgs/code/robot_model.dm
+++ b/modular_skyrat/modules/borgs/code/robot_model.dm
@@ -313,7 +313,7 @@
 /obj/item/robot_model/cargo
 	name = "Cargo"
 	basic_modules = list(
-		/obj/item/stamp,
+		/obj/item/stamp/granted,
 		/obj/item/stamp/denied,
 		/obj/item/pen/cyborg,
 		/obj/item/clipboard/cyborg,


### PR DESCRIPTION


## About The Pull Request

Gives the Cargoborg their granted stamp back.
Also allows hacked cargoborgs to weaponize paperwork again by fixing the paper airplane crossbow launcher.

## Why It's Good For The Game

Cargoborg was due for bugfixes. 

## Proof Of Testing
<details>
<summary></summary>
<img width="730" height="353" alt="image" src="https://github.com/user-attachments/assets/67a026bc-ca64-4e36-85db-4a8f0acde16b" />


</details>

## Changelog


:cl: Zeerum, Odairu
fix: Cargoborgs have been given their granted stamp back
fix: Emagged cargoborgs can once again weaponize paperwork
/:cl:

