### PR TITLE
Fixes small silicons from being unable to be agro grabbed or picked up

### DIFF
--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -1,6 +1,8 @@
 
+/* BUBBER EDIT BEGIN - moved to <modular_zubber/code/modules/mob/living/silicon/silicon_defense.dm.
 /mob/living/silicon/grippedby(mob/living/carbon/user, instant = FALSE)
 	return //can't upgrade a simple pull into a more aggressive grab.
+*/ // BUBBER EDIT END
 
 /mob/living/silicon/get_ear_protection(ignore_deafness = FALSE)
 	return ..() + EAR_PROTECTION_HEAVY //no ears

--- a/modular_zubbers/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/modular_zubbers/code/modules/mob/living/silicon/silicon_defense.dm
@@ -1,0 +1,4 @@
+/mob/living/silicon/grippedby(mob/living/carbon/user, instant = FALSE) //allows PAIs and small mob silicons to be agro grabbed
+	if(mob_size < MOB_SIZE_HUMAN && user.grab_state < GRAB_AGGRESSIVE)
+		return ..()
+	return

--- a/modular_zubbers/code/modules/silicons/borgs/code/robot_model_traits.dm
+++ b/modular_zubbers/code/modules/silicons/borgs/code/robot_model_traits.dm
@@ -54,12 +54,12 @@
 	if (!istype(robot))
 		return
 	if (model_features && (TRAIT_R_LIGHT_WEIGHT in model_features))
-		AddElement(/datum/element/can_be_held)
-		cyborg.held_w_class = WEIGHT_CLASS_HUGE
+		cyborg.AddElement(/datum/element/can_be_held)
+		cyborg.held_w_class = WEIGHT_CLASS_BULKY
 		cyborg.add_traits(list(TRAIT_CATLIKE_GRACE), INNATE_TRAIT)
 		cyborg.mob_size = MOB_SIZE_SMALL
 	else
-		RemoveElement(/datum/element/can_be_held)
+		cyborg.RemoveElement(/datum/element/can_be_held)
 		cyborg.held_w_class = WEIGHT_CLASS_NORMAL
 		cyborg.remove_traits(list(TRAIT_CATLIKE_GRACE), INNATE_TRAIT)
 		cyborg.mob_size = MOB_SIZE_HUMAN

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10085,6 +10085,7 @@
 #include "modular_zubbers\code\modules\mob\living\carbon\human\species_types\vulpkanin.dm"
 #include "modular_zubbers\code\modules\mob\living\carbon\human\species_types\zombie.dm"
 #include "modular_zubbers\code\modules\mob\living\silicon\silicon.dm"
+#include "modular_zubbers\code\modules\mob\living\silicon\silicon_defense.dm"
 #include "modular_zubbers\code\modules\mob\living\silicon\robot\robot.dm"
 #include "modular_zubbers\code\modules\mob\living\simple_animal\friendly\syndicatefox.dm"
 #include "modular_zubbers\code\modules\mob\living\simple_animal\guardian\guardian.dm"


### PR DESCRIPTION

## About The Pull Request
This PR is to fix Small silicons mainly PAIs and Cat borgs from being unable to be aggressively grabbed and being unable to be picked up.

This also fixes a small runtime error I had accidentally caused where it would apply pick up elements to the robot module and not the robot mob its self.

Also this pr lowers the weight class of a cat borg silicon since it was set wrong.

## Why It's Good For The Game
Bugs in the code are very bad and seeing the red RUNTIME error in my debug console makes me sad

Adding aggressive grabbing to small silicon mobs just makes sense they are small and should be able to be aggressively grabbed and if fixes a very ucky yucky bug.

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="865" height="809" alt="dreamseeker_tbT43805pc" src="https://github.com/user-attachments/assets/31ea415d-d90d-46f5-8dcf-8d474e0e7ff5" />
<img width="519" height="322" alt="dreamseeker_HRArX26JRr" src="https://github.com/user-attachments/assets/10a02c57-3dab-4f2b-a2e6-ef3cef5e2f4a" />


</details>

## Changelog
:cl:
add: Aggressive grabbing of small silicon mobs
fix: Silicons being unable to be aggressively grabbed or picked up
fix: Fixed a bad instance of AddElement and RemoveElement in robot_model_traits.dm that were causing runtimes
code: grippedby was commented out in code/modules/mob/living/silicon/silicon_defense.dm and replaced with modular_zubber/code/modules/mob/living/silicon/silicon_defense.dm's own implementation of grippedby
code: changed weight class of "cyborg.held_w_class" to be WEIGHT_CLASS_BULKY instead of WEIGHT_CLASS_HUGE since huge is for two handed items.
/:cl:
