### PR TITLE
makes it so the vote reminder is reset when the vote resets

### DIFF
--- a/modular_zubbers/code/controllers/subsystem/vote.dm
+++ b/modular_zubbers/code/controllers/subsystem/vote.dm
@@ -6,6 +6,10 @@
 	/// Do we force open the panel for people who havent voted on our reminder?
 	var/force_open_panel_on_reminder = FALSE
 
+/datum/vote/reset()
+	reminder_fired = FALSE
+	return ..()
+
 /datum/controller/subsystem/vote
 	dependencies = list(
 		/datum/controller/subsystem/persistence,


### PR DESCRIPTION
## About The Pull Request

So the vote reminder wasn't being reset when the vote was concluding, making it so that whenever a vote was ended and then fired again, it wouldn't fire the reminder again. There is only one vote with the reminder functionality, the storyteller one, which makes it not probable that this bug will appear in normal play, but if anything else uses the function, then it will be a problem.

## Why It's Good For The Game

Fixes a bug

## Proof Of Testing

I run it locally and the reminder poped up on subsequent voting attempts. Confirmed with the debugger. Don't have time to make a video rn but if necessary I will add one.

## Changelog

:cl: Swan
fix: fixes the vote reminder not reseting after a vote is finished
/:cl: