### PR TITLE
Fixes heirloom lettign you choose implant items as your heirloom

### DIFF
--- a/modular_zubbers/code/datums/quirks/negative_quirks/family_heirloom.dm
+++ b/modular_zubbers/code/datums/quirks/negative_quirks/family_heirloom.dm
@@ -59,6 +59,10 @@ GLOBAL_LIST_INIT(invalid_heirloom_types, typecacheof(list(
 		living_owner.balloon_alert(living_owner, "no held item!")
 		return FALSE
 
+	if (HAS_TRAIT(held_item, TRAIT_NODROP))
+		living_owner.balloon_alert(living_owner, "item must be droppable!")
+		return FALSE
+
 	if (GLOB.invalid_heirloom_types[held_item.type])
 		living_owner.balloon_alert(living_owner, "invalid item type!")
 		return FALSE


### PR DESCRIPTION

## About The Pull Request
title
## Why It's Good For The Game
buggy wuggy
## Proof Of Testing
<img width="1076" height="994" alt="image" src="https://github.com/user-attachments/assets/c96d6bec-78c8-4794-907d-51e4c071a35b" />
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: implanted items are no longer valid heirloom targets for non-random heirlooms
/:cl:
