### PR TITLE
Re-adds the Captain's Console to Tramstation's Captain office

### DIFF
--- a/_maps/bubber/automapper/templates/tramstation/tramstation_blueshield.dmm
+++ b/_maps/bubber/automapper/templates/tramstation/tramstation_blueshield.dmm
@@ -109,7 +109,6 @@
 /obj/machinery/keycard_auth/wall_mounted/directional/north{
 	pixel_x = 26
 	},
-/obj/item/radio/intercom/command/directional/east,
 /turf/template_noop,
 /area/template_noop)
 "r" = (

--- a/_maps/bubber/automapper/templates/tramstation/tramstation_blueshield.dmm
+++ b/_maps/bubber/automapper/templates/tramstation/tramstation_blueshield.dmm
@@ -110,10 +110,8 @@
 	pixel_x = 26
 	},
 /obj/item/radio/intercom/command/directional/east,
-/obj/structure/bed/dogbed/renault,
-/mob/living/basic/pet/fox/renault,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/captain)
+/turf/template_noop,
+/area/template_noop)
 "r" = (
 /obj/structure/closet/secure_closet/tac{
 	req_access = list("captain")
@@ -287,8 +285,10 @@
 	name = "Captain's Requests Console";
 	department = "Captain's Desk"
 	},
-/turf/template_noop,
-/area/template_noop)
+/obj/structure/bed/dogbed/renault,
+/mob/living/basic/pet/fox/renault,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/captain)
 "L" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,


### PR DESCRIPTION
## About The Pull Request

I accidentally removed the captain's console from tramstation's captain office, because I misplaced Renault's bed. Whoops.

## Why It's Good For The Game

Fix

## Proof Of Testing

<img width="359" height="340" alt="image" src="https://github.com/user-attachments/assets/088d7250-c0cc-41dc-9bfe-25510ac270a3" />


## Changelog

:cl:
map: Re-added the (mistakenly removed) Communications Console in Tramstation's Captain Office.
/:cl:
