### PR TITLE
Re-Enable heretic/acolyte roll for Chaplains

### DIFF
--- a/modular_zubbers/code/modules/storyteller/event_defines/crewset/heretic.dm
+++ b/modular_zubbers/code/modules/storyteller/event_defines/crewset/heretic.dm
@@ -13,7 +13,7 @@
 	tags = list(TAG_COMBAT, TAG_SPOOKY, TAG_CREW_ANTAG)
 
 /datum/round_event_control/antagonist/solo/heretic/New()
-	protected_roles |= JOB_CHAPLAIN // Would be silly to get chaplain heretics
+//	protected_roles |= JOB_CHAPLAIN // Would be silly to get chaplain heretics
 	. = ..()
 
 #define TIME_CUTOFF 1.2 HOURS


### PR DESCRIPTION

## About The Pull Request
Comments out the part of the code that restricts chaplains from rolling acolyte.

## Why It's Good For The Game
It's arguably a subjective change and a biased one on my end, but it's strange to single out the chaplain for not becoming an Acolyte. My first argument is that if you can be a vampire chaplain (who can literally burn in their own church), you should be able to become an acolyte chaplain. I don't think chaplains (at least at the moment) have a whole lot of tools that counter acolyte anyway that you can't get elsewhere. (I'm pretty sure you can get magic immunity by drinking silver or holding holymelons, and nullrods don't do extra damage to heretics)

I also believe a heretical/acolyte chaplain is quite thematic, and would make for interesting roleplay. (Imagine them turning their chapel into horrible ritual grounds, being tested on their beliefs, etc.)

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

I can't easily prove that it works since I'd need to roll the heretic naturally on a chaplain with enough players in the round, but I have compiled the code many times and gotten no errors.

## Changelog
:cl: Dragon Lee
add: The chaplain can now roll the acolyte/heretic antagonist again.
/:cl:
