### PR TITLE
Adds RPG style damage numbers to combat hits. 

### DIFF
--- a/code/game/atom/atom_defense.dm
+++ b/code/game/atom/atom_defense.dm
@@ -32,7 +32,10 @@
 		return
 
 	. = damage_amount
-
+	// BUBBER EDIT ADDITION - HIT NUMBERS
+	var/obj/effect/overlay/damage_marker/damage_marker = new()
+	damage_marker.animate_damage(damage_amount, src, damage_type)
+	// BUBBER EDIT END
 	var/previous_atom_integrity = atom_integrity
 
 	update_integrity(atom_integrity - damage_amount)

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -99,7 +99,37 @@
 			damage_dealt = -1 * adjust_organ_loss(ORGAN_SLOT_BRAIN, damage_amount)
 
 	SEND_SIGNAL(src, COMSIG_MOB_AFTER_APPLY_DAMAGE, damage_dealt, damagetype, def_zone, blocked, wound_bonus, exposed_wound_bonus, sharpness, attack_direction, attacking_item, wound_clothing)
+	// BUBBER EDIT ADDITION - HIT NUMBERS
+	var/obj/effect/overlay/hitmarker/hitmarker = new()
+	hitmarker.animate_damage(damage, src, damagetype)
+	// BUBBED EDIT END
 	return damage_dealt
+
+/obj/effect/overlay/hitmarker // BUBBER EDIT - Damage Markers
+	icon = 'icons/effects/96x160.dmi'
+	plane = BALLOON_CHAT_PLANE
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	alpha = 64
+	var/mob/living/carbon/my_carbon_mob
+	var/list/static/colour = list(
+		BRUTE = "#FF0000",
+		BURN = "#FF9900",
+		TOX = "#00FF00",
+		OXY = "#7777FF",
+
+	)
+	proc/animate_damage(damage, my_mob, damagetype)
+
+		my_carbon_mob = my_mob
+		pixel_z = rand(-8,8)
+		pixel_w = rand(-8,8)
+		appearance_flags |= (KEEP_TOGETHER|RESET_COLOR|RESET_TRANSFORM)
+		my_carbon_mob.vis_contents |= src
+		maptext = MAPTEXT_SPESSFONT("<span style=\"color:[damagetype];\">[ROUND_UP(damage)]!</span>")
+		animate(src, pixel_z = rand(-64,64), pixel_w = rand(-64,64), time = 1 SECONDS, easing = BOUNCE_EASING, alpha = 255)
+		animate(alpha = 0, time = 0.5 SECONDS)
+		QDEL_IN(src, 1.5 SECONDS)
+
 
 /**
  * Used in tandem with [/mob/living/proc/apply_damage] to calculate modifier applied into incoming damage

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -125,7 +125,7 @@
 		pixel_w = rand(-8,8)
 		appearance_flags |= (KEEP_TOGETHER|RESET_COLOR|RESET_TRANSFORM)
 		my_carbon_mob.vis_contents |= src
-		maptext = MAPTEXT_SPESSFONT("<span style=\"color:[damagetype];\">[ROUND_UP(damage)]!</span>")
+		maptext = MAPTEXT_SPESSFONT("<span style=\"color:[colour[damagetype]];\">[ROUND_UP(damage)]!</span>")
 		animate(src, pixel_z = rand(-64,64), pixel_w = rand(-64,64), time = 1 SECONDS, easing = BOUNCE_EASING, alpha = 255)
 		animate(alpha = 0, time = 0.5 SECONDS)
 		QDEL_IN(src, 1.5 SECONDS)

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -98,6 +98,11 @@
 		if(BRAIN)
 			damage_dealt = -1 * adjust_organ_loss(ORGAN_SLOT_BRAIN, damage_amount)
 
+	// BUBBER EDIT ADDITION - HIT NUMBERS
+	var/obj/effect/overlay/damage_marker/damage_marker = new()
+	damage_marker.animate_damage(damage_amount, src, damagetype)
+	// BUBBER EDIT END
+
 	SEND_SIGNAL(src, COMSIG_MOB_AFTER_APPLY_DAMAGE, damage_dealt, damagetype, def_zone, blocked, wound_bonus, exposed_wound_bonus, sharpness, attack_direction, attacking_item, wound_clothing)
 	return damage_dealt
 

--- a/modular_zubbers/code/modules/effects/damage_marker.dm
+++ b/modular_zubbers/code/modules/effects/damage_marker.dm
@@ -1,0 +1,25 @@
+/obj/effect/overlay/damage_marker
+	icon = 'icons/effects/96x160.dmi'
+	plane = BALLOON_CHAT_PLANE
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	alpha = 64
+	var/mob/living/carbon/my_carbon_mob
+	var/list/static/colour = list(
+		BRUTE = list("clr" = "#FF0000", "str" = list("thwack", "smack", "bang", "crunch")),
+		BURN = list("clr" = "#FF9900", "str" = list("sizzle", "smoulder", "fizz", "burst")),
+		TOX = list("clr" = "#00FF00", "str" = list("")),
+		OXY = list("clr" = "#7777FF", "str" = list("")),
+
+	)
+	proc/animate_damage(damage, my_mob, damagetype)
+		my_carbon_mob = my_mob
+		pixel_z = rand(-8,8)
+		pixel_w = rand(-8,8)
+		appearance_flags |= (KEEP_TOGETHER|RESET_COLOR|RESET_TRANSFORM)
+		my_carbon_mob.vis_contents |= src
+		maptext = MAPTEXT_SPESSFONT("<span style=\"color:[colour[damagetype]["clr"]];\">[pick(colour[damagetype]["str"])]!</span>")
+		animate(src, pixel_z = rand(-64,64), pixel_w = rand(-64,64), time = 1 SECONDS, easing = BOUNCE_EASING, alpha = 255)
+		animate(alpha = 0, time = 0.5 SECONDS)
+		QDEL_IN(src, 1.5 SECONDS)
+		message_admins(maptext)
+

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9572,6 +9572,7 @@
 #include "modular_zubbers\code\modules\designs\limbgrower_designs.dm"
 #include "modular_zubbers\code\modules\disease\disease_transmission.dm"
 #include "modular_zubbers\code\modules\disease\hidden.dm"
+#include "modular_zubbers\code\modules\effects\damage_marker.dm"
 #include "modular_zubbers\code\modules\emotes\emotes.dm"
 #include "modular_zubbers\code\modules\emotes\hand_items.dm"
 #include "modular_zubbers\code\modules\emotes\scream_datums.dm"


### PR DESCRIPTION

## About The Pull Request
Adds RPG style damage numbers to combat hits. A video should do here:

https://github.com/user-attachments/assets/1bb44dc0-64cf-4491-9e89-cdb0ada4db8f

I made this for april fools - and people liked it so maybe it can live as a real feature? This is much better than the april fools version. 
## Why It's Good For The Game

I think it is cool. I think it would add a nice visual stimulation to combat. 

## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
add: added a new RPG style damage indicator. 
/:cl:
