### PR TITLE
Removes the ability to cuff shields to your person

### DIFF
--- a/code/game/objects/items/weaponry/shields.dm
+++ b/code/game/objects/items/weaponry/shields.dm
@@ -44,7 +44,7 @@
 /obj/item/shield/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/disarm_attack)
-	///AddElement(/datum/element/cuffable_item) //BUBBER EDIT - No cuffing shields. Bootleg nodrop at no real cost.
+	//AddElement(/datum/element/cuffable_item) //BUBBER EDIT - No cuffing shields. Bootleg nodrop at no real cost.
 
 /obj/item/shield/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK, damage_type = BRUTE)
 	var/effective_block_chance = final_block_chance

--- a/code/game/objects/items/weaponry/shields.dm
+++ b/code/game/objects/items/weaponry/shields.dm
@@ -44,7 +44,7 @@
 /obj/item/shield/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/disarm_attack)
-	AddElement(/datum/element/cuffable_item)
+	///AddElement(/datum/element/cuffable_item) //BUBBER EDIT - No cuffing shields. Bootleg nodrop at no real cost.
 
 /obj/item/shield/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK, damage_type = BRUTE)
 	var/effective_block_chance = final_block_chance


### PR DESCRIPTION

## About The Pull Request
Title. No longer can you do this with shields in specific. Other items can still be cuffed to your person. 

Artur told me I can PR this despite freeze.
<img width="374" height="223" alt="afbeelding" src="https://github.com/user-attachments/assets/c4ffa137-9902-40bb-bc34-44f8beea3b90" />

## Why It's Good For The Game
Quite frankly? It's bootleg nodrop at no actual cost, and seeing people cuff a shield to their person roundstart and then drag it around them all shift long is a little immersion breaking. Between that and the strength of Bootleg Nodrop I think it's best if it goes.

## Proof Of Testing

https://github.com/user-attachments/assets/14f29e15-f17c-4760-8e51-a79c06697324


<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog

:cl:
balance: Shields can no longer be cuffed to your arm.
/:cl:

