### PR TITLE
Dorms are actually radiation storm shielded for real real this time

### DIFF
--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -274,6 +274,10 @@
 			continue
 		if(!(weather_flags & WEATHER_INDOORS) && !affected_area.outdoors)
 			continue
+		// BUBBER EDIT - ADDITION - START - DORMS WEATHER PROTECTION
+		if(engaged_roleplay_filter(affected_area))
+			continue
+		// BUBBER EDIT - ADDITION - END
 
 		for(var/z in impacted_z_levels)
 			var/total_turfs = length(affected_area.turfs_by_zlevel) >= z && length(affected_area.turfs_by_zlevel[z])

--- a/modular_zubbers/code/datums/weather/weather_types/radiation_storm.dm
+++ b/modular_zubbers/code/datums/weather/weather_types/radiation_storm.dm
@@ -21,7 +21,6 @@
 	if(!GLOB.emergency_access)
 		maint_flipped = TRUE
 		addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(make_maint_all_access), TRUE), 0.5 SECONDS) // timed to match the status display
-	dorms_check()
 
 /datum/weather/rad_storm/end()
 	. = ..()

--- a/modular_zubbers/code/modules/events/ev_roleplay_check.dm
+++ b/modular_zubbers/code/modules/events/ev_roleplay_check.dm
@@ -5,13 +5,18 @@ GLOBAL_LIST_EMPTY(dorms_areas)
 	. = ..()
 	GLOB.dorms_areas[src] = TRUE
 
-/datum/weather/rad_storm/proc/dorms_check(mob/player)
-	var/turf/player_turf = get_turf(player)
+/datum/weather/proc/engaged_roleplay_filter(area/engaged_roleplay_area)
+	return FALSE
 
-	if(player_turf && length(GLOB.dorms_areas))
-		var/area/player_area = player_turf.loc
-		if(GLOB.dorms_areas[player_area])
-			protected_areas += player_area
+/datum/weather/rad_storm/engaged_roleplay_filter(area/engaged_roleplay_area)
+	if(!is_type_in_list(engaged_roleplay_area, GLOB.dorms_areas))
+		return FALSE
+
+	for(var/mob/living/carbon/human/roleplayer in engaged_roleplay_area.contents)
+		if(engaged_role_play_check(player = roleplayer, station = FALSE, dorms = TRUE))
+			return TRUE
+
+	return FALSE
 
 /datum/weather/rad_storm/send_alert(alert_msg, alert_sfx, alert_sfx_vol = 100)
 	for(var/area/impacted_area as anything in impacted_areas)


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Bubberstation/Bubberstation/issues/6087

Reverted to the previous style check and added the missing proc call in setup_weather_area() that got removed during an upstream merge.

## Why It's Good For The Game

Quits interrupting my ERP

## Changelog

:cl: LT3
fix: Fixed dorms not being protected from radiation storms. Yes, that's what we said last time but this time it's real.
/:cl:
