### PR TITLE
Adds the waddle quirk to borgs via module

### DIFF
--- a/modular_skyrat/modules/borgs/code/robot_upgrade.dm
+++ b/modular_skyrat/modules/borgs/code/robot_upgrade.dm
@@ -379,3 +379,22 @@
 						/obj/item/clothing/erp_leash,
 						/obj/item/clicker
 						)
+
+/// Cyborgs are bad at dancing too
+/obj/item/borg/upgrade/waddle_module
+	name = "borg waddle module"
+	desc = "A module that puts a little spring in each borg's step"
+	custom_materials = list(
+		/datum/material/iron = SHEET_MATERIAL_AMOUNT,
+		/datum/material/glass = SHEET_MATERIAL_AMOUNT,
+	)
+
+/obj/item/borg/upgrade/waddle_module/action(mob/living/silicon/robot/borg, mob/living/user)
+	. = ..()
+	if(.)
+		borg.add_quirk(/datum/quirk/waddle)
+
+/obj/item/borg/upgrade/waddle_module/deactivate(mob/living/silicon/robot/borg, mob/living/user)
+	. = ..()
+	if(.)
+		borg.remove_quirk(/datum/quirk/waddle)

--- a/modular_zubbers/code/datums/quirks/neutral_quirks/waddle.dm
+++ b/modular_zubbers/code/datums/quirks/neutral_quirks/waddle.dm
@@ -6,7 +6,7 @@
 	icon = FA_ICON_WIND
 	gain_text = span_notice("You feel like walking silly")
 	lose_text = span_notice("You no longer feel like walking silly")
-	quirk_flags = QUIRK_HUMAN_ONLY
+	quirk_flags = null
 	mail_goodies = list(/obj/item/food/grown/banana)
 
 

--- a/modular_zubbers/code/modules/research/designs/mechfab_designs.dm
+++ b/modular_zubbers/code/modules/research/designs/mechfab_designs.dm
@@ -114,6 +114,20 @@
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_ALL
 	)
 
+/datum/design/borg_waddle
+	name = "Cyborg Waddle Module"
+	id = "waddle_module"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/waddle_module
+	materials = list(
+		/datum/material/iron = SHEET_MATERIAL_AMOUNT,
+		/datum/material/glass = SHEET_MATERIAL_AMOUNT,
+	)
+	construction_time = 4 SECONDS
+	category = list(
+		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_ALL
+	)
+
 //so we have our own category
 /datum/design/borg_upgrade_surgical_processor_sci
 	name = "Research Surgical Processor"

--- a/modular_zubbers/code/modules/research/techweb/all_nodes.dm
+++ b/modular_zubbers/code/modules/research/techweb/all_nodes.dm
@@ -169,6 +169,7 @@
 		"obediencemodule",
 		"borg_upgrade_expand",
 		"borg_upgrade_shrink",
+		"waddle_module"
 	)
 
 /datum/techweb_node/borg_utility/New()


### PR DESCRIPTION

## About The Pull Request
title
## Why It's Good For The Game
Borgs can be bad at dancing too, so we ought to let them show off their moves
## Proof Of Testing

https://github.com/user-attachments/assets/efac0093-28ae-47e9-b080-5e9fa9f2b092
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
add: Adds Cyborg waddle module
/:cl:
