### PR TITLE
Fixes normalization items from making you a macro, much to the dismay of my kink enjoyment

### DIFF
--- a/modular_zubbers/code/datums/quirks/neutral_quirks/oversized/oversized_quirk.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/oversized/oversized_quirk.dm
@@ -17,7 +17,7 @@
 
 /datum/quirk/oversized/add(client/client_source)
 	var/mob/living/carbon/human/human_holder = quirk_holder
-	human_holder.update_transform(2 * RESIZE_DEFAULT_SIZE / human_holder?.client?.prefs?.read_preference(/datum/preference/numeric/body_size))
+	human_holder.update_transform(2 * RESIZE_DEFAULT_SIZE / human_holder.current_size)
 	human_holder.maxHealth = HUMAN_MAXHEALTH * OVERSIZED_HEALTH_BUFF
 	human_holder.health += ((HUMAN_MAXHEALTH * OVERSIZED_HEALTH_BUFF) - HUMAN_MAXHEALTH)
 

--- a/modular_zubbers/code/datums/quirks/neutral_quirks/oversized/oversized_quirk.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/oversized/oversized_quirk.dm
@@ -17,7 +17,7 @@
 
 /datum/quirk/oversized/add(client/client_source)
 	var/mob/living/carbon/human/human_holder = quirk_holder
-	human_holder.update_transform(2 * RESIZE_DEFAULT_SIZE)
+	human_holder.update_transform(2 * RESIZE_DEFAULT_SIZE / human_holder?.client?.prefs?.read_preference(/datum/preference/numeric/body_size))
 	human_holder.maxHealth = HUMAN_MAXHEALTH * OVERSIZED_HEALTH_BUFF
 	human_holder.health += ((HUMAN_MAXHEALTH * OVERSIZED_HEALTH_BUFF) - HUMAN_MAXHEALTH)
 

--- a/modular_zubbers/code/modules/clothing/clothing.dm
+++ b/modular_zubbers/code/modules/clothing/clothing.dm
@@ -20,8 +20,9 @@
 		flash_lighting_fx(3, 3, LIGHT_COLOR_YELLOW)
 		resizer.visible_message(span_warning("Golden light engulfs [resizer], and they shoot back to their default height!"), span_notice("Energy rushes through your body, and you return to normal."))
 		for(var/datum/quirk/oversized/oversized as anything in resizer?.client?.prefs?.all_quirks)
-			if(oversized)
+			if(istype(oversized))
 				resizer.add_quirk(/datum/quirk/oversized, announce = FALSE)
+				break
 		if(!resizer.get_quirk(/datum/quirk/oversized))
 			resizer.update_transform(resizer?.client?.prefs?.read_preference(/datum/preference/numeric/body_size))
 		resizer.normalized = FALSE

--- a/modular_zubbers/code/modules/clothing/clothing.dm
+++ b/modular_zubbers/code/modules/clothing/clothing.dm
@@ -19,8 +19,8 @@
 		playsound(resizer,'sound/items/weapons/emitter2.ogg', 50, 1)
 		flash_lighting_fx(3, 3, LIGHT_COLOR_YELLOW)
 		resizer.visible_message(span_warning("Golden light engulfs [resizer], and they shoot back to their default height!"), span_notice("Energy rushes through your body, and you return to normal."))
-		for(var/datum/quirk/oversized/oversized as anything in resizer?.client?.prefs?.all_quirks)
-			if(istype(oversized))
+		for(var/quirk as anything in resizer?.client?.prefs?.all_quirks)
+			if(quirk == "Oversized")
 				resizer.add_quirk(/datum/quirk/oversized, announce = FALSE)
 				break
 		if(!resizer.get_quirk(/datum/quirk/oversized))

--- a/modular_zubbers/code/modules/clothing/clothing.dm
+++ b/modular_zubbers/code/modules/clothing/clothing.dm
@@ -19,7 +19,7 @@
 		playsound(resizer,'sound/items/weapons/emitter2.ogg', 50, 1)
 		flash_lighting_fx(3, 3, LIGHT_COLOR_YELLOW)
 		resizer.visible_message(span_warning("Golden light engulfs [resizer], and they shoot back to their default height!"), span_notice("Energy rushes through your body, and you return to normal."))
-		for(var/quirk as anything in resizer?.client?.prefs?.all_quirks)
+		for(var/quirk in resizer?.client?.prefs?.all_quirks)
 			if(quirk == "Oversized")
 				resizer.add_quirk(/datum/quirk/oversized, announce = FALSE)
 				break


### PR DESCRIPTION

## About The Pull Request
The normalize procs just gave you oversized regardless of whether or not you actually had the quirk, this PR fixes that so it properly respects the size you want:tm:
Also it stops the for loop from iterating once it finds your oversized quirk (if you have one)
Also re-limits oversized to 2 tiles tall like god intended (fuck my life, I want giant women back)
## Why It's Good For The Game
Bug fix go brrr
## Proof Of Testing
It works, I tested it, I pawmise
<img width="1305" height="613" alt="image" src="https://github.com/user-attachments/assets/bc59ba93-96df-4d09-bac8-271770041ee0" />

<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: Normalization items properly respect size/prefs
fix: Oversized is limited to 2 tiles tall once again
/:cl:
