### PR TITLE
narrate text doesn't have a shitty glow anymore

### DIFF
--- a/code/__DEFINES/~~bubber_defines/span.dm
+++ b/code/__DEFINES/~~bubber_defines/span.dm
@@ -1,3 +1,4 @@
+#define span_narrate(str) ("<span class='narrate'>" + str + "</span>")
 #define span_subtle(str) ("<span class='subtle'>" + str + "</span>")
 #define span_subtlepda(str) ("<span class='subtlepda'>" + str + "</span>")
 #define span_subtler(str) ("<span class='subtler'>" + str + "</span>")

--- a/modular_skyrat/modules/customization/modules/mob/living/living_verbs.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/living_verbs.dm
@@ -80,7 +80,7 @@ GAME_VERB_DESC(/mob/living, narrate, "Narrate", "Allows you to send a narration 
 		return
 
 	user.log_message(message, LOG_EMOTE)
-	user.show_message(span_cyan("[message]"))
+	user.show_message(span_narrate("[message]"))
 
 	// Handle target = range
 	if(isnum(target))
@@ -91,7 +91,7 @@ GAME_VERB_DESC(/mob/living, narrate, "Narrate", "Allows you to send a narration 
 				viewers |= holo.Impersonation
 
 		for(var/mob/receiver in viewers)
-			receiver.show_message(span_cyan("[message] \n\ (Narration: [user])"), MSG_VISUAL)
+			receiver.show_message(span_narrate("[message] \n\ (Narration: [user])"), MSG_VISUAL)
 	// Handle target = an individual
 	else
 		var/mob/target_mob = astype(target, /obj/effect/overlay/holo_pad_hologram)?.Impersonation || target
@@ -100,7 +100,7 @@ GAME_VERB_DESC(/mob/living, narrate, "Narrate", "Allows you to send a narration 
 		if(get_dist(user_mob_or_hologram.loc, target_mob.loc) > world.view)
 			to_chat(user, span_warning("Your narration was unable to be sent to your target: Too far away."))
 			return
-		target_mob.show_message(span_cyan("[message] \n\ (Narration: [user])"), MSG_VISUAL)
+		target_mob.show_message(span_narrate("[message] \n\ (Narration: [user])"), MSG_VISUAL)
 
 #undef NARRATE_RANGE_MAX
 #undef NARRATE_RANGE_SAME_TILE

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -1369,7 +1369,7 @@ $border-width-px: $border-width * 1px;
   font-weight: bold;
 }
 
-.cyan {
+.narrate {
   color: #0ea1e6;
   font-weight: bold;
 }

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -1362,7 +1362,7 @@ $border-width-px: $border-width * 1px;
   font-weight: bold;
 }
 
-.cyan {
+.narrate {
   color: #0ea1e6;
   font-weight: bold;
 }


### PR DESCRIPTION
## About The Pull Request

About 4 months ago TG added a new `.cyan` style which has a shitty bright shadow effect. Unfortunately, the "narrate" verb used skyrat defined `.cyan` style as well. This resulted in the narrate verb being absolutely disgusting to look at because of the bright glow. This PR brings back the old narrate look by making the narrate cyan style its own style.

## Why It's Good For The Game

Makes the narrate verb text look not like vomit. HOWEVER, because I simply renamed the style, this will mean that all styles that relied on it will now be using the default TG style. If a maintainer desires it I can bring back the old skyrat defined `.cyan` style, and just keep the old narrate separate.

## Proof Of Testing

<details>
<summary>Screenshots</summary>
<img width="678" height="33" alt="image" src="https://github.com/user-attachments/assets/3f0ab866-0d63-4ba7-a8db-b2d7aa387f68" />
<img width="218" height="43" alt="image" src="https://github.com/user-attachments/assets/676021b9-81bd-47f8-ba0e-bc7ced28eac2" />

</details>

## Changelog

:cl: Swan
qol: the narrate verb doesn't have its disgusting white-ish glow anymore
/:cl: