### PR TITLE
Fixes marking issues 

### DIFF
--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -1225,13 +1225,19 @@
 		limb_alpha = human_owner.dna.features[limb_alpha_key]
 	// BUBBER EDIT ADDITION END
 
+	// BUBBER EDIT ADDITION START - Hand marking fixes
+	markings_alpha = owner_species.markings_alpha // Has no default, and a null alpha renders nothing
+
 	if(body_zone in owner_species.body_markings)
 		markings = LAZYCOPY(owner_species.body_markings[body_zone])
-		if(aux_zone && (aux_zone in owner_species.body_markings))
-			aux_zone_markings = LAZYCOPY(owner_species.body_markings[aux_zone])
-		markings_alpha = owner_species.markings_alpha
 	else
 		markings = list()
+
+	if(aux_zone && (aux_zone in owner_species.body_markings))
+		aux_zone_markings = LAZYCOPY(owner_species.body_markings[aux_zone])
+	else
+		aux_zone_markings = list()
+	// BUBBER EDIT ADDITION END
 	// SKYRAT EDIT END
 	return TRUE
 

--- a/modular_skyrat/modules/customization/modules/surgery/bodyparts/_bodyparts.dm
+++ b/modular_skyrat/modules/customization/modules/surgery/bodyparts/_bodyparts.dm
@@ -17,6 +17,11 @@
 		. += limb_id == "digitigrade" ? ("digitigrade_1_" + body_zone) : body_zone
 		. += "-[key]_[markings[key][MARKING_INDEX_COLOR]]_[markings[key][MARKING_INDEX_EMISSIVE]]"
 
+	// Hand markings are drawn by this limb too, so they have to be part of its cache key.
+	for(var/key in aux_zone_markings)
+		. += aux_zone
+		. += "-[key]_[aux_zone_markings[key][MARKING_INDEX_COLOR]]_[aux_zone_markings[key][MARKING_INDEX_EMISSIVE]]"
+
 	return .
 
 /**


### PR DESCRIPTION
## About The Pull Request

Hand markings have been broken in a few different ways for a while now. This fixes them.

I've tracked down three unique symptoms that all have the same cause. 

1. Hand markings would refuse to display unless you also had a marking on the matching arm.
2. Once a hand marking appeared, removing it did nothing. It would remain until server restart.
3. Hand markings would show up on other characters that never had them.

The arm/hand link was the clue. Bubberstation caches limb icons in one shared list, and the cache key is built in `generate_icon_key()`. That key includes the limb's own markings, but it never included the hand markings, which the arm also draws. So the game had no idea anything had changed when you touched a hand dropdown. Changing an arm marking altered the key, forced a real redraw, and the hand marking came along for the ride. That is why there seemed to be a chain between the hand and arm marks.

The cache is shared across every mob, including the preview dummies in character setup, which is how one character's hands ended up on another character.

There was also a smaller problem in `update_limb()`. The hand marking lookup sat inside the arm's `if` block, and `markings_alpha` was only set in that same block. Alpha has no default, and a null alpha draws nothing. Both are now handled on their own.

Closes https://github.com/Bubberstation/Bubberstation/issues/5880
Closes https://github.com/Bubberstation/Bubberstation/issues/3864
Closes https://github.com/Bubberstation/Bubberstation/issues/5879
Closes https://github.com/Bubberstation/Bubberstation/issues/6047

## Proof of Testing
Behold, the amazing Technicolor Dream Man. (I made him specifically to test if this fix works, it does) 
<img width="1080" height="1027" alt="image" src="https://github.com/user-attachments/assets/1ad5c184-7582-4852-ac6e-8ffbe34e2b13" />


## Why It's Good For The Game

Markings you applied to your character should appear on your character. Markings you deleted should go away. Neither of those was true, and the bugs that were caused by these fixes not being in the game caused markings to be smuggled unintentionally between character slots.

## Changelog

:cl: Aeri
fix: Hand markings now work without needing an arm marking, can be removed, and no longer leak onto other characters.
/:cl: