### PR TITLE
WCAG AAA whisper color

### DIFF
--- a/tgui/packages/tgui-say/styles/colors.scss
+++ b/tgui/packages/tgui-say/styles/colors.scss
@@ -30,7 +30,7 @@ $_channel_map: (
   'Synd': hsl(359.1, 31.8%, 42.5%),
   // BUBBER EDIT - START
   'LOOC': hsl(48, 41%, 49%),
-  'Whis': hsl(276, 36%, 25%), // BUBBER EDIT - END
+  'Whis': hsl(336, 41%, 65%), // BUBBER EDIT - END
 );
 
 $channel_keys: map.keys($_channel_map) !default;


### PR DESCRIPTION
## About The Pull Request

Gives the whisper text a 7.14:1 contrast ratio, which means it should be readable even for the elderly.

I'm surprised nobody in our playerbase was annoyed at the low contrast for this long.

## Why It's Good For The Game

Ever since I changed my monitor to this fuck that's seemingly got the most washed out colors imaginable, I can barely read my whisper messages. This fixes that, and probably makes it better for everyone else in the shit eyesight club.

## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

<img width="236" height="73" alt="image" src="https://github.com/user-attachments/assets/0672a197-4563-4e8f-aa30-6be427d12ab7" />

<img width="247" height="80" alt="image" src="https://github.com/user-attachments/assets/39c11d66-6803-4c66-a9dc-c2fb2f805d80" />

<img width="237" height="70" alt="image" src="https://github.com/user-attachments/assets/71e71c0f-4671-41c4-8a86-0e0e73ece455" />

Old whisper (1.7:1 contrast):

<img width="241" height="48" alt="image" src="https://github.com/user-attachments/assets/7fd73281-cc1c-4038-838a-2e46fc208502" />


</details>

## Changelog

:cl:
qol: The whisper text is now high contrast and passes WCAG AAA
/:cl: