### PR TITLE
Reverts various nerfs to the Berserker suit

### DIFF
--- a/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
+++ b/modular_skyrat/modules/gladiator/code/game/objects/items/gladiator_items.dm
@@ -58,29 +58,15 @@
 	resistance_flags = INDESTRUCTIBLE
 
 /datum/armor/berserker_gatsu
-	melee = 40
-	bullet = 10
+	melee = 30
+	bullet = 30
 	laser = 10
-	energy = 10
-	bomb = 70
-	bio = 70
+	energy = 20
+	bomb = 50
+	bio = 60
 	fire = 100
 	acid = 100
-	wound = -5
-
-/datum/armor/drake_empowerment //Modular Override: nerfs beserker armour so I can keep this armour balanced
-	laser = 10
-	energy = 0
-
-/datum/armor/drake_empowerment_gatsu
-	melee = 30
-	laser = 10
-	bomb = 20
-
-/obj/item/clothing/suit/hooded/berserker/gatsu/Initialize(mapload)
-	. = ..()
-	AddComponent(/datum/component/armor_plate, maxamount = 1, upgrade_item = /obj/item/drake_remains, armor_mod = /datum/armor/drake_empowerment_gatsu, upgrade_prefix = "empowered")
-	allowed = GLOB.mining_suit_allowed
+	wound = 10
 
 /obj/item/clothing/suit/hooded/berserker/gatsu/examine()
 	. = ..()
@@ -100,8 +86,6 @@
 /obj/item/clothing/head/hooded/berserker/gatsu/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, LOCKED_HELMET_TRAIT)
-	AddComponent(/datum/component/anti_magic, ALL, inventory_flags = ITEM_SLOT_OCLOTHING)
-	AddComponent(/datum/component/armor_plate, maxamount = 1, upgrade_item = /obj/item/drake_remains, armor_mod = /datum/armor/drake_empowerment_gatsu, upgrade_prefix = "empowered")
 
 /obj/item/clothing/head/hooded/berserker/gatsu/examine()
 	. = ..()

--- a/modular_zubbers/code/modules/beserk_ability_onstation/beserk.dm
+++ b/modular_zubbers/code/modules/beserk_ability_onstation/beserk.dm
@@ -1,9 +1,0 @@
-/datum/action/item_action/berserk_mode/IsAvailable(feedback = FALSE)
-	. = ..()
-	if(!.)
-		return FALSE
-	if(!lavaland_equipment_pressure_check(get_turf(owner)))
-		if(feedback)
-			to_chat(owner, span_warning("You can't use this in a pressurised environment!"))
-		return FALSE
-	return TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9725,7 +9725,6 @@
 #include "modular_zubbers\code\modules\autolathe_components_adv\advpartdisks.dm"
 #include "modular_zubbers\code\modules\automapper\code\area_spawn_entries.dm"
 #include "modular_zubbers\code\modules\automapper\code\overrides\area_spawn_subsystem.dm"
-#include "modular_zubbers\code\modules\beserk_ability_onstation\beserk.dm"
 #include "modular_zubbers\code\modules\bitrunning\disks.dm"
 #include "modular_zubbers\code\modules\bitrunning\spawners.dm"
 #include "modular_zubbers\code\modules\bitrunning\virtual_domains\island_brawl.dm"


### PR DESCRIPTION
## About The Pull Request

I have fabricated this PR in response to a direct request from Dat_Legion/Azalea Briar, opened on their behalf. Please direct any input to them. 
⚠️I do not have a stake in the outcome of this PR ⚠️

It reverts two changes to the Marked One / berserker gear.

- Reverts #2293. `/datum/armor/berserker_gatsu` goes back to the stock berserker values

- Reverts #2428. The berserk ability is no longer blocked in pressurized areas. Upstream's `IsAvailable()` still covers the charge and already-active checks, so the pressure gate is the only thing removed.

## Why It's Good For The Game

My personal opinion is that we should not be balancing the game around a single person on the right tail of the bell curve. 

Beyond that, the numbers put a challenging boss drop below the stock berserker armor on melee, bomb and bio. That is a hard sell for a reward you have to earn at great personal risk, a lot of miners just kinda beef it and nobody ever hears from em' again. 

I will be honest that I cannot bring my usual auteur input to this, I don't do mining, I tried it once, I hated it. 

## Proof Of Testing

It compiles, the numbers on the armor 

## Changelog

:cl:
balance: Reverted the Marked One / berserker armor nerf; it uses the stock upstream values
/:cl: