### PR TITLE
Fixes GAGS previews

### DIFF
--- a/code/modules/admin/greyscale_modify_menu.dm
+++ b/code/modules/admin/greyscale_modify_menu.dm
@@ -33,6 +33,10 @@
 	var/refreshing = TRUE
 	///BUBBER VAR: Optional display labels for color groups, keyed by color index.
 	var/list/color_labels
+	///BUBBER VAR: The asset url of the last preview image we sent. Used to make the client ask for it again.
+	var/last_preview_url
+	///BUBBER VAR: Counts up on every new preview. The menu uses it to reload an image that failed.
+	var/preview_generation = 0
 
 	/**
 	 * Whether the menu is currently locked down to prevent abuse from players.
@@ -122,6 +126,7 @@
 	data["sprites_dir"] = dir2text(sprite_dir)
 	data["icon_state"] = icon_state
 	data["sprites"] = sprite_data
+	data["preview_generation"] = preview_generation //BUBBER ADDITION
 	return data
 
 /datum/greyscale_modify_menu/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
@@ -129,6 +134,13 @@
 	if(.)
 		return
 	switch(action)
+		//BUBBER ADDITION START: Lets the menu ask for the preview image again if it did not load.
+		if("reload_preview")
+			forget_preview_asset()
+			queue_refresh()
+			return TRUE
+		//BUBBER ADDITION END
+
 		if("select_config")
 			var/datum/greyscale_config/new_config = input(
 				usr,
@@ -330,8 +342,48 @@ This is highly likely to cause massive amounts of lag as every object in the gam
 			// SKYRAT EDIT END
 
 	sprite_data["time_spent"] = TICK_DELTA_TO_MS(time_spent)
-	sprite_data["finished"] = icon2html(finished, user, dir=sprite_dir, sourceonly=TRUE)
+	set_finished_sprite(finished) //BUBBER EDIT: was an inline icon2html. See set_finished_sprite.
 	refreshing = FALSE
+
+//BUBBER ADDITION START
+/**
+ * Stores the finished preview image and remembers its url.
+ * The url is what the menu re-requests if the image does not load.
+ */
+/datum/greyscale_modify_menu/proc/set_finished_sprite(image/finished)
+	last_preview_url = icon2html(finished, user, dir = sprite_dir, sourceonly = TRUE)
+	sprite_data["finished"] = last_preview_url
+	preview_generation++
+
+/**
+ * Drops our record of the client already holding the last preview image.
+ * The server marks an asset as delivered the moment it is queued to send, so a send that fails is never retried.
+ * Clearing the record lets the next refresh send the file again.
+ */
+/datum/greyscale_modify_menu/proc/forget_preview_asset()
+	if(!last_preview_url)
+		return
+	if(findtext(last_preview_url, "/"))
+		return // Not a plain file name, so the client copy is not ours to manage.
+	// The user var is typed as a client, but the loadout and vending menus pass a mob into it.
+	var/client/preview_client = get_preview_client()
+	if(!preview_client)
+		return
+	preview_client.sent_assets -= last_preview_url
+
+/// Returns the client that owns this menu, whether the user var holds a client or a mob.
+/datum/greyscale_modify_menu/proc/get_preview_client()
+	var/datum/menu_user = user
+	if(isnull(menu_user))
+		return null
+	if(istype(menu_user, /client))
+		var/client/user_client = menu_user
+		return user_client
+	if(ismob(menu_user))
+		var/mob/user_mob = menu_user
+		return user_mob.client
+	return null
+//BUBBER ADDITION END
 
 /datum/greyscale_modify_menu/proc/Unlock()
 	allowed_configs = SSgreyscale.configurations

--- a/modular_zubbers/code/modules/greyscale/component_style.dm
+++ b/modular_zubbers/code/modules/greyscale/component_style.dm
@@ -764,6 +764,7 @@
 		"steps" = list(),
 		"time_spent" = 0,
 	)
+	data["preview_generation"] = preview_generation
 	data["hide_full_color_string"] = FALSE
 	data["component_style"] = list(
 		"core_components" = component_style.core_ui_data(selected_cores),
@@ -861,6 +862,6 @@
 	time_spent = TICK_USAGE - time_spent
 
 	sprite_data["time_spent"] = TICK_DELTA_TO_MS(time_spent)
-	sprite_data["finished"] = icon2html(finished, user, dir = sprite_dir, sourceonly = TRUE)
+	set_finished_sprite(finished)
 	sprite_data["steps"] = list()
 	refreshing = FALSE

--- a/tgui/packages/tgui/interfaces/GreyscaleModifyMenu.tsx
+++ b/tgui/packages/tgui/interfaces/GreyscaleModifyMenu.tsx
@@ -43,6 +43,7 @@ type GreyscaleMenuData = {
   hide_full_color_string?: boolean;
   component_style?: ComponentStyleData;
   //BUBBER ADDITION END - dynamic uniforms
+  preview_generation?: number; //BUBBER ADDITION - preview reliability
   sprites: SpriteData;
   generate_full_preview: boolean;
   unlocked: boolean;
@@ -304,7 +305,8 @@ const IconStatesDisplay = (props) => {
   return (
     <Section title="Icon States">
       <Flex>
-        {data.sprites.icon_states.map((item) => (
+        {/* BUBBER EDIT: null guard. sprites can be empty before the first preview lands. */}
+        {data.sprites?.icon_states?.map((item) => (
           <Flex.Item key={item}>
             <Button
               mx={0.5}
@@ -320,32 +322,52 @@ const IconStatesDisplay = (props) => {
 };
 
 const PreviewDisplay = (props) => {
-  const { data } = useBackend<GreyscaleMenuData>();
+  const { act, data } = useBackend<GreyscaleMenuData>(); //BUBBER EDIT: act added for reload_preview
   return (
-    <Section title={`Preview (${data.sprites_dir})`}>
+    <Section
+      title={`Preview (${data.sprites_dir})`}
+      /* BUBBER ADDITION: refresh control, top right of the section header. */
+      buttons={
+        <Button
+          icon="rotate-right"
+          onClick={() => act('reload_preview')}
+          tooltip="Refresh preview"
+        />
+      }
+    >
       <Table>
         <Table.Row>
           <Table.Cell width="50%">
             <PreviewCompassSelect />
           </Table.Cell>
-          {data.sprites?.finished ? (
-            <Table.Cell>
-              <Image m={0} mx="10%" src={data.sprites.finished} width="75%" />
-            </Table.Cell>
-          ) : (
-            <Table.Cell>
+          {/* BUBBER EDIT START - preview reliability. Was a plain Image with no retry.
+              The fixed cell height stops the row collapsing while a new image loads,
+              which used to make the compass jump up the panel. */}
+          <Table.Cell height="8rem" verticalAlign="middle">
+            {data.sprites?.finished ? (
+              <Image
+                key={data.preview_generation}
+                fixErrors
+                m={0}
+                mx="10%"
+                src={data.sprites.finished}
+                width="75%"
+              />
+            ) : (
               <Box>
                 <Icon name="image" ml="25%" size={5} />
               </Box>
-            </Table.Cell>
-          )}
+            )}
+          </Table.Cell>
+          {/* BUBBER EDIT END - preview reliability */}
         </Table.Row>
       </Table>
-      {!!data.unlocked && `Time Spent: ${data.sprites.time_spent}ms`}
+      {/* BUBBER EDIT: null guard */}
+      {!!data.unlocked && `Time Spent: ${data.sprites?.time_spent ?? 0}ms`}
       <Divider />
       {!data.refreshing && (
         <Table>
-          {!!data.generate_full_preview && data.sprites.steps !== null && (
+          {!!data.generate_full_preview && !!data.sprites?.steps && (
             <Table.Row header>
               <Table.Cell width="50%" textAlign="center">
                 Layer Source
@@ -359,7 +381,7 @@ const PreviewDisplay = (props) => {
             </Table.Row>
           )}
           {!!data.generate_full_preview &&
-            data.sprites.steps !== null &&
+            !!data.sprites?.steps &&
             data.sprites.steps.map((item) => (
               <Table.Row key={`${item.result}|${item.layer}`}>
                 <Table.Cell verticalAlign="middle">
@@ -386,8 +408,21 @@ const SingleSprite = (props) => {
 
 const LoadingAnimation = () => {
   return (
-    <Box height={0} mt="-100%">
-      <Icon name="cog" height={22.7} opacity={0.5} size={25} spin />
+    // BUBBER EDIT: was a negative-margin box, which drifted off centre at most window sizes.
+    <Box
+      position="fixed"
+      top={0}
+      left={0}
+      width="100%"
+      height="100%"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        pointerEvents: 'none',
+      }}
+    >
+      <Icon name="cog" opacity={0.5} size={10} spin />
     </Box>
   );
 };


### PR DESCRIPTION
## What this does

Fixes the broken image that shows up in the color menu instead of your item preview in like, I don't know, 50 percent of cases.

The menu makes a preview image, hands the integrated browser a link to it, and sends the image file separately. Those two things are not in step. If the link lands first, the browser asks for a file that doesn't exist, gives up, shits pants, and never tries again. On top of that the server has already written the file down as delivered, so it will not send it a second time. The preview stays broken until you change a color and get a different link.

Now the menu retries a failed image on its own, and there is a refresh button in the corner of the preview if you really want to give it a push (this shouldn't be necessary it SHOULD recover on its own, but I've been wrong before). The refresh also clears the server's note saying you already have the file, so it actually gets sent again.

Oh and nobody ever actually reported this as a bug, but it's been bugging me for like six months or so, it was on the Aeri issue tracker that lives exclusively in my brain. 

## Why this is a Bubber fix

In addition to the fact I refuse to touch TG directly if at all possible; the preview code for our dynamic uniforms lives in modular_zubbers and has no matching proc upstream, so there is nothing over there to fix. Bubbercode also makes vastly greater use of this functionality than upstream does, from the loadout and other places, and our previews rebuild a new image more often. Upstream makes one image per color string and opens the menu from VV or a spraycan, so it breaks less. 

## Testing

Recolored items from the loadout and in round. Caught the preview breaking and watched it come back on its own. Confirmed the refresh button works and throws no runtimes. There's nothing interesting to take a picture of here! OK fine, here, here's a GAGS menu doing nothing out of the ordinary. You can even see the little refresh doodad. 

<img width="474" height="801" alt="image" src="https://github.com/user-attachments/assets/ba501e84-d407-4cac-903c-898b8b80522f" />


:cl: Aeri
fix: GAGS menus no longer show broken images (and will recover on their own if they somehow do)
/:cl: