### PR TITLE
Revert "Tweaks the VOKSHOD's armor values, removes the wound 30 on the unpowered HEV suit, and makes them all not marked contra. Also adds a seperate order for the MOD as a premium."

### DIFF
--- a/modular_skyrat/modules/novaya_ert/code/suit.dm
+++ b/modular_skyrat/modules/novaya_ert/code/suit.dm
@@ -43,14 +43,14 @@
 
 /datum/armor/hev_suit_nri
 	melee = 25
-	bullet = 35
-	laser = 30
+	bullet = 25
+	laser = 25
 	energy = 25
 	bomb = 25
 	bio = 25
 	fire = 30
 	acid = 30
-	wound = 20
+	wound = 30
 	consume = 10
 
 /datum/armor/hev_suit_nri/powered

--- a/modular_zubbers/code/modules/cargo/packs/contraband.dm
+++ b/modular_zubbers/code/modules/cargo/packs/contraband.dm
@@ -49,3 +49,13 @@
 	)
 	crate_name = "Battle Rifle Crate"
 	order_flags = ORDER_CONTRABAND
+
+/datum/supply_pack/imports/depowerarmor
+	name = "Depowered VOSKHOD Armor Set"
+	desc = "We've gotten in some of the PSC's 'finest' sets of armor, these have seen much better days. But hey, we know you guys love this shit!"
+	cost = 3500
+	contains = list(
+		/obj/item/clothing/head/helmet/space/voskhod,
+		/obj/item/clothing/suit/space/voskhod,
+	)
+	order_flags = ORDER_CONTRABAND

--- a/modular_zubbers/code/modules/cargo/packs/general.dm
+++ b/modular_zubbers/code/modules/cargo/packs/general.dm
@@ -49,26 +49,4 @@
 	crate_name = "EVA Suit Crate"
 	crate_type = /obj/structure/closet/crate/secure
 
-/datum/supply_pack/emergency/voskhod
-	name = "VOSKHOD Modular Combat Suit crate"
-	desc = "Contains one 'brand new' MODular VOSKHOD suit, refitted by one of the many nations under the banner of the CIN."
-	contains = list(
-			/obj/item/mod/control/pre_equipped/voskhod
-	)
-	cost = CARGO_CRATE_VALUE * 24
-	access = ACCESS_EVA
-	crate_name = "Combat Suit Crate"
-	crate_type = /obj/structure/closet/crate/secure
-
-/datum/supply_pack/emergency/depowerarmor
-	name = "Depowered VOSKHOD Armor Set"
-	desc = "We've gotten in some of the PSC's 'finest' sets of armor, these have seen much better days. But hey, we know you guys love this shit!"
-	cost = CARGO_CRATE_VALUE * 12
-	contains = list(
-		/obj/item/clothing/head/helmet/space/voskhod,
-		/obj/item/clothing/suit/space/voskhod,
-	)
-	access = ACCESS_EVA
-	crate_name = "Combat Suit Crate"
-	crate_type = /obj/structure/closet/crate/secure
 

--- a/modular_zubbers/code/modules/mod/mod_theme.dm
+++ b/modular_zubbers/code/modules/mod/mod_theme.dm
@@ -226,10 +226,10 @@
 	)
 
 /datum/armor/mod_theme_voskhod
-	melee = 20
-	bullet = 35
+	melee = 30
+	bullet = 30
 	laser = 30
-	energy = 20
+	energy = 30
 	bomb = 30
 	bio = 30
 	fire = 80


### PR DESCRIPTION
Reverts Bubberstation/Bubberstation#6039