### PR TITLE
Removes Die of Fate from the maintenance loot pools

### DIFF
--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -120,6 +120,10 @@ GLOBAL_LIST_EMPTY(wizard_spellbook_purchases_by_key)
 
 /// Initialises the grand ritual action for this mob
 /datum/antagonist/wizard/proc/assign_ritual()
+	// BUBBER EDIT ADDITION - START
+	if(SSgamemode.active_crew < 35) // Same as with blob and other high intensity antags
+		return
+	// BUBBER EDIT ADDITION - END
 	ritual = new(src)
 	RegisterSignal(ritual, COMSIG_GRAND_RITUAL_FINAL_COMPLETE, PROC_REF(on_ritual_complete))
 

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -120,10 +120,6 @@ GLOBAL_LIST_EMPTY(wizard_spellbook_purchases_by_key)
 
 /// Initialises the grand ritual action for this mob
 /datum/antagonist/wizard/proc/assign_ritual()
-	// BUBBER EDIT ADDITION - START
-	if(SSgamemode.active_crew < 35) // Same as with blob and other high intensity antags
-		return
-	// BUBBER EDIT ADDITION - END
 	ritual = new(src)
 	RegisterSignal(ritual, COMSIG_GRAND_RITUAL_FINAL_COMPLETE, PROC_REF(on_ritual_complete))
 

--- a/modular_zubbers/code/_globalvars/lists/maintenance_loot_one_of_a_kind.dm
+++ b/modular_zubbers/code/_globalvars/lists/maintenance_loot_one_of_a_kind.dm
@@ -2,7 +2,6 @@ GLOBAL_LIST_INIT(one_of_a_kind_loot, list(
 	/obj/item/clothing/suit/armor/reactive/table,
 	/obj/item/clothing/shoes/jackboots/fast,
 	/obj/item/melee/energy/sword/bananium,
-	/obj/item/dice/d20/teleporting_die_of_fate,
 	/obj/item/modular_computer/pda/clear,
 	/obj/item/gun/energy/meteorgun/pen,
 	/obj/item/clothing/shoes/gunboots/disabler,


### PR DESCRIPTION

## About The Pull Request
Does exactly as the title would suggest. Staff seems to have wanted it and I got permission to PR this despite the freeze.

## Why It's Good For The Game
While previously I was going to remove the ability for wizards to do rituals at under 35 active crew members, other maintainers said I should just remove the DoF from the loot pool instead. Ultimately, wizards are typically a higher chaos antagonist, and the event that spawns the DoF naturally is already locked behind 30 players, so it being able to be bypassed by RNG isn't really a good thing.

## Proof Of Testing
There are only 9 items in the list when previously there was 10.
<details>
<summary>Screenshots/Videos</summary>
<img width="473" height="211" alt="image" src="https://github.com/user-attachments/assets/5b76deca-d8a1-4a00-8dc3-345f885e0d10" />

</details>

## Changelog
:cl:
del: The Die of Fate can no longer be found via maintenance loot (trash, random maints spawns, etc.)
/:cl:
