### PR TITLE
Add toggle stat panel to stat panel

### DIFF
--- a/code/modules/client/verbs/stat_panel.dm
+++ b/code/modules/client/verbs/stat_panel.dm
@@ -1,6 +1,6 @@
 /client/verb/toggle_stat_panel()
 	set name = "Toggle Stat Panel"
-	set hidden = TRUE
+	// set hidden = TRUE // BUBBER EDIT CHANGE - SHOW STAT PANEL TOGGLE
 
 	//Flip it
 	prefs.write_preference(GLOB.preference_entries[/datum/preference/toggle/statpanel], !prefs.read_preference(/datum/preference/toggle/statpanel))

--- a/code/modules/client/verbs/stat_panel.dm
+++ b/code/modules/client/verbs/stat_panel.dm
@@ -1,5 +1,6 @@
 /client/verb/toggle_stat_panel()
 	set name = "Toggle Stat Panel"
+	set category = "OOC" // BUBBER EDIT ADDITION - SHOW STAT PANEL TOGGLE
 	// set hidden = TRUE // BUBBER EDIT CHANGE - SHOW STAT PANEL TOGGLE
 
 	//Flip it


### PR DESCRIPTION
## About The Pull Request

Un-hides the secret toggle-stat-panel verb
## Why It's Good For The Game

Friday somehow hid the stat panel and didn't know how to fix it. It'll probably happen again with somebody else.

## Changelog

:cl: LT3
add: Toggle Stat Panel is now available in the OOC panel
/:cl: