### PR TITLE
Adds a Combat Gloves goodie pack to cargo

### DIFF
--- a/modular_zubbers/code/modules/cargo/packs/goodies.dm
+++ b/modular_zubbers/code/modules/cargo/packs/goodies.dm
@@ -257,3 +257,9 @@
 	cost = PAYCHECK_COMMAND * 1.5
 	contains = list(/obj/item/ammo_box/magazine/lanca)
 	order_flags = ORDER_CONTRABAND
+
+/datum/supply_pack/goody/combatgloves
+	name = "Combat Gloves Single-Pack"
+	desc = "Contains a single pair of tactical, shock-resistant gloves. Ever since Centcomm finally stopped cheaping out with RoroCo, normal insuls have been able to fit in triggers, but combat gloves are still... cool..."\
+	cost = PAYCHECK_COMMAND * 3 // LARP TAX
+	contains = list(/obj/item/clothing/gloves/combat)

--- a/modular_zubbers/code/modules/cargo/packs/goodies.dm
+++ b/modular_zubbers/code/modules/cargo/packs/goodies.dm
@@ -261,5 +261,5 @@
 /datum/supply_pack/goody/combatgloves
 	name = "Combat Gloves Single-Pack"
 	desc = "Contains a single pair of tactical, shock-resistant gloves. Ever since Centcomm finally stopped cheaping out with RoroCo, normal insuls have been able to fit in triggers, but combat gloves are still... cool..."\
-	cost = PAYCHECK_COMMAND * 3 // LARP TAX
+	cost = PAYCHECK_COMMAND * 3
 	contains = list(/obj/item/clothing/gloves/combat)

--- a/modular_zubbers/code/modules/cargo/packs/goodies.dm
+++ b/modular_zubbers/code/modules/cargo/packs/goodies.dm
@@ -260,6 +260,6 @@
 
 /datum/supply_pack/goody/combatgloves
 	name = "Combat Gloves Single-Pack"
-	desc = "Contains a single pair of tactical, shock-resistant gloves. Ever since Centcomm finally stopped cheaping out with RoroCo, normal insuls have been able to fit in triggers, but combat gloves are still... cool..."
+	desc = "Contains a single pair of tactical, shock-resistant gloves. Ever since Centcom finally stopped cheaping out with RoroCo, normal insuls have been able to fit in triggers, but combat gloves are still... cool..."
 	cost = PAYCHECK_COMMAND * 5
 	contains = list(/obj/item/clothing/gloves/combat)

--- a/modular_zubbers/code/modules/cargo/packs/goodies.dm
+++ b/modular_zubbers/code/modules/cargo/packs/goodies.dm
@@ -261,5 +261,5 @@
 /datum/supply_pack/goody/combatgloves
 	name = "Combat Gloves Single-Pack"
 	desc = "Contains a single pair of tactical, shock-resistant gloves. Ever since Centcomm finally stopped cheaping out with RoroCo, normal insuls have been able to fit in triggers, but combat gloves are still... cool..."
-	cost = PAYCHECK_COMMAND * 3
+	cost = PAYCHECK_COMMAND * 5
 	contains = list(/obj/item/clothing/gloves/combat)

--- a/modular_zubbers/code/modules/cargo/packs/goodies.dm
+++ b/modular_zubbers/code/modules/cargo/packs/goodies.dm
@@ -260,6 +260,6 @@
 
 /datum/supply_pack/goody/combatgloves
 	name = "Combat Gloves Single-Pack"
-	desc = "Contains a single pair of tactical, shock-resistant gloves. Ever since Centcomm finally stopped cheaping out with RoroCo, normal insuls have been able to fit in triggers, but combat gloves are still... cool..."\
+	desc = "Contains a single pair of tactical, shock-resistant gloves. Ever since Centcomm finally stopped cheaping out with RoroCo, normal insuls have been able to fit in triggers, but combat gloves are still... cool..."
 	cost = PAYCHECK_COMMAND * 3
 	contains = list(/obj/item/clothing/gloves/combat)


### PR DESCRIPTION

## About The Pull Request

TG buffed insuls by removing chunky fingers like a year ago at this point. Combat gloves are kinda just there for the larp. Allow the people to larp.

## Why It's Good For The Game

this allows people to pay a tax to have funny combat gloves. (we removed illegal tech from them ages ago)

## Proof Of Testing

worked on my machine

## Changelog
:cl:
add: Combat gloves goodie order
/:cl:
