### PR TITLE
Fix an appraisal NIFSoft runtime

### DIFF
--- a/modular_skyrat/modules/modular_implants/code/nifsofts/money_sense.dm
+++ b/modular_skyrat/modules/modular_implants/code/nifsofts/money_sense.dm
@@ -32,8 +32,8 @@
 	RegisterSignal(parent, COMSIG_MOB_EXAMINATE, PROC_REF(add_examine))
 
 /datum/component/money_sense/Destroy(force, silent)
-	. = ..()
 	UnregisterSignal(parent, COMSIG_MOB_EXAMINATE)
+	return ..()
 
 ///Scans the item the user is looking at and generates the cargo value of it.
 /datum/component/money_sense/proc/add_examine(mob/user, atom/target)


### PR DESCRIPTION
## About The Pull Request

The Automatic Appraisal NIFSoft's component shits pant every time it's destroyed with a living owner.

Current code triggers a runtime whenever anyone with an Automatic Appraisal NIFSoft active is gibbed, deleted, or otherwise destroyed.

## Why It's Good For The Game

Removes a runtime error from a live feature. Nothing you can ever see or experience will change.

## Changelog

:cl: Aeri
fix: The Automatic Appraisal NIFSoft no longer throws a runtime when its owner is deleted.
/:cl: