### PR TITLE
Removes the port tarkon stacking machine and console

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon.dmm
+++ b/_maps/RandomRuins/SpaceRuins/skyrat/port_tarkon.dmm
@@ -77,9 +77,6 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/centerhall)
 "aw" = (
-/obj/machinery/mineral/stacking_machine{
-	id_tag = "tarkon"
-	},
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/port_tarkon/cargo)
@@ -4049,9 +4046,6 @@
 /obj/machinery/conveyor{
 	id = "tarkonrecycle";
 	dir = 1
-	},
-/obj/machinery/mineral/stacking_unit_console{
-	pixel_x = -32
 	},
 /obj/machinery/recycler,
 /turf/open/floor/plating/reinforced,


### PR DESCRIPTION


## About The Pull Request

This PR removes the stacking machine and stacking console from port tarkons cargo center

## Why It's Good For The Game

This makes it so you dont accidentally lose mats to the stacking console since its sticking out in an ugly position and probably needs to stay that way so new players dont lose mats to it.

## Proof Of Testing

Isnt a new feature or code so testing isnt really needed.

## Changelog

:cl:
del: Removed stacking console
del: Removed the stacking machine
/:cl:


