### PR TITLE
Fix TEG circulator flipping by making it right clickable

### DIFF
--- a/modular_skyrat/master_files/code/modules/power/circulator.dm
+++ b/modular_skyrat/master_files/code/modules/power/circulator.dm
@@ -37,7 +37,22 @@
 	.=..()
 	component_parts = list(new /obj/item/circuitboard/machine/circulator)
 	update_appearance()
+	register_context()
 
+/obj/machinery/atmospherics/components/binary/circulator/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+	if(!held_item)
+		context[SCREENTIP_CONTEXT_RMB] = "Flip"
+		return CONTEXTUAL_SCREENTIP_SET
+	switch(held_item.tool_behaviour)
+		if(TOOL_SCREWDRIVER)
+			context[SCREENTIP_CONTEXT_LMB] = "[panel_open ? "Close" : "Open"] panel"
+		if(TOOL_WRENCH)
+			context[SCREENTIP_CONTEXT_LMB] = "[anchored ? "Unan" : "An"]chor"
+			context[SCREENTIP_CONTEXT_RMB] = "Rotate"
+		if(TOOL_MULTITOOL)
+			context[SCREENTIP_CONTEXT_LMB] = "Change to [mode ? "hot" : "cold"] mode"
+	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/machinery/atmospherics/components/binary/circulator/Destroy()
 	if(generator)

--- a/modular_skyrat/master_files/code/modules/power/circulator.dm
+++ b/modular_skyrat/master_files/code/modules/power/circulator.dm
@@ -278,19 +278,20 @@
 GAME_VERB_SRC(/obj/machinery/atmospherics/components/binary/circulator, circulator_flip, oview(1), "Flip", "Object")
 	if(!ishuman(usr))
 		return
-	flipped = !flipped
-	balloon_alert(usr, "you flip [src].")
-	playsound(src, 'sound/items/tools/change_drill.ogg', 50)
-	update_icon_nopipes()
+	flip(usr)
 
 /obj/machinery/atmospherics/components/binary/circulator/attack_hand_secondary(mob/user, list/modifiers)
 	if(!ishuman(user))
 		return
+	flip(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+// DO A FLIP
+/obj/machinery/atmospherics/components/binary/circulator/proc/flip(mob/living/carbon/human/user)
 	flipped = !flipped
 	balloon_alert(user, "you flip [src].")
 	playsound(src, 'sound/items/tools/change_drill.ogg', 50)
 	update_icon_nopipes()
-	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/machinery/atmospherics/components/binary/circulator/atom_break(damage_flag)
 	if(generator)

--- a/modular_skyrat/master_files/code/modules/power/circulator.dm
+++ b/modular_skyrat/master_files/code/modules/power/circulator.dm
@@ -268,6 +268,15 @@ GAME_VERB_SRC(/obj/machinery/atmospherics/components/binary/circulator, circulat
 	playsound(src, 'sound/items/tools/change_drill.ogg', 50)
 	update_icon_nopipes()
 
+/obj/machinery/atmospherics/components/binary/circulator/attack_hand_secondary(mob/user, list/modifiers)
+	if(!ishuman(user))
+		return
+	flipped = !flipped
+	balloon_alert(user, "you flip [src].")
+	playsound(src, 'sound/items/tools/change_drill.ogg', 50)
+	update_icon_nopipes()
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
 /obj/machinery/atmospherics/components/binary/circulator/atom_break(damage_flag)
 	if(generator)
 		generator.null_circulators()

--- a/modular_skyrat/master_files/code/modules/power/thermoelectric_generator.dm
+++ b/modular_skyrat/master_files/code/modules/power/thermoelectric_generator.dm
@@ -37,7 +37,21 @@
 	SSair.start_processing_machine(src, mapload)
 	update_appearance()
 	component_parts = list(new /obj/item/circuitboard/machine/thermoelectric_generator)
+	register_context()
 
+/obj/machinery/power/thermoelectric_generator/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+	if (!held_item)
+		return CONTEXTUAL_SCREENTIP_SET
+	switch(held_item.tool_behaviour)
+		if(TOOL_SCREWDRIVER)
+			context[SCREENTIP_CONTEXT_LMB] = "[panel_open ? "Close" : "Open"] panel"
+		if(TOOL_WRENCH)
+			if (panel_open)
+				context[SCREENTIP_CONTEXT_LMB] = "[anchored ? "Unan" : "An"]chor"
+			else
+				context[SCREENTIP_CONTEXT_LMB] = "Connect circulators"
+	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/machinery/power/thermoelectric_generator/Destroy()
 	null_circulators()


### PR DESCRIPTION
## About The Pull Request

So it turns out that game verbs are broken and they won't be unbroken until we grab a fix from TG. I noticed it yesterday when I was playing with the TEG and I noticed that the "flip" verb on the circulators doesn't work. Now, I cannot grab the fix from TG because that would require rewriting like 70 files on the codebase, so I will leave that for the next upstream merge. As an interim solution, I simply made the circulators flip behavior happen on right click with an empty hand. And because the controls of the TEG are complicated, I also added the context menu to it and the circulators.

## Why It's Good For The Game

Bandaids a TG bug until it can be merged proper, adds context menu to a complicated machine to make it easier to operate.

## Proof Of Testing

<details>
<summary>Video</summary>

https://github.com/user-attachments/assets/c3702766-d310-429e-9bfd-86e04f52d612

</details>

## Changelog

:cl: Swan
qol: Makes the TEGs circulator flip behavior happen on right click. Also adds context info to it.
/:cl: