### PR TITLE
fix chameleon (ghost cafe) outfits looking off

### DIFF
--- a/modular_skyrat/master_files/code/modules/clothing/chameleon.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/chameleon.dm
@@ -29,6 +29,7 @@
 	if(istype(target, /obj/item/clothing/))
 		var/obj/item/clothing/target_clothing = target
 		var/obj/item/clothing/picked_clothing = picked_item
+		target_clothing.greyscale_colors = initial(picked_clothing.greyscale_colors)
 		target_clothing.supports_variations_flags = initial(picked_clothing.supports_variations_flags)
 		target_clothing.worn_icon_digi = initial(picked_clothing.worn_icon_digi)
 		target_clothing.worn_icon_taur_snake = initial(picked_clothing.worn_icon_taur_snake)
@@ -53,6 +54,14 @@
 				target_clothing.worn_icon_taur_big = SSgreyscale.GetColoredIconByType(picked_item::greyscale_config_worn_taur_big, picked_item::greyscale_colors)
 			if(picked_item::greyscale_config_worn_muzzled)
 				target_clothing.worn_icon_muzzled = SSgreyscale.GetColoredIconByType(picked_item::greyscale_config_worn_muzzled, picked_item::greyscale_colors)
+			if(picked_item::greyscale_config_worn_monkey)
+				target_clothing.worn_icon_monkey = SSgreyscale.GetColoredIconByType(picked_item::greyscale_config_worn_monkey, picked_item::greyscale_colors)
+			if(picked_item::greyscale_config_worn_vox)
+				target_clothing.worn_icon_vox = SSgreyscale.GetColoredIconByType(picked_item::greyscale_config_worn_vox, picked_item::greyscale_colors)
+			if(picked_item::greyscale_config_worn_better_vox)
+				target_clothing.worn_icon_better_vox = SSgreyscale.GetColoredIconByType(picked_item::greyscale_config_worn_better_vox, picked_item::greyscale_colors)
+			if(picked_item::greyscale_config_worn_teshari)
+				target_clothing.worn_icon_teshari = SSgreyscale.GetColoredIconByType(picked_item::greyscale_config_worn_teshari, picked_item::greyscale_colors)
 		// var/slow = initial(picked_clothing.slowdown) /// DISABLED UNTIL YOU CAN MAKE THIS WORK WITH THE BROKEN CHAMELEON CLOTHES!!!
 		// if(slow)
 		// 	slowtoggle = new(target_clothing, slow)

--- a/modular_skyrat/master_files/code/modules/clothing/chameleon.dm
+++ b/modular_skyrat/master_files/code/modules/clothing/chameleon.dm
@@ -39,6 +39,20 @@
 		target_clothing.flags_inv = initial(picked_clothing.flags_inv)
 		target_clothing.visor_flags_cover = initial(picked_clothing.visor_flags_cover)
 		target_clothing.slowdown = 0
+
+		if(picked_item::greyscale_colors)
+			if(picked_item::greyscale_config_worn_digi)
+				target_clothing.worn_icon_digi = SSgreyscale.GetColoredIconByType(picked_item::greyscale_config_worn_digi, picked_item::greyscale_colors)
+			if(picked_item::greyscale_config_worn_taur_snake)
+				target_clothing.worn_icon_taur_snake = SSgreyscale.GetColoredIconByType(picked_item::greyscale_config_worn_taur_snake, picked_item::greyscale_colors)
+			if(picked_item::greyscale_config_worn_taur_paw)
+				target_clothing.worn_icon_taur_paw = SSgreyscale.GetColoredIconByType(picked_item::greyscale_config_worn_taur_paw, picked_item::greyscale_colors)
+			if(picked_item::greyscale_config_worn_taur_hoof)
+				target_clothing.worn_icon_taur_hoof = SSgreyscale.GetColoredIconByType(picked_item::greyscale_config_worn_taur_hoof, picked_item::greyscale_colors)
+			if(picked_item::greyscale_config_worn_taur_big)
+				target_clothing.worn_icon_taur_big = SSgreyscale.GetColoredIconByType(picked_item::greyscale_config_worn_taur_big, picked_item::greyscale_colors)
+			if(picked_item::greyscale_config_worn_muzzled)
+				target_clothing.worn_icon_muzzled = SSgreyscale.GetColoredIconByType(picked_item::greyscale_config_worn_muzzled, picked_item::greyscale_colors)
 		// var/slow = initial(picked_clothing.slowdown) /// DISABLED UNTIL YOU CAN MAKE THIS WORK WITH THE BROKEN CHAMELEON CLOTHES!!!
 		// if(slow)
 		// 	slowtoggle = new(target_clothing, slow)


### PR DESCRIPTION

## About The Pull Request
fixes the chameleon outfit looking broken on digitgrade legs and colours being wrong. the list is taken from https://github.com/Bubberstation/Bubberstation/blob/4f204ca55ea14bd6d945d34ba20b218fd438fb49/code/game/objects/items.dm#L393-L418
maybe there is a better way? idk.
## Why It's Good For The Game
no more purple and black on your feet and mismatched pants.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

before:
<img width="106" height="119" alt="image" src="https://github.com/user-attachments/assets/73709092-f24c-458b-8aab-8ad83b743043" />

after:
<img width="136" height="109" alt="image" src="https://github.com/user-attachments/assets/dd770412-8d3e-474e-8d70-c9ef4408bbd3" />

before (forgot the shoes but they were the same grey):
<img width="54" height="77" alt="image" src="https://github.com/user-attachments/assets/4cacb0b3-753a-4b39-ab4f-914a01425d76" />
after:
<img width="86" height="91" alt="image" src="https://github.com/user-attachments/assets/1d0f765a-7be2-424f-8f8f-e13996fdd2e7" />


</details>

## Changelog
:cl:
fix: chameleon outfit (ghost cafe) looking wrong
/:cl:
