### PR TITLE
Fixes Proteans being unable to eject assimilated modsuits

### DIFF
--- a/modular_zubbers/code/modules/customization/species/proteans/_proteans_species.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/_proteans_species.dm
@@ -241,8 +241,8 @@
 	species_modsuit.desc = initial(species_modsuit.desc)
 	species_modsuit.extended_desc = initial(species_modsuit.extended_desc)
 
-	if(user?.can_put_in_hand(species_modsuit.stored_modsuit, user.active_hand_index))
-		user.put_in_hand(species_modsuit.stored_modsuit, user.active_hand_index)
+	if(!user?.put_in_hand(species_modsuit.stored_modsuit, user.active_hand_index))
+		species_modsuit.stored_modsuit.forceMove(species_modsuit.drop_location()) // Never leave it orphaned inside us.
 
 	species_modsuit.stored_modsuit = null
 	update_static_data_for_all_viewers()

--- a/modular_zubbers/code/modules/customization/species/proteans/_proteans_species.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/_proteans_species.dm
@@ -241,7 +241,7 @@
 	species_modsuit.desc = initial(species_modsuit.desc)
 	species_modsuit.extended_desc = initial(species_modsuit.extended_desc)
 
-	if(!user?.put_in_hand(species_modsuit.stored_modsuit, user.active_hand_index))
+	if(!user?.put_in_hand(species_modsuit.stored_modsuit, user.active_hand_index) && species_modsuit.stored_modsuit.loc == species_modsuit)
 		species_modsuit.stored_modsuit.forceMove(species_modsuit.drop_location()) // Never leave it orphaned inside us.
 
 	species_modsuit.stored_modsuit = null

--- a/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/protean_modsuit.dm
@@ -190,13 +190,6 @@
 		return UI_INTERACTIVE
 	. = ..()
 
-GAME_VERB_HIDDEN(/obj/item/mod/control/pre_equipped/protean, remove_modsuit, "Remove Assimilated Modsuit")
-	var/obj/item/mod/core/protean/p_core = core
-	to_chat(usr, span_notice("You begin to pry at the [stored_modsuit] to seperate it."))
-	if(!do_after(usr, 5 SECONDS))
-		return
-	p_core.linked_species.unassimilate_modsuit(usr)
-
 /obj/item/mod/control/pre_equipped/protean/examine(mob/user)
 	. = ..()
 	var/obj/item/mod/core/protean/protean_core = core

--- a/modular_zubbers/code/modules/customization/species/proteans/protean_ui.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/protean_ui.dm
@@ -16,6 +16,8 @@
 	data["icon"] = species_modsuit?.icon
 	data["icon_state"] = species_modsuit?.icon_state
 	data["transform"] = species_modsuit?.wearer?.GetComponent(/datum/component/transformation)
+	data["assimilated"] = !isnull(species_modsuit?.stored_modsuit)
+	data["is_owner"] = user == owner
 	return data
 
 /datum/species/protean/ui_status(mob/user) // Protean's UI
@@ -38,6 +40,13 @@
 			owner.suit_transformation(owner == usr ? FALSE : TRUE) // Others can force the protean to fold.
 		if("heal")
 			owner.protean_heal()
+		if("eject_modsuit")
+			if(usr != owner) 
+				return TRUE
+			if(!species_modsuit?.stored_modsuit)
+				owner.balloon_alert(owner, "no assimilated suit")
+				return TRUE
+			INVOKE_ASYNC(src, PROC_REF(pry_suit_loose))
 		if("protean_transform")
 			if(COOLDOWN_FINISHED(src, transform_cooldown)) // Anti-spam
 				var/component = species_modsuit.wearer?.GetComponent(/datum/component/transformation)
@@ -53,6 +62,14 @@
 					RegisterSignal(species_modsuit, COMSIG_ITEM_PRE_UNEQUIP, PROC_REF(protean_transform_unequip))
 				COOLDOWN_START(src, transform_cooldown, 1 SECONDS)
 	return TRUE
+
+/datum/species/protean/proc/pry_suit_loose()
+	to_chat(owner, span_notice("You begin to eject [species_modsuit.stored_modsuit] from your body."))
+	if(!do_after(owner, 5 SECONDS))
+		return
+	if(!species_modsuit?.stored_modsuit)
+		return
+	unassimilate_modsuit(owner)
 
 /datum/species/protean/proc/protean_transform_unequip(/obj/item/source)
 	SIGNAL_HANDLER

--- a/modular_zubbers/code/modules/customization/species/proteans/protean_ui.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/protean_ui.dm
@@ -64,7 +64,7 @@
 	return TRUE
 
 /datum/species/protean/proc/pry_suit_loose()
-	to_chat(owner, span_notice("You begin to eject [species_modsuit.stored_modsuit] from your body."))
+	to_chat(owner, span_notice("You begin to extract [species_modsuit.stored_modsuit] from your body."))
 	if(!do_after(owner, 5 SECONDS))
 		return
 	if(!species_modsuit?.stored_modsuit)

--- a/modular_zubbers/code/modules/customization/species/proteans/protean_ui.dm
+++ b/modular_zubbers/code/modules/customization/species/proteans/protean_ui.dm
@@ -41,12 +41,12 @@
 		if("heal")
 			owner.protean_heal()
 		if("eject_modsuit")
-			if(usr != owner) 
+			if(usr != owner)
 				return TRUE
 			if(!species_modsuit?.stored_modsuit)
 				owner.balloon_alert(owner, "no assimilated suit")
 				return TRUE
-			INVOKE_ASYNC(src, PROC_REF(pry_suit_loose))
+			INVOKE_ASYNC(src, PROC_REF(eject_stored_modsuit))
 		if("protean_transform")
 			if(COOLDOWN_FINISHED(src, transform_cooldown)) // Anti-spam
 				var/component = species_modsuit.wearer?.GetComponent(/datum/component/transformation)
@@ -63,7 +63,7 @@
 				COOLDOWN_START(src, transform_cooldown, 1 SECONDS)
 	return TRUE
 
-/datum/species/protean/proc/pry_suit_loose()
+/datum/species/protean/proc/eject_stored_modsuit()
 	to_chat(owner, span_notice("You begin to extract [species_modsuit.stored_modsuit] from your body."))
 	if(!do_after(owner, 5 SECONDS))
 		return

--- a/tgui/packages/tgui/interfaces/ProteanUI.tsx
+++ b/tgui/packages/tgui/interfaces/ProteanUI.tsx
@@ -28,7 +28,7 @@ type ProteanData = {
 
 export const ProteanUI = () => {
   return (
-    <Window width={430} height={290}>
+    <Window width={400} height={300}>
       <Protean />
     </Window>
   );
@@ -123,36 +123,40 @@ export const Protean = () => {
         </Table.Row>
       </Table>
       <Divider />
-      <Stack
-        align="center"
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          width: '100%',
-        }}
-      >
-        <Button.Confirm
-          icon="right-from-bracket"
-          color="bad"
-          disabled={!assimilated || !is_owner}
-          tooltip={
-            assimilated
-              ? 'Extract the modsuit you absorbed from your body'
-              : 'No assimilated modsuit'
-          }
-          confirmContent="Are you sure?"
-          onClick={() => act('eject_modsuit')}
-        >
-          Eject Assimilated Modsuit
-        </Button.Confirm>
-        <ImageButton
-          dmIcon={icon}
-          dmIconState={icon_state}
-          style={{ display: 'inline-flex' }}
-          tooltipPosition="top"
-          tooltip="Modsuit UI"
-          onClick={() => act('openui')}
-        />
+      <Stack justify="flex-end">
+        <Stack.Item>
+          <Stack vertical align="center">
+            <Stack.Item>
+              <ImageButton
+                dmIcon={icon}
+                dmIconState={icon_state}
+                style={{ display: 'inline-flex' }}
+                tooltipPosition="top"
+                tooltip="Modsuit UI"
+                onClick={() => act('openui')}
+              />
+            </Stack.Item>
+            <Stack.Item>
+              <Button.Confirm
+                fluid
+                textAlign="center"
+                icon="right-from-bracket"
+                color="good"
+                confirmColor="bad"
+                confirmContent="Are you sure?"
+                disabled={!assimilated || !is_owner}
+                tooltip={
+                  assimilated
+                    ? 'Extract the modsuit you absorbed from your body'
+                    : 'No assimilated modsuit'
+                }
+                onClick={() => act('eject_modsuit')}
+              >
+                Eject Suit
+              </Button.Confirm>
+            </Stack.Item>
+          </Stack>
+        </Stack.Item>
       </Stack>
     </Section>
   );

--- a/tgui/packages/tgui/interfaces/ProteanUI.tsx
+++ b/tgui/packages/tgui/interfaces/ProteanUI.tsx
@@ -20,13 +20,15 @@ type ProteanData = {
   low_power: boolean;
   transformation: boolean;
   lock: boolean;
+  assimilated: boolean;
+  is_owner: boolean;
   icon: string;
   icon_state: string;
 };
 
 export const ProteanUI = () => {
   return (
-    <Window width={400} height={270}>
+    <Window width={400} height={320}>
       <Protean />
     </Window>
   );
@@ -42,6 +44,8 @@ export const Protean = () => {
     icon_state,
     low_power,
     transformation,
+    assimilated,
+    is_owner,
   } = data;
 
   return (
@@ -118,6 +122,23 @@ export const Protean = () => {
           </Table.Cell>
         </Table.Row>
       </Table>
+      <Divider />
+      <Stack
+        style={{ display: 'flex', justifyContent: 'left', width: '100%' }}
+      >
+        <Button
+          icon="right-from-bracket"
+          disabled={!assimilated || !is_owner}
+          tooltip={
+            assimilated
+              ? 'Pry the modsuit you absorbed back out of yourself'
+              : 'No assimilated modsuit'
+          }
+          onClick={() => act('eject_modsuit')}
+        >
+          Eject Assimilated Modsuit
+        </Button>
+      </Stack>
       <Divider />
       <Stack
         style={{ display: 'flex', justifyContent: 'right', width: '100%' }}

--- a/tgui/packages/tgui/interfaces/ProteanUI.tsx
+++ b/tgui/packages/tgui/interfaces/ProteanUI.tsx
@@ -28,7 +28,7 @@ type ProteanData = {
 
 export const ProteanUI = () => {
   return (
-    <Window width={400} height={320}>
+    <Window width={430} height={290}>
       <Protean />
     </Window>
   );
@@ -124,25 +124,27 @@ export const Protean = () => {
       </Table>
       <Divider />
       <Stack
-        style={{ display: 'flex', justifyContent: 'left', width: '100%' }}
+        align="center"
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          width: '100%',
+        }}
       >
-        <Button
+        <Button.Confirm
           icon="right-from-bracket"
+          color="bad"
           disabled={!assimilated || !is_owner}
           tooltip={
             assimilated
-              ? 'Pry the modsuit you absorbed back out of yourself'
+              ? 'Extract the modsuit you absorbed from your body'
               : 'No assimilated modsuit'
           }
+          confirmContent="Are you sure?"
           onClick={() => act('eject_modsuit')}
         >
           Eject Assimilated Modsuit
-        </Button>
-      </Stack>
-      <Divider />
-      <Stack
-        style={{ display: 'flex', justifyContent: 'right', width: '100%' }}
-      >
+        </Button.Confirm>
         <ImageButton
           dmIcon={icon}
           dmIconState={icon_state}


### PR DESCRIPTION
## About The Pull Request

Proteans could only separate an assimilated modsuit by using the hidden and abstract "Remove Assimilated Modsuit" verb which was technically in the game, which nobody knows exists unless somebody tells them. That verb is also on its way out upstream, since TG is deprecating `verb`/`verb()`, so #6174 was rejected on the grounds that the whole thing needs a refactor rather than a patch. I groan, stretch my neck and hands and make a ton of unsettling cracking noises and get to it. 

So the verb is gone. The eject now lives in the Protean Interface, next to the rest of the Protean specific options. A button marked "EJECT MODSUIT" under the little preview of the suit is now present, it will even make sure you're absolutely sure. 

I also fixed an adjacent problem with un-assimilating suits while I was in here. Sometimes removing a suit would erase it. You might ask how this could possibly happen, the answer is "I was testing it and unintentionally deleted an admin modsuit and I was like 'well that shouldn't happen'" 

Closes #6114! 

## Proof of Testing
<img width="618" height="449" alt="image" src="https://github.com/user-attachments/assets/7d2591e8-a984-4072-a72b-41bd58f560b3" />
<img width="122" height="156" alt="image" src="https://github.com/user-attachments/assets/8c0035b2-89d8-4bba-a803-a05451108c5f" />


## Why It's Good For The Game

A player who absorbed a modsuit had no way to gat it back out without ELITE BALL KNOWLEDGE short of reading the code or asking in Discord. This was an unintentional regression that resulted from TG doing something fucking stupid. 

Putting it on the Protean Interface means it is discoverable in the same place as every other Protean control. 

## Changelog

:cl: Aeri
fix: Proteans can once again eject an assimilated modsuit from the Protean Interface.
/:cl: