### PR TITLE
Somebody help me, the micro's are going to grab their tiny forks and stab my ankles

### DIFF
--- a/modular_zubbers/code/datums/quirks/negative_quirks/micro.dm
+++ b/modular_zubbers/code/datums/quirks/negative_quirks/micro.dm
@@ -36,7 +36,7 @@
 
 /datum/quirk/micro/post_add()
 	var/mob/living/carbon/living_as_carbon = quirk_holder
-	living_as_carbon.update_transform(size_reduced)
+	living_as_carbon.update_transform(size_reduced / quirk_holder.client?.prefs?.read_preference(/datum/preference/numeric/body_size))
 	living_as_carbon.AddComponent( \
 		/datum/component/squashable, \
 		squash_chance = squash_chance_, \

--- a/modular_zubbers/code/modules/mob/living/carbon/human/species_types/slimepeople.dm
+++ b/modular_zubbers/code/modules/mob/living/carbon/human/species_types/slimepeople.dm
@@ -343,7 +343,7 @@
 			if(new_body_size == RESIZE_DEFAULT_SIZE)
 				alterer.update_transform(RESIZE_DEFAULT_SIZE / alterer.current_size)
 			else
-				alterer.update_transform(new_body_size)
+				alterer.update_transform(new_body_size / alterer.current_size)
 
 		if("Genitals")
 			alter_genitals(alterer)


### PR DESCRIPTION

## About The Pull Request
Fixes the rest of the update_transform() procs from #6042 that allowed for some silly size shenanigans, notably, micro folk being able to take 0.8 and being less than half a tile tall (sorry) and infinite size via polymorph spell as a slime/nif/whatever else has it.
## Why It's Good For The Game
bug fix go brr
## Proof Of Testing
<img width="358" height="274" alt="image" src="https://github.com/user-attachments/assets/91e584cc-bd9b-48a2-bef2-46a5dc865f14" />
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: Sizes are now consistent as intended on micro quirks
fix: Polymorph spell no longer makes you infinitely big/small
/:cl:
