### PR TITLE
Tells contributors they’re not allowed to AI generate PR bodies or reviews.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ As of our recent split from Skyrat, a lot of codedocs/modularization guides need
 **3. Usage of Code Generation Tools**
 
 - Usage of autocompletes, auto documentation generation and other tools are allowed
-- It is fully expected of a person using any of these tools to ensure the output and quality of said tools
-- Any code written by tooling is expected to be heavily tested and proven to work
+- It is fully expected of a person using any of these tools to ensure the output and quality of said tools.
+- Any code written by tooling is expected to be heavily tested and proven to work.
+- AI generation to complete PR bodies, PR comments, or PR reviews is forbidden. Don't have an AI write your pull requests.
 
 **4. The Licensing is Non-negotiable**
 


### PR DESCRIPTION
AI generation to complete PR bodies, PR comments, or PR reviews is forbidden. Don't have an AI write your pull requests.