### PR TITLE
fixes missing sprites when using some tailcoats with digi legs

### DIFF
--- a/modular_zubbers/code/modules/clothing/suits/jacket.dm
+++ b/modular_zubbers/code/modules/clothing/suits/jacket.dm
@@ -391,6 +391,7 @@
 	icon_state = "chem"
 	icon = 'modular_zubbers/icons/obj/clothing/suits/jacket.dmi'
 	worn_icon = 'modular_zubbers/icons/mob/clothing/suits/jacket.dmi'
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 	post_init_icon_state = null
 	greyscale_config = null
 	greyscale_config_worn = null
@@ -402,6 +403,7 @@
 	icon_state = "virologist"
 	icon = 'modular_zubbers/icons/obj/clothing/suits/jacket.dmi'
 	worn_icon = 'modular_zubbers/icons/mob/clothing/suits/jacket.dmi'
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 	post_init_icon_state = null
 	greyscale_config = null
 	greyscale_config_worn = null
@@ -413,6 +415,7 @@
 	icon_state = "coroner"
 	icon = 'modular_zubbers/icons/obj/clothing/suits/jacket.dmi'
 	worn_icon = 'modular_zubbers/icons/mob/clothing/suits/jacket.dmi'
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 	post_init_icon_state = null
 	greyscale_config = null
 	greyscale_config_worn = null
@@ -424,6 +427,7 @@
 	icon_state = "cmo"
 	icon = 'modular_zubbers/icons/obj/clothing/suits/jacket.dmi'
 	worn_icon = 'modular_zubbers/icons/mob/clothing/suits/jacket.dmi'
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 
 //SCIENCE
 
@@ -433,6 +437,7 @@
 	icon_state = "science"
 	icon = 'modular_zubbers/icons/obj/clothing/suits/jacket.dmi'
 	worn_icon = 'modular_zubbers/icons/mob/clothing/suits/jacket.dmi'
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 	post_init_icon_state = null
 	greyscale_config = null
 	greyscale_config_worn = null
@@ -444,6 +449,7 @@
 	icon_state = "roboticist"
 	icon = 'modular_zubbers/icons/obj/clothing/suits/jacket.dmi'
 	worn_icon = 'modular_zubbers/icons/mob/clothing/suits/jacket.dmi'
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 	post_init_icon_state = null
 	greyscale_config = null
 	greyscale_config_worn = null
@@ -456,6 +462,7 @@
 	icon_state = "genetics"
 	icon = 'modular_zubbers/icons/obj/clothing/suits/jacket.dmi'
 	worn_icon = 'modular_zubbers/icons/mob/clothing/suits/jacket.dmi'
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 	post_init_icon_state = null
 	greyscale_config = null
 	greyscale_config_worn = null


### PR DESCRIPTION

## About The Pull Request

Wearing the following tailcoats with digitigrade legs would result in a missing textured suit item:
- roboticist's tailcoat
- scientist's tailcoat
- coroner's tailcoat
- pathologist's tailcoat
- chemist's tailcoat
- geneticist's tailcoat
- chief medical officer's tailcoat

This has been fixed by adding 
```
supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
```
to all of them, which uses the regular sprite as a fallback, which is what all the other non-bugged tailcoats do.
## Why It's Good For The Game

Less missing sprites good!
Fixes https://github.com/Bubberstation/Bubberstation/issues/6222
## Proof Of Testing

Works on my machine.
<details>
<summary>Screenshots/Videos</summary>
<img width="290" height="164" alt="Screenshot_591" src="https://github.com/user-attachments/assets/1c8be218-4e59-4799-8b2c-4d14391e7393" />


</details>

## Changelog
:cl:
fix: fixed some med/sci tailcoats being missing textured for digitgrade legs
/:cl:
