### PR TITLE
fix blueshift atmos sanity flaky test. Also a hard delete flake.

### DIFF
--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -7068,8 +7068,6 @@
 /area/space/nearstation)
 "bsN" = (
 /obj/item/radio/intercom/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/directional/south{
 	c_tag = "Security - Shuttle Bay East"
 	},
@@ -22059,6 +22057,7 @@
 "ejd" = (
 /obj/structure/railing/corner/end,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "eje" = (
@@ -27161,6 +27160,8 @@
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/stairs,
 /area/station/security/execution/transfer)
 "feL" = (
@@ -32886,6 +32887,7 @@
 "glU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "glW" = (
@@ -45960,6 +45962,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "iNE" = (
@@ -48728,8 +48731,6 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/stairs,
 /area/station/security/execution/transfer)
 "jpC" = (
@@ -71464,8 +71465,6 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Shuttlebay"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
@@ -72040,6 +72039,8 @@
 /area/station/medical/psychology)
 "nOQ" = (
 /obj/item/stack/cable_coil,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "nPa" = (
@@ -76128,6 +76129,12 @@
 	dir = 8
 	},
 /area/station/command/heads_quarters/nt_rep)
+"oAp" = (
+/obj/effect/decal/cleanable/blood/oil/slippery,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/security/execution/transfer)
 "oAu" = (
 /obj/structure/chair/sofa/middle/brown,
 /obj/structure/window/spawner/directional/north,
@@ -99260,6 +99267,7 @@
 "sVu" = (
 /obj/structure/railing/corner/end/flip,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "sVz" = (
@@ -107398,8 +107406,6 @@
 /area/station/science/genetics)
 "uwI" = (
 /obj/effect/turf_decal/vg_decals/numbers/one,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "uwO" = (
@@ -115096,9 +115102,10 @@
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/captain/private)
 "vUC" = (
+/obj/effect/turf_decal/box/white/corners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "vUH" = (
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -119192,6 +119199,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/bar/atrium)
+"wGJ" = (
+/obj/effect/turf_decal/stripes/full,
+/obj/effect/turf_decal/stripes/white/full,
+/obj/machinery/door/poddoor/shutters{
+	id = "securitydock2";
+	name = "Security Dock 2"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/security/execution/transfer)
 "wGO" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating,
@@ -119227,9 +119245,7 @@
 "wHi" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/botanist,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -126829,8 +126845,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
 "yfU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/landmark/firealarm_sanity,
 /turf/open/floor/iron,
@@ -150444,14 +150458,14 @@ euE
 euE
 faw
 euE
-euE
+oyI
 nOQ
-euE
-euE
-cgu
-sAN
-euE
-iHC
+oyI
+oyI
+vUC
+wGJ
+oyI
+sBh
 tNz
 tNz
 tNz
@@ -150701,7 +150715,7 @@ doG
 eTH
 iNB
 feJ
-faw
+oAp
 mhN
 bdt
 mhN
@@ -151728,7 +151742,7 @@ euE
 euE
 euE
 euE
-oyI
+euE
 euE
 euE
 euE
@@ -151985,7 +151999,7 @@ faw
 euE
 euE
 euE
-oyI
+euE
 inc
 euE
 euE
@@ -152499,7 +152513,7 @@ euE
 euE
 euE
 inc
-oyI
+euE
 euE
 faw
 euE
@@ -152756,7 +152770,7 @@ euE
 piH
 euE
 euE
-oyI
+euE
 euE
 kWs
 piH
@@ -153270,7 +153284,7 @@ dwK
 mgt
 iHC
 mhN
-vUC
+jHK
 mhN
 iHC
 xYh
@@ -154041,7 +154055,7 @@ iRb
 xJs
 jMz
 sIh
-vUC
+jHK
 hZI
 uda
 wJg

--- a/code/modules/power/monitor.dm
+++ b/code/modules/power/monitor.dm
@@ -25,6 +25,10 @@
 	history["supply"] = list()
 	history["demand"] = list()
 
+/obj/machinery/computer/monitor/Destroy(force)
+	SSmachines.processing_late -= src
+	return ..()
+
 /obj/machinery/computer/monitor/process_late()
 	if(!get_powernet())
 		update_use_power(IDLE_POWER_USE)


### PR DESCRIPTION
## About The Pull Request

**I'VE HAD IT WITH THIS MOTHERFUCKING FLAKY TEST ON THIS MOTHERFUCKING MAP**

Blueshift has had a flaky test related to atmos sanity, where the entire air supply and scrubbers pipenets were being destroyed during unit tests. This was apparently caused by the atmos piping running under the laborcamp shuttle, which sometimes just nuked the entire pipenet. This PR fixes it by re-routing it via the other side of that room.

Also, removes one stupid pipe prefab that for some reason had direction set despite being connected in all directions anyway.

Oh and also ports a fix to a flaky test from TG.

<details>
<Summary>Old vs New</Summary>

Old
<img width="682" height="446" alt="image" src="https://github.com/user-attachments/assets/417eef8d-db79-4e55-aec0-5cf20bc644fc" />

New
<img width="666" height="493" alt="image" src="https://github.com/user-attachments/assets/7b96aa07-8540-46f4-b6b7-1370dcda3c08" />
</details>

## Why It's Good For The Game

Fixes #5943 
Fixes #6106 

## Proof Of Testing

On my downstream repo, I had to move my game version to 516.1686 to fix an unrelated bug. However, this caused the flaky test to show up every time instead of occasionally. I applied the same fix as I am PR'ing rn and the atmos sanity test stopped failing.

## Changelog

No player facing changes. I mean pipes get routed a little differently but I doubt anyone will notice.